### PR TITLE
Add rate limiting and security headers configuration

### DIFF
--- a/root/app/auth/auth.py
+++ b/root/app/auth/auth.py
@@ -4,6 +4,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 from pydantic import BaseModel, EmailStr
 from app.core.database import get_db
+from app.core.rate_limit import sensitive_route_limit
 from app.auth.security import verify_password, create_access_token, get_password_hash
 from app.models.models import User
 from app.schemas.schemas import Token, UserCreate
@@ -15,6 +16,7 @@ class LoginIn(BaseModel):
     password: str
 
 @router.post("/login", response_model=Token)
+@sensitive_route_limit()
 async def login(form_data: OAuth2PasswordRequestForm = Depends(), db: AsyncSession = Depends(get_db)):
     email = form_data.username.strip().lower()
     res = await db.execute(select(User).where(User.email == email))
@@ -27,6 +29,7 @@ async def login(form_data: OAuth2PasswordRequestForm = Depends(), db: AsyncSessi
     return {"access_token": token, "token_type": "bearer"}
 
 @router.post("/login-json", response_model=Token)
+@sensitive_route_limit()
 async def login_json(payload: LoginIn, db: AsyncSession = Depends(get_db)):
     email = payload.email.strip().lower()
     res = await db.execute(select(User).where(User.email == email))
@@ -39,6 +42,7 @@ async def login_json(payload: LoginIn, db: AsyncSession = Depends(get_db)):
     return {"access_token": token, "token_type": "bearer"}
 
 @router.post("/register")
+@sensitive_route_limit()
 async def register(user: UserCreate, db: AsyncSession = Depends(get_db)):
     email = user.email.strip().lower()
     res = await db.execute(select(User).where(User.email == email))

--- a/root/app/core/rate_limit.py
+++ b/root/app/core/rate_limit.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TypeVar
+
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+
+from app.core.config import settings
+
+F = TypeVar("F", bound=Callable[..., object])
+
+
+def _default_limits() -> list[str] | None:
+    limits = settings.rate_limit_default_list
+    return limits or None
+
+
+limiter = Limiter(
+    key_func=get_remote_address,
+    default_limits=_default_limits(),
+    storage_uri=settings.rate_limit_storage_uri,
+    headers_enabled=settings.rate_limit_headers_enabled,
+    enabled=settings.rate_limit_enabled,
+)
+
+
+def limit_if_configured(limit_value: str | None) -> Callable[[F], F]:
+    if not limit_value:
+        def decorator(func: F) -> F:
+            return func
+
+        return decorator
+    return limiter.limit(limit_value)
+
+
+def sensitive_route_limit() -> Callable[[F], F]:
+    return limit_if_configured(settings.rate_limit_sensitive_value)
+

--- a/root/app/core/security_headers.py
+++ b/root/app/core/security_headers.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.responses import Response
+from starlette.types import ASGIApp
+
+from app.core.config import Settings
+
+
+class SecurityHeadersMiddleware(BaseHTTPMiddleware):
+    def __init__(self, app: ASGIApp, *, settings: Settings):
+        super().__init__(app)
+        self._settings = settings
+
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:  # type: ignore[override]
+        response = await call_next(request)
+        self._apply_hsts(response)
+        self._apply_csp(response)
+        self._apply_frame_options(response)
+        self._apply_permissions_policy(response)
+        return response
+
+    def _apply_hsts(self, response: Response) -> None:
+        headers = response.headers
+        if not self._settings.security_hsts_enabled:
+            headers.pop("Strict-Transport-Security", None)
+            return
+        value = f"max-age={int(self._settings.security_hsts_max_age)}"
+        if self._settings.security_hsts_include_subdomains:
+            value += "; includeSubDomains"
+        if self._settings.security_hsts_preload:
+            value += "; preload"
+        headers["Strict-Transport-Security"] = value
+
+    def _apply_csp(self, response: Response) -> None:
+        headers = response.headers
+        policy = self._settings.security_csp.strip()
+        report_uri = self._settings.security_csp_report_uri.strip()
+        header_name = "Content-Security-Policy"
+        if self._settings.security_csp_report_only:
+            header_name = "Content-Security-Policy-Report-Only"
+        alternate = "Content-Security-Policy" if header_name.endswith("Report-Only") else "Content-Security-Policy-Report-Only"
+        if not policy:
+            headers.pop("Content-Security-Policy", None)
+            headers.pop("Content-Security-Policy-Report-Only", None)
+            return
+        normalized = policy.rstrip("; ")
+        if report_uri:
+            normalized = f"{normalized}; report-uri {report_uri}"
+        headers[header_name] = normalized
+        headers.pop(alternate, None)
+
+    def _apply_frame_options(self, response: Response) -> None:
+        headers = response.headers
+        value = self._settings.security_x_frame_options.strip()
+        if value:
+            headers["X-Frame-Options"] = value
+        else:
+            headers.pop("X-Frame-Options", None)
+
+    def _apply_permissions_policy(self, response: Response) -> None:
+        headers = response.headers
+        value = self._settings.security_permissions_policy.strip()
+        if value:
+            headers["Permissions-Policy"] = value
+        else:
+            headers.pop("Permissions-Policy", None)
+

--- a/root/app/cors_setup.py
+++ b/root/app/cors_setup.py
@@ -4,11 +4,11 @@ from app.core.config import settings
 
 
 def setup_cors(app):
-    origins = settings.frontend_origins_list
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=origins,
-        allow_credentials=True,
-        allow_methods=["GET","POST","PUT","PATCH","DELETE","OPTIONS"],
-        allow_headers=["*"],
+        allow_origins=settings.frontend_origins_list,
+        allow_credentials=settings.cors_allow_credentials,
+        allow_methods=settings.cors_allow_methods_list,
+        allow_headers=settings.cors_allow_headers_list,
+        expose_headers=settings.cors_expose_headers_list,
     )

--- a/root/app/main.py
+++ b/root/app/main.py
@@ -2,10 +2,13 @@ from __future__ import annotations
 
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 from sqlalchemy import text
+from slowapi.errors import RateLimitExceeded
+from slowapi.middleware import SlowAPIMiddleware
 
 from app.api.notifications import router as notifications_router
 from app.api.push import router as push_router
@@ -15,13 +18,14 @@ from app.auth.auth import router as auth_router
 from app.core.config import settings
 from app.core.database import Base, engine, wait_db
 from app.core.observability import configure_observability, shutdown_observability
+from app.core.rate_limit import limiter
+from app.core.security_headers import SecurityHeadersMiddleware
 from app.services.notifications import start_notifications_scheduler
 
 try:  # pragma: no cover - optional dependency
     from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 except Exception:  # pragma: no cover - optional dependency
     ProxyHeadersMiddleware = None
-
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -45,10 +49,15 @@ configure_observability(app, engine=engine)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=settings.frontend_origins_list,
-    allow_credentials=True,
-    allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
-    allow_headers=["*"],
+    allow_credentials=settings.cors_allow_credentials,
+    allow_methods=settings.cors_allow_methods_list,
+    allow_headers=settings.cors_allow_headers_list,
+    expose_headers=settings.cors_expose_headers_list,
 )
+
+app.add_middleware(SecurityHeadersMiddleware, settings=settings)
+app.add_middleware(SlowAPIMiddleware, limiter=limiter)
+app.state.limiter = limiter
 
 if ProxyHeadersMiddleware:
     trusted_hosts = settings.trusted_hosts_list
@@ -83,3 +92,8 @@ app.include_router(spotify_router)
 app.include_router(notifications_router)
 app.include_router(push_router)
 app.include_router(main_router)
+
+
+@app.exception_handler(RateLimitExceeded)
+async def rate_limit_handler(request: Request, exc: RateLimitExceeded):
+    return JSONResponse(status_code=429, content={"detail": "Too Many Requests"})

--- a/root/requirements.txt
+++ b/root/requirements.txt
@@ -15,6 +15,7 @@ python-multipart>=0.0.7
 aiofiles>=23.0
 pywebpush>=1.9
 psycopg[binary]>=3.1
+slowapi>=0.1.9
 
 opentelemetry-api==1.37.0
 opentelemetry-sdk==1.37.0


### PR DESCRIPTION
## Summary
- add configurable SlowAPI rate limiting with global defaults and stricter rules for auth endpoints
- introduce middleware for CSP (report-only by default), HSTS, X-Frame-Options, and Permissions-Policy headers driven by settings
- expose CORS and security tuning options via settings and document how to relax policies for development

## Testing
- pip install -r root/requirements.txt
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d498d21190832e8724bfb61c206179