### PR TITLE
feat(theme): adopt css variables and motion prefs

### DIFF
--- a/root/frontend/src/assets/themes.css
+++ b/root/frontend/src/assets/themes.css
@@ -67,7 +67,24 @@
   --hint-fg: rgba(0,0,0,.6);
   --placeholder-fg: rgba(0,0,0,.45);
   --bn-h: clamp(58px, 9.5vh, 92px);
-  --bn-pad-v: 6px
+  --bn-pad-v: 6px;
+  --ue-spacing-2xs: 0.25rem;
+  --ue-spacing-xs: 0.5rem;
+  --ue-spacing-sm: 0.75rem;
+  --ue-spacing-md: 1rem;
+  --ue-spacing-lg: 1.5rem;
+  --ue-spacing-xl: 2rem;
+  --ue-radius-xs: 0.35rem;
+  --ue-radius-sm: 0.5rem;
+  --ue-radius-md: 0.75rem;
+  --ue-radius-lg: 1rem;
+  --ue-radius-xl: 1.75rem;
+  --ue-radius-pill: 999px;
+  --ue-focus-ring: 0 0 0 1px rgba(255,255,255,.92), 0 0 0 4px rgba(0,94,162,.35);
+  --ue-z-index-nav: 2600;
+  --ue-z-index-overlay: 2500;
+  --ue-z-index-floating: 2800;
+  --ue-z-index-toast: 3400
 }
 body.dark {
   --nav-bg: #0E1116;
@@ -105,14 +122,35 @@ body.dark {
   --glass-tint-3: rgba(255,255,255,.01);
   --glass-alpha: .05;
   --hint-fg: rgba(255,255,255,.72);
-  --placeholder-fg: rgba(255,255,255,.64)
+  --placeholder-fg: rgba(255,255,255,.64);
+  --ue-focus-ring: 0 0 0 1px rgba(11,15,21,.92), 0 0 0 4px rgba(105,169,220,.5)
 }
-* { outline: none }
 ::selection { background: var(--selection-bg); color: var(--selection-text) }
 ::-moz-selection { background: var(--selection-bg); color: var(--selection-text) }
 html, body, #root { height: 100%; margin: 0 }
 #root { min-height: 100dvh }
 html { scroll-behavior: smooth }
+button:not(.MuiButtonBase-root),
+.menu-link,
+.menu-btn-settings,
+.burger-btn,
+.bottom-nav__item { min-height: 44px; min-width: 44px }
+
+button:not(.MuiButtonBase-root),
+.menu-link,
+.menu-btn-settings,
+.burger-btn,
+.bottom-nav__item { touch-action: manipulation }
+
+button:not(.MuiButtonBase-root):focus-visible,
+.menu-link:focus-visible,
+.menu-btn-settings:focus-visible,
+.burger-btn:focus-visible,
+.bottom-nav__item:focus-visible {
+  outline: none;
+  box-shadow: var(--ue-focus-ring);
+  border-radius: max(var(--ue-radius-sm), 0.75rem)
+}
 body {
   background: var(--page-bg);
   color: var(--page-text);
@@ -141,8 +179,11 @@ h1 { font-size: var(--fs-h1) }
 h2 { font-size: var(--fs-h2) }
 h3 { font-size: var(--fs-h3) }
 .menu-link {
-  display: inline-block;
-  padding: 8px 14px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  padding: 10px 16px;
   border-radius: 12px;
   font-weight: 700;
   font-size: 1rem;
@@ -151,17 +192,22 @@ h3 { font-size: var(--fs-h3) }
   text-decoration: none;
   transition: transform var(--anim-fast), box-shadow var(--anim-fast), color var(--anim-fast), background var(--anim-fast)
 }
-.menu-link:hover,.menu-link:focus {
+.menu-link:hover,
+.menu-link:focus {
   color: var(--menu-hover-text) !important;
   background: var(--menu-hover-bg);
-  transform: translateY(-1px) scale(1.08);
+  transform: translateY(-1px) scale(1.05);
   box-shadow: 0 6px 20px rgba(0,94,162,.18);
   text-decoration: none;
   z-index: 2
 }
-.menu-link:focus-visible { box-shadow: var(--shadow-focus) }
+.menu-link:focus-visible {
+  transform: none;
+  box-shadow: var(--ue-focus-ring);
+}
 .menu-link.settings { background: transparent; border: none; color: var(--nav-text); box-shadow: none }
-.menu-link.settings:hover,.menu-link.settings:focus { background: var(--menu-hover-bg); color: var(--menu-hover-text) !important; box-shadow: 0 2px 10px #0001 }
+.menu-link.settings:hover,
+.menu-link.settings:focus { background: var(--menu-hover-bg); color: var(--menu-hover-text) !important; box-shadow: 0 2px 10px #0001 }
 .menu-link.logout {
   color: #e53935 !important;
   background: #fff4f4;
@@ -293,6 +339,31 @@ a:hover { color: var(--nav-link-hover); text-decoration: underline; text-underli
 body.dark ::-webkit-scrollbar-thumb { background: #343c59 }
 body,.menu-link,.navbar-root,.menu-btn-settings,.burger-btn,.menu-link.logout,.main-card,.option-card,.gradient-card-btn {
   transition: background var(--anim-med), color var(--anim-med), border-color var(--anim-med), box-shadow var(--anim-med)
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html { scroll-behavior: auto !important }
+  *, *::before, *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    transition-delay: 0ms !important;
+  }
+  body,
+  .menu-link,
+  .navbar-root,
+  .menu-btn-settings,
+  .burger-btn,
+  .menu-link.logout,
+  .main-card,
+  .option-card,
+  .gradient-card-btn,
+  .mobile-drawer,
+  .mobile-drawer nav { transition: none !important }
+  .menu-link:hover,
+  .menu-link.logout:hover,
+  .card-hover:hover,
+  .card-hover:focus-within { transform: none !important; box-shadow: none !important }
 }
 body.dark .MuiDayCalendar-weekDayLabel,
 body.dark .MuiDayCalendar-header,

--- a/root/frontend/src/components/MotionPresence.tsx
+++ b/root/frontend/src/components/MotionPresence.tsx
@@ -1,12 +1,14 @@
 import type { ComponentProps } from "react";
-import { AnimatePresence } from "framer-motion";
+import { AnimatePresence, useReducedMotion } from "framer-motion";
 
 export default function MotionPresence({
   children,
+  initial = false,
   ...props
 }: ComponentProps<typeof AnimatePresence>) {
+  const reduce = useReducedMotion();
   return (
-    <AnimatePresence initial={false} mode="wait" {...props}>
+    <AnimatePresence initial={reduce ? false : initial} mode="wait" {...props}>
       {children}
     </AnimatePresence>
   );

--- a/root/frontend/src/components/Navbar.tsx
+++ b/root/frontend/src/components/Navbar.tsx
@@ -90,25 +90,11 @@ const Navbar = () => {
   const location = useLocation();
   const { user, isAuth, loading } = useAuth();
 
-  const [dark, setDark] = useState(() => {
-    const saved = localStorage.getItem("theme");
-    if (saved === "dark") return true;
-    if (saved === "light") return false;
-    if (typeof window !== "undefined" && "matchMedia" in window) {
-      return window.matchMedia("(prefers-color-scheme: dark)").matches;
-    }
-    return false;
-  });
   const [mobileMenu, setMobileMenu] = useState(false);
 
   const isMobile = useIsMobile();
   const prevIsMobile = useRef(isMobile);
   const navRef = useRef<HTMLDivElement | null>(null);
-
-  useEffect(() => {
-    document.body.classList.toggle("dark", dark);
-    localStorage.setItem("theme", dark ? "dark" : "light");
-  }, [dark]);
 
   useEffect(() => {
     if (prevIsMobile.current !== isMobile && !isMobile) setMobileMenu(false);
@@ -199,7 +185,7 @@ const Navbar = () => {
           overflowX: "hidden",
           position: "sticky",
           top: "env(safe-area-inset-top, 0px)",
-          zIndex: 2600
+          zIndex: "var(--ue-z-index-nav)"
         }}
       >
         <div
@@ -329,7 +315,7 @@ const Navbar = () => {
         <div
           id="mobile-drawer"
           className="mobile-drawer"
-          style={{ position: "fixed", top: 0, left: 0, width: "100vw", height: "100vh", zIndex: 2500, pointerEvents: mobileMenu ? "auto" : "none", background: mobileMenu ? "rgba(0,0,0,0.23)" : "transparent", transition: "background 0.28s", display: "flex" }}
+          style={{ position: "fixed", top: 0, left: 0, width: "100vw", height: "100vh", zIndex: "var(--ue-z-index-overlay)", pointerEvents: mobileMenu ? "auto" : "none", background: mobileMenu ? "rgba(0,0,0,0.23)" : "transparent", transition: "background 0.28s", display: "flex" }}
           onClick={() => setMobileMenu(false)}
           role="dialog"
           aria-modal="true"

--- a/root/frontend/src/components/PageTransition.tsx
+++ b/root/frontend/src/components/PageTransition.tsx
@@ -16,6 +16,10 @@ const loadMotionModule = async () => {
 const PageTransition: FC<Props> = ({ children }) => {
   const [motionModule, setMotionModule] = useState<MotionModule | null>(null)
   const [hasPainted, setHasPainted] = useState(didPaint)
+  const [reduceMotion, setReduceMotion] = useState(() => {
+    if (typeof window === "undefined" || !("matchMedia" in window)) return false
+    return window.matchMedia("(prefers-reduced-motion: reduce)").matches
+  })
 
   useEffect(() => {
     didPaint = true
@@ -23,6 +27,21 @@ const PageTransition: FC<Props> = ({ children }) => {
   }, [])
 
   useEffect(() => {
+    if (typeof window === "undefined" || !("matchMedia" in window)) return
+    const media = window.matchMedia("(prefers-reduced-motion: reduce)")
+    const handleChange = (event: MediaQueryListEvent) => {
+      setReduceMotion(event.matches)
+    }
+    if (typeof media.addEventListener === "function") {
+      media.addEventListener("change", handleChange)
+      return () => media.removeEventListener("change", handleChange)
+    }
+    media.addListener(handleChange)
+    return () => media.removeListener(handleChange)
+  }, [])
+
+  useEffect(() => {
+    if (reduceMotion) return
     let active = true
     loadMotionModule()
       .then((mod) => {
@@ -32,9 +51,15 @@ const PageTransition: FC<Props> = ({ children }) => {
     return () => {
       active = false
     }
-  }, [])
+  }, [reduceMotion])
 
-  if (!motionModule) return <>{children}</>
+  if (reduceMotion || !motionModule) {
+    return (
+      <div style={{ position: "relative", minHeight: "100%", background: "var(--page-bg)" }}>
+        <div style={{ position: "relative", zIndex: 1 }}>{children}</div>
+      </div>
+    )
+  }
 
   const { LazyMotion, domAnimation, motion } = motionModule
   const initial = hasPainted ? { opacity: 0.001, y: 12 } : false

--- a/root/frontend/src/main.tsx
+++ b/root/frontend/src/main.tsx
@@ -1,6 +1,7 @@
-import React from "react"
+import React, { useEffect } from "react"
 import ReactDOM from "react-dom/client"
-import { ThemeProvider, CssBaseline } from "@mui/material"
+import { CssBaseline } from "@mui/material"
+import { CssVarsProvider, useColorScheme } from "@mui/material/styles"
 import { registerSW } from "virtual:pwa-register"
 import App from "./App"
 import theme from "./theme"
@@ -20,11 +21,33 @@ const updateSW = registerSW({
   },
 })
 
+function BodyColorSchemeSync() {
+  const { mode, systemMode } = useColorScheme()
+
+  useEffect(() => {
+    const resolved = mode === "system" ? systemMode ?? "light" : mode ?? "light"
+    document.body.dataset.colorScheme = resolved
+    document.body.classList.toggle("dark", resolved === "dark")
+    return () => {
+      document.body.classList.remove("dark")
+      document.body.removeAttribute("data-color-scheme")
+    }
+  }, [mode, systemMode])
+
+  return null
+}
+
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <ThemeProvider theme={theme}>
+    <CssVarsProvider
+      theme={theme}
+      defaultMode="system"
+      modeStorageKey="theme"
+      disableTransitionOnChange
+    >
       <CssBaseline enableColorScheme />
+      <BodyColorSchemeSync />
       <App />
-    </ThemeProvider>
+    </CssVarsProvider>
   </React.StrictMode>
 )

--- a/root/frontend/src/mui.d.ts
+++ b/root/frontend/src/mui.d.ts
@@ -1,0 +1,10 @@
+import type theme from "./theme";
+
+declare module "@mui/material/styles" {
+  interface ThemeVars {
+    focusRing: typeof theme.vars.focusRing;
+    radiusScale: typeof theme.vars.radiusScale;
+    spacingScale: typeof theme.vars.spacingScale;
+    zIndexTokens: typeof theme.vars.zIndexTokens;
+  }
+}

--- a/root/frontend/src/pages/Settings.tsx
+++ b/root/frontend/src/pages/Settings.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, useCallback } from "react";
+import { useEffect, useRef, useState, useCallback, ChangeEvent } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 import { useNavigate } from "react-router-dom";
 import api from "@/api/axios";
@@ -27,6 +27,7 @@ import {
   DialogContent,
   DialogActions
 } from "@mui/material";
+import { useColorScheme } from "@mui/material/styles";
 import SettingsIcon from "@mui/icons-material/Settings";
 import DarkModeIcon from "@mui/icons-material/DarkMode";
 import LightModeIcon from "@mui/icons-material/LightMode";
@@ -52,30 +53,15 @@ export default function Settings() {
   const [tab, setTab] = useState(0);
   const [snack, setSnack] = useState<{ text: string; sev?: "success" | "info" | "warning" | "error" } | null>(null);
 
-  const sysPref = window.matchMedia("(prefers-color-scheme: dark)");
-  const readStored = () => (localStorage.getItem("theme") as ThemeMode | null) || "system";
-  const [theme, setTheme] = useState<ThemeMode>(readStored());
+  const { mode: storedMode, setMode } = useColorScheme();
+  const theme = (storedMode ?? "system") as ThemeMode;
 
-  const applyTheme = useCallback(
-    (mode: ThemeMode) => {
-      const dark = mode === "dark" || (mode === "system" && sysPref.matches);
-      document.body.classList.toggle("dark", dark);
+  const handleThemeChange = useCallback(
+    (_: ChangeEvent<HTMLInputElement>, value: string) => {
+      setMode(value as ThemeMode);
     },
-    [sysPref.matches]
+    [setMode]
   );
-
-  useEffect(() => {
-    applyTheme(theme);
-    localStorage.setItem("theme", theme);
-  }, [theme, applyTheme]);
-
-  useEffect(() => {
-    const onChange = () => {
-      if (theme === "system") applyTheme("system");
-    };
-    sysPref.addEventListener?.("change", onChange);
-    return () => sysPref.removeEventListener?.("change", onChange);
-  }, [theme, applyTheme, sysPref]);
 
   useEffect(() => {
     const sp = new URLSearchParams(window.location.search);
@@ -296,7 +282,7 @@ export default function Settings() {
               <Typography variant="h6" sx={{ mb: 1.2, color: "var(--page-text)" }}>
                 Тема
               </Typography>
-              <RadioGroup row value={theme} onChange={(e) => setTheme(e.target.value as ThemeMode)}>
+              <RadioGroup row value={theme} onChange={handleThemeChange}>
                 <FormControlLabel
                   value="system"
                   control={<Radio />}

--- a/root/frontend/src/theme.ts
+++ b/root/frontend/src/theme.ts
@@ -1,41 +1,360 @@
-import { createTheme, responsiveFontSizes } from "@mui/material/styles";
+import { extendTheme, responsiveFontSizes } from "@mui/material/styles";
 
-const theme = responsiveFontSizes(
-  createTheme({
-    typography: {
-      fontFamily: "var(--font-ui)",
-      h1: { fontFamily: "var(--font-display)", fontWeight: 400, letterSpacing: "var(--ls-display)", fontSize: "var(--fs-h1)", lineHeight: 1.22 },
-      h2: { fontFamily: "var(--font-display)", fontWeight: 400, letterSpacing: "var(--ls-display)", fontSize: "var(--fs-h2)", lineHeight: 1.22 },
-      h3: { fontFamily: "var(--font-display)", fontWeight: 400, letterSpacing: "var(--ls-display)", fontSize: "var(--fs-h3)", lineHeight: 1.22 },
-      h4: { fontFamily: "var(--font-display)", fontWeight: 400, letterSpacing: "var(--ls-display)", lineHeight: 1.22 },
-      h5: { fontFamily: "var(--font-display)", fontWeight: 400, letterSpacing: "var(--ls-display)", lineHeight: 1.22 },
-      h6: { fontFamily: "var(--font-display)", fontWeight: 400, letterSpacing: "var(--ls-display)", lineHeight: 1.22 },
-      body1: { fontSize: "var(--fs-body)", letterSpacing: "var(--ls-ui)", lineHeight: 1.55 },
-      body2: { fontSize: "calc(var(--fs-body) - 0.02rem)", letterSpacing: "var(--ls-ui)", lineHeight: 1.55 },
-      subtitle1: { fontSize: "var(--fs-body)", letterSpacing: "var(--ls-ui)", lineHeight: 1.55, fontWeight: 500 },
-      subtitle2: { fontSize: "calc(var(--fs-body) - 0.04rem)", letterSpacing: "var(--ls-ui)", lineHeight: 1.55, fontWeight: 600 },
-      button: { textTransform: "none", fontWeight: 600, letterSpacing: "var(--ls-ui)" },
-      caption: { fontSize: "calc(var(--fs-body) - 0.08rem)", letterSpacing: "0.01em", lineHeight: 1.4 },
-      overline: { fontSize: "calc(var(--fs-body) - 0.1rem)", letterSpacing: "0.08em", textTransform: "uppercase", lineHeight: 1.4 }
+const spacingScale = {
+  "2xs": "0.25rem",
+  xs: "0.5rem",
+  sm: "0.75rem",
+  md: "1rem",
+  lg: "1.5rem",
+  xl: "2rem",
+  "2xl": "3rem",
+} as const;
+
+const radiusScale = {
+  xs: "0.35rem",
+  sm: "0.5rem",
+  md: "0.75rem",
+  lg: "1rem",
+  xl: "1.75rem",
+  pill: "999px",
+} as const;
+
+const zIndexTokens = {
+  navbar: 2600,
+  overlay: 2500,
+  floating: 2800,
+  toast: 3400,
+} as const;
+
+const focusRing = {
+  light: "0 0 0 1px rgba(255, 255, 255, 0.92), 0 0 0 4px rgba(var(--mui-palette-primary-mainChannel) / 0.35)",
+  dark: "0 0 0 1px rgba(11, 15, 21, 0.92), 0 0 0 4px rgba(var(--mui-palette-primary-mainChannel) / 0.5)",
+} as const;
+
+const baseTheme = extendTheme({
+  cssVarPrefix: "ue",
+  colorSchemes: {
+    light: {
+      palette: {
+        mode: "light",
+        primary: {
+          main: "#005EA2",
+          light: "#3B82F6",
+          dark: "#1A4480",
+          contrastText: "#ffffff",
+        },
+        secondary: {
+          main: "#1A4480",
+          contrastText: "#ffffff",
+        },
+        info: {
+          main: "#0B5CAD",
+          contrastText: "#ffffff",
+        },
+        success: {
+          main: "#2E7D32",
+          contrastText: "#ffffff",
+        },
+        warning: {
+          main: "#B7791F",
+          contrastText: "#11161E",
+        },
+        error: {
+          main: "#D14343",
+          contrastText: "#ffffff",
+        },
+        text: {
+          primary: "#10151B",
+          secondary: "#4B5563",
+        },
+        divider: "rgba(16, 21, 27, 0.12)",
+        background: {
+          default: "#F3F6FA",
+          paper: "#FFFFFF",
+        },
+      },
     },
-    components: {
-      MuiButton: { styleOverrides: { root: { fontFamily: "var(--font-ui)" } } },
-      MuiInputBase: { styleOverrides: { input: { fontFamily: "var(--font-ui)" } } },
-      MuiInputLabel: { styleOverrides: { root: { fontFamily: "var(--font-ui)" } } },
-      MuiTypography: { styleOverrides: { root: { fontFamily: "var(--font-ui)" } } },
-      MuiCssBaseline: {
-        styleOverrides: {
-          body: {
-            fontFamily: "var(--font-ui)",
-            WebkitFontSmoothing: "antialiased",
-            MozOsxFontSmoothing: "grayscale",
-            textRendering: "optimizeLegibility",
-            fontFeatureSettings: '"tnum" 1, "lnum" 1'
-          }
-        }
-      }
-    }
-  })
-);
+    dark: {
+      palette: {
+        mode: "dark",
+        primary: {
+          main: "#69A9DC",
+          light: "#89BCE7",
+          dark: "#2B4C72",
+          contrastText: "#0B0F15",
+        },
+        secondary: {
+          main: "#1E3A5F",
+          contrastText: "#E6EBF2",
+        },
+        info: {
+          main: "#7FB6E6",
+          contrastText: "#0B0F15",
+        },
+        success: {
+          main: "#4ADE80",
+          contrastText: "#08121A",
+        },
+        warning: {
+          main: "#FBBF24",
+          contrastText: "#08121A",
+        },
+        error: {
+          main: "#F87171",
+          contrastText: "#08121A",
+        },
+        text: {
+          primary: "#E6EBF2",
+          secondary: "#B8C2D0",
+        },
+        divider: "rgba(230, 235, 242, 0.16)",
+        background: {
+          default: "#0B0F15",
+          paper: "#11161E",
+        },
+      },
+    },
+  },
+  typography: {
+    fontFamily: "var(--font-ui)",
+    h1: {
+      fontFamily: "var(--font-display)",
+      fontWeight: 400,
+      letterSpacing: "var(--ls-display)",
+      fontSize: "var(--fs-h1)",
+      lineHeight: 1.22,
+    },
+    h2: {
+      fontFamily: "var(--font-display)",
+      fontWeight: 400,
+      letterSpacing: "var(--ls-display)",
+      fontSize: "var(--fs-h2)",
+      lineHeight: 1.22,
+    },
+    h3: {
+      fontFamily: "var(--font-display)",
+      fontWeight: 400,
+      letterSpacing: "var(--ls-display)",
+      fontSize: "var(--fs-h3)",
+      lineHeight: 1.22,
+    },
+    h4: {
+      fontFamily: "var(--font-display)",
+      fontWeight: 400,
+      letterSpacing: "var(--ls-display)",
+      lineHeight: 1.22,
+    },
+    h5: {
+      fontFamily: "var(--font-display)",
+      fontWeight: 400,
+      letterSpacing: "var(--ls-display)",
+      lineHeight: 1.22,
+    },
+    h6: {
+      fontFamily: "var(--font-display)",
+      fontWeight: 400,
+      letterSpacing: "var(--ls-display)",
+      lineHeight: 1.22,
+    },
+    body1: {
+      fontSize: "var(--fs-body)",
+      letterSpacing: "var(--ls-ui)",
+      lineHeight: 1.55,
+    },
+    body2: {
+      fontSize: "calc(var(--fs-body) - 0.02rem)",
+      letterSpacing: "var(--ls-ui)",
+      lineHeight: 1.55,
+    },
+    subtitle1: {
+      fontSize: "var(--fs-body)",
+      letterSpacing: "var(--ls-ui)",
+      lineHeight: 1.55,
+      fontWeight: 500,
+    },
+    subtitle2: {
+      fontSize: "calc(var(--fs-body) - 0.04rem)",
+      letterSpacing: "var(--ls-ui)",
+      lineHeight: 1.55,
+      fontWeight: 600,
+    },
+    button: {
+      textTransform: "none",
+      fontWeight: 600,
+      letterSpacing: "var(--ls-ui)",
+    },
+    caption: {
+      fontSize: "calc(var(--fs-body) - 0.08rem)",
+      letterSpacing: "0.01em",
+      lineHeight: 1.4,
+    },
+    overline: {
+      fontSize: "calc(var(--fs-body) - 0.1rem)",
+      letterSpacing: "0.08em",
+      textTransform: "uppercase",
+      lineHeight: 1.4,
+    },
+  },
+  shape: {
+    borderRadius: 12,
+  },
+  spacing: 4,
+  zIndex: {
+    appBar: zIndexTokens.navbar,
+    drawer: zIndexTokens.overlay,
+    modal: zIndexTokens.floating,
+    snackbar: zIndexTokens.toast,
+    tooltip: zIndexTokens.toast + 100,
+  },
+  components: {
+    MuiCssBaseline: {
+      styleOverrides: {
+        ":root": {
+          "--ue-spacing-2xs": spacingScale["2xs"],
+          "--ue-spacing-xs": spacingScale.xs,
+          "--ue-spacing-sm": spacingScale.sm,
+          "--ue-spacing-md": spacingScale.md,
+          "--ue-spacing-lg": spacingScale.lg,
+          "--ue-spacing-xl": spacingScale.xl,
+          "--ue-spacing-2xl": spacingScale["2xl"],
+          "--ue-radius-xs": radiusScale.xs,
+          "--ue-radius-sm": radiusScale.sm,
+          "--ue-radius-md": radiusScale.md,
+          "--ue-radius-lg": radiusScale.lg,
+          "--ue-radius-xl": radiusScale.xl,
+          "--ue-radius-pill": radiusScale.pill,
+          "--ue-focus-ring": focusRing.light,
+          "--ue-z-index-nav": `${zIndexTokens.navbar}`,
+          "--ue-z-index-overlay": `${zIndexTokens.overlay}`,
+          "--ue-z-index-floating": `${zIndexTokens.floating}`,
+          "--ue-z-index-toast": `${zIndexTokens.toast}`,
+        },
+        ":root[data-mui-color-scheme='dark']": {
+          "--ue-focus-ring": focusRing.dark,
+        },
+        "html": {
+          scrollBehavior: "smooth",
+        },
+        "body": {
+          fontFamily: "var(--font-ui)",
+          WebkitFontSmoothing: "antialiased",
+          MozOsxFontSmoothing: "grayscale",
+          textRendering: "optimizeLegibility",
+          fontFeatureSettings: '"tnum" 1, "lnum" 1',
+        },
+        "*:focus-visible": {
+          outline: "none",
+        },
+        "@media (prefers-reduced-motion: reduce)": {
+          "html": {
+            scrollBehavior: "auto",
+          },
+          "*, *::before, *::after": {
+            animationDuration: "0.001ms !important",
+            animationIterationCount: "1 !important",
+            transitionDuration: "0.001ms !important",
+            transitionDelay: "0ms !important",
+          },
+        },
+      },
+    },
+    MuiButtonBase: {
+      styleOverrides: {
+        root: ({ theme }) => ({
+          minHeight: "44px",
+          minWidth: "44px",
+          borderRadius: `max(${theme.vars.radiusScale.md}, 0.75rem)`,
+          transition: "background-color 0.18s ease, box-shadow 0.2s ease, transform 0.18s ease",
+          outline: "none",
+          "&:focus-visible": {
+            outline: "none",
+            boxShadow: `var(--ue-focus-ring, ${theme.vars.focusRing.light})`,
+          },
+        }),
+      },
+    },
+    MuiButton: {
+      styleOverrides: {
+        root: ({ theme }) => ({
+          borderRadius: theme.vars.radiusScale.lg,
+          paddingInline: `max(${theme.vars.spacingScale.sm}, ${theme.spacing(2)})`,
+          paddingBlock: `max(${theme.vars.spacingScale["2xs"]}, ${theme.spacing(1)})`,
+          minHeight: "44px",
+        }),
+      },
+    },
+    MuiIconButton: {
+      styleOverrides: {
+        root: ({ theme }) => ({
+          minWidth: "44px",
+          minHeight: "44px",
+          borderRadius: theme.vars.radiusScale.pill,
+          padding: theme.vars.spacingScale.xs,
+          "&:focus-visible": {
+            boxShadow: `var(--ue-focus-ring, ${theme.vars.focusRing.light})`,
+          },
+        }),
+      },
+    },
+    MuiToggleButton: {
+      styleOverrides: {
+        root: ({ theme }) => ({
+          minHeight: "44px",
+          borderRadius: theme.vars.radiusScale.md,
+          paddingInline: theme.vars.spacingScale.sm,
+          "&:focus-visible": {
+            boxShadow: `var(--ue-focus-ring, ${theme.vars.focusRing.light})`,
+          },
+        }),
+      },
+    },
+    MuiListItemButton: {
+      styleOverrides: {
+        root: ({ theme }) => ({
+          minHeight: "48px",
+          borderRadius: theme.vars.radiusScale.md,
+          "&:focus-visible": {
+            boxShadow: `var(--ue-focus-ring, ${theme.vars.focusRing.light})`,
+          },
+        }),
+      },
+    },
+    MuiLink: {
+      styleOverrides: {
+        root: ({ theme }) => ({
+          borderRadius: theme.vars.radiusScale.sm,
+          outline: "none",
+          "&:focus-visible": {
+            outline: "none",
+            boxShadow: `var(--ue-focus-ring, ${theme.vars.focusRing.light})`,
+          },
+        }),
+      },
+    },
+    MuiPaper: {
+      styleOverrides: {
+        root: {
+          borderRadius: "var(--ue-radius-lg)",
+        },
+      },
+    },
+    MuiDialog: {
+      styleOverrides: {
+        paper: {
+          borderRadius: "var(--ue-radius-lg)",
+        },
+      },
+    },
+  },
+});
+
+baseTheme.vars.focusRing = focusRing;
+baseTheme.vars.radiusScale = radiusScale;
+baseTheme.vars.spacingScale = spacingScale;
+baseTheme.vars.zIndexTokens = zIndexTokens;
+
+const theme = responsiveFontSizes(baseTheme);
 
 export default theme;
+
+export type AppTheme = typeof theme;


### PR DESCRIPTION
## Summary
- replace the legacy theme provider with MUI's CSS variables theme, define light/dark palettes, and expose spacing/radius/z-index tokens with consistent focus styles
- sync the app's color-scheme state via CssVarsProvider, update the settings page toggle, and remove ad-hoc body class toggles while keeping legacy dark styles working
- honour prefers-reduced-motion globally and in motion components, and enforce accessible focus rings and touch target sizes in shared styles

## Testing
- npm run lint
- npm run typecheck
- npm run lint:all *(fails: repository has pre-existing lint errors outside the touched files)*

------
https://chatgpt.com/codex/tasks/task_e_68d4a1cb7428832e944053956207c287