### PR TITLE
Configure async pytest testing and coverage CI

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -1,0 +1,31 @@
+name: Backend tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  pytest:
+    name: Pytest with coverage
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: root
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run pytest
+        run: pytest --cov=app --cov-report=xml --cov-report=term-missing
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-coverage-xml
+          path: root/coverage.xml
+          if-no-files-found: warn

--- a/root/pytest.ini
+++ b/root/pytest.ini
@@ -1,0 +1,8 @@
+[pytest]
+asyncio_mode = auto
+testpaths = tests
+filterwarnings =
+    error
+    ignore::DeprecationWarning:opentelemetry\.
+    ignore::DeprecationWarning:pkg_resources\.
+    ignore:.*crypt.*:DeprecationWarning

--- a/root/requirements.txt
+++ b/root/requirements.txt
@@ -31,3 +31,4 @@ aiosqlite>=0.19
 pytest>=7.4
 pytest-asyncio>=0.23
 pytest-cov>=4.1
+sentry-sdk[opentelemetry]>=2,<3

--- a/root/requirements.txt
+++ b/root/requirements.txt
@@ -16,7 +16,7 @@ aiofiles>=23.0
 pywebpush>=1.9
 psycopg[binary]>=3.1
 slowapi>=0.1.9
-
+sentry-sdk>=1.40
 opentelemetry-api==1.37.0
 opentelemetry-sdk==1.37.0
 opentelemetry-exporter-otlp==1.37.0
@@ -27,3 +27,7 @@ opentelemetry-instrumentation-httpx==0.58b0
 opentelemetry-instrumentation-sqlalchemy==0.58b0
 opentelemetry-instrumentation-asyncpg==0.58b0
 opentelemetry-semantic-conventions==0.58b0
+aiosqlite>=0.19
+pytest>=7.4
+pytest-asyncio>=0.23
+pytest-cov>=4.1

--- a/root/tests/conftest.py
+++ b/root/tests/conftest.py
@@ -1,0 +1,146 @@
+import asyncio
+import os
+import uuid
+from collections.abc import AsyncIterator, Awaitable, Callable
+from pathlib import Path
+import sys
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+try:
+    from opentelemetry.sdk import _logs as otel_logs
+except Exception:  # pragma: no cover - optional dependency
+    otel_logs = None
+else:
+    if not hasattr(otel_logs, "set_logger_provider"):
+        def _set_logger_provider(provider):
+            return None
+        otel_logs.set_logger_provider = _set_logger_provider
+
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///./test.db")
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("ALGORITHM", "HS256")
+os.environ.setdefault("ACCESS_TOKEN_EXPIRE_MINUTES", "30")
+os.environ.setdefault("STATIC_DIR", "app/test-static")
+os.environ.setdefault("ENVIRONMENT", "testing")
+os.environ.setdefault("RATE_LIMIT_ENABLED", "false")
+os.environ.setdefault("RATE_LIMIT_SENSITIVE", "")
+
+
+try:
+    from slowapi import middleware as slowapi_middleware
+except Exception:  # pragma: no cover - optional dependency
+    slowapi_middleware = None
+else:
+    class _PatchedSlowAPIMiddleware(slowapi_middleware.SlowAPIMiddleware):
+        def __init__(self, app, *args, **kwargs):
+            super().__init__(app)
+
+    slowapi_middleware.SlowAPIMiddleware = _PatchedSlowAPIMiddleware
+
+
+from app.core import security_headers as security_headers_module
+
+
+class _PatchedSecurityHeadersMiddleware(security_headers_module.SecurityHeadersMiddleware):
+    async def dispatch(self, request, call_next):
+        response = await call_next(request)
+        return response
+
+
+security_headers_module.SecurityHeadersMiddleware = _PatchedSecurityHeadersMiddleware
+
+from app import main
+from app.core.database import Base, async_session, engine
+from app.models import models
+
+
+@pytest.fixture(scope="session")
+def event_loop() -> AsyncIterator[asyncio.AbstractEventLoop]:
+    "Provide a dedicated event loop for the test session."
+    loop = asyncio.new_event_loop()
+    try:
+        yield loop
+    finally:
+        loop.close()
+
+
+@pytest.fixture(scope="session", autouse=True)
+async def prepare_database() -> AsyncIterator[None]:
+    "Ensure that the database schema exists for the duration of the test run."
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+
+@pytest.fixture(autouse=True)
+async def clean_database(prepare_database: None) -> AsyncIterator[None]:
+    "Clean all tables between tests to guarantee isolation."
+    yield
+    async with engine.begin() as conn:
+        for table in reversed(Base.metadata.sorted_tables):
+            await conn.execute(table.delete())
+
+
+@pytest.fixture
+def app():
+    "Return the FastAPI application instance."
+    return main.app
+
+
+@pytest.fixture
+async def async_client(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[AsyncClient]:
+    "Yield an HTTPX asynchronous client configured for the FastAPI app."
+
+    async def _start_notifications_scheduler(*args, **kwargs) -> Callable[[], Awaitable[None]]:
+        async def _stop() -> None:
+            return None
+
+        return _stop
+
+    monkeypatch.setattr(main, "start_notifications_scheduler", _start_notifications_scheduler)
+    transport = ASGITransport(app=main.app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+
+
+@pytest.fixture
+async def db_session() -> AsyncIterator[AsyncSession]:
+    "Yield a database session bound to the test engine."
+    async with async_session() as session:
+        yield session
+
+
+@pytest.fixture
+async def user_factory(db_session) -> Callable[..., Awaitable[models.User]]:
+    "Return a factory that persists user instances for tests."
+
+    async def _factory(**kwargs) -> models.User:
+        defaults = {
+            "email": f"user-{uuid.uuid4().hex[:8]}@example.com",
+            "hashed_password": "hashed-password",
+            "role": "student",
+            "is_active": True,
+        }
+        defaults.update(kwargs)
+        user = models.User(**defaults)
+        db_session.add(user)
+        await db_session.commit()
+        await db_session.refresh(user)
+        return user
+
+    return _factory
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"

--- a/root/tests/conftest.py
+++ b/root/tests/conftest.py
@@ -10,13 +10,12 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 import pytest
-from httpx import ASGITransport, AsyncClient
+import httpx
 from sqlalchemy.ext.asyncio import AsyncSession
-
 
 try:
     from opentelemetry.sdk import _logs as otel_logs
-except Exception:  # pragma: no cover - optional dependency
+except Exception:
     otel_logs = None
 else:
     if not hasattr(otel_logs, "set_logger_provider"):
@@ -33,27 +32,22 @@ os.environ.setdefault("ENVIRONMENT", "testing")
 os.environ.setdefault("RATE_LIMIT_ENABLED", "false")
 os.environ.setdefault("RATE_LIMIT_SENSITIVE", "")
 
-
 try:
     from slowapi import middleware as slowapi_middleware
-except Exception:  # pragma: no cover - optional dependency
+except Exception:
     slowapi_middleware = None
 else:
     class _PatchedSlowAPIMiddleware(slowapi_middleware.SlowAPIMiddleware):
         def __init__(self, app, *args, **kwargs):
             super().__init__(app)
-
     slowapi_middleware.SlowAPIMiddleware = _PatchedSlowAPIMiddleware
 
-
 from app.core import security_headers as security_headers_module
-
 
 class _PatchedSecurityHeadersMiddleware(security_headers_module.SecurityHeadersMiddleware):
     async def dispatch(self, request, call_next):
         response = await call_next(request)
         return response
-
 
 security_headers_module.SecurityHeadersMiddleware = _PatchedSecurityHeadersMiddleware
 
@@ -61,69 +55,51 @@ from app import main
 from app.core.database import Base, async_session, engine
 from app.models import models
 
-
 @pytest.fixture(scope="session")
 def event_loop() -> AsyncIterator[asyncio.AbstractEventLoop]:
-    "Provide a dedicated event loop for the test session."
     loop = asyncio.new_event_loop()
     try:
         yield loop
     finally:
         loop.close()
 
-
 @pytest.fixture(scope="session", autouse=True)
 async def prepare_database() -> AsyncIterator[None]:
-    "Ensure that the database schema exists for the duration of the test run."
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
     yield
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.drop_all)
 
-
 @pytest.fixture(autouse=True)
 async def clean_database(prepare_database: None) -> AsyncIterator[None]:
-    "Clean all tables between tests to guarantee isolation."
     yield
     async with engine.begin() as conn:
         for table in reversed(Base.metadata.sorted_tables):
             await conn.execute(table.delete())
 
-
 @pytest.fixture
 def app():
-    "Return the FastAPI application instance."
     return main.app
 
-
 @pytest.fixture
-async def async_client(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[AsyncClient]:
-    "Yield an HTTPX asynchronous client configured for the FastAPI app."
-
+async def async_client(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[httpx.AsyncClient]:
     async def _start_notifications_scheduler(*args, **kwargs) -> Callable[[], Awaitable[None]]:
         async def _stop() -> None:
             return None
-
         return _stop
-
     monkeypatch.setattr(main, "start_notifications_scheduler", _start_notifications_scheduler)
-    transport = ASGITransport(app=main.app)
-    async with AsyncClient(transport=transport, base_url="http://test") as client:
+    transport = httpx.ASGITransport(app=main.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
         yield client
-
 
 @pytest.fixture
 async def db_session() -> AsyncIterator[AsyncSession]:
-    "Yield a database session bound to the test engine."
     async with async_session() as session:
         yield session
 
-
 @pytest.fixture
 async def user_factory(db_session) -> Callable[..., Awaitable[models.User]]:
-    "Return a factory that persists user instances for tests."
-
     async def _factory(**kwargs) -> models.User:
         defaults = {
             "email": f"user-{uuid.uuid4().hex[:8]}@example.com",
@@ -137,9 +113,7 @@ async def user_factory(db_session) -> Callable[..., Awaitable[models.User]]:
         await db_session.commit()
         await db_session.refresh(user)
         return user
-
     return _factory
-
 
 @pytest.fixture
 def anyio_backend() -> str:

--- a/root/tests/test_schemas.py
+++ b/root/tests/test_schemas.py
@@ -1,0 +1,27 @@
+import pytest
+from pydantic import ValidationError
+
+from app.schemas import schemas
+
+pytestmark = pytest.mark.anyio("asyncio")
+
+def test_user_create_requires_valid_email():
+    with pytest.raises(ValidationError):
+        schemas.UserCreate(email="invalid-email", password="secret")
+
+
+def test_user_profile_update_validates_email():
+    with pytest.raises(ValidationError):
+        schemas.UserProfileUpdate(email="not-an-email")
+
+
+async def test_user_out_contract(user_factory):
+    user = await user_factory(full_name="Test User", spotify_is_connected=True, spotify_display_name="DJ Test")
+    payload = schemas.UserOut.from_orm(user)
+    data = payload.model_dump()
+
+    assert data["id"] == user.id
+    assert data["email"] == user.email
+    assert data["spotify_connected"] is True
+    assert data["spotify_is_connected"] is True
+    assert "hashed_password" not in data

--- a/root/tests/test_smoke.py
+++ b/root/tests/test_smoke.py
@@ -1,0 +1,21 @@
+import pytest
+
+pytestmark = pytest.mark.anyio("asyncio")
+
+
+async def test_root_endpoint(async_client):
+    response = await async_client.get("/")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+async def test_healthcheck(async_client):
+    response = await async_client.get("/healthz")
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"
+
+
+async def test_readiness(async_client):
+    response = await async_client.get("/ready")
+    assert response.status_code == 200
+    assert response.json()["status"] == "ready"


### PR DESCRIPTION
## Summary
- add async-aware pytest fixtures that isolate the FastAPI app from optional integrations and spin up a SQLite test database
- create smoke and schema validation tests exercising key endpoints and Pydantic contracts
- document pytest defaults, extend backend requirements with testing tools, and add a GitHub Actions workflow that reports coverage

## Testing
- `pytest --cov=app --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68d52d90eedc832e9b09425e55389182