### PR TITLE
Add VS Code Dev Container and Docker Compose workflow

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,19 @@
+# syntax=docker/dockerfile:1.7
+
+FROM mcr.microsoft.com/devcontainers/python:3.13
+
+ARG NODE_VERSION=20
+
+# Install system dependencies for building Python packages (e.g. psycopg)
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Pre-install backend dependencies to speed up container start
+COPY root/requirements.txt /tmp/pip-tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/pip-tmp/requirements.txt \
+    && rm -rf /tmp/pip-tmp
+
+WORKDIR /workspace

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+{
+  "name": "University Ecosystem",
+  "dockerComposeFile": ["../docker-compose.yml"],
+  "service": "backend",
+  "workspaceFolder": "/workspace",
+  "shutdownAction": "stopCompose",
+  "postCreateCommand": "pip install --no-cache-dir -r root/requirements.txt && npm install --prefix root/frontend",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "ms-azuretools.vscode-docker",
+        "esbenp.prettier-vscode",
+        "dbaeumer.vscode-eslint"
+      ],
+      "settings": {
+        "python.analysis.typeCheckingMode": "basic",
+        "python.defaultInterpreterPath": "/usr/local/bin/python"
+      }
+    }
+  },
+  "forwardPorts": [8000, 5173],
+  "remoteUser": "vscode"
+}

--- a/README.md
+++ b/README.md
@@ -23,6 +23,32 @@
 3. Обновите `FRONTEND_ORIGINS`/`FRONTEND_ORIGIN`, чтобы CORS принимал только ваши домены, и при необходимости укажите `APP_BASE_URL` для ссылок из писем.
 4. Для ограничений по трафику и заголовков безопасности доступны параметры: `RATE_LIMIT_DEFAULT`, `RATE_LIMIT_SENSITIVE`, `RATE_LIMIT_ENABLED`, `SECURITY_CSP`, `SECURITY_CSP_REPORT_ONLY`, `SECURITY_CSP_REPORT_URI`, `SECURITY_HSTS_ENABLED`, `SECURITY_HSTS_MAX_AGE`, `SECURITY_PERMISSIONS_POLICY`, `SECURITY_X_FRAME_OPTIONS` и др. Все они читаются из `.env`.
 
+## Разработка в VS Code Dev Container
+
+> Требования: [Docker Desktop](https://www.docker.com/products/docker-desktop/) или совместимый движок, [Visual Studio Code](https://code.visualstudio.com/) и расширение [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers).
+
+1. Создайте `root/.env` из примера, как описано выше — файл автоматически пробрасывается во все сервисы.
+2. Откройте репозиторий в VS Code и выполните команду **Dev Containers: Reopen in Container**.
+3. После сборки образа автоматически установятся Python/Node зависимости, а рекомендуемые расширения (`Python`, `Pylance`, `Docker`, `ESLint`, `Prettier`) будут добавлены в рабочую среду.
+4. Бэкенд (FastAPI) и фронтенд (Vite) стартуют внутри контейнеров по адресам `http://localhost:8000` и `http://localhost:5173` соответственно. База данных доступна на `localhost:5432`.
+
+Остановка dev-контейнера автоматически выключит связанные сервисы (`shutdownAction: stopCompose`).
+
+## Локальный запуск через Docker Compose
+
+1. Убедитесь, что Docker запущен, и подготовьте `root/.env`.
+2. Выполните единственную команду для поднятия всей инфраструктуры:
+
+   ```bash
+   docker compose up --build
+   ```
+
+   - `backend`: FastAPI на `http://localhost:8000` с hot-reload и доступом к Postgres.
+   - `frontend`: Vite dev-server на `http://localhost:5173` с прокинутой переменной `VITE_BACKEND_ORIGIN`.
+   - `postgres`: база данных с данными в volume `postgres-data`.
+
+3. Для остановки и очистки томов выполните `docker compose down -v`.
+
 ## Быстрый старт на Windows
 
 1. Установите Python 3.13 и PostgreSQL, убедитесь, что сервер БД запущен, а учётные данные совпадают с параметрами из `.env`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,57 @@
+services:
+  backend:
+    build:
+      context: .
+      dockerfile: .devcontainer/Dockerfile
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload --env-file root/.env
+    working_dir: /workspace/root
+    volumes:
+      - .:/workspace:cached
+    env_file:
+      - root/.env
+    environment:
+      DATABASE_URL: postgresql+psycopg://postgres:postgres@postgres:5432/university
+      FRONTEND_ORIGIN: http://localhost:5173
+      FRONTEND_ORIGINS: http://localhost:5173
+    depends_on:
+      postgres:
+        condition: service_healthy
+    ports:
+      - "8000:8000"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  frontend:
+    image: node:20-alpine
+    working_dir: /workspace/root/frontend
+    command: sh -c "npm install && npm run dev -- --host 0.0.0.0 --port 5173"
+    environment:
+      VITE_BACKEND_ORIGIN: http://localhost:8000
+    volumes:
+      - .:/workspace:cached
+      - frontend-node-modules:/workspace/root/frontend/node_modules
+    depends_on:
+      backend:
+        condition: service_started
+    ports:
+      - "5173:5173"
+
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: university
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    ports:
+      - "5432:5432"
+
+volumes:
+  postgres-data:
+  frontend-node-modules:


### PR DESCRIPTION
## Summary
- add a VS Code Dev Container with Python base image and recommended extensions
- define a docker-compose stack with backend, frontend, and Postgres services that share volumes
- document the new workflow for launching the project through Dev Containers or docker compose

## Testing
- docker compose config *(fails: docker not available in CI container)*

------
https://chatgpt.com/codex/tasks/task_e_68d58b7b9c5c832e9b30d0bd8055481b