### PR TITLE
feat: finalize action forms and tests

### DIFF
--- a/root/frontend/src/pages/ForgotPassword.tsx
+++ b/root/frontend/src/pages/ForgotPassword.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useActionState, useEffect, useMemo, useRef, useState } from "react";
 import axios from "../api/axios";
 import { Box, Paper, Typography, TextField, Button, Stack, Chip, useMediaQuery } from "@mui/material";
 import { Link } from "react-router-dom";
@@ -39,16 +39,19 @@ function suggestEmailDomain(email: string) {
 
 const FORGOT_URL = "/password/forgot";
 
+type ForgotState = {
+  status: "idle" | "success" | "error";
+  email?: string;
+  error?: string;
+};
+
 export default function ForgotPassword() {
   const [email, setEmail] = useState("");
   const [emailSuggestion, setEmailSuggestion] = useState<string | null>(null);
-  const [sent, setSent] = useState(false);
-  const [submitting, setSubmitting] = useState(false);
   const [cooldown, setCooldown] = useState(0);
+  const emailInputRef = useRef<HTMLInputElement | null>(null);
   const isMobile = useMediaQuery("(max-width:600px)");
   const emailValid = useMemo(() => email.length === 0 || emailRe.test(email), [email]);
-  const canSubmit = emailRe.test(email) && !submitting && cooldown === 0;
-
   useEffect(() => {
     if (!cooldown) return;
     const id = setInterval(() => setCooldown(s => Math.max(0, s - 1)), 1000);
@@ -67,38 +70,66 @@ export default function ForgotPassword() {
     }
   };
 
-  const submit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!canSubmit) return;
-    setSubmitting(true);
-    try {
-      await axios.post(FORGOT_URL, { email: email.trim() });
-      setSent(true);
-      setCooldown(30);
-    } catch {
-      setSent(true);
-      setCooldown(30);
-    } finally {
-      setSubmitting(false);
+  const [forgotState, forgotAction, forgotPending] = useActionState(async (_prev: ForgotState, input: FormData) => {
+    if (input.get("__reset__") === "1") {
+      return { status: "idle" as const };
     }
+
+    const value = String(input.get("email") ?? "").trim();
+    if (!emailRe.test(value)) {
+      return { status: "error" as const, error: "Введите корректный email" };
+    }
+
+    setEmail(value);
+
+    try {
+      await axios.post(FORGOT_URL, { email: value });
+    } catch {
+      // Игнорируем ошибки, сообщение одинаково
+    }
+
+    setCooldown(30);
+    return { status: "success" as const, email: value };
+  }, { status: "idle" as const });
+
+  const forgotStatus = forgotState.status;
+  const forgotErrorMessage = forgotStatus === "error" ? forgotState.error ?? "" : "";
+
+  const canSubmit = emailRe.test(email) && !forgotPending && cooldown === 0;
+
+  useEffect(() => {
+    if (!forgotPending && forgotStatus === "error") {
+      emailInputRef.current?.focus();
+    }
+  }, [forgotPending, forgotStatus]);
+
+  const resetRequest = () => {
+    const marker = new FormData();
+    marker.append("__reset__", "1");
+    forgotAction(marker);
+    setCooldown(0);
+    setEmail("");
+    setEmailSuggestion(null);
+    emailInputRef.current?.focus();
   };
 
   return (
     <Box sx={{ minHeight: "100vh", bgcolor: "var(--page-bg)", color: "var(--page-text)", display: "flex", alignItems: "center", justifyContent: "center", px: 1 }}>
       <Paper elevation={7} sx={{ width: "100%", maxWidth: 440, p: { xs: 2, sm: 4 }, borderRadius: { xs: 3, sm: 5 }, bgcolor: "var(--card-bg)" }}>
         <Typography variant={isMobile ? "h5" : "h4"} fontWeight={700} align="center" mb={3}>Восстановление пароля</Typography>
-        {sent ? (
+        {forgotStatus === "success" ? (
           <Stack spacing={2} alignItems="center">
             <Typography align="center">Если аккаунт с адресом <b>{email}</b> существует, мы отправили письмо со ссылкой для сброса пароля.</Typography>
             <Typography color="text.secondary" align="center" sx={{ mt: -1 }}>Ссылка действует ограниченное время. Проверьте «Спам», если письма нет.</Typography>
             <Button component={Link} to="/login" variant="outlined" sx={{ mt: 1 }}>Вернуться ко входу</Button>
-            <Button onClick={(e)=>{ setSent(false); e.preventDefault(); }} disabled={cooldown>0}>Ввести другой адрес {cooldown>0 ? `(${cooldown}s)` : ""}</Button>
+            <Button type="button" onClick={resetRequest} disabled={cooldown>0}>Ввести другой адрес {cooldown>0 ? `(${cooldown}s)` : ""}</Button>
           </Stack>
         ) : (
-          <form onSubmit={submit} autoComplete="off">
+          <form action={forgotAction} autoComplete="off">
             <Stack spacing={2}>
               <TextField
                 label="E-mail"
+                name="email"
                 type="email"
                 value={email}
                 onChange={(e)=>setEmail(e.target.value)}
@@ -108,12 +139,17 @@ export default function ForgotPassword() {
                 autoComplete="email"
                 error={!emailValid}
                 helperText={!emailValid ? "Неверный формат email" : " "}
+                inputRef={emailInputRef}
+                disabled={forgotPending || cooldown > 0}
                 inputProps={{ inputMode: "email", autoCapitalize: "none", autoCorrect: "off", spellCheck: "false" }}
               />
               {emailSuggestion && (
                 <Chip size="small" variant="outlined" color="primary" label={`Исправить на ${emailSuggestion}`} onClick={applySuggestion} />
               )}
-              <Button type="submit" variant="contained" size="large" fullWidth disabled={!canSubmit}>{submitting ? "Отправляю…" : "Отправить ссылку"}</Button>
+              {forgotErrorMessage && (
+                <Typography color="error" fontSize={15} align="center">{forgotErrorMessage}</Typography>
+              )}
+              <Button type="submit" variant="contained" size="large" fullWidth disabled={!canSubmit}>{forgotPending ? "Отправляю…" : "Отправить ссылку"}</Button>
               <Button component={Link} to="/login" variant="text">Назад ко входу</Button>
             </Stack>
           </form>

--- a/root/frontend/src/pages/Register.tsx
+++ b/root/frontend/src/pages/Register.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useActionState, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, Link } from "react-router-dom";
 import api from "../api/axios";
 import { Box, Paper, Typography, TextField, Button, Stack, Select, MenuItem, InputLabel, FormControl, useMediaQuery, CircularProgress, InputAdornment, IconButton, LinearProgress, Chip, Tooltip } from "@mui/material";
@@ -40,6 +40,12 @@ function suggestEmailDomain(email: string) {
 
 const emailRe = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
+type RegisterState = {
+  status: "idle" | "success" | "error";
+  error?: string;
+  field?: "full_name" | "email" | "password" | "confirm" | "invite_code";
+};
+
 const Register = () => {
   const navigate = useNavigate();
   const [form, setForm] = useState({ full_name: "", email: "", password: "", confirm: "", role: "student", invite_code: "" });
@@ -48,11 +54,14 @@ const Register = () => {
   const [capsPass, setCapsPass] = useState(false);
   const [capsConfirm, setCapsConfirm] = useState(false);
   const [strength, setStrength] = useState<number | null>(null);
-  const [error, setError] = useState("");
-  const [loading, setLoading] = useState(false);
   const [emailSuggestion, setEmailSuggestion] = useState<string | null>(null);
 
   const isMobile = useMediaQuery("(max-width:600px)");
+  const fullNameRef = useRef<HTMLInputElement | null>(null);
+  const emailRef = useRef<HTMLInputElement | null>(null);
+  const inviteRef = useRef<HTMLInputElement | null>(null);
+  const passwordRef = useRef<HTMLInputElement | null>(null);
+  const confirmRef = useRef<HTMLInputElement | null>(null);
   const needsInvite = form.role === "teacher" || form.role === "admin";
   const minLenOk = form.password.length >= 8;
   const matchOk = form.confirm.length > 0 && form.password === form.confirm;
@@ -61,7 +70,6 @@ const Register = () => {
 
   const handleChange = (e: any) => {
     setForm((f) => ({ ...f, [e.target.name]: e.target.value }));
-    setError("");
   };
 
   const handleEmailBlur = () => {
@@ -71,7 +79,6 @@ const Register = () => {
 
   const handlePass = async (v: string) => {
     setForm((f) => ({ ...f, password: v }));
-    setError("");
     if (!v) {
       setStrength(null);
       return;
@@ -85,47 +92,70 @@ const Register = () => {
     }
   };
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (loading) return;
-    setError("");
-    if (!form.full_name || !form.email || !form.password) {
-      setError("Пожалуйста, заполните все поля.");
-      return;
+  const [registerState, registerAction, registerPending] = useActionState(async (_prev: RegisterState, formData: FormData) => {
+    const fullName = String(formData.get("full_name") ?? "").trim();
+    const email = String(formData.get("email") ?? "").trim();
+    const password = String(formData.get("password") ?? "");
+    const confirm = String(formData.get("confirm") ?? "");
+    const role = String(formData.get("role") ?? "student");
+    const inviteCode = String(formData.get("invite_code") ?? "").trim();
+
+    if (!fullName || !email || !password) {
+      const field: RegisterState["field"] = !fullName ? "full_name" : !email ? "email" : "password";
+      return { status: "error" as const, error: "Пожалуйста, заполните все поля.", field };
     }
-    if (form.password !== form.confirm) {
-      setError("Пароли не совпадают.");
-      return;
+
+    if (!emailRe.test(email)) {
+      return { status: "error" as const, error: "Неверный формат email", field: "email" };
     }
-    if ((form.role === "teacher" || form.role === "admin") && !form.invite_code) {
-      setError("Необходим код приглашения для выбранной роли.");
-      return;
+
+    if (password !== confirm) {
+      return { status: "error" as const, error: "Пароли не совпадают.", field: "confirm" };
     }
-    setLoading(true);
+
+    if ((role === "teacher" || role === "admin") && !inviteCode) {
+      return { status: "error" as const, error: "Необходим код приглашения для выбранной роли.", field: "invite_code" };
+    }
+
     try {
       await api.post("/users", {
-        full_name: form.full_name.trim(),
-        email: form.email.trim(),
-        password: form.password,
-        role: form.role,
-        invite_code: form.invite_code.trim(),
+        full_name: fullName,
+        email,
+        password,
+        role,
+        invite_code: inviteCode,
       });
       navigate("/login");
+      return { status: "success" as const };
     } catch (err: any) {
       const msg = err?.response?.data?.detail || "Ошибка регистрации";
-      setError(typeof msg === "string" ? msg : Array.isArray(msg) ? msg.join("; ") : "Ошибка регистрации");
+      const text = typeof msg === "string" ? msg : Array.isArray(msg) ? msg.join("; ") : "Ошибка регистрации";
+      return { status: "error" as const, error: text };
     }
-    setLoading(false);
-  };
+  }, { status: "idle" as const });
+
+  const registerStatus = registerState.status;
+  const registerErrorField = registerState.field;
+  const registerErrorMessage = registerStatus === "error" ? registerState.error ?? "" : "";
+
+  useEffect(() => {
+    if (!registerPending && registerStatus === "error" && registerErrorField) {
+      if (registerErrorField === "full_name") fullNameRef.current?.focus();
+      else if (registerErrorField === "email") emailRef.current?.focus();
+      else if (registerErrorField === "password") passwordRef.current?.focus();
+      else if (registerErrorField === "confirm") confirmRef.current?.focus();
+      else if (registerErrorField === "invite_code") inviteRef.current?.focus();
+    }
+  }, [registerPending, registerStatus, registerErrorField]);
 
   return (
     <Box sx={{ minHeight: "100vh", bgcolor: "var(--page-bg)", color: "var(--page-text)", display: "flex", alignItems: "center", justifyContent: "center", flexDirection: "column", px: 1, width: "100vw", overflow: "visible" }}>
       <Paper elevation={7} sx={{ width: "100%", minWidth: 0, maxWidth: 460, p: { xs: 2, sm: 4 }, borderRadius: { xs: 3, sm: 5 }, boxShadow: 8, bgcolor: "var(--card-bg)", mx: "auto" }}>
-        <form onSubmit={handleSubmit} autoComplete="off">
+        <form action={registerAction} autoComplete="off">
           <Typography variant={isMobile ? "h5" : "h4"} fontWeight={700} align="center" mb={3}>Регистрация</Typography>
           <Stack spacing={2}>
-            <TextField name="full_name" label="Имя" value={form.full_name} onChange={handleChange} fullWidth variant="outlined" autoComplete="name" autoFocus inputProps={{ autoCapitalize: "words", spellCheck: "false" }} />
-            <TextField name="email" label="E-mail" type="email" value={form.email} onChange={handleChange} onBlur={handleEmailBlur} fullWidth variant="outlined" autoComplete="email" error={!emailValid} helperText={!emailValid ? "Неверный формат email" : " "} inputProps={{ inputMode: "email", autoCapitalize: "none", autoCorrect: "off", spellCheck: "false" }} />
+            <TextField name="full_name" label="Имя" value={form.full_name} onChange={handleChange} fullWidth variant="outlined" autoComplete="name" autoFocus inputRef={fullNameRef} disabled={registerPending} inputProps={{ autoCapitalize: "words", spellCheck: "false" }} />
+            <TextField name="email" label="E-mail" type="email" value={form.email} onChange={handleChange} onBlur={handleEmailBlur} fullWidth variant="outlined" autoComplete="email" error={!emailValid} helperText={!emailValid ? "Неверный формат email" : " "} inputRef={emailRef} disabled={registerPending} inputProps={{ inputMode: "email", autoCapitalize: "none", autoCorrect: "off", spellCheck: "false" }} />
             {emailSuggestion && (
               <Box sx={{ mt: -1.5 }}>
                 <Chip size="small" variant="outlined" color="primary" label={`Исправить на ${emailSuggestion}`} onClick={() => { setForm(f => ({ ...f, email: emailSuggestion })); setEmailSuggestion(null); }} />
@@ -133,14 +163,14 @@ const Register = () => {
             )}
             <FormControl fullWidth>
               <InputLabel id="role-label">Роль</InputLabel>
-              <Select labelId="role-label" name="role" label="Роль" value={form.role} onChange={handleChange} variant="outlined" MenuProps={{ PaperProps: { sx: { maxHeight: 220, borderRadius: 2 } }, anchorOrigin: { vertical: "bottom", horizontal: "left" }, transformOrigin: { vertical: "top", horizontal: "left" }, sx: { zIndex: 3000 } }}>
+              <Select labelId="role-label" name="role" label="Роль" value={form.role} onChange={handleChange} variant="outlined" disabled={registerPending} MenuProps={{ PaperProps: { sx: { maxHeight: 220, borderRadius: 2 } }, anchorOrigin: { vertical: "bottom", horizontal: "left" }, transformOrigin: { vertical: "top", horizontal: "left" }, sx: { zIndex: 3000 } }}>
                 <MenuItem value="student">Студент</MenuItem>
                 <MenuItem value="teacher">Преподаватель</MenuItem>
                 <MenuItem value="admin">Админ</MenuItem>
               </Select>
             </FormControl>
             {(form.role === "teacher" || form.role === "admin") && (
-              <TextField name="invite_code" label="Код приглашения" value={form.invite_code} onChange={handleChange} fullWidth variant="outlined" autoComplete="one-time-code" inputProps={{ autoCapitalize: "characters", spellCheck: "false" }} />
+              <TextField name="invite_code" label="Код приглашения" value={form.invite_code} onChange={handleChange} fullWidth variant="outlined" autoComplete="one-time-code" inputRef={inviteRef} disabled={registerPending} inputProps={{ autoCapitalize: "characters", spellCheck: "false" }} />
             )}
             <TextField
               name="password"
@@ -153,6 +183,8 @@ const Register = () => {
               fullWidth
               variant="outlined"
               autoComplete="new-password"
+              inputRef={passwordRef}
+              disabled={registerPending}
               helperText="Минимум 8 символов"
               FormHelperTextProps={{ sx: { mt: 0.5 } }}
               InputProps={{
@@ -186,6 +218,8 @@ const Register = () => {
               fullWidth
               variant="outlined"
               autoComplete="new-password"
+              inputRef={confirmRef}
+              disabled={registerPending}
               InputProps={{
                 endAdornment: (
                   <InputAdornment position="end">
@@ -199,8 +233,8 @@ const Register = () => {
               }}
             />
             <Box sx={{ minHeight: 20 }}>{capsConfirm && <Typography color="warning.main" fontSize={13}>Включён Caps Lock</Typography>}</Box>
-            <Box sx={{ minHeight: 22, display: "flex", alignItems: "center", justifyContent: "center" }} aria-live="assertive">{!!error && <Typography color="error" fontSize={15}>{error}</Typography>}</Box>
-            <Button type="submit" variant="contained" size="large" fullWidth sx={{ mt: 1, fontWeight: 600, borderRadius: 2, fontSize: 17, py: 1.2 }} disabled={loading || !isValid}>{loading ? <CircularProgress size={26} color="inherit" /> : "Зарегистрироваться"}</Button>
+            <Box sx={{ minHeight: 22, display: "flex", alignItems: "center", justifyContent: "center" }} aria-live="assertive">{registerErrorMessage && <Typography color="error" fontSize={15}>{registerErrorMessage}</Typography>}</Box>
+            <Button type="submit" variant="contained" size="large" fullWidth sx={{ mt: 1, fontWeight: 600, borderRadius: 2, fontSize: 17, py: 1.2 }} disabled={registerPending || !isValid}>{registerPending ? <CircularProgress size={26} color="inherit" /> : "Зарегистрироваться"}</Button>
           </Stack>
           <Box mt={4} textAlign="center" fontSize={15}>
             Уже есть аккаунт? <Link to="/login" style={{ color: "var(--nav-link)", textDecoration: "underline" }}>Войти</Link>

--- a/root/frontend/src/pages/__tests__/ForgotPassword.test.tsx
+++ b/root/frontend/src/pages/__tests__/ForgotPassword.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { vi } from "vitest";
+import ForgotPassword from "../ForgotPassword";
+import api from "../../api/axios";
+
+vi.mock("../../api/axios", () => ({
+  default: {
+    post: vi.fn(),
+  },
+}));
+
+describe("ForgotPassword", () => {
+  const mockedPost = vi.mocked(api.post);
+
+  beforeEach(() => {
+    mockedPost.mockReset();
+    vi.useRealTimers();
+  });
+
+  it("highlights invalid email format", async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <ForgotPassword />
+      </MemoryRouter>
+    );
+
+    await user.type(screen.getByLabelText(/e-mail/i), "invalid");
+
+    expect(screen.getByText("Неверный формат email")).toBeInTheDocument();
+    expect(mockedPost).not.toHaveBeenCalled();
+  });
+
+  it("shows confirmation message and cooldown on success", async () => {
+    const user = userEvent.setup();
+    mockedPost.mockResolvedValue({ data: {} } as any);
+    render(
+      <MemoryRouter>
+        <ForgotPassword />
+      </MemoryRouter>
+    );
+
+    await user.type(screen.getByLabelText(/e-mail/i), "user@example.com");
+    await user.click(screen.getByRole("button", { name: /отправить ссылку/i }));
+
+    expect(mockedPost).toHaveBeenCalledWith("/password/forgot", { email: "user@example.com" });
+    expect(await screen.findByText(/если аккаунт с адресом/i)).toBeInTheDocument();
+
+    const resetButton = screen.getByRole("button", { name: /ввести другой адрес/i });
+    expect(resetButton).toBeDisabled();
+    expect(resetButton.textContent).toContain("30s");
+  });
+});

--- a/root/frontend/src/pages/__tests__/Login.test.tsx
+++ b/root/frontend/src/pages/__tests__/Login.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { vi } from "vitest";
+import Login from "../Login";
+import api from "../../api/axios";
+
+vi.mock("../../api/axios", () => ({
+  default: {
+    post: vi.fn(),
+  },
+}));
+
+const mockLogin = vi.fn();
+const mockNavigate = vi.fn();
+
+vi.mock("../../contexts/AuthContext", () => ({
+  useAuth: () => ({ login: mockLogin }),
+}));
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+describe("Login", () => {
+  const mockedPost = vi.mocked(api.post);
+
+  beforeEach(() => {
+    mockedPost.mockReset();
+    mockLogin.mockReset();
+    mockNavigate.mockReset();
+    localStorage.clear();
+  });
+
+  it("shows validation error for invalid email", async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <Login />
+      </MemoryRouter>
+    );
+
+    await user.type(screen.getByRole("textbox", { name: /email/i }), "invalid");
+    await user.type(screen.getByLabelText(/^пароль/i), "secret123");
+    await user.click(screen.getByRole("button", { name: /войти/i }));
+
+    expect(await screen.findByText("Введите корректный email")).toBeInTheDocument();
+    expect(mockedPost).not.toHaveBeenCalled();
+  });
+
+  it("submits credentials and navigates on success", async () => {
+    const user = userEvent.setup();
+    let resolvePost: (value: any) => void = () => {};
+    mockedPost.mockImplementation(() => new Promise((resolve) => { resolvePost = resolve; }) as any);
+
+    render(
+      <MemoryRouter>
+        <Login />
+      </MemoryRouter>
+    );
+
+    await user.type(screen.getByRole("textbox", { name: /email/i }), "user@example.com");
+    await user.type(screen.getByLabelText(/^пароль/i), "secret123");
+
+    const submitButton = screen.getByRole("button", { name: /войти/i });
+    await user.click(submitButton);
+
+    expect(submitButton).toBeDisabled();
+
+    resolvePost({ data: { access_token: "token123" } });
+
+    await waitFor(() => expect(mockLogin).toHaveBeenCalledWith("token123"));
+    expect(mockNavigate).toHaveBeenCalledWith("/dashboard");
+    expect(submitButton).not.toBeDisabled();
+  });
+});

--- a/root/frontend/src/pages/__tests__/Register.test.tsx
+++ b/root/frontend/src/pages/__tests__/Register.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { vi } from "vitest";
+import Register from "../Register";
+import api from "../../api/axios";
+
+vi.mock("../../api/axios", () => ({
+  default: {
+    post: vi.fn(),
+  },
+}));
+
+const mockNavigate = vi.fn();
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+describe("Register", () => {
+  const mockedPost = vi.mocked(api.post);
+
+  beforeEach(() => {
+    mockedPost.mockReset();
+    mockNavigate.mockReset();
+  });
+
+  it("shows API error message when registration fails", async () => {
+    const user = userEvent.setup();
+    mockedPost.mockRejectedValue({ response: { data: { detail: "Email already used" } } });
+
+    render(
+      <MemoryRouter>
+        <Register />
+      </MemoryRouter>
+    );
+
+    await user.type(screen.getByLabelText("Имя"), "Test User");
+    await user.type(screen.getByLabelText(/e-mail/i), "user@example.com");
+    await user.type(screen.getByLabelText(/^пароль$/i), "password123");
+    await user.type(screen.getByLabelText(/повторите пароль/i), "password123");
+
+    await user.click(screen.getByRole("button", { name: /зарегистрироваться/i }));
+
+    expect(await screen.findByText("Email already used")).toBeInTheDocument();
+  });
+
+  it("submits registration data and navigates on success", async () => {
+    const user = userEvent.setup();
+    let resolvePost: (value: any) => void = () => {};
+    mockedPost.mockImplementation(() => new Promise((resolve) => { resolvePost = resolve; }) as any);
+
+    render(
+      <MemoryRouter>
+        <Register />
+      </MemoryRouter>
+    );
+
+    await user.type(screen.getByLabelText("Имя"), "Test User");
+    await user.type(screen.getByLabelText(/e-mail/i), "user@example.com");
+    await user.type(screen.getByLabelText(/^пароль$/i), "password123");
+    await user.type(screen.getByLabelText(/повторите пароль/i), "password123");
+
+    const submitButton = screen.getByRole("button", { name: /зарегистрироваться/i });
+    await user.click(submitButton);
+
+    expect(submitButton).toBeDisabled();
+
+    resolvePost({ data: {} });
+
+    await waitFor(() => expect(mockedPost).toHaveBeenCalledWith("/users", {
+      full_name: "Test User",
+      email: "user@example.com",
+      password: "password123",
+      role: "student",
+      invite_code: "",
+    }));
+    expect(mockNavigate).toHaveBeenCalledWith("/login");
+    await waitFor(() => expect(submitButton).not.toBeDisabled());
+  });
+});

--- a/root/frontend/src/pages/__tests__/ResetPassword.test.tsx
+++ b/root/frontend/src/pages/__tests__/ResetPassword.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { vi } from "vitest";
+import ResetPassword from "../ResetPassword";
+import api from "../../api/axios";
+
+vi.mock("../../api/axios", () => ({
+  default: {
+    post: vi.fn(),
+  },
+}));
+
+vi.mock("zxcvbn", () => ({
+  default: () => ({ score: 3, feedback: { warning: "", suggestions: [] } }),
+}));
+
+describe("ResetPassword", () => {
+  const mockedPost = vi.mocked(api.post);
+  const digestMock = vi.fn(() => Promise.resolve(new ArrayBuffer(20)));
+
+  beforeEach(() => {
+    mockedPost.mockReset();
+    digestMock.mockClear();
+    vi.stubGlobal("fetch", vi.fn(() => Promise.resolve({ ok: false, text: () => Promise.resolve("") }) as any));
+    if (globalThis.crypto && globalThis.crypto.subtle) {
+      vi.spyOn(globalThis.crypto.subtle, "digest").mockImplementation(digestMock as any);
+    } else {
+      (globalThis as any).crypto = { subtle: { digest: digestMock } };
+    }
+  });
+
+  const renderWithToken = () =>
+    render(
+      <MemoryRouter initialEntries={["/reset/token123"]}>
+        <Routes>
+          <Route path="/reset/:token" element={<ResetPassword />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+  it("shows API error message when request fails", async () => {
+    const user = userEvent.setup();
+    mockedPost.mockRejectedValue({ response: { data: { detail: "Ссылка устарела" } } });
+
+    renderWithToken();
+
+    await user.type(screen.getByLabelText(/^пароль$/i), "Password123!");
+    await user.type(screen.getByLabelText(/повторите пароль/i), "Password123!");
+    await user.click(screen.getByRole("button", { name: /сохранить пароль/i }));
+
+    expect(await screen.findByText("Ссылка устарела")).toBeInTheDocument();
+  });
+
+  it("submits new password and shows success message", async () => {
+    const user = userEvent.setup();
+    mockedPost.mockResolvedValue({ data: {} } as any);
+
+    renderWithToken();
+
+    await user.type(screen.getByLabelText(/^пароль$/i), "Password123!");
+    await user.type(screen.getByLabelText(/повторите пароль/i), "Password123!");
+
+    const submitButton = screen.getByRole("button", { name: /сохранить пароль/i });
+    await user.click(submitButton);
+
+    expect(submitButton).toBeDisabled();
+
+    await waitFor(() => expect(mockedPost).toHaveBeenCalledWith("/password/reset", {
+      password: "Password123!",
+      token: "token123",
+    }));
+
+    expect(await screen.findByText(/пароль обновлён/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- finalize login, register, forgot, and reset password flows on React 19 form actions with pending/error handling
- migrate event file upload/delete to useActionState & useOptimistic for optimistic UI updates
- add RTL/Vitest coverage for happy/error/pending paths across auth forms

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d58f67fd0c832ebd20927bda0c131e