### PR TITLE
Add npm audit job to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,6 +188,26 @@ jobs:
           path: root/frontend/vitest-report.xml
           if-no-files-found: warn
 
+  npm-audit:
+    name: NPM audit
+    runs-on: ubuntu-latest
+    needs: frontend-tests
+    defaults:
+      run:
+        working-directory: root/frontend
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: root/frontend/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Run npm audit
+        run: npm audit --audit-level=high
+
   build:
     name: Frontend build
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add an npm audit job that runs after the frontend tests
- fail the pipeline when high or critical vulnerabilities are detected

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d897e16260832e930405fd01b455fd