### PR TITLE
Configure ruff import sorting and add gitleaks hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,8 +3,8 @@ repos:
     rev: v0.7.3
     hooks:
       - id: ruff
-        name: ruff lint
-        args: [--fix]
+        name: ruff check
+        args: ["--select", "I", "--fix"]
       - id: ruff-format
         name: ruff format
   - repo: https://github.com/psf/black
@@ -17,3 +17,8 @@ repos:
     hooks:
       - id: isort
         args: [--profile=black]
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.18.3
+    hooks:
+      - id: gitleaks
+        args: ["protect", "--staged"]


### PR DESCRIPTION
## Summary
- configure the ruff pre-commit hook to auto-sort imports via the I rule
- add a gitleaks hook that scans staged changes for secrets

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d89f92f084832e9c15cbd89c17f874