### PR TITLE
feat: add production error boundary

### DIFF
--- a/root/frontend/src/App.tsx
+++ b/root/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import useMediaQuery from "@mui/material/useMediaQuery"
 import { registerServiceWorker } from "./push/register-sw"
 import MobileBottomNav from "./components/MobileBottomNav"
 import BackToTop from "./components/BackToTop"
+import ErrorBoundary from "./app/ErrorBoundary"
 
 const PageTransition = lazy(() => import("./components/PageTransition"))
 const Dashboard = lazy(() => import("./pages/Dashboard"))
@@ -135,9 +136,11 @@ export default function App() {
   return (
     <AuthProvider>
       <LocalizationProvider dateAdapter={AdapterDayjs} adapterLocale="ru">
-        <Router>
-          <AppContent />
-        </Router>
+        <ErrorBoundary>
+          <Router>
+            <AppContent />
+          </Router>
+        </ErrorBoundary>
       </LocalizationProvider>
     </AuthProvider>
   )

--- a/root/frontend/src/app/ErrorBoundary.test.tsx
+++ b/root/frontend/src/app/ErrorBoundary.test.tsx
@@ -1,0 +1,75 @@
+import { useState } from "react"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+import ErrorBoundary, { APP_ERROR_EVENT } from "./ErrorBoundary"
+
+describe("ErrorBoundary", () => {
+  it("logs, dispatches and renders a fallback screen", () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    const dispatchSpy = vi.spyOn(window, "dispatchEvent")
+
+    const Problem = () => {
+      throw new Error("Boom")
+    }
+
+    render(
+      <ErrorBoundary>
+        <Problem />
+      </ErrorBoundary>
+    )
+
+    expect(
+      consoleSpy.mock.calls.some((call) => call[0] === "[ErrorBoundary] Unhandled error captured")
+    ).toBe(true)
+
+    const eventCall = dispatchSpy.mock.calls.find((call) => call[0] instanceof CustomEvent)
+    expect(eventCall?.[0]).toBeInstanceOf(CustomEvent)
+    expect((eventCall?.[0] as CustomEvent<unknown>).type).toBe(APP_ERROR_EVENT)
+
+    expect(screen.getByRole("heading", { name: /что-то пошло не так/i })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /перезагрузить страницу/i })).toBeInTheDocument()
+
+    consoleSpy.mockRestore()
+    dispatchSpy.mockRestore()
+  })
+
+  it("allows retrying rendering after the issue is resolved", async () => {
+    const user = userEvent.setup()
+
+    function Harness() {
+      const [shouldThrow, setShouldThrow] = useState(true)
+
+      return (
+        <ErrorBoundary
+          fallback={({ resetError }) => (
+            <div>
+              <span>fallback</span>
+              <button
+                type="button"
+                onClick={() => {
+                  setShouldThrow(false)
+                  resetError()
+                }}
+              >
+                retry
+              </button>
+            </div>
+          )}
+        >
+          {shouldThrow ? <Problem /> : <p>recovered</p>}
+        </ErrorBoundary>
+      )
+    }
+
+    function Problem() {
+      throw new Error("Controlled failure")
+    }
+
+    render(<Harness />)
+
+    expect(screen.getByText("fallback")).toBeInTheDocument()
+    await user.click(screen.getByRole("button", { name: "retry" }))
+    expect(screen.getByText("recovered")).toBeInTheDocument()
+  })
+})

--- a/root/frontend/src/app/ErrorBoundary.tsx
+++ b/root/frontend/src/app/ErrorBoundary.tsx
@@ -1,0 +1,127 @@
+import { Component, type ErrorInfo, type ReactNode } from "react"
+
+export const APP_ERROR_EVENT = "app:error"
+
+export type ErrorBoundaryFallbackRender = (args: {
+  error: Error | null
+  resetError: () => void
+}) => ReactNode
+
+export type ErrorBoundaryProps = {
+  children: ReactNode
+  fallback?: ReactNode | ErrorBoundaryFallbackRender
+  onReset?: () => void
+}
+
+type ErrorBoundaryState = {
+  hasError: boolean
+  error: Error | null
+}
+
+function DefaultFallback({ onRetry }: { onRetry: () => void }) {
+  return (
+    <div
+      role="alert"
+      style={{
+        minHeight: "100dvh",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: "1.5rem",
+        padding: "2rem",
+        textAlign: "center",
+        backgroundColor: "var(--page-bg, #0b0d11)",
+        color: "var(--page-text, #f5f7fa)",
+      }}
+    >
+      <div style={{ maxWidth: "32rem" }}>
+        <h1 style={{ fontSize: "clamp(1.5rem, 4vw, 2.5rem)", marginBottom: "0.5rem" }}>
+          Что-то пошло не так
+        </h1>
+        <p style={{ opacity: 0.8, lineHeight: 1.6 }}>
+          Мы уже работаем над проблемой. Попробуйте обновить страницу или вернуться чуть позже.
+        </p>
+      </div>
+      <div style={{ display: "flex", gap: "1rem", flexWrap: "wrap", justifyContent: "center" }}>
+        <button
+          type="button"
+          onClick={() => {
+            if (typeof window !== "undefined" && typeof window.location?.reload === "function") {
+              window.location.reload()
+              return
+            }
+            onRetry()
+          }}
+          style={{
+            padding: "0.75rem 1.5rem",
+            fontSize: "1rem",
+            borderRadius: "9999px",
+            border: "none",
+            cursor: "pointer",
+            background: "#0b63f4",
+            color: "white",
+            fontWeight: 600,
+          }}
+        >
+          Перезагрузить страницу
+        </button>
+        <button
+          type="button"
+          onClick={onRetry}
+          style={{
+            padding: "0.75rem 1.5rem",
+            fontSize: "1rem",
+            borderRadius: "9999px",
+            border: "1px solid rgba(255, 255, 255, 0.4)",
+            background: "transparent",
+            color: "currentColor",
+            cursor: "pointer",
+            fontWeight: 500,
+          }}
+        >
+          Попробовать снова
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { hasError: false, error: null }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error }
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error("[ErrorBoundary] Unhandled error captured", error, errorInfo)
+
+    if (typeof window !== "undefined" && typeof window.dispatchEvent === "function") {
+      const detail = { error, errorInfo }
+      window.dispatchEvent(new CustomEvent(APP_ERROR_EVENT, { detail }))
+    }
+  }
+
+  private reset = () => {
+    this.setState({ hasError: false, error: null })
+    this.props.onReset?.()
+  }
+
+  override render(): ReactNode {
+    if (this.state.hasError) {
+      const { fallback } = this.props
+      if (typeof fallback === "function") {
+        return fallback({ error: this.state.error, resetError: this.reset })
+      }
+      if (fallback) {
+        return fallback
+      }
+      return <DefaultFallback onRetry={this.reset} />
+    }
+
+    return this.props.children
+  }
+}
+
+export default ErrorBoundary

--- a/root/frontend/src/main.tsx
+++ b/root/frontend/src/main.tsx
@@ -4,6 +4,7 @@ import { CssBaseline } from "@mui/material"
 import { CssVarsProvider, useColorScheme } from "@mui/material/styles"
 import { registerSW } from "virtual:pwa-register"
 import App from "./App"
+import ErrorBoundary from "./app/ErrorBoundary"
 import theme from "./theme"
 import "./assets/themes.css"
 import "dayjs/locale/ru"
@@ -47,7 +48,9 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
     >
       <CssBaseline enableColorScheme />
       <BodyColorSchemeSync />
-      <App />
+      <ErrorBoundary>
+        <App />
+      </ErrorBoundary>
     </CssVarsProvider>
   </React.StrictMode>
 )


### PR DESCRIPTION
## Summary
- add an application-level error boundary with a user-facing crash screen and test-friendly event dispatch
- wrap the React root and router tree in the new boundary to guard navigation flows
- add vitest coverage for logging, event dispatch, and recovery behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd0ff9ddcc83279546b3c1ec103a25