### PR TITLE
Add TypeScript checks to CI and pre-push hook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,6 +200,8 @@ jobs:
           cache-dependency-path: root/frontend/package-lock.json
       - name: Install dependencies
         run: npm ci
+      - name: Run type check
+        run: npm run typecheck
       - name: Run unit tests
         run: npm run test
       - name: Upload vitest report

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+npm --prefix root/frontend run typecheck

--- a/root/frontend/package-lock.json
+++ b/root/frontend/package-lock.json
@@ -34,6 +34,7 @@
         "@testing-library/user-event": "^14.5.2",
         "@types/node": "^22.14.1",
         "@types/qrcode": "^1.5.5",
+        "@types/qrcode.react": "^1.0.5",
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.2",
         "@types/zxcvbn": "^4.4.5",
@@ -4015,6 +4016,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/qrcode.react": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/qrcode.react/-/qrcode.react-1.0.5.tgz",
+      "integrity": "sha512-BghPtnlwvrvq8QkGa1H25YnN+5OIgCKFuQruncGWLGJYOzeSKiix/4+B9BtfKF2wf5ja8yfyWYA3OXju995G8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/raf": {

--- a/root/frontend/package.json
+++ b/root/frontend/package.json
@@ -51,6 +51,7 @@
     "@testing-library/user-event": "^14.5.2",
     "@types/node": "^22.14.1",
     "@types/qrcode": "^1.5.5",
+    "@types/qrcode.react": "^1.0.5",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
     "@types/zxcvbn": "^4.4.5",

--- a/root/frontend/src/app/ErrorBoundary.test.tsx
+++ b/root/frontend/src/app/ErrorBoundary.test.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { type JSX, useState } from "react"
 import { render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { describe, expect, it, vi } from "vitest"
@@ -9,7 +9,7 @@ describe("ErrorBoundary", () => {
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {})
     const dispatchSpy = vi.spyOn(window, "dispatchEvent")
 
-    const Problem = () => {
+    const Problem = (): JSX.Element => {
       throw new Error("Boom")
     }
 
@@ -62,7 +62,7 @@ describe("ErrorBoundary", () => {
       )
     }
 
-    function Problem() {
+    function Problem(): JSX.Element {
       throw new Error("Controlled failure")
     }
 

--- a/root/frontend/src/pages/Profile.tsx
+++ b/root/frontend/src/pages/Profile.tsx
@@ -118,37 +118,44 @@ const NowPlayingCard = memo(function NowPlayingCard({ data }: { data: NowPlaying
   const href = data.track_url || "https://open.spotify.com";
 
   return (
-    <MotionPaper
+    <Box
       component="a"
       href={href}
       target="_blank"
       rel="noopener noreferrer"
       aria-label={data.track_name ? `Открыть в Spotify: ${data.track_name}` : "Открыть Spotify"}
-      elevation={0}
-      className="nowplaying--spotify"
-      initial={isTest ? false : { y: reduced ? 0 : 12, opacity: reduced ? 1 : 0.94, scale: 1 }}
-      animate={{ y: 0, opacity: 1, scale: 1 }}
-      whileHover={reduced ? {} : { y: -1, scale: 1.002 }}
-      whileTap={reduced ? {} : { scale: 0.997 }}
-      transition={isTest ? { duration: 0 } : { type: "spring", stiffness: 520, damping: 36, mass: 0.9 }}
       sx={{
-        width: "100%",
-        display: "grid",
-        gridTemplateColumns: "auto 1fr",
-        alignItems: "center",
-        columnGap: 2,
-        rowGap: 1,
-        px: 2,
-        py: 1.8,
-        borderRadius: 3,
-        position: "relative",
-        overflow: "hidden",
-        border: `1px solid ${borderCol}`,
+        display: "block",
         textDecoration: "none",
-        ["--glass-alpha" as any]: ".018",
-        ["--glass-highlight" as any]: "rgba(255,255,255,0)",
+        width: "100%",
       }}
     >
+      <MotionPaper
+        elevation={0}
+        className="nowplaying--spotify"
+        initial={isTest ? false : { y: reduced ? 0 : 12, opacity: reduced ? 1 : 0.94, scale: 1 }}
+        animate={{ y: 0, opacity: 1, scale: 1 }}
+        whileHover={reduced ? {} : { y: -1, scale: 1.002 }}
+        whileTap={reduced ? {} : { scale: 0.997 }}
+        transition={isTest ? { duration: 0 } : { type: "spring", stiffness: 520, damping: 36, mass: 0.9 }}
+        sx={{
+          width: "100%",
+          display: "grid",
+          gridTemplateColumns: "auto 1fr",
+          alignItems: "center",
+          columnGap: 2,
+          rowGap: 1,
+          px: 2,
+          py: 1.8,
+          borderRadius: 3,
+          position: "relative",
+          overflow: "hidden",
+          border: `1px solid ${borderCol}`,
+          textDecoration: "none",
+          ["--glass-alpha" as any]: ".018",
+          ["--glass-highlight" as any]: "rgba(255,255,255,0)",
+        }}
+      >
       <Box
         sx={{
           position: "relative",
@@ -187,7 +194,8 @@ const NowPlayingCard = memo(function NowPlayingCard({ data }: { data: NowPlaying
           </Typography>
         </Box>
       </Box>
-    </MotionPaper>
+      </MotionPaper>
+    </Box>
   );
 });
 


### PR DESCRIPTION
## Summary
- add a Husky pre-push hook that runs the frontend type checker
- fix existing TypeScript issues and install the QR code React type definitions to keep the check green
- run `npm run typecheck` in CI before executing the frontend unit tests

## Testing
- npm --prefix root/frontend run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68dd147e98208327ae59c0ee8af438e9