### PR TITLE
Add Lighthouse CI workflow for frontend

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -34,7 +34,8 @@ jobs:
         run: npm run build
 
       - name: Clean previous Lighthouse reports
-        run: rm -rf .lighthouseci
+        run: rm -rf .lighthouseci root/frontend/.lighthouseci
+        working-directory: .
 
       - name: Run Lighthouse CI
         run: npx lhci autorun --config=../../lighthouserc.json

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Build preview bundle
         run: npm run build
 
+      - name: Clean previous Lighthouse reports
+        run: rm -rf .lighthouseci
+
       - name: Run Lighthouse CI
         run: npx lhci autorun --config=../../lighthouserc.json
 

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -40,5 +40,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: lighthouse-report
-          path: root/frontend/.lighthouseci
+          path: .lighthouseci
           if-no-files-found: error

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,44 @@
+name: Lighthouse CI
+
+on:
+  pull_request:
+    paths:
+      - "root/frontend/**"
+      - "lighthouserc.json"
+      - ".github/workflows/lighthouse.yml"
+
+jobs:
+  lhci:
+    name: Audit preview build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: root/frontend
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: root/frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build preview bundle
+        run: npm run build
+
+      - name: Run Lighthouse CI
+        run: npx lhci autorun --config=../../lighthouserc.json
+
+      - name: Upload Lighthouse report
+        uses: actions/upload-artifact@v4
+        with:
+          name: lighthouse-report
+          path: root/frontend/.lighthouseci
+          if-no-files-found: error

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -43,5 +43,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: lighthouse-report
-          path: .lighthouseci
+          path: root/frontend/.lighthouseci
           if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -195,3 +195,5 @@ root/app/static/uploads/**
 !root/app/static/uploads/.gitkeep
 root/frontend/public/maskable-icon-192.png
 root/frontend/public/maskable-icon-512.png
+# Lighthouse CI artifacts
+.lighthouseci/

--- a/.gitignore
+++ b/.gitignore
@@ -197,3 +197,4 @@ root/frontend/public/maskable-icon-192.png
 root/frontend/public/maskable-icon-512.png
 # Lighthouse CI artifacts
 .lighthouseci/
+root/frontend/.lighthouseci/

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,0 +1,32 @@
+{
+  "ci": {
+    "collect": {
+      "staticDistDir": "root/frontend/dist",
+      "numberOfRuns": 2,
+      "isSinglePageApplication": true,
+      "url": [
+        "/index.html"
+      ],
+      "settings": {
+        "preset": "desktop",
+        "formFactor": "desktop"
+      }
+    },
+    "assert": {
+      "preset": "lighthouse:no-pwa",
+      "assertions": {
+        "categories:pwa": [
+          "warn",
+          {
+            "minScore": 0.8
+          }
+        ]
+      }
+    },
+    "upload": {
+      "target": "filesystem",
+      "outputDir": "root/frontend/.lighthouseci",
+      "reportFilenamePattern": "%%PATHNAME%%-%%DATETIME%%.%%EXTENSION%%"
+    }
+  }
+}

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,7 +1,7 @@
 {
   "ci": {
     "collect": {
-      "staticDistDir": "root/frontend/dist",
+      "staticDistDir": "./dist",
       "numberOfRuns": 2,
       "isSinglePageApplication": true,
       "url": [
@@ -25,7 +25,7 @@
     },
     "upload": {
       "target": "filesystem",
-      "outputDir": "root/frontend/.lighthouseci",
+      "outputDir": "./.lighthouseci",
       "reportFilenamePattern": "%%PATHNAME%%-%%DATETIME%%.%%EXTENSION%%"
     }
   }

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,7 +1,7 @@
 {
   "ci": {
     "collect": {
-      "staticDistDir": "./root/frontend/dist",
+      "staticDistDir": "./dist",
       "numberOfRuns": 2,
       "isSinglePageApplication": true,
       "url": [
@@ -49,7 +49,7 @@
     },
     "upload": {
       "target": "filesystem",
-      "outputDir": "./root/frontend/.lighthouseci",
+      "outputDir": "./.lighthouseci",
       "reportFilenamePattern": "%%PATHNAME%%-%%DATETIME%%.%%EXTENSION%%"
     }
   }

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,7 +1,7 @@
 {
   "ci": {
     "collect": {
-      "staticDistDir": "./dist",
+      "staticDistDir": "./root/frontend/dist",
       "numberOfRuns": 2,
       "isSinglePageApplication": true,
       "url": [
@@ -49,7 +49,7 @@
     },
     "upload": {
       "target": "filesystem",
-      "outputDir": "./.lighthouseci",
+      "outputDir": "./root/frontend/.lighthouseci",
       "reportFilenamePattern": "%%PATHNAME%%-%%DATETIME%%.%%EXTENSION%%"
     }
   }

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -13,12 +13,35 @@
       }
     },
     "assert": {
-      "preset": "lighthouse:no-pwa",
       "assertions": {
+        "categories:performance": [
+          "error",
+          {
+            "minScore": 0.8
+          }
+        ],
+        "categories:accessibility": [
+          "error",
+          {
+            "minScore": 0.9
+          }
+        ],
+        "categories:best-practices": [
+          "error",
+          {
+            "minScore": 0.9
+          }
+        ],
+        "categories:seo": [
+          "error",
+          {
+            "minScore": 0.9
+          }
+        ],
         "categories:pwa": [
           "warn",
           {
-            "minScore": 0.8
+            "minScore": 0.6
           }
         ]
       }

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -5,7 +5,8 @@
       "numberOfRuns": 2,
       "isSinglePageApplication": true,
       "url": [
-        "/index.html"
+        "/index.html",
+        "/dashboard"
       ],
       "settings": {
         "preset": "desktop",

--- a/root/frontend/index.html
+++ b/root/frontend/index.html
@@ -33,6 +33,11 @@
     <meta name="theme-color" media="(prefers-color-scheme: light)" content="#f4f8fd" />
     <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#0b0d11" />
     <meta name="description" content="Экосистема ГУУ — профиль, расписание, новости и события." />
+    <meta name="application-name" content="Экосистема ГУУ" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="apple-mobile-web-app-title" content="Экосистема ГУУ" />
+    <meta name="mobile-web-app-capable" content="yes" />
     <meta property="og:type" content="website" />
     <meta property="og:title" content="Экосистема ГУУ" />
     <meta property="og:description" content="Личный кабинет: профиль, расписание, новости и события." />
@@ -45,6 +50,8 @@
     <meta name="twitter:image" content="/og-image.png" />
     <title>Экосистема ГУУ</title>
     <link rel="icon" type="image/png" href="/guu_logo.png" />
+    <link rel="apple-touch-icon" href="/maskable-icon-192.png" />
+    <link rel="manifest" href="/manifest.webmanifest" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Oxygen:wght@300;400;700&family=Varela&family=Manrope:wght@400;500;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />

--- a/root/frontend/public/robots.txt
+++ b/root/frontend/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+# Allow all crawlers to index the preview build.


### PR DESCRIPTION
## Summary
- add a Lighthouse CI configuration file for auditing the built frontend
- run Lighthouse in a dedicated GitHub Actions workflow and upload the reports as artifacts
- enhance the frontend HTML entry point with additional PWA-focused meta tags and links

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dec02ae4c08327b26b461ff0cdc833