### PR TITLE
feat: add schedule iCal export

### DIFF
--- a/root/app/main.py
+++ b/root/app/main.py
@@ -16,6 +16,7 @@ from app.core.config import settings
 from app.core.database import Base, engine, wait_db
 from app.core.observability import configure_observability, shutdown_observability
 from app.core.security_headers import SecurityHeadersMiddleware
+from app.routers.schedule import router as schedule_router
 from app.services.notifications import start_notifications_scheduler
 
 try:
@@ -86,4 +87,5 @@ app.include_router(auth_router)
 app.include_router(spotify_router)
 app.include_router(notifications_router)
 app.include_router(push_router)
+app.include_router(schedule_router)
 app.include_router(main_router)

--- a/root/app/routers/__init__.py
+++ b/root/app/routers/__init__.py
@@ -1,0 +1,1 @@
+"""Application routers package."""

--- a/root/app/routers/schedule.py
+++ b/root/app/routers/schedule.py
@@ -1,0 +1,43 @@
+"""Schedule-specific API routes."""
+
+from __future__ import annotations
+
+import re
+from typing import Sequence
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Response
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app import crud
+from app.core.database import get_db
+from app.models import models
+from app.services.ical import generate_schedule_ics
+
+router = APIRouter(prefix="/schedule", tags=["schedule"])
+
+
+def _build_filename(group: models.Group) -> str:
+    name = getattr(group, "name", None) or f"group-{group.id}"
+    normalized = re.sub(r"[^A-Za-z0-9]+", "-", name, flags=re.UNICODE).strip("-")
+    safe_name = normalized.lower() or f"group-{group.id}"
+    return f"schedule-{safe_name}.ics"
+
+
+@router.get("/ics", response_class=Response)
+async def download_schedule_ics(
+    group: int = Query(..., description="Идентификатор группы"),
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    group_obj = await db.get(models.Group, group)
+    if not group_obj:
+        raise HTTPException(status_code=404, detail="Группа не найдена")
+
+    lessons: Sequence[models.Schedule] = await crud.get_schedule_by_group(db, group)
+    ics_body = generate_schedule_ics(group_obj, lessons)
+    filename = _build_filename(group_obj)
+
+    headers = {
+        "Content-Disposition": f'attachment; filename="{filename}"',
+        "Cache-Control": "no-cache",
+    }
+    return Response(content=ics_body, media_type="text/calendar; charset=utf-8", headers=headers)

--- a/root/app/routers/schedule.py
+++ b/root/app/routers/schedule.py
@@ -40,4 +40,6 @@ async def download_schedule_ics(
         "Content-Disposition": f'attachment; filename="{filename}"',
         "Cache-Control": "no-cache",
     }
-    return Response(content=ics_body, media_type="text/calendar; charset=utf-8", headers=headers)
+    return Response(
+        content=ics_body, media_type="text/calendar; charset=utf-8", headers=headers
+    )

--- a/root/app/services/ical.py
+++ b/root/app/services/ical.py
@@ -1,0 +1,171 @@
+"""Utilities for generating iCalendar exports."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, time, timedelta, timezone
+from typing import Iterable, Sequence
+
+from app.models import models
+
+_WEEKDAY_ALIASES: dict[str, int] = {
+    "monday": 0,
+    "mon": 0,
+    "понедельник": 0,
+    "tuesday": 1,
+    "tue": 1,
+    "вторник": 1,
+    "wednesday": 2,
+    "wed": 2,
+    "среда": 2,
+    "thursday": 3,
+    "thu": 3,
+    "четверг": 3,
+    "friday": 4,
+    "fri": 4,
+    "пятница": 4,
+    "saturday": 5,
+    "sat": 5,
+    "суббота": 5,
+    "sunday": 6,
+    "sun": 6,
+    "воскресенье": 6,
+}
+
+
+def _weekday_index(value: str | None) -> int | None:
+    if not value:
+        return None
+    normalized = value.strip().lower()
+    return _WEEKDAY_ALIASES.get(normalized)
+
+
+def _ensure_time(value: datetime | time | None) -> time | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.timetz() if value.tzinfo else value.time()
+    return value
+
+
+def _escape(value: str | None) -> str:
+    if not value:
+        return ""
+    return (
+        str(value)
+        .replace("\\", "\\\\")
+        .replace(";", "\\;")
+        .replace(",", "\\,")
+        .replace("\n", "\\n")
+    )
+
+
+def _format_dt(dt: datetime) -> str:
+    if dt.tzinfo is timezone.utc:
+        return dt.strftime("%Y%m%dT%H%M%SZ")
+    if dt.tzinfo:
+        aware = dt.astimezone(timezone.utc)
+        return aware.strftime("%Y%m%dT%H%M%SZ")
+    return dt.strftime("%Y%m%dT%H%M%S")
+
+
+def _iter_lesson_dates(
+    weekday_idx: int,
+    parity: str,
+    weeks: int,
+    *,
+    start_monday: date,
+    current_week_parity: str,
+) -> Iterable[date]:
+    step = 1
+    offset = 0
+    parity_normalized = parity.lower()
+    if parity_normalized in {"odd", "even"}:
+        step = 2
+        if parity_normalized != current_week_parity:
+            offset = 1
+    for week in range(offset, weeks, step):
+        yield start_monday + timedelta(days=weekday_idx + week * 7)
+
+
+def generate_schedule_ics(
+    group: models.Group,
+    lessons: Sequence[models.Schedule],
+    *,
+    weeks: int = 16,
+) -> str:
+    """Generate an iCalendar representation for the provided schedule."""
+
+    now = datetime.now(timezone.utc)
+    today = now.date()
+    start_monday = today - timedelta(days=today.weekday())
+    current_week_number = today.isocalendar()[1]
+    current_week_parity = "odd" if current_week_number % 2 else "even"
+
+    calendar_name = f"Расписание {group.name}" if getattr(group, "name", None) else "Расписание"
+
+    lines: list[str] = [
+        "BEGIN:VCALENDAR",
+        "PRODID:-//University Ecosystem//Schedule//RU",
+        "VERSION:2.0",
+        "CALSCALE:GREGORIAN",
+        f"NAME:{_escape(calendar_name)}",
+        f"X-WR-CALNAME:{_escape(calendar_name)}",
+    ]
+
+    dtstamp = _format_dt(now)
+    for lesson in lessons:
+        weekday_idx = _weekday_index(getattr(lesson, "weekday", None))
+        start_time = _ensure_time(getattr(lesson, "start_time", None))
+        end_time = _ensure_time(getattr(lesson, "end_time", None))
+
+        if weekday_idx is None or start_time is None or end_time is None:
+            continue
+
+        parity = getattr(lesson, "parity", "both") or "both"
+        subject = getattr(lesson, "subject", "Занятие") or "Занятие"
+        lesson_type = getattr(lesson, "lesson_type", None)
+        summary = subject if not lesson_type else f"{subject} ({lesson_type})"
+        teacher = getattr(lesson, "teacher", None)
+        room = getattr(lesson, "room", None)
+
+        for lesson_date in _iter_lesson_dates(
+            weekday_idx,
+            parity,
+            weeks,
+            start_monday=start_monday,
+            current_week_parity=current_week_parity,
+        ):
+            start_dt = datetime.combine(lesson_date, start_time)
+            end_dt = datetime.combine(lesson_date, end_time)
+            uid = f"lesson-{getattr(lesson, 'id', 'x')}-{lesson_date.strftime('%Y%m%d')}@university-ecosystem"
+            description_parts = []
+            if teacher:
+                description_parts.append(f"Преподаватель: {teacher}")
+            if room:
+                description_parts.append(f"Аудитория: {room}")
+            if parity and parity.lower() in {"odd", "even"}:
+                description_parts.append(
+                    "Нечётные недели" if parity.lower() == "odd" else "Чётные недели"
+                )
+            description = "\\n".join(description_parts) if description_parts else ""
+
+            lines.extend(
+                [
+                    "BEGIN:VEVENT",
+                    f"UID:{uid}",
+                    f"DTSTAMP:{dtstamp}",
+                    f"SUMMARY:{_escape(summary)}",
+                    f"DTSTART:{_format_dt(start_dt)}",
+                    f"DTEND:{_format_dt(end_dt)}",
+                ]
+            )
+
+            if room:
+                lines.append(f"LOCATION:{_escape(room)}")
+            if description:
+                lines.append(f"DESCRIPTION:{_escape(description)}")
+
+            lines.append("END:VEVENT")
+
+    lines.append("END:VCALENDAR")
+    return "\r\n".join(lines) + "\r\n"

--- a/root/app/services/ical.py
+++ b/root/app/services/ical.py
@@ -101,7 +101,9 @@ def generate_schedule_ics(
     current_week_number = today.isocalendar()[1]
     current_week_parity = "odd" if current_week_number % 2 else "even"
 
-    calendar_name = f"Расписание {group.name}" if getattr(group, "name", None) else "Расписание"
+    calendar_name = (
+        f"Расписание {group.name}" if getattr(group, "name", None) else "Расписание"
+    )
 
     lines: list[str] = [
         "BEGIN:VCALENDAR",

--- a/root/frontend/src/pages/Schedule.tsx
+++ b/root/frontend/src/pages/Schedule.tsx
@@ -54,6 +54,12 @@ const dayShort = ["Пн", "Вт", "Ср", "Чт", "Пт", "Сб"]
 dayjs.extend(isoWeek)
 dayjs.locale("ru")
 
+const API_BASE = (() => {
+  const raw = (api.defaults.baseURL as string | undefined) || (import.meta.env.VITE_BACKEND_ORIGIN || "/api")
+  if (!raw) return "/api"
+  return raw.endsWith("/") ? raw.slice(0, -1) : raw
+})()
+
 type LessonParity = "odd" | "even" | "both"
 type LessonWeekday = (typeof days)[number] | string
 
@@ -176,6 +182,14 @@ export default function Schedule() {
     return () => clearInterval(id)
   }, [])
   const minutesNow = useMemo(() => nowTick.hour() * 60 + nowTick.minute(), [nowTick])
+
+  const exportHref = useMemo(() => {
+    const groupValue = selectedGroup ?? user?.group_id
+    if (!groupValue && groupValue !== 0) return null
+    const value = typeof groupValue === "number" ? groupValue.toString() : String(groupValue)
+    if (!value) return null
+    return `${API_BASE}/schedule/ics?group=${encodeURIComponent(value)}`
+  }, [selectedGroup, user])
 
   const cachedGetGroups = useCallback(async () => {
     try {
@@ -415,6 +429,24 @@ export default function Schedule() {
       >
         Чётная
       </Button>
+      <Tooltip
+        title={exportHref ? "" : "Выберите группу"}
+        disableHoverListener={!!exportHref}
+        placement="top"
+      >
+        <span>
+          <Button
+            component="a"
+            href={exportHref ?? undefined}
+            variant="outlined"
+            startIcon={<CalendarMonthIcon />}
+            disabled={!exportHref}
+            download={exportHref ? "" : undefined}
+          >
+            Экспорт в календарь
+          </Button>
+        </span>
+      </Tooltip>
     </Stack>
   )
 

--- a/root/frontend/tests/e2e/schedule-export.spec.ts
+++ b/root/frontend/tests/e2e/schedule-export.spec.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "@playwright/test";
+import { promises as fs } from "fs";
+
+import { useMockApi } from "./utils/mockApi";
+
+test.describe("Schedule export", () => {
+  test("allows downloading the schedule as an iCal file", async ({ page }) => {
+    const mock = await useMockApi(page);
+    await mock.login(page);
+
+    await page.getByRole("link", { name: "Расписание" }).click();
+    await expect(page).toHaveURL(/\/schedule$/);
+
+    const downloadPromise = page.waitForEvent("download");
+    await page.getByRole("link", { name: "Экспорт в календарь" }).click();
+    const download = await downloadPromise;
+
+    expect(download.suggestedFilename()).toMatch(/schedule-iu-21\.ics$/);
+    const filePath = await download.path();
+    expect(filePath).toBeTruthy();
+    if (filePath) {
+      const content = await fs.readFile(filePath, "utf-8");
+      expect(content).toContain("BEGIN:VCALENDAR");
+      expect(content).toContain("SUMMARY:Математика");
+    }
+  });
+});

--- a/root/frontend/tests/e2e/utils/mockApi.ts
+++ b/root/frontend/tests/e2e/utils/mockApi.ts
@@ -58,6 +58,11 @@ const mockSchedule = [
   },
 ];
 
+const mockGroups = [
+  { id: 1, name: "ИУ-21", course: 1, faculty: "ИТ" },
+  { id: 2, name: "БИ-22", course: 2, faculty: "Бизнес" },
+];
+
 export async function useMockApi(page: Page) {
   const state: MockState = {
     loggedIn: false,
@@ -173,11 +178,43 @@ export async function useMockApi(page: Page) {
       return;
     }
 
+    if (pathname.startsWith("api/schedule/ics")) {
+      const body = [
+        "BEGIN:VCALENDAR",
+        "VERSION:2.0",
+        "BEGIN:VEVENT",
+        "SUMMARY:Математика",
+        "DTSTART:20240101T090000",
+        "DTEND:20240101T103000",
+        "END:VEVENT",
+        "END:VCALENDAR",
+      ].join("\r\n");
+
+      await route.fulfill({
+        status: 200,
+        contentType: "text/calendar",
+        headers: {
+          "content-disposition": "attachment; filename=\"schedule-iu-21.ics\"",
+        },
+        body,
+      });
+      return;
+    }
+
     if (pathname.startsWith("api/schedule")) {
       await route.fulfill({
         status: 200,
         contentType: "application/json",
         body: JSON.stringify(mockSchedule),
+      });
+      return;
+    }
+
+    if (pathname === "api/groups") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(mockGroups),
       });
       return;
     }

--- a/root/tests/test_schedule_ics.py
+++ b/root/tests/test_schedule_ics.py
@@ -1,0 +1,60 @@
+from datetime import datetime
+
+import pytest
+
+from app.models import models
+from app.services.ical import generate_schedule_ics
+
+
+def test_generate_schedule_ics_includes_lessons() -> None:
+    group = models.Group(id=1, name="ИУ-21", course=1, faculty="ИТ")
+    lesson = models.Schedule(
+        id=10,
+        group_id=group.id,
+        subject="Алгебра",
+        teacher="Проф. Смирнов",
+        room="А-101",
+        weekday="Понедельник",
+        start_time=datetime(2024, 1, 1, 9, 0),
+        end_time=datetime(2024, 1, 1, 10, 30),
+        parity="both",
+        lesson_type="Лекция",
+    )
+
+    ics = generate_schedule_ics(group, [lesson], weeks=1)
+
+    assert "BEGIN:VCALENDAR" in ics
+    assert "END:VCALENDAR" in ics
+    assert "SUMMARY:Алгебра (Лекция)" in ics
+    assert "DTSTART:" in ics
+    assert "DTEND:" in ics
+
+
+@pytest.mark.anyio
+async def test_schedule_ics_endpoint(async_client, db_session) -> None:
+    group = models.Group(name="ИУ-21", course=1, faculty="ИТ")
+    db_session.add(group)
+    await db_session.commit()
+    await db_session.refresh(group)
+
+    lesson = models.Schedule(
+        group_id=group.id,
+        subject="Алгебра",
+        teacher="Проф. Смирнов",
+        room="А-101",
+        weekday="Понедельник",
+        start_time=datetime(2024, 1, 1, 9, 0),
+        end_time=datetime(2024, 1, 1, 10, 30),
+        parity="both",
+        lesson_type="Лекция",
+    )
+    db_session.add(lesson)
+    await db_session.commit()
+
+    response = await async_client.get(f"/schedule/ics?group={group.id}")
+
+    assert response.status_code == 200
+    assert response.headers.get("content-type", "").startswith("text/calendar")
+    disposition = response.headers.get("content-disposition", "")
+    assert "schedule-" in disposition.lower()
+    assert "Алгебра" in response.text


### PR DESCRIPTION
## Summary
- add a dedicated /schedule/ics endpoint that returns schedule exports as downloadable iCal files
- implement reusable iCal generation helper with coverage from new backend tests
- surface the export action in the schedule page UI and cover it with an end-to-end Playwright test

## Testing
- pytest
- npx playwright test *(fails: Playwright browsers not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68def450b5a88327a626cee5a5e2d280