### PR TITLE
Implement Redis-based rate limiting middleware

### DIFF
--- a/root/app/core/rate_limit.py
+++ b/root/app/core/rate_limit.py
@@ -1,39 +1,181 @@
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import TypeVar
+import asyncio
+import math
+import time
+import uuid
+from typing import Callable, Optional
 
-from slowapi import Limiter
-from slowapi.util import get_remote_address
+from fastapi import Request
+from redis.asyncio import Redis
+from redis.exceptions import RedisError
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse
 
-from app.core.config import settings
+_RATE_LIMIT_SCRIPT = """
+local key = KEYS[1]
+local now = tonumber(ARGV[1])
+local window = tonumber(ARGV[2])
+local limit = tonumber(ARGV[3])
+local member = ARGV[4]
 
-F = TypeVar("F", bound=Callable[..., object])
+local cutoff = now - window
+redis.call('ZREMRANGEBYSCORE', key, 0, cutoff)
+local count = redis.call('ZCARD', key)
+
+if count >= limit then
+  local retry_after = 0
+  local oldest = redis.call('ZRANGE', key, 0, 0, 'WITHSCORES')
+  if oldest[2] then
+    retry_after = window - (now - tonumber(oldest[2]))
+    if retry_after < 0 then
+      retry_after = 0
+    end
+  end
+  return {0, 0, retry_after}
+end
+
+redis.call('ZADD', key, now, member)
+redis.call('PEXPIRE', key, window)
+
+local remaining = limit - (count + 1)
+if remaining < 0 then
+  remaining = 0
+end
+
+return {1, remaining, 0}
+"""
 
 
-def _default_limits() -> list[str] | None:
-    limits = settings.rate_limit_default_list
-    return limits or None
+def _create_redis_pool(url: str) -> Redis:
+    return Redis.from_url(url, encoding="utf-8", decode_responses=False, health_check_interval=30)
 
 
-limiter = Limiter(
-    key_func=get_remote_address,
-    default_limits=_default_limits(),
-    storage_uri=settings.rate_limit_storage_uri,
-    headers_enabled=settings.rate_limit_headers_enabled,
-    enabled=settings.rate_limit_enabled,
-)
+_RedisFactory = Callable[[str], Redis]
+_redis_factory: _RedisFactory = _create_redis_pool
 
 
-def limit_if_configured(limit_value: str | None) -> Callable[[F], F]:
-    if not limit_value:
-
-        def decorator(func: F) -> F:
-            return func
-
-        return decorator
-    return limiter.limit(limit_value)
+def set_rate_limit_client_factory(factory: Optional[_RedisFactory]) -> None:
+    global _redis_factory
+    if factory is None:
+        _redis_factory = _create_redis_pool
+    else:
+        _redis_factory = factory
 
 
-def sensitive_route_limit() -> Callable[[F], F]:
-    return limit_if_configured(settings.rate_limit_sensitive_value)
+class RateLimitMiddleware(BaseHTTPMiddleware):
+    def __init__(
+        self,
+        app,
+        *,
+        redis_url: str,
+        limit: int = 60,
+        window_seconds: int = 60,
+        enabled: bool = True,
+        headers_enabled: bool = True,
+    ) -> None:
+        super().__init__(app)
+        self._redis_url = redis_url.strip()
+        self._limit = max(int(limit), 0)
+        self._window_ms = max(int(window_seconds * 1000), 0)
+        self._enabled = enabled and bool(self._redis_url) and self._limit > 0 and self._window_ms > 0
+        self._headers_enabled = headers_enabled
+        self._client: Redis | None = None
+        self._client_lock = asyncio.Lock()
+
+    async def dispatch(self, request: Request, call_next):  # type: ignore[override]
+        if not self._enabled:
+            return await call_next(request)
+
+        identifier = self._build_identifier(request)
+        try:
+            allowed, remaining, retry_after = await self._check_limit(identifier)
+        except (RedisError, OSError):
+            return await call_next(request)
+
+        if not allowed:
+            retry_after_seconds = max(0, math.ceil(retry_after / 1000))
+            headers = {"Retry-After": str(retry_after_seconds)}
+            if self._headers_enabled:
+                headers["X-RateLimit-Limit"] = str(self._limit)
+                headers["X-RateLimit-Remaining"] = "0"
+            return JSONResponse(
+                status_code=429,
+                content={"detail": "Too many requests"},
+                headers=headers,
+            )
+
+        response = await call_next(request)
+        if self._headers_enabled:
+            response.headers.setdefault("X-RateLimit-Limit", str(self._limit))
+            response.headers.setdefault("X-RateLimit-Remaining", str(max(0, remaining)))
+        return response
+
+    async def _check_limit(self, identifier: str) -> tuple[bool, int, int]:
+        client = await self._get_client()
+        now_ms = int(time.time() * 1000)
+        member = f"{now_ms}:{uuid.uuid4().hex}"
+        key = self._redis_key(identifier)
+        try:
+            result = await client.eval(
+                _RATE_LIMIT_SCRIPT,
+                1,
+                key,
+                now_ms,
+                self._window_ms,
+                self._limit,
+                member,
+            )
+        except RedisError as exc:
+            if "unknown command" not in str(exc).lower():
+                raise
+            return await self._check_limit_fallback(client, key, now_ms, member)
+        allowed = bool(int(result[0]))
+        remaining = int(result[1])
+        retry_after = int(result[2])
+        return allowed, remaining, retry_after
+
+    async def _check_limit_fallback(
+        self,
+        client: Redis,
+        key: str,
+        now_ms: int,
+        member: str,
+    ) -> tuple[bool, int, int]:
+        cutoff = now_ms - self._window_ms
+        await client.zremrangebyscore(key, 0, cutoff)
+        count = await client.zcard(key)
+        if count >= self._limit:
+            oldest = await client.zrange(key, 0, 0, withscores=True)
+            retry_after = 0
+            if oldest:
+                retry_after = self._window_ms - (now_ms - int(float(oldest[0][1])))
+                if retry_after < 0:
+                    retry_after = 0
+            return False, 0, int(retry_after)
+        await client.zadd(key, mapping={member: now_ms})
+        await client.pexpire(key, self._window_ms)
+        remaining = max(0, self._limit - (count + 1))
+        return True, remaining, 0
+
+    async def _get_client(self) -> Redis:
+        if self._client is not None:
+            return self._client
+        async with self._client_lock:
+            if self._client is None:
+                self._client = _redis_factory(self._redis_url)
+        return self._client
+
+    def _build_identifier(self, request: Request) -> str:
+        auth_header = request.headers.get("authorization")
+        if auth_header:
+            parts = auth_header.strip().split()
+            if len(parts) == 2 and parts[0].lower() == "bearer" and parts[1]:
+                return f"token:{parts[1]}"
+        client = request.client
+        if client and client.host:
+            return f"ip:{client.host}"
+        return "ip:unknown"
+
+    def _redis_key(self, identifier: str) -> str:
+        return f"rate-limit:{identifier}"

--- a/root/app/core/rate_limit.py
+++ b/root/app/core/rate_limit.py
@@ -48,7 +48,9 @@ return {1, remaining, 0}
 
 
 def _create_redis_pool(url: str) -> Redis:
-    return Redis.from_url(url, encoding="utf-8", decode_responses=False, health_check_interval=30)
+    return Redis.from_url(
+        url, encoding="utf-8", decode_responses=False, health_check_interval=30
+    )
 
 
 _RedisFactory = Callable[[str], Redis]
@@ -78,7 +80,12 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         self._redis_url = redis_url.strip()
         self._limit = max(int(limit), 0)
         self._window_ms = max(int(window_seconds * 1000), 0)
-        self._enabled = enabled and bool(self._redis_url) and self._limit > 0 and self._window_ms > 0
+        self._enabled = (
+            enabled
+            and bool(self._redis_url)
+            and self._limit > 0
+            and self._window_ms > 0
+        )
         self._headers_enabled = headers_enabled
         self._client: Redis | None = None
         self._client_lock = asyncio.Lock()

--- a/root/app/main.py
+++ b/root/app/main.py
@@ -15,6 +15,7 @@ from app.auth.auth import router as auth_router
 from app.core.config import settings
 from app.core.database import Base, engine, wait_db
 from app.core.observability import configure_observability, shutdown_observability
+from app.core.rate_limit import RateLimitMiddleware
 from app.core.security_headers import SecurityHeadersMiddleware
 from app.deps.cache import shutdown_cache
 from app.routers.schedule import router as schedule_router
@@ -56,6 +57,16 @@ app.add_middleware(
 )
 
 app.add_middleware(SecurityHeadersMiddleware, settings=settings)
+
+rate_limit_url = settings.rate_limit_storage_uri.strip()
+if settings.rate_limit_enabled and rate_limit_url.lower().startswith(("redis://", "rediss://")):
+    app.add_middleware(
+        RateLimitMiddleware,
+        redis_url=rate_limit_url,
+        limit=60,
+        window_seconds=60,
+        headers_enabled=settings.rate_limit_headers_enabled,
+    )
 
 if ProxyHeadersMiddleware:
     trusted_hosts = settings.trusted_hosts_list

--- a/root/app/main.py
+++ b/root/app/main.py
@@ -59,7 +59,9 @@ app.add_middleware(
 app.add_middleware(SecurityHeadersMiddleware, settings=settings)
 
 rate_limit_url = settings.rate_limit_storage_uri.strip()
-if settings.rate_limit_enabled and rate_limit_url.lower().startswith(("redis://", "rediss://")):
+if settings.rate_limit_enabled and rate_limit_url.lower().startswith(
+    ("redis://", "rediss://")
+):
     app.add_middleware(
         RateLimitMiddleware,
         redis_url=rate_limit_url,

--- a/root/tests/conftest.py
+++ b/root/tests/conftest.py
@@ -34,8 +34,9 @@ os.environ.setdefault("ALGORITHM", "HS256")
 os.environ.setdefault("ACCESS_TOKEN_EXPIRE_MINUTES", "30")
 os.environ.setdefault("STATIC_DIR", "app/test-static")
 os.environ.setdefault("ENVIRONMENT", "testing")
-os.environ.setdefault("RATE_LIMIT_ENABLED", "false")
+os.environ.setdefault("RATE_LIMIT_ENABLED", "true")
 os.environ.setdefault("RATE_LIMIT_SENSITIVE", "")
+os.environ.setdefault("RATE_LIMIT_STORAGE_URI", "redis://test")
 Path(os.environ.get("STATIC_DIR", "app/test-static")).mkdir(parents=True, exist_ok=True)
 
 try:
@@ -68,6 +69,7 @@ security_headers_module.SecurityHeadersMiddleware = _NoopSecurityHeadersMiddlewa
 
 from app import main
 from app.core.config import settings
+from app.core.rate_limit import set_rate_limit_client_factory
 from app.core.database import Base, async_session, engine
 from app.deps import cache as cache_module
 from app.models import models
@@ -99,6 +101,25 @@ async def clean_database(prepare_database: None) -> AsyncIterator[None]:
         for table in reversed(Base.metadata.sorted_tables):
             await conn.execute(table.delete())
         await conn.exec_driver_sql("PRAGMA foreign_keys=ON")
+
+
+@pytest.fixture(scope="session")
+def _rate_limit_redis_client() -> AsyncIterator[fakeredis.aioredis.FakeRedis]:
+    fake = fakeredis.aioredis.FakeRedis(encoding="utf-8", decode_responses=False)
+    set_rate_limit_client_factory(lambda url: fake)
+    try:
+        yield fake
+    finally:
+        set_rate_limit_client_factory(None)
+
+
+@pytest.fixture(autouse=True)
+async def configure_rate_limit(_rate_limit_redis_client: fakeredis.aioredis.FakeRedis) -> AsyncIterator[None]:
+    await _rate_limit_redis_client.flushall()
+    try:
+        yield
+    finally:
+        await _rate_limit_redis_client.flushall()
 
 
 @pytest.fixture

--- a/root/tests/conftest.py
+++ b/root/tests/conftest.py
@@ -69,8 +69,8 @@ security_headers_module.SecurityHeadersMiddleware = _NoopSecurityHeadersMiddlewa
 
 from app import main
 from app.core.config import settings
-from app.core.rate_limit import set_rate_limit_client_factory
 from app.core.database import Base, async_session, engine
+from app.core.rate_limit import set_rate_limit_client_factory
 from app.deps import cache as cache_module
 from app.models import models
 
@@ -114,7 +114,9 @@ def _rate_limit_redis_client() -> AsyncIterator[fakeredis.aioredis.FakeRedis]:
 
 
 @pytest.fixture(autouse=True)
-async def configure_rate_limit(_rate_limit_redis_client: fakeredis.aioredis.FakeRedis) -> AsyncIterator[None]:
+async def configure_rate_limit(
+    _rate_limit_redis_client: fakeredis.aioredis.FakeRedis,
+) -> AsyncIterator[None]:
     await _rate_limit_redis_client.flushall()
     try:
         yield

--- a/root/tests/test_rate_limit.py
+++ b/root/tests/test_rate_limit.py
@@ -21,5 +21,7 @@ async def test_rate_limit_per_token(async_client):
     blocked = await async_client.get("/healthz", headers=headers)
     assert blocked.status_code == 429
 
-    other = await async_client.get("/healthz", headers={"Authorization": "Bearer token-b"})
+    other = await async_client.get(
+        "/healthz", headers={"Authorization": "Bearer token-b"}
+    )
     assert other.status_code == 200

--- a/root/tests/test_rate_limit.py
+++ b/root/tests/test_rate_limit.py
@@ -1,0 +1,25 @@
+import pytest
+
+
+@pytest.mark.anyio
+async def test_rate_limit_per_ip(async_client):
+    for _ in range(60):
+        response = await async_client.get("/healthz")
+        assert response.status_code == 200
+    response = await async_client.get("/healthz")
+    assert response.status_code == 429
+    assert response.json()["detail"] == "Too many requests"
+    assert response.headers.get("Retry-After") is not None
+
+
+@pytest.mark.anyio
+async def test_rate_limit_per_token(async_client):
+    headers = {"Authorization": "Bearer token-a"}
+    for _ in range(60):
+        response = await async_client.get("/healthz", headers=headers)
+        assert response.status_code == 200
+    blocked = await async_client.get("/healthz", headers=headers)
+    assert blocked.status_code == 429
+
+    other = await async_client.get("/healthz", headers={"Authorization": "Bearer token-b"})
+    assert other.status_code == 200


### PR DESCRIPTION
## Summary
- add a Redis-backed rate limiting middleware that enforces 60 requests per minute per IP or bearer token and exposes standard headers
- integrate the middleware into the FastAPI application when a Redis URL is configured
- extend the pytest fixtures with fakeredis and add coverage to ensure 429 responses after the limit is exceeded

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68defe39d1088327b16e00f161969a73