### PR TITLE
Add multi-stage Dockerfiles for backend and frontend services

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,37 @@
+# Global ignores
+.git
+.gitignore
+.gitattributes
+.devcontainer
+.husky
+.vscode
+ruff.toml
+start-dev.ps1
+**/__pycache__
+**/*.py[cod]
+*.py[cod]
+*.pyc
+*.pyo
+*.pyd
+*.so
+
+# Environment files and local databases
+.env
+.env.*
+root/dev.db
+
+# Node artifacts
+root/node_modules
+root/frontend/node_modules
+root/frontend/dist
+
+# Python virtual environments and caches
+.venv
+venv
+env
+pip-wheel-metadata
+.pytest_cache
+.mypy_cache
+
+# Docker build outputs (if present)
+Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
     build:
       context: .
       dockerfile: root/backend.Dockerfile
+      target: runtime
     env_file:
       - root/.env
     environment:
@@ -21,6 +22,7 @@ services:
     build:
       context: .
       dockerfile: root/frontend.Dockerfile
+      target: development
     environment:
       VITE_BACKEND_ORIGIN: http://localhost:8000
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,11 +2,7 @@ services:
   backend:
     build:
       context: .
-      dockerfile: .devcontainer/Dockerfile
-    command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload --env-file root/.env
-    working_dir: /workspace/root
-    volumes:
-      - .:/workspace:cached
+      dockerfile: root/backend.Dockerfile
     env_file:
       - root/.env
     environment:
@@ -22,17 +18,16 @@ services:
       - "host.docker.internal:host-gateway"
 
   frontend:
-    image: node:20-alpine
-    working_dir: /workspace/root/frontend
-    command: sh -c "npm install && npm run dev -- --host 0.0.0.0 --port 5173"
+    build:
+      context: .
+      dockerfile: root/frontend.Dockerfile
     environment:
       VITE_BACKEND_ORIGIN: http://localhost:8000
-    volumes:
-      - .:/workspace:cached
-      - frontend-node-modules:/workspace/root/frontend/node_modules
     depends_on:
       backend:
-        condition: service_started
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
     ports:
       - "5173:5173"
 
@@ -54,4 +49,3 @@ services:
 
 volumes:
   postgres-data:
-  frontend-node-modules:

--- a/root/app/deps/cache.py
+++ b/root/app/deps/cache.py
@@ -41,15 +41,16 @@ class BaseCache:
 class NullCache(BaseCache):
     enabled = False
 
-    async def get(self, key: str) -> CacheEntry | None:  # noqa: ARG002
+    async def get(self, key: str) -> CacheEntry | None:
+        _ = key
         return None
 
-    async def set(
-        self, key: str, payload: Any, ttl: int | None = None
-    ) -> CacheEntry:  # noqa: ARG002
+    async def set(self, key: str, payload: Any, ttl: int | None = None) -> CacheEntry:
+        _ = (key, ttl)
         return CacheEntry(etag="", payload=payload)
 
-    async def invalidate(self, *keys: str) -> None:  # noqa: ARG002
+    async def invalidate(self, *keys: str) -> None:
+        _ = keys
         return None
 
 

--- a/root/backend.Dockerfile
+++ b/root/backend.Dockerfile
@@ -1,0 +1,33 @@
+# syntax=docker/dockerfile:1.6
+
+FROM python:3.11-slim AS base
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+WORKDIR /app
+
+FROM base AS builder
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential \
+    && rm -rf /var/lib/apt/lists/*
+COPY root/requirements.txt ./
+RUN pip install --upgrade pip \
+    && pip install --no-cache-dir --prefix=/install -r requirements.txt
+
+FROM base AS runtime
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /install /usr/local
+COPY root/app ./app
+COPY root/alembic ./alembic
+COPY root/alembic.ini ./alembic.ini
+COPY root/create_invite_code.py ./create_invite_code.py
+ENV PYTHONPATH="/app"
+RUN groupadd --system app \
+    && useradd --system --gid app --create-home app \
+    && chown -R app:app /app
+USER app
+EXPOSE 8000
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 CMD curl -f http://localhost:8000/healthz || exit 1
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/root/backend.Dockerfile
+++ b/root/backend.Dockerfile
@@ -2,8 +2,7 @@
 
 FROM python:3.11-slim AS base
 ENV PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1 \
-    PIP_NO_CACHE_DIR=1
+    PYTHONUNBUFFERED=1
 WORKDIR /app
 
 FROM base AS builder
@@ -11,22 +10,22 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends build-essential \
     && rm -rf /var/lib/apt/lists/*
 COPY root/requirements.txt ./
-RUN pip install --upgrade pip \
-    && pip install --no-cache-dir --prefix=/install -r requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --upgrade pip \
+    && pip install --prefix=/install -r requirements.txt
 
 FROM base AS runtime
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl \
     && rm -rf /var/lib/apt/lists/*
-COPY --from=builder /install /usr/local
-COPY root/app ./app
-COPY root/alembic ./alembic
-COPY root/alembic.ini ./alembic.ini
-COPY root/create_invite_code.py ./create_invite_code.py
-ENV PYTHONPATH="/app"
 RUN groupadd --system app \
-    && useradd --system --gid app --create-home app \
-    && chown -R app:app /app
+    && useradd --system --gid app --create-home app
+COPY --from=builder --chown=app:app /install /usr/local
+COPY --chown=app:app root/app ./app
+COPY --chown=app:app root/alembic ./alembic
+COPY --chown=app:app root/alembic.ini ./alembic.ini
+COPY --chown=app:app root/create_invite_code.py ./create_invite_code.py
+ENV PYTHONPATH="/app"
 USER app
 EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 CMD curl -f http://localhost:8000/healthz || exit 1

--- a/root/frontend.Dockerfile
+++ b/root/frontend.Dockerfile
@@ -1,0 +1,18 @@
+# syntax=docker/dockerfile:1.6
+
+FROM node:20-alpine AS base
+WORKDIR /app
+
+FROM base AS deps
+COPY root/frontend/package*.json ./
+RUN npm ci
+
+FROM base AS development
+COPY --from=deps /app/node_modules ./node_modules
+COPY root/frontend ./
+RUN addgroup -S app && adduser -S app -G app \
+    && chown -R app:app /app
+USER app
+EXPOSE 5173
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 CMD wget -qO- http://localhost:5173/ >/dev/null || exit 1
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0", "--port", "5173"]

--- a/root/frontend.Dockerfile
+++ b/root/frontend.Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 
 FROM base AS deps
 COPY root/frontend/package*.json ./
-RUN npm ci
+RUN --mount=type=cache,target=/root/.npm npm ci
 
 FROM base AS development
 COPY --from=deps /app/node_modules ./node_modules


### PR DESCRIPTION
## Summary
- add dedicated multi-stage Dockerfiles for the backend and frontend with dependency caching, non-root users, and health checks
- update docker-compose to build from the new images and gate the frontend startup on healthy backend and database services

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df06467eb88327b004269ccff2df00