### PR TITLE
Fix Vitest setup and align bcrypt dependencies

### DIFF
--- a/root/app/deps/cache.py
+++ b/root/app/deps/cache.py
@@ -44,9 +44,12 @@ class NullCache(BaseCache):
     async def get(self, key: str) -> CacheEntry | None:  # noqa: ARG002
         return None
 
-    async def set(
-        self, key: str, payload: Any, ttl: int | None = None
-    ) -> CacheEntry:  # noqa: ARG002
+    async def set(  # noqa: ARG002
+        self,
+        key: str,
+        payload: Any,
+        ttl: int | None = None,
+    ) -> CacheEntry:
         return CacheEntry(etag="", payload=payload)
 
     async def invalidate(self, *keys: str) -> None:  # noqa: ARG002

--- a/root/frontend/src/setupTests.ts
+++ b/root/frontend/src/setupTests.ts
@@ -21,9 +21,10 @@ dispatchEvent: () => false,
 }),
 });
 }
-if (!window.scrollTo) {
-// @ts-expect-error jsdom polyfill
-window.scrollTo = () => {};
+type ScrollToFunction = (options?: ScrollToOptions | number, y?: number) => void;
+const windowWithScroll = window as typeof window & { scrollTo?: ScrollToFunction };
+if (!windowWithScroll.scrollTo) {
+windowWithScroll.scrollTo = () => undefined;
 }
 vi.mock('qrcode.react', () => ({
 QRCodeSVG: () => null,

--- a/root/frontend/src/setupTests.ts
+++ b/root/frontend/src/setupTests.ts
@@ -1,0 +1,30 @@
+/// <reference types="vitest" />
+import '@testing-library/jest-dom';
+import { TextEncoder, TextDecoder } from 'node:util';
+import { webcrypto } from 'node:crypto';
+import { vi } from 'vitest';
+if (!(globalThis as any).TextEncoder) (globalThis as any).TextEncoder = TextEncoder;
+if (!(globalThis as any).TextDecoder) (globalThis as any).TextDecoder = TextDecoder as any;
+if (!(globalThis as any).crypto) (globalThis as any).crypto = webcrypto;
+if (!('matchMedia' in window)) {
+Object.defineProperty(window, 'matchMedia', {
+writable: true,
+value: (query: string) => ({
+matches: false,
+media: query,
+onchange: null,
+addListener: () => {},
+removeListener: () => {},
+addEventListener: () => {},
+removeEventListener: () => {},
+dispatchEvent: () => false,
+}),
+});
+}
+if (!window.scrollTo) {
+// @ts-expect-error jsdom polyfill
+window.scrollTo = () => {};
+}
+vi.mock('qrcode.react', () => ({
+QRCodeSVG: () => null,
+}));

--- a/root/frontend/vitest.config.ts
+++ b/root/frontend/vitest.config.ts
@@ -3,18 +3,19 @@ import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 import path from 'node:path';
 export default defineConfig({
-plugins: [react()],
-resolve: {
-alias: {
-'@': path.resolve(__dirname, 'src'),
-},
-},
-test: {
-environment: 'jsdom',
-setupFiles: ['src/setupTests.ts'],
-globals: true,
-css: true,
-reporters: ['default'],
-cache: { dir: path.resolve(__dirname, '.vitest') },
-},
+  cacheDir: path.resolve(__dirname, '.vitest'),
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['src/setupTests.ts'],
+    globals: true,
+    css: true,
+    reporters: ['default'],
+    exclude: ['node_modules', 'dist', '.idea', '.git', '.cache', 'tests/e2e/**'],
+  },
 });

--- a/root/frontend/vitest.config.ts
+++ b/root/frontend/vitest.config.ts
@@ -1,0 +1,20 @@
+/// <reference types="vitest" />
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+import path from 'node:path';
+export default defineConfig({
+plugins: [react()],
+resolve: {
+alias: {
+'@': path.resolve(__dirname, 'src'),
+},
+},
+test: {
+environment: 'jsdom',
+setupFiles: ['src/setupTests.ts'],
+globals: true,
+css: true,
+reporters: ['default'],
+cache: { dir: path.resolve(__dirname, '.vitest') },
+},
+});

--- a/root/requirements.txt
+++ b/root/requirements.txt
@@ -7,7 +7,7 @@ python-dotenv>=1.0
 sqlalchemy[asyncio]>=2
 asyncpg>=0.30.0
 alembic>=1.13
-passlib[bcrypt]>=1.7
+passlib[bcrypt]==1.7.4
 bcrypt==4.0.1
 python-jose[cryptography]>=3.3
 email-validator>=2.0


### PR DESCRIPTION
## Summary
- add a Vitest setup file with required polyfills and mocks so frontend unit tests can run under jsdom
- configure Vitest to load the shared setup and alias the src directory for stable test imports
- pin passlib and bcrypt to compatible versions to avoid runtime import issues

## Testing
- python -m pip install -r requirements.txt
- pytest
- npm ci
- npm test *(fails: Playwright E2E specs are picked up by Vitest and error out)*
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dfa56b5f648327b13fbc63b35b0564