### PR TITLE
Harden security headers and tighten CORS defaults

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,3 +15,14 @@ To report a vulnerability, use the **Security** tab on GitHub and open a new **P
 - Legacy bcrypt hashes are accepted for login and rehashed to Argon2id on success; bcrypt's 72-byte input limit is enforced during legacy hashing to prevent silent truncation issues.
 - Password length requirements: **8–200 characters**. Unicode is fully supported and input is stored verbatim (no trimming or normalization).
 - Password changes and account provisioning use the same policy and algorithm, and the behaviour is covered by automated tests.
+
+## HTTP Security Headers & Browser Hardening
+
+Our FastAPI middleware enables a strict set of transport and browser security headers in production:
+
+- `Strict-Transport-Security: max-age=31536000; includeSubDomains; preload` – enables one year of HSTS for all subdomains and opts into the Chromium preload list so browsers remember to use HTTPS.
+- `Content-Security-Policy` denies inline script execution by default and issues a per-response nonce for any inline scripts that must run (`script-src 'self' 'nonce-…'`). The policy further blocks framing (`frame-ancestors 'none'`), upgrades legacy HTTP links (`upgrade-insecure-requests`), and limits images to our origin plus `data:` URLs to support avatar uploads and QR codes without relaxing the whole policy.
+- `Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: require-corp` isolate browsing contexts to mitigate cross-origin data leaks (Spectre, XS-Leaks). If future features require cross-origin embeddings (e.g., Spotify or Telegram previews), they must be proxied or explicitly opted in via dedicated endpoints; the default policy forbids direct third-party frames.
+- Existing headers remain in place: `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy: no-referrer`, and `Permissions-Policy: geolocation=(), microphone=(), camera=()`.
+
+Cross-Origin Resource Sharing (CORS) is also tightened: wildcard origins are rejected, non-local HTTP origins are ignored in strict mode, and cookies/credentials are only permitted for HTTPS origins or localhost during development/testing. Configure additional trusted origins via `FRONTEND_ORIGINS` if external dashboards need access.

--- a/root/app/core/config.py
+++ b/root/app/core/config.py
@@ -256,9 +256,7 @@ class Settings(BaseSettings):
     @cached_property
     def strict_security_csp(self) -> str:
         directives = [
-            part.strip()
-            for part in self.security_csp.split(";")
-            if part.strip()
+            part.strip() for part in self.security_csp.split(";") if part.strip()
         ]
         policy = "; ".join(directives)
         if not policy:

--- a/root/app/core/config.py
+++ b/root/app/core/config.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from functools import cached_property
 from pathlib import Path
 from typing import Iterable
+from urllib.parse import urlparse
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -81,22 +82,23 @@ class Settings(BaseSettings):
     rate_limit_headers_enabled: bool = True
     security_csp: str = (
         "default-src 'self'; "
-        "base-uri 'none'; "
+        "base-uri 'self'; "
         "frame-ancestors 'none'; "
         "form-action 'self'; "
-        "script-src 'self'; "
+        "script-src 'self' 'nonce-{nonce}'; "
         "style-src 'self'; "
         "img-src 'self' data:; "
         "connect-src 'self'; "
         "font-src 'self'; "
-        "object-src 'none'"
+        "object-src 'none'; "
+        "upgrade-insecure-requests"
     )
-    security_csp_report_only: bool = True
+    security_csp_report_only: bool = False
     security_csp_report_uri: str = ""
     security_hsts_enabled: bool = True
     security_hsts_max_age: int = 31536000
     security_hsts_include_subdomains: bool = True
-    security_hsts_preload: bool = False
+    security_hsts_preload: bool = True
     security_x_frame_options: str = "DENY"
     security_permissions_policy: str = "geolocation=(), microphone=(), camera=()"
     security_referrer_policy: str = "no-referrer"
@@ -136,7 +138,8 @@ class Settings(BaseSettings):
         _extend(self.frontend_origins)
         _extend(self.frontend_origin)
         _extend(self.app_base_url)
-        raw.extend(["http://localhost:5173", "http://127.0.0.1:5173"])
+        if self.is_development:
+            raw.extend(["http://localhost:5173", "http://127.0.0.1:5173"])
         seen: set[str] = set()
         result: list[str] = []
         for origin in raw:
@@ -146,6 +149,46 @@ class Settings(BaseSettings):
                 seen.add(key)
                 result.append(normalized)
         return result
+
+    @cached_property
+    def cors_allow_origins_list(self) -> list[str]:
+        allowed: list[str] = []
+        seen: set[str] = set()
+        for origin in self.frontend_origins_list:
+            candidate = origin.strip()
+            if not candidate or candidate == "*":
+                continue
+            parsed = urlparse(candidate)
+            scheme = parsed.scheme.lower()
+            hostname = (parsed.hostname or "").lower()
+            if self.strict_security_headers_enabled and hostname not in {
+                "localhost",
+                "127.0.0.1",
+            }:
+                if scheme != "https":
+                    continue
+            key = candidate.lower()
+            if key not in seen:
+                seen.add(key)
+                allowed.append(candidate)
+        return allowed
+
+    @cached_property
+    def cors_allow_credentials_effective(self) -> bool:
+        if not self.cors_allow_credentials:
+            return False
+        if not self.cors_allow_origins_list:
+            return False
+        if self.strict_security_headers_enabled:
+            for origin in self.cors_allow_origins_list:
+                parsed = urlparse(origin)
+                scheme = parsed.scheme.lower()
+                hostname = (parsed.hostname or "").lower()
+                if hostname in {"localhost", "127.0.0.1"}:
+                    continue
+                if scheme != "https":
+                    return False
+        return True
 
     @cached_property
     def trusted_hosts_list(self) -> list[str]:
@@ -212,16 +255,21 @@ class Settings(BaseSettings):
 
     @cached_property
     def strict_security_csp(self) -> str:
-        policy = self.security_csp.strip()
+        directives = [
+            part.strip()
+            for part in self.security_csp.split(";")
+            if part.strip()
+        ]
+        policy = "; ".join(directives)
         if not policy:
             policy = "default-src 'self'"
-        normalized = policy.rstrip("; ")
-        if "default-src" not in normalized.lower():
-            normalized = f"default-src 'self'; {normalized}".rstrip("; ")
+        if "default-src" not in policy.lower():
+            policy = f"default-src 'self'; {policy}"
+        policy = policy.rstrip("; ")
         report_uri = self.security_csp_report_uri.strip()
         if report_uri:
-            normalized = f"{normalized}; report-uri {report_uri}".rstrip("; ")
-        return normalized
+            policy = f"{policy}; report-uri {report_uri}".rstrip("; ")
+        return policy
 
 
 settings = Settings()

--- a/root/app/core/security_headers.py
+++ b/root/app/core/security_headers.py
@@ -58,7 +58,9 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
             else:
                 policy = policy.replace("'nonce-{nonce}'", "").replace("  ", " ")
         if policy:
-            segments = [segment.strip() for segment in policy.split(";") if segment.strip()]
+            segments = [
+                segment.strip() for segment in policy.split(";") if segment.strip()
+            ]
             policy = "; ".join(segments)
         headers["Content-Security-Policy"] = policy
         try:

--- a/root/app/core/security_headers.py
+++ b/root/app/core/security_headers.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import secrets
+
 from fastapi import Request
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.responses import Response
@@ -16,15 +18,20 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
     async def dispatch(
         self, request: Request, call_next: RequestResponseEndpoint
     ) -> Response:  # type: ignore[override]
+        nonce: str | None = None
+        if self._settings.strict_security_headers_enabled:
+            nonce = secrets.token_urlsafe(16)
+            request.state.csp_nonce = nonce
         response = await call_next(request)
         if not self._settings.strict_security_headers_enabled:
             return response
         self._apply_hsts(response)
-        self._apply_csp(response)
+        self._apply_csp(response, nonce=nonce)
         self._apply_frame_options(response)
         self._apply_permissions_policy(response)
         self._apply_content_type_options(response)
         self._apply_referrer_policy(response)
+        self._apply_cross_origin_policies(response)
         return response
 
     def _apply_hsts(self, response: Response) -> None:
@@ -42,19 +49,27 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
             value += "; preload"
         headers["Strict-Transport-Security"] = value
 
-    def _apply_csp(self, response: Response) -> None:
+    def _apply_csp(self, response: Response, *, nonce: str | None) -> None:
         headers = response.headers
-        base = "default-src 'self'"
-        extra = (self._settings.strict_security_csp or "").strip()
-        if extra:
-            policy = extra if "default-src" in extra else f"{base}; {extra}"
-        else:
-            policy = base
+        policy = (self._settings.strict_security_csp or "").strip()
+        if "{nonce}" in policy:
+            if nonce:
+                policy = policy.replace("{nonce}", nonce)
+            else:
+                policy = policy.replace("'nonce-{nonce}'", "").replace("  ", " ")
+        if policy:
+            segments = [segment.strip() for segment in policy.split(";") if segment.strip()]
+            policy = "; ".join(segments)
         headers["Content-Security-Policy"] = policy
         try:
             del headers["Content-Security-Policy-Report-Only"]
         except KeyError:
             pass
+
+    def _apply_cross_origin_policies(self, response: Response) -> None:
+        headers = response.headers
+        headers["Cross-Origin-Opener-Policy"] = "same-origin"
+        headers["Cross-Origin-Embedder-Policy"] = "require-corp"
 
     def _apply_frame_options(self, response: Response) -> None:
         headers = response.headers

--- a/root/app/cors_setup.py
+++ b/root/app/cors_setup.py
@@ -6,8 +6,8 @@ from app.core.config import settings
 def setup_cors(app):
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=settings.frontend_origins_list,
-        allow_credentials=settings.cors_allow_credentials,
+        allow_origins=settings.cors_allow_origins_list,
+        allow_credentials=settings.cors_allow_credentials_effective,
         allow_methods=settings.cors_allow_methods_list,
         allow_headers=settings.cors_allow_headers_list,
         expose_headers=settings.cors_expose_headers_list,

--- a/root/app/main.py
+++ b/root/app/main.py
@@ -49,8 +49,8 @@ configure_observability(app, engine=engine)
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=settings.frontend_origins_list,
-    allow_credentials=settings.cors_allow_credentials,
+    allow_origins=settings.cors_allow_origins_list,
+    allow_credentials=settings.cors_allow_credentials_effective,
     allow_methods=settings.cors_allow_methods_list,
     allow_headers=settings.cors_allow_headers_list,
     expose_headers=settings.cors_expose_headers_list,

--- a/root/tests/test_security_headers.py
+++ b/root/tests/test_security_headers.py
@@ -37,12 +37,71 @@ async def test_strict_security_headers_enabled(monkeypatch):
             response = await client.get("/")
 
     headers = response.headers
-    assert headers.get("Strict-Transport-Security")
+    hsts = headers.get("Strict-Transport-Security", "")
+    assert "max-age=" in hsts
+    assert "includeSubDomains" in hsts
+    assert "preload" in hsts
     assert headers.get("X-Content-Type-Options") == "nosniff"
     assert headers.get("X-Frame-Options") == "DENY"
     assert headers.get("Referrer-Policy") == "no-referrer"
     assert (
         headers.get("Permissions-Policy") == "geolocation=(), microphone=(), camera=()"
     )
+    assert headers.get("Cross-Origin-Opener-Policy") == "same-origin"
+    assert headers.get("Cross-Origin-Embedder-Policy") == "require-corp"
     csp = headers.get("Content-Security-Policy", "")
     assert "default-src 'self'" in csp
+    assert "frame-ancestors 'none'" in csp
+    assert "upgrade-insecure-requests" in csp
+    assert "img-src 'self' data:" in csp
+    assert "script-src 'self' 'nonce-" in csp
+    assert "'unsafe-inline'" not in csp
+    assert "Content-Security-Policy-Report-Only" not in headers
+
+
+def _reset_security_env(monkeypatch):
+    for key in (
+        "FRONTEND_ORIGINS",
+        "CORS_ALLOW_CREDENTIALS",
+        "ENABLE_STRICT_SECURITY_HEADERS",
+        "ENVIRONMENT",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("FRONTEND_ORIGIN", "")
+    monkeypatch.setenv("APP_BASE_URL", "")
+
+
+def test_cors_hardening_filters_insecure_origins(monkeypatch):
+    _reset_security_env(monkeypatch)
+    monkeypatch.setenv("ENABLE_STRICT_SECURITY_HEADERS", "true")
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv(
+        "FRONTEND_ORIGINS",
+        "https://app.example.com, http://example.com, *",
+    )
+    monkeypatch.setenv("CORS_ALLOW_CREDENTIALS", "true")
+    settings = Settings()
+    assert settings.cors_allow_origins_list == ["https://app.example.com"]
+    assert settings.cors_allow_credentials_effective is True
+
+
+def test_cors_credentials_disabled_for_insecure_hosts(monkeypatch):
+    _reset_security_env(monkeypatch)
+    monkeypatch.setenv("ENABLE_STRICT_SECURITY_HEADERS", "true")
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("FRONTEND_ORIGINS", "http://example.com")
+    monkeypatch.setenv("CORS_ALLOW_CREDENTIALS", "true")
+    settings = Settings()
+    assert settings.cors_allow_origins_list == []
+    assert settings.cors_allow_credentials_effective is False
+
+
+def test_cors_allows_localhost_when_strict(monkeypatch):
+    _reset_security_env(monkeypatch)
+    monkeypatch.setenv("ENABLE_STRICT_SECURITY_HEADERS", "true")
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("FRONTEND_ORIGINS", "http://localhost:5173")
+    monkeypatch.setenv("CORS_ALLOW_CREDENTIALS", "true")
+    settings = Settings()
+    assert settings.cors_allow_origins_list == ["http://localhost:5173"]
+    assert settings.cors_allow_credentials_effective is True


### PR DESCRIPTION
## Summary
- enforce stricter HTTP response headers including nonce-based CSP, HSTS preload, and COOP/COEP
- harden the CORS configuration by filtering origins/credentials and using the sanitized settings everywhere
- document the policy updates in SECURITY.md and add regression coverage for headers and CORS handling

## Testing
- pytest root/tests/test_security_headers.py

------
https://chatgpt.com/codex/tasks/task_e_68dfdc86aeac83279e9898963a2fbf91