### PR TITLE
Add install prompt and offline profile caching

### DIFF
--- a/root/frontend/index.html
+++ b/root/frontend/index.html
@@ -45,6 +45,11 @@
     <meta name="twitter:image" content="/og-image.png" />
     <title>Экосистема ГУУ</title>
     <link rel="icon" type="image/png" href="/guu_logo.png" />
+    <link rel="apple-touch-icon" sizes="192x192" href="/maskable-icon-192.png" />
+    <link rel="apple-touch-icon" sizes="512x512" href="/maskable-icon-512.png" />
+    <link rel="manifest" href="/manifest.webmanifest" crossorigin="use-credentials" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Oxygen:wght@300;400;700&family=Varela&family=Manrope:wght@400;500;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />

--- a/root/frontend/public/manifest.webmanifest
+++ b/root/frontend/public/manifest.webmanifest
@@ -1,4 +1,5 @@
 {
+  "id": "/?source=pwa",
   "name": "Экосистема ГУУ — цифровой кампус",
   "short_name": "Экосистема ГУУ",
   "description": "Расписание пар, новости университета и интерактивная карта кампуса — всё доступно даже офлайн.",
@@ -6,11 +7,14 @@
   "dir": "ltr",
   "display": "standalone",
   "display_override": ["standalone", "browser"],
-  "start_url": "/",
+  "start_url": "/?source=pwa",
   "scope": "/",
   "orientation": "portrait-primary",
   "theme_color": "#0b63f4",
   "background_color": "#f4f8fd",
+  "launch_handler": {
+    "client_mode": "navigate-existing"
+  },
   "categories": ["education", "productivity"],
   "shortcuts": [
     {

--- a/root/frontend/src/App.tsx
+++ b/root/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import { registerServiceWorker } from "./push/register-sw"
 import MobileBottomNav from "./components/MobileBottomNav"
 import BackToTop from "./components/BackToTop"
 import ErrorBoundary from "./app/ErrorBoundary"
+import InstallPrompt from "./components/InstallPrompt"
 
 const PageTransition = lazy(() => import("./components/PageTransition"))
 const Dashboard = lazy(() => import("./pages/Dashboard"))
@@ -128,6 +129,7 @@ function AppContent() {
       {!hideNavbar && <BackToTop />}
       {!hideNavbar && <Footer />}
       {!hideNavbar && <MobileBottomNav />}
+      {!hideNavbar && <InstallPrompt />}
     </>
   )
 }

--- a/root/frontend/src/components/InstallPrompt.tsx
+++ b/root/frontend/src/components/InstallPrompt.tsx
@@ -1,0 +1,183 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import CloseIcon from "@mui/icons-material/Close"
+import { Button, IconButton, Paper, Slide, Stack, Typography } from "@mui/material"
+
+interface BeforeInstallPromptEvent extends Event {
+  readonly platforms?: string[]
+  readonly userChoice: Promise<{ outcome: "accepted" | "dismissed" }>
+  prompt: () => Promise<void>
+}
+
+type NavigatorStandalone = Navigator & { standalone?: boolean }
+
+const DISMISS_TTL = 1000 * 60 * 60 * 24 * 7
+const DISMISS_STORAGE_KEY = "ecosystem.pwa.install.dismissedAt"
+
+const isStandalone = () => {
+  if (typeof window === "undefined") return false
+  const navigatorWithStandalone = window.navigator as NavigatorStandalone
+  return (
+    window.matchMedia("(display-mode: standalone)").matches ||
+    window.matchMedia("(display-mode: minimal-ui)").matches ||
+    navigatorWithStandalone.standalone === true
+  )
+}
+
+const readDismissedAt = () => {
+  try {
+    const raw = localStorage.getItem(DISMISS_STORAGE_KEY)
+    if (!raw) return 0
+    const parsed = Number(raw)
+    return Number.isFinite(parsed) ? parsed : 0
+  } catch {
+    return 0
+  }
+}
+
+const rememberDismiss = () => {
+  try {
+    localStorage.setItem(DISMISS_STORAGE_KEY, String(Date.now()))
+  } catch {
+    /* ignore */
+  }
+}
+
+const clearDismissed = () => {
+  try {
+    localStorage.removeItem(DISMISS_STORAGE_KEY)
+  } catch {
+    /* ignore */
+  }
+}
+
+export default function InstallPrompt() {
+  const [deferredPrompt, setDeferredPrompt] = useState<BeforeInstallPromptEvent | null>(null)
+  const [visible, setVisible] = useState(false)
+  const [installing, setInstalling] = useState(false)
+  const suppressUntilRef = useRef<number>(0)
+
+  const isEligible = useMemo(() => !isStandalone(), [])
+
+  useEffect(() => {
+    if (!isEligible) return
+
+    suppressUntilRef.current = readDismissedAt() + DISMISS_TTL
+
+    const handleBeforeInstallPrompt = (event: Event) => {
+      const now = Date.now()
+      if (suppressUntilRef.current && now < suppressUntilRef.current) {
+        return
+      }
+
+      event.preventDefault()
+      setDeferredPrompt(event as BeforeInstallPromptEvent)
+      setVisible(true)
+    }
+
+    window.addEventListener("beforeinstallprompt", handleBeforeInstallPrompt)
+
+    return () => {
+      window.removeEventListener("beforeinstallprompt", handleBeforeInstallPrompt)
+    }
+  }, [isEligible])
+
+  useEffect(() => {
+    if (!isEligible) return
+
+    const onAppInstalled = () => {
+      clearDismissed()
+      setVisible(false)
+      setDeferredPrompt(null)
+    }
+
+    window.addEventListener("appinstalled", onAppInstalled)
+    return () => window.removeEventListener("appinstalled", onAppInstalled)
+  }, [isEligible])
+
+  const handleInstall = useCallback(async () => {
+    if (!deferredPrompt) return
+    setInstalling(true)
+    try {
+      await deferredPrompt.prompt()
+      const choice = await deferredPrompt.userChoice
+      if (choice.outcome === "accepted") {
+        clearDismissed()
+        setVisible(false)
+        setDeferredPrompt(null)
+      } else {
+        suppressUntilRef.current = Date.now() + DISMISS_TTL
+        rememberDismiss()
+        setVisible(false)
+        setDeferredPrompt(null)
+      }
+    } catch {
+      suppressUntilRef.current = Date.now() + DISMISS_TTL
+      rememberDismiss()
+      setVisible(false)
+      setDeferredPrompt(null)
+    } finally {
+      setInstalling(false)
+    }
+  }, [deferredPrompt])
+
+  const handleClose = useCallback(() => {
+    suppressUntilRef.current = Date.now() + DISMISS_TTL
+    rememberDismiss()
+    setVisible(false)
+    setDeferredPrompt(null)
+  }, [])
+
+  if (!isEligible) return null
+
+  return (
+    <Slide direction="up" in={visible && Boolean(deferredPrompt)} mountOnEnter unmountOnExit>
+      <Paper
+        elevation={8}
+        role="dialog"
+        aria-live="polite"
+        sx={{
+          position: "fixed",
+          bottom: { xs: 16, sm: 24 },
+          right: { xs: 12, sm: 24 },
+          left: { xs: 12, sm: "auto" },
+          zIndex: (theme) => theme.zIndex.snackbar,
+          maxWidth: 360,
+          borderRadius: 3,
+          p: 2.5,
+          boxShadow: (theme) =>
+            theme.palette.mode === "dark"
+              ? "0px 18px 45px rgba(11, 15, 22, 0.6)"
+              : "0px 18px 45px rgba(11, 99, 244, 0.16)",
+        }}
+      >
+        <Stack spacing={2} alignItems="flex-start">
+          <Stack direction="row" spacing={1.5} alignItems="flex-start" sx={{ width: "100%" }}>
+            <Typography component="h2" variant="h6" sx={{ flex: 1, fontWeight: 700 }}>
+              Установить «Экосистема ГУУ»
+            </Typography>
+            <IconButton aria-label="Скрыть предложение" onClick={handleClose} size="small">
+              <CloseIcon fontSize="small" />
+            </IconButton>
+          </Stack>
+          <Typography variant="body2" sx={{ opacity: 0.85 }}>
+            Добавьте приложение на главный экран, чтобы открывать профиль, расписание и новости без браузера.
+          </Typography>
+          <Stack direction="row" spacing={1.5} sx={{ width: "100%" }}>
+            <Button
+              variant="contained"
+              color="primary"
+              onClick={handleInstall}
+              disabled={!deferredPrompt || installing}
+              sx={{ flexGrow: 1 }}
+            >
+              Установить
+            </Button>
+            <Button variant="text" color="inherit" onClick={handleClose}>
+              Позже
+            </Button>
+          </Stack>
+        </Stack>
+      </Paper>
+    </Slide>
+  )
+}

--- a/root/frontend/src/contexts/AuthContext.tsx
+++ b/root/frontend/src/contexts/AuthContext.tsx
@@ -1,4 +1,5 @@
-import { createContext, useContext, useEffect, useMemo, useState, ReactNode } from "react"
+import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from "react"
+import type { AxiosError } from "axios"
 import api from "../api/axios"
 
 type AuthContextType = {
@@ -21,17 +22,69 @@ export const AuthContext = createContext<AuthContextType>({
 
 export const useAuth = () => useContext(AuthContext)
 
+const PROFILE_CACHE_KEY = "ecosystem.profile.cache.v1"
+
+const readCachedUser = () => {
+  try {
+    const raw = localStorage.getItem(PROFILE_CACHE_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw)
+    if (parsed && typeof parsed === "object" && "data" in parsed) {
+      return (parsed as { data: unknown }).data
+    }
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+const persistUserToCache = (value: any) => {
+  try {
+    if (value) {
+      localStorage.setItem(
+        PROFILE_CACHE_KEY,
+        JSON.stringify({ data: value, savedAt: new Date().toISOString() })
+      )
+    } else {
+      localStorage.removeItem(PROFILE_CACHE_KEY)
+    }
+  } catch {
+    /* ignore */
+  }
+}
+
 export const AuthProvider = ({ children }: { children: ReactNode }) => {
-  const [user, setUser] = useState<any>(null)
+  const [user, setUserState] = useState<any>(() => readCachedUser())
   const [loading, setLoading] = useState(true)
-  const [isAuth, setIsAuth] = useState<boolean>(!!localStorage.getItem("token"))
+  const [isAuth, setIsAuth] = useState<boolean>(() => {
+    try {
+      return !!localStorage.getItem("token")
+    } catch {
+      return false
+    }
+  })
+
+  const setUser = useCallback(
+    (value: any) => {
+      setUserState((prev) => {
+        const next = typeof value === "function" ? value(prev) : value
+        persistUserToCache(next)
+        return next
+      })
+    },
+    []
+  )
 
   const applyToken = (token?: string | null) => {
     if (token) {
-      localStorage.setItem("token", token)
+      try {
+        localStorage.setItem("token", token)
+      } catch {}
       api.defaults.headers.common["Authorization"] = `Bearer ${token}`
     } else {
-      localStorage.removeItem("token")
+      try {
+        localStorage.removeItem("token")
+      } catch {}
       delete api.defaults.headers.common["Authorization"]
     }
   }
@@ -42,15 +95,38 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       setUser(res.data)
       setIsAuth(true)
       return res.data
-    } catch {
-      setUser(null)
+    } catch (error) {
+      const status = (error as AxiosError | undefined)?.response?.status
+      if (status === 401) {
+        setUser(null)
+        setIsAuth(false)
+        return null
+      }
+
+      const cached = readCachedUser()
+      if (cached) {
+        setUser(cached)
+        let tokenExists = true
+        try {
+          tokenExists = !!localStorage.getItem("token")
+        } catch {
+          tokenExists = true
+        }
+        setIsAuth(tokenExists)
+        return cached
+      }
+
       setIsAuth(false)
+      setUser(null)
       return null
     }
   }
 
   useEffect(() => {
-    const token = localStorage.getItem("token")
+    let token: string | null = null
+    try {
+      token = localStorage.getItem("token")
+    } catch {}
     if (token) api.defaults.headers.common["Authorization"] = `Bearer ${token}`
     fetchMe().finally(() => setLoading(false))
   }, [])
@@ -86,7 +162,10 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     setIsAuth(false)
   }
 
-  const value = useMemo(() => ({ isAuth, login, logout, user, loading, setUser }), [isAuth, user, loading])
+  const value = useMemo(
+    () => ({ isAuth, login, logout, user, loading, setUser }),
+    [isAuth, login, logout, user, loading, setUser]
+  )
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
 }

--- a/root/frontend/src/contexts/AuthContext.tsx
+++ b/root/frontend/src/contexts/AuthContext.tsx
@@ -2,13 +2,15 @@ import { createContext, useCallback, useContext, useEffect, useMemo, useState, t
 import type { AxiosError } from "axios"
 import api from "../api/axios"
 
+type SetUserArg = any | ((prev: any) => any)
+
 type AuthContextType = {
   isAuth: boolean
   login: (token: string) => Promise<void>
   logout: () => void
   user: any
   loading: boolean
-  setUser: (user: any) => void
+  setUser: (user: SetUserArg) => void
 }
 
 export const AuthContext = createContext<AuthContextType>({
@@ -65,9 +67,10 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   })
 
   const setUser = useCallback(
-    (value: any) => {
-      setUserState((prev) => {
-        const next = typeof value === "function" ? value(prev) : value
+    (value: any | ((prev: any) => any)) => {
+      setUserState((prev: any) => {
+        const next =
+          typeof value === "function" ? (value as (prev: any) => any)(prev) : value
         persistUserToCache(next)
         return next
       })

--- a/root/frontend/tests/e2e/offline.spec.ts
+++ b/root/frontend/tests/e2e/offline.spec.ts
@@ -35,4 +35,36 @@ test.describe("PWA offline support", () => {
       await context.setOffline(false);
     }
   });
+
+  test("profile data stays available offline after it was cached", async ({ page, context }) => {
+    const mock = await useMockApi(page);
+    await mock.login(page);
+
+    await page.waitForLoadState("networkidle");
+    await page.evaluate(async () => {
+      await navigator.serviceWorker?.ready;
+    });
+
+    let controlled = await page.evaluate(() => Boolean(navigator.serviceWorker?.controller));
+    if (!controlled) {
+      await page.reload({ waitUntil: "networkidle" });
+      await page.evaluate(async () => {
+        await navigator.serviceWorker?.ready;
+      });
+      controlled = await page.evaluate(() => Boolean(navigator.serviceWorker?.controller));
+    }
+
+    await page.goto("/profile", { waitUntil: "networkidle" });
+    await expect(page).toHaveURL(/\/profile/);
+    await expect(page.getByText("Иван Иванов")).toBeVisible();
+
+    await context.setOffline(true);
+    try {
+      await page.reload({ waitUntil: "domcontentloaded" });
+      await expect(page).toHaveURL(/\/profile/);
+      await expect(page.getByText("Иван Иванов")).toBeVisible();
+    } finally {
+      await context.setOffline(false);
+    }
+  });
 });

--- a/root/frontend/vite.config.ts
+++ b/root/frontend/vite.config.ts
@@ -88,6 +88,8 @@ export default defineConfig(({ mode }) => {
         navigateFallbackAllowlist: [/^\/[^_].*/],
         navigationPreload: true,
         cleanupOutdatedCaches: true,
+        skipWaiting: true,
+        clientsClaim: true,
         runtimeCaching: [
           {
             urlPattern: ({ sameOrigin, url }) =>
@@ -136,6 +138,19 @@ export default defineConfig(({ mode }) => {
                 maxAgeSeconds: 60 * 60 * 24 * 30,
               },
               cacheableResponse: { statuses: [0, 200] },
+            },
+          },
+          {
+            urlPattern: ({ sameOrigin, url }) => sameOrigin && url.pathname === "/api/users/me",
+            handler: "NetworkFirst",
+            options: {
+              cacheName: "profile-data",
+              networkTimeoutSeconds: 3,
+              cacheableResponse: { statuses: [0, 200] },
+              expiration: {
+                maxEntries: 1,
+                maxAgeSeconds: 60 * 60 * 24 * 30,
+              },
             },
           },
           {


### PR DESCRIPTION
## Summary
- link the web manifest and add mobile icons so the PWA metadata is available to browsers
- tune the PWA service worker to precache core assets, cache profile data, and surface an install prompt
- cache authenticated user data locally and add an e2e check ensuring the profile page stays available offline

## Testing
- `npm run lint:all` *(fails: existing lint violations throughout the project)*

------
https://chatgpt.com/codex/tasks/task_e_68e0602c1b748327b0ea3b10b7288f89