### PR TITLE
Lazy load React Query devtools in development

### DIFF
--- a/root/frontend/src/app/queryClient.ts
+++ b/root/frontend/src/app/queryClient.ts
@@ -1,5 +1,18 @@
 import { QueryClient } from "@tanstack/react-query"
 import { isAxiosError } from "axios"
+import { lazy } from "react"
+
+// TanStack Query Devtools are recommended only for development usage:
+// https://tanstack.com/query/latest/docs/framework/react/devtools#only-in-dev
+export const lazyDevtools = () => {
+  if (!import.meta.env.DEV) return null
+
+  return lazy(() =>
+    import("@tanstack/react-query-devtools").then((module) => ({
+      default: module.ReactQueryDevtools,
+    })),
+  )
+}
 
 const retryDelay = (attemptIndex: number) => Math.min(1000 * 2 ** attemptIndex, 30_000)
 

--- a/root/frontend/src/main.tsx
+++ b/root/frontend/src/main.tsx
@@ -1,13 +1,12 @@
-import React, { useEffect } from "react"
+import React, { Suspense, useEffect } from "react"
 import ReactDOM from "react-dom/client"
 import { CssBaseline } from "@mui/material"
 import { CssVarsProvider, useColorScheme } from "@mui/material/styles"
 import { registerSW } from "virtual:pwa-register"
 import { QueryClientProvider } from "@tanstack/react-query"
-import { ReactQueryDevtools } from "@tanstack/react-query-devtools"
 import App from "./App"
 import ErrorBoundary from "./app/ErrorBoundary"
-import { queryClient } from "./app/queryClient"
+import { lazyDevtools, queryClient } from "./app/queryClient"
 import theme from "./theme"
 import "./assets/themes.css"
 import "dayjs/locale/ru"
@@ -41,6 +40,8 @@ function BodyColorSchemeSync() {
   return null
 }
 
+const ReactQueryDevtools = lazyDevtools()
+
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
@@ -56,7 +57,11 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
           <App />
         </ErrorBoundary>
       </CssVarsProvider>
-      {import.meta.env.DEV ? <ReactQueryDevtools buttonPosition="bottom-left" /> : null}
+      {ReactQueryDevtools ? (
+        <Suspense fallback={null}>
+          <ReactQueryDevtools buttonPosition="bottom-left" />
+        </Suspense>
+      ) : null}
     </QueryClientProvider>
   </React.StrictMode>
 )


### PR DESCRIPTION
## Summary
- dynamically import the TanStack Query devtools only when running in development
- add a helper alongside the query client to keep the devtools bundle out of production builds per TanStack guidance

## Testing
- npm run build
- npx source-map-explorer dist/assets/*.js
- npm run dev -- --host 0.0.0.0 --port 5173

------
https://chatgpt.com/codex/tasks/task_e_68e13b760c5c83279a02f336020c316e