### PR TITLE
Enable typed router future flag configuration

### DIFF
--- a/root/frontend/src/App.tsx
+++ b/root/frontend/src/App.tsx
@@ -1,11 +1,5 @@
 import { Suspense, lazy, useEffect, type ReactElement } from "react"
-import {
-  BrowserRouter as Router,
-  Routes,
-  Route,
-  Navigate,
-  useLocation,
-} from "react-router-dom"
+import { BrowserRouter as Router, Routes, Route, Navigate, useLocation } from "react-router-dom"
 import type { FutureConfig as RouterFutureConfig } from "@remix-run/router"
 import Navbar from "./components/Navbar"
 import Footer from "./components/Footer"

--- a/root/frontend/src/App.tsx
+++ b/root/frontend/src/App.tsx
@@ -1,5 +1,12 @@
 import { Suspense, lazy, useEffect, type ReactElement } from "react"
-import { BrowserRouter as Router, Routes, Route, Navigate, useLocation } from "react-router-dom"
+import {
+  BrowserRouter as Router,
+  Routes,
+  Route,
+  Navigate,
+  useLocation,
+} from "react-router-dom"
+import type { FutureConfig as RouterFutureConfig } from "@remix-run/router"
 import Navbar from "./components/Navbar"
 import Footer from "./components/Footer"
 import { AuthProvider, currentUserQueryKey, useAuth } from "./contexts/AuthContext"
@@ -140,7 +147,7 @@ export const routerFutureFlags = {
   v7_fetcherPersist: true,
   v7_normalizeFormMethod: true,
   v7_skipActionErrorRevalidation: true,
-} as const
+} satisfies Partial<RouterFutureConfig>
 
 export default function App() {
   return (

--- a/root/frontend/src/App.tsx
+++ b/root/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { Suspense, lazy, useEffect, type ReactElement } from "react"
 import { BrowserRouter as Router, Routes, Route, Navigate, useLocation } from "react-router-dom"
-import type { FutureConfig as RouterFutureConfig } from "@remix-run/router"
+import type { FutureConfig as RouterDataFutureConfig } from "@remix-run/router"
+import type { FutureConfig as RouterComponentFutureConfig } from "react-router"
 import Navbar from "./components/Navbar"
 import Footer from "./components/Footer"
 import { AuthProvider, currentUserQueryKey, useAuth } from "./contexts/AuthContext"
@@ -134,6 +135,8 @@ function AppContent() {
   )
 }
 
+type RouterFutureFlags = Partial<RouterDataFutureConfig> & Partial<RouterComponentFutureConfig>
+
 export const routerFutureFlags = {
   v7_startTransition: true,
   v7_relativeSplatPath: true,
@@ -141,7 +144,7 @@ export const routerFutureFlags = {
   v7_fetcherPersist: true,
   v7_normalizeFormMethod: true,
   v7_skipActionErrorRevalidation: true,
-} satisfies Partial<RouterFutureConfig>
+} satisfies RouterFutureFlags
 
 export default function App() {
   return (


### PR DESCRIPTION
## Summary
- type the shared router future flags against the React Router FutureConfig to prepare for v7
- keep the v7 opt-in flags centralized for BrowserRouter and MemoryRouter usage

## Testing
- npm --prefix root/frontend test -- src/pages/__tests__/ForgotPassword.test.tsx src/pages/__tests__/Login.test.tsx src/pages/__tests__/Register.test.tsx src/pages/__tests__/ResetPassword.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e14ed95da88327a7980b27a441becd