### PR TITLE
Split route bundles and tighten budgets

### DIFF
--- a/.lighthouserc.js
+++ b/.lighthouserc.js
@@ -20,7 +20,7 @@ module.exports = {
         ? {}
         : {
             startServerCommand:
-              `npm run preview -- --host 0.0.0.0 --port ${LOCAL_PREVIEW_PORT} --strictPort`,
+              `npm run build && npm run preview -- --host 0.0.0.0 --port ${LOCAL_PREVIEW_PORT} --strictPort`,
             startServerReadyPattern: 'Local:',
             startServerReadyTimeout: 120000,
           }),

--- a/.lighthouserc.js
+++ b/.lighthouserc.js
@@ -19,9 +19,9 @@ module.exports = {
       ...(useRemotePreview
         ? {}
         : {
-            startServerCommand:
-              `npm run build && npm run preview -- --host 0.0.0.0 --port ${LOCAL_PREVIEW_PORT} --strictPort`,
-            startServerReadyPattern: 'Local:',
+            beforeAllScript: 'npm run build',
+            startServerCommand: `npm run preview -- --host 127.0.0.1 --port ${LOCAL_PREVIEW_PORT} --strictPort`,
+            startServerReadyPattern: `127\\.0\\.0\\.1:${LOCAL_PREVIEW_PORT}`,
             startServerReadyTimeout: 120000,
           }),
     },

--- a/budget.json
+++ b/budget.json
@@ -2,7 +2,7 @@
   {
     "path": "/*",
     "resourceSizes": [
-      { "resourceType": "script", "budget": 350 },
+      { "resourceType": "script", "budget": 200 },
       { "resourceType": "stylesheet", "budget": 120 }
     ],
     "timings": [
@@ -10,5 +10,12 @@
       { "metric": "total-blocking-time", "budget": 300 },
       { "metric": "cumulative-layout-shift", "budget": 0.1 }
     ]
+  },
+  {
+    "path": "/map",
+    "resourceSizes": [
+      { "resourceType": "script", "budget": 250 }
+    ],
+    "timings": []
   }
 ]

--- a/root/frontend/.lighthouserc.js
+++ b/root/frontend/.lighthouserc.js
@@ -17,9 +17,10 @@ const collect = {
 }
 
 if (!useRemotePreview) {
+  collect.beforeAllScript = "npm run build"
   collect.startServerCommand =
-    `npm run build && npm run preview -- --host 0.0.0.0 --port ${LOCAL_PREVIEW_PORT} --strictPort`
-  collect.startServerReadyPattern = "Local:"
+    `npm run preview -- --host 127.0.0.1 --port ${LOCAL_PREVIEW_PORT} --strictPort`
+  collect.startServerReadyPattern = `127\\.0\\.0\\.1:${LOCAL_PREVIEW_PORT}`
   collect.startServerReadyTimeout = 120000
 }
 

--- a/root/frontend/.lighthouserc.js
+++ b/root/frontend/.lighthouserc.js
@@ -1,20 +1,26 @@
+const LOCAL_PREVIEW_PORT = 4174
 const base = process.env.PREVIEW_URL || process.env.LHCI_URL || ""
-const explicitUrls = base ? [base, `${base}/login`] : undefined
+const useRemotePreview = Boolean(base)
 
 const collect = {
   numberOfRuns: 3,
-  url: explicitUrls ?? ["/", "/login"],
-  staticDistDir: "dist",
-  isSinglePageApplication: true,
+  url: useRemotePreview
+    ? [base, `${base}/login`]
+    : [
+        `http://127.0.0.1:${LOCAL_PREVIEW_PORT}/`,
+        `http://127.0.0.1:${LOCAL_PREVIEW_PORT}/login`,
+      ],
   settings: {
     preset: "desktop",
     chromeFlags: "--no-sandbox --disable-dev-shm-usage",
   },
 }
 
-if (explicitUrls) {
-  delete collect.isSinglePageApplication
-  collect.staticDistDir = undefined
+if (!useRemotePreview) {
+  collect.startServerCommand =
+    `npm run build && npm run preview -- --host 0.0.0.0 --port ${LOCAL_PREVIEW_PORT} --strictPort`
+  collect.startServerReadyPattern = "Local:"
+  collect.startServerReadyTimeout = 120000
 }
 
 const config = {

--- a/root/frontend/src/pages/Dashboard.tsx
+++ b/root/frontend/src/pages/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, useCallback } from "react"
+import { useEffect, useMemo, useState, useCallback, type KeyboardEvent } from "react"
 import Layout from "../components/Layout"
 import { useAuth } from "../contexts/AuthContext"
 import axios from "../api/client"
@@ -282,12 +282,18 @@ export default function Dashboard() {
   const focusRing = "0 0 0 3px #2563eb33, 0 0 0 6px #2563eb1f"
   const btnSx = { borderRadius: 2, fontWeight: 700, px: 1.8, py: 0.5, whiteSpace: "nowrap", transition: "background .16s,color .16s,border-color .16s,box-shadow .16s, transform .16s", "&:hover": { background: "linear-gradient(100deg,#1976d2 20%,#449aff 100%)", color: "#fff", borderColor: "transparent", transform: "translateY(-1px)" }, "&:active": { transform: "translateY(0)" }, "&:focus-visible": { boxShadow: focusRing, outline: "none" } }
 
-  const prefetchNewsPage = () => import("../pages/News").catch(() => {})
-  const prefetchEventsPage = () => import("../pages/Events").catch(() => {})
-  const prefetchSchedulePage = () => import("../pages/Schedule").catch(() => {})
+  const warmNewsPage = () => import("../pages/News").catch(() => {})
+  const warmEventsPage = () => import("../pages/Events").catch(() => {})
+  const warmSchedulePage = () => import("../pages/Schedule").catch(() => {})
   const prefetchData = (type: "news" | "events") => {
     if (type === "news") axios.get("/news").then(r => setCache("prefetch:news", r.data)).catch(() => {})
     if (type === "events") axios.get("/events", { params: { is_active: true } }).then(r => setCache("prefetch:events", r.data)).catch(() => {})
+  }
+
+  const prepareOnKey = (event: KeyboardEvent, callback: () => void) => {
+    if (event.key === "Enter" || event.key === " " || event.key === "Spacebar") {
+      callback()
+    }
   }
 
   const newsLikeHover = {
@@ -404,8 +410,8 @@ export default function Dashboard() {
                   variant="outlined"
                   sx={{ ...btnSx, px: 3, py: 0.9 }}
                   aria-label="Перейти к полному расписанию"
-                  onMouseEnter={prefetchSchedulePage}
-                  onFocus={prefetchSchedulePage}
+                  onPointerDown={warmSchedulePage}
+                  onKeyDown={(event) => prepareOnKey(event, warmSchedulePage)}
                 >
                   Полное расписание
                 </Button>
@@ -484,8 +490,13 @@ export default function Dashboard() {
                 variant="outlined"
                 sx={btnSx}
                 aria-label="Смотреть все новости"
-                onMouseEnter={() => { prefetchNewsPage(); prefetchData("news") }}
-                onFocus={() => { prefetchNewsPage(); prefetchData("news") }}
+                onPointerDown={() => { warmNewsPage(); prefetchData("news") }}
+                onKeyDown={(event) => {
+                  prepareOnKey(event, () => {
+                    warmNewsPage()
+                    prefetchData("news")
+                  })
+                }}
               >
                 Смотреть все
               </Button>
@@ -550,8 +561,13 @@ export default function Dashboard() {
                 variant="outlined"
                 sx={btnSx}
                 aria-label="Смотреть все события"
-                onMouseEnter={() => { prefetchEventsPage(); prefetchData("events") }}
-                onFocus={() => { prefetchEventsPage(); prefetchData("events") }}
+                onPointerDown={() => { warmEventsPage(); prefetchData("events") }}
+                onKeyDown={(event) => {
+                  prepareOnKey(event, () => {
+                    warmEventsPage()
+                    prefetchData("events")
+                  })
+                }}
               >
                 Смотреть все
               </Button>

--- a/root/frontend/vite.config.mts
+++ b/root/frontend/vite.config.mts
@@ -140,6 +140,20 @@ export default defineConfig(({ mode }) => {
     )
   }
 
+  const toPosix = (value: string) => value.replace(/\\/g, "/")
+  const routeChunks = [
+    { name: "map", patterns: [toPosix(resolve(srcDir, "pages/Map.tsx"))] },
+    { name: "schedule", patterns: [toPosix(resolve(srcDir, "pages/Schedule.tsx"))] },
+    {
+      name: "news",
+      patterns: [
+        toPosix(resolve(srcDir, "pages/News.tsx")),
+        toPosix(resolve(srcDir, "components/NewsCard.tsx")),
+        toPosix(resolve(srcDir, "components/NewsDetail.tsx")),
+      ],
+    },
+  ] as const
+
   return {
     plugins,
     resolve: { alias: { "@": srcDir } },
@@ -157,19 +171,26 @@ export default defineConfig(({ mode }) => {
     optimizeDeps: {
       exclude: ["jspdf", "qrcode", "zxcvbn"],
     },
+    modulepreload: { polyfill: false },
     build: {
       sourcemap: true,
       chunkSizeWarningLimit: 1024,
       rollupOptions: {
         output: {
           manualChunks(id) {
-            if (!id.includes("node_modules")) return
-            if (id.includes("framer-motion")) return "motion"
-            if (id.includes("@mui")) return "mui"
-            if (id.includes("react-router")) return "router"
-            if (id.includes("dayjs")) return "dayjs"
-            if (id.includes("zxcvbn")) return "zxcvbn"
-            if (id.includes("jspdf")) return "pdf"
+            const normalizedId = toPosix(id)
+            for (const chunk of routeChunks) {
+              if (chunk.patterns.some(pattern => normalizedId.startsWith(pattern))) {
+                return chunk.name
+              }
+            }
+            if (!normalizedId.includes("node_modules")) return
+            if (normalizedId.includes("framer-motion")) return "motion"
+            if (normalizedId.includes("@mui")) return "mui"
+            if (normalizedId.includes("react-router")) return "router"
+            if (normalizedId.includes("dayjs")) return "dayjs"
+            if (normalizedId.includes("zxcvbn")) return "zxcvbn"
+            if (normalizedId.includes("jspdf")) return "pdf"
           },
         },
       },

--- a/root/frontend/vite.config.mts
+++ b/root/frontend/vite.config.mts
@@ -180,7 +180,7 @@ export default defineConfig(({ mode }) => {
           manualChunks(id) {
             const normalizedId = toPosix(id)
             for (const chunk of routeChunks) {
-              if (chunk.patterns.some(pattern => normalizedId.startsWith(pattern))) {
+              if (chunk.patterns.some((pattern) => normalizedId.startsWith(pattern))) {
                 return chunk.name
               }
             }


### PR DESCRIPTION
## Summary
- add manual chunk rules for the map, schedule, and news routes while disabling the modulepreload polyfill
- limit dashboard page prefetching to imminent navigations so heavy chunks stay idle until needed
- tighten Lighthouse budgets to 200 KB for core bundles and 250 KB for the map route

## Testing
- CI=1 npm run build -- --logLevel info --clearScreen false

------
https://chatgpt.com/codex/tasks/task_e_68e1746431f4832798f44bfeda60cb32