### PR TITLE
Add accessibility regression tests and skip link

### DIFF
--- a/root/frontend/src/App.tsx
+++ b/root/frontend/src/App.tsx
@@ -148,14 +148,19 @@ export const routerFutureFlags = {
 
 export default function App() {
   return (
-    <AuthProvider>
-      <LocalizationProvider dateAdapter={AdapterDayjs} adapterLocale="ru">
-        <ErrorBoundary>
-          <Router future={routerFutureFlags}>
-            <AppContent />
-          </Router>
-        </ErrorBoundary>
-      </LocalizationProvider>
-    </AuthProvider>
+    <>
+      <a href="#main" className="skip-link">
+        Перейти к содержанию
+      </a>
+      <AuthProvider>
+        <LocalizationProvider dateAdapter={AdapterDayjs} adapterLocale="ru">
+          <ErrorBoundary>
+            <Router future={routerFutureFlags}>
+              <AppContent />
+            </Router>
+          </ErrorBoundary>
+        </LocalizationProvider>
+      </AuthProvider>
+    </>
   )
 }

--- a/root/frontend/src/app/__tests__/a11y.test.tsx
+++ b/root/frontend/src/app/__tests__/a11y.test.tsx
@@ -1,0 +1,156 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { PropsWithChildren } from "react";
+import { describe, it, beforeEach, afterEach, vi } from "vitest";
+
+import Navbar from "@/components/Navbar";
+import Dashboard from "@/pages/Dashboard";
+import Profile from "@/pages/Profile";
+import { AuthContext } from "@/contexts/AuthContext";
+import { routerFutureFlags } from "@/App";
+import { checkA11y } from "@/tests/axeTest";
+import { createQueryClient } from "@/app/queryClient";
+import api from "@/api/client";
+
+vi.mock("@/components/NotificationsBell", () => ({
+  default: ({ iconColor }: { iconColor?: string }) => (
+    <div data-testid="notifications-bell" data-color={iconColor ?? ""} />
+  ),
+}));
+
+vi.mock("@/hooks/useNotifications", () => ({
+  useNotifications: () => ({
+    items: [],
+    loading: false,
+    unreadCount: 0,
+    hasMore: false,
+    loadMore: vi.fn(),
+    markRead: vi.fn(),
+    markAllRead: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/useNowPlaying", async () => {
+  const actual = await vi.importActual<typeof import("@/hooks/useNowPlaying")>(
+    "@/hooks/useNowPlaying",
+  );
+  return {
+    ...actual,
+    useNowPlaying: () => ({
+      data: null,
+      status: "success",
+      fetchStatus: "idle",
+      isFetching: false,
+      isLoading: false,
+      isSuccess: true,
+      isPending: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    }),
+  };
+});
+
+const baseUser = {
+  id: "user-1",
+  full_name: "Тестовый Пользователь",
+  email: "user@example.com",
+  role: "student",
+  group_id: "group-1",
+  telegram: "@testuser",
+  about: "Студент ГУУ",
+  achievements: "Победитель олимпиады|ГУУ|2023",
+  institute: "Институт цифровых технологий",
+  course: "3",
+  record_book_number: "123456",
+  status: "Студент",
+  program: "Информатика",
+  track: "Разработка",
+  department: "Кафедра ИТ",
+  position: "",
+  avatar_url: "",
+  cover_url: "",
+  spotify_connected: false,
+};
+
+const activeClients: QueryClient[] = [];
+
+const createWrapper = (route = "/dashboard") => {
+  const queryClient = createQueryClient();
+  activeClients.push(queryClient);
+  const authValue = {
+    isAuth: true,
+    login: vi.fn(),
+    logout: vi.fn(),
+    setUser: vi.fn(),
+    loading: false,
+    user: { ...baseUser },
+  };
+
+  const Wrapper = ({ children }: PropsWithChildren) => (
+    <MemoryRouter future={routerFutureFlags} initialEntries={[route]}>
+      <QueryClientProvider client={queryClient}>
+        <AuthContext.Provider value={authValue}>{children}</AuthContext.Provider>
+      </QueryClientProvider>
+    </MemoryRouter>
+  );
+
+  return { Wrapper };
+};
+
+describe("Accessibility checks", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      configurable: true,
+      value: (query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn().mockReturnValue(false),
+      }),
+    });
+  });
+
+  afterEach(() => {
+    activeClients.splice(0).forEach((client) => client.clear());
+    vi.clearAllMocks();
+  });
+
+  it("Navbar has no axe violations", async () => {
+    const { Wrapper } = createWrapper("/dashboard");
+    const { container } = render(<Navbar />, { wrapper: Wrapper });
+
+    await waitFor(() => expect(screen.getByRole("navigation")).toBeInTheDocument());
+
+    await checkA11y(container);
+  });
+
+  it("Dashboard page has no axe violations", async () => {
+    const getSpy = vi.spyOn(api, "get").mockImplementation(async () => ({ data: [] }) as any);
+
+    const { Wrapper } = createWrapper("/dashboard");
+    const { container } = render(<Dashboard />, { wrapper: Wrapper });
+
+    await waitFor(() => expect(api.get).toHaveBeenCalled());
+
+    await checkA11y(container);
+    getSpy.mockRestore();
+  });
+
+  it("Profile page has no axe violations", async () => {
+    const { Wrapper } = createWrapper("/profile");
+    const { container } = render(<Profile />, { wrapper: Wrapper });
+
+    await waitFor(() => expect(screen.getByTestId("profile-root")).toBeInTheDocument());
+
+    await checkA11y(container);
+  });
+});

--- a/root/frontend/src/assets/themes.css
+++ b/root/frontend/src/assets/themes.css
@@ -136,6 +136,30 @@ button:not(.MuiButtonBase-root),
 .burger-btn,
 .bottom-nav__item { min-height: 44px; min-width: 44px }
 
+.skip-link {
+  position: fixed;
+  top: 0.5rem;
+  left: 50%;
+  transform: translate(-50%, -150%);
+  background: var(--nav-bg);
+  color: var(--nav-text);
+  padding: 0.75rem 1.25rem;
+  border-radius: 0 0 var(--ue-radius-md) var(--ue-radius-md);
+  text-decoration: none;
+  font-weight: 700;
+  z-index: calc(var(--ue-z-index-nav) + 10);
+  box-shadow: var(--shadow-1);
+  opacity: 0;
+  transition: transform var(--anim-med), opacity var(--anim-med);
+}
+
+.skip-link:focus-visible {
+  transform: translate(-50%, 0);
+  opacity: 1;
+  outline: none;
+  box-shadow: var(--ue-focus-ring);
+}
+
 button:not(.MuiButtonBase-root),
 .menu-link,
 .menu-btn-settings,

--- a/root/frontend/src/components/Layout.tsx
+++ b/root/frontend/src/components/Layout.tsx
@@ -7,6 +7,8 @@ type LayoutProps = {
 
 const Layout = ({ children }: LayoutProps) => (
   <Box
+    component="main"
+    id="main"
     sx={{
       minHeight: "100vh",
       bgcolor: "var(--page-bg)",

--- a/root/frontend/src/pages/Profile.tsx
+++ b/root/frontend/src/pages/Profile.tsx
@@ -14,7 +14,6 @@ import {
   CircularProgress,
   IconButton,
   Snackbar,
-  Tooltip,
   Chip,
   Alert,
   LinearProgress,
@@ -569,9 +568,9 @@ export default function Profile() {
       >
         <Box
           component="main"
+          id="main"
           className="profile-page"
           data-testid="profile-root"
-          role="region"
           aria-label="Профиль"
           sx={{ position: "relative", minHeight: "100svh", display: "flex", flexDirection: "column", py: { xs: 8, sm: 9, md: 10 }, px: { xs: 1.5, sm: 2, md: 3 } }}
         >
@@ -793,21 +792,20 @@ export default function Profile() {
                             </a>
                           </Typography>
                         </Stack>
-                        <Tooltip title="Скопировать email">
-                          <IconButton
-                            size="small"
-                            className="glass--btn"
-                            onClick={(e) => copy(user!.email, e)}
-                            aria-label="Скопировать email"
-                            data-testid="copy-email"
-                            sx={{
-                              transition: reduced ? "color 140ms ease" : "transform 200ms ease, box-shadow 200ms ease, color 200ms ease",
-                              "&:hover": { transform: reduced ? "none" : "translateY(-1px) scale(1.05)" },
-                            }}
-                          >
-                            <ContentCopyIcon fontSize="small" />
-                          </IconButton>
-                        </Tooltip>
+                        <IconButton
+                          size="small"
+                          className="glass--btn"
+                          onClick={(e) => copy(user!.email, e)}
+                          aria-label="Скопировать email"
+                          title="Скопировать email"
+                          data-testid="copy-email"
+                          sx={{
+                            transition: reduced ? "color 140ms ease" : "transform 200ms ease, box-shadow 200ms ease, color 200ms ease",
+                            "&:hover": { transform: reduced ? "none" : "translateY(-1px) scale(1.05)" },
+                          }}
+                        >
+                          <ContentCopyIcon fontSize="small" />
+                        </IconButton>
                       </Stack>
 
                       {!!user!.telegram && (
@@ -827,21 +825,20 @@ export default function Profile() {
                               </a>
                             </Typography>
                           </Stack>
-                          <Tooltip title="Скопировать ник">
-                            <IconButton
-                              size="small"
-                              className="glass--btn"
-                              onClick={(e) => copy(user!.telegram!, e)}
-                              aria-label="Скопировать ник в Telegram"
-                              data-testid="copy-telegram"
-                              sx={{
-                                transition: reduced ? "color 140ms ease" : "transform 200ms ease, box-shadow 200ms ease, color 200ms ease",
-                                "&:hover": { transform: reduced ? "none" : "translateY(-1px) scale(1.05)" },
-                              }}
-                            >
-                              <ContentCopyIcon fontSize="small" />
-                            </IconButton>
-                          </Tooltip>
+                          <IconButton
+                            size="small"
+                            className="glass--btn"
+                            onClick={(e) => copy(user!.telegram!, e)}
+                            aria-label="Скопировать ник в Telegram"
+                            title="Скопировать ник в Telegram"
+                            data-testid="copy-telegram"
+                            sx={{
+                              transition: reduced ? "color 140ms ease" : "transform 200ms ease, box-shadow 200ms ease, color 200ms ease",
+                              "&:hover": { transform: reduced ? "none" : "translateY(-1px) scale(1.05)" },
+                            }}
+                          >
+                            <ContentCopyIcon fontSize="small" />
+                          </IconButton>
                         </Stack>
                       )}
                     </Stack>
@@ -918,7 +915,11 @@ export default function Profile() {
                           ["--glass-highlight" as any]: "rgba(255,255,255,0)",
                         }}
                       >
-                        <Typography variant="h5" sx={{ fontWeight: 900, fontSize: "clamp(1.3rem, 2.3vw, 1.8rem)", mb: 2.2, letterSpacing: "-.01em" }}>
+                        <Typography
+                          variant="h5"
+                          component="h2"
+                          sx={{ fontWeight: 900, fontSize: "clamp(1.3rem, 2.3vw, 1.8rem)", mb: 2.2, letterSpacing: "-.01em" }}
+                        >
                           Сведения
                         </Typography>
                         <Accordion
@@ -967,7 +968,7 @@ export default function Profile() {
                             })()}
                             {achievementsList.length > 0 && (
                               <Box sx={{ mt: 2.4 }}>
-                                <Typography variant="subtitle1" sx={{ fontWeight: 800, mb: 1.4 }}>
+                                <Typography variant="subtitle1" component="h3" sx={{ fontWeight: 800, mb: 1.4 }}>
                                   Достижения
                                 </Typography>
                                 <Box

--- a/root/frontend/src/tests/axeTest.ts
+++ b/root/frontend/src/tests/axeTest.ts
@@ -1,7 +1,6 @@
 import { render } from "@testing-library/react";
 import { configureAxe } from "jest-axe";
 import type { ReactElement } from "react";
-import type { RunOptions } from "axe-core";
 
 const axe = configureAxe({
   rules: {
@@ -14,14 +13,16 @@ const axe = configureAxe({
 type RenderConfig = Parameters<typeof render>[1];
 type RenderWrapper = RenderConfig extends { wrapper?: infer W } ? W : never;
 
+type AxeRunOptions = Parameters<typeof axe>[1];
+
 type RenderWithAxeOptions = {
-  axeOptions?: RunOptions;
+  axeOptions?: AxeRunOptions;
   wrapper?: RenderWrapper;
 };
 
 export async function checkA11y(
   container: HTMLElement,
-  options?: RunOptions,
+  options?: AxeRunOptions,
 ) {
   const results = await axe(container, options);
   expect(results).toHaveNoViolations();

--- a/root/frontend/src/tests/axeTest.ts
+++ b/root/frontend/src/tests/axeTest.ts
@@ -1,0 +1,38 @@
+import { render } from "@testing-library/react";
+import { configureAxe } from "jest-axe";
+import type { ReactElement } from "react";
+import type { RunOptions } from "axe-core";
+
+const axe = configureAxe({
+  rules: {
+    "document-title": { enabled: false },
+    "html-has-lang": { enabled: false },
+    "landmark-one-main": { enabled: false },
+  },
+});
+
+type RenderConfig = Parameters<typeof render>[1];
+type RenderWrapper = RenderConfig extends { wrapper?: infer W } ? W : never;
+
+type RenderWithAxeOptions = {
+  axeOptions?: RunOptions;
+  wrapper?: RenderWrapper;
+};
+
+export async function checkA11y(
+  container: HTMLElement,
+  options?: RunOptions,
+) {
+  const results = await axe(container, options);
+  expect(results).toHaveNoViolations();
+  return results;
+}
+
+export async function renderWithA11y(
+  ui: ReactElement,
+  options: RenderWithAxeOptions = {},
+) {
+  const renderResult = render(ui, { wrapper: options.wrapper });
+  await checkA11y(renderResult.container, options.axeOptions);
+  return renderResult;
+}


### PR DESCRIPTION
## Summary
- add reusable axe helper and accessibility regression test suite for key screens
- add skip link, update Layout/Profile landmarks, and expose copy button labels
- style the skip link so it stays visually hidden until focused

## Testing
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68e1934ffe8c832798a79d2a858a9f69