### PR TITLE
Add Workbox push notification handling

### DIFF
--- a/root/frontend/src/sw.ts
+++ b/root/frontend/src/sw.ts
@@ -31,20 +31,21 @@ const navigationHandler = createHandlerBoundToURL(OFFLINE_URL)
 registerRoute(
   new NavigationRoute(async (options) => {
     const { event, request, url } = options
+    const fetchEvent = event as FetchEvent
 
     if (!/^\/[^_].*/.test(url.pathname)) {
       return fetch(request)
     }
 
     try {
-      const preload = await event.preloadResponse
+      const preload = "preloadResponse" in fetchEvent ? await fetchEvent.preloadResponse : undefined
       if (preload) {
         return preload
       }
 
       return await fetch(request)
     } catch (error) {
-      return navigationHandler({ request, event })
+      return navigationHandler(options)
     }
   }, { allowlist: [/^\/[^_].*/] })
 )
@@ -72,6 +73,12 @@ registerRoute(
 type NotificationData = {
   url?: string
   [key: string]: unknown
+}
+
+type NotificationAction = {
+  action: string
+  title: string
+  icon?: string
 }
 
 type PushPayload = {
@@ -117,12 +124,31 @@ self.addEventListener("push", (event) => {
     badge: payload.badge || payload.icon || DEFAULT_ICON,
     tag: payload.tag,
     data,
-    renotify: payload.renotify,
     requireInteraction: payload.requireInteraction,
     silent: payload.silent,
-    timestamp: payload.timestamp,
-    vibrate: payload.vibrate,
-    actions: payload.actions,
+  }
+
+  const extendedOptions = options as NotificationOptions & {
+    renotify?: boolean
+    timestamp?: number
+    vibrate?: number[]
+    actions?: NotificationAction[]
+  }
+
+  if (payload.renotify !== undefined) {
+    extendedOptions.renotify = payload.renotify
+  }
+
+  if (payload.timestamp !== undefined) {
+    extendedOptions.timestamp = payload.timestamp
+  }
+
+  if (payload.vibrate) {
+    extendedOptions.vibrate = payload.vibrate
+  }
+
+  if (payload.actions) {
+    extendedOptions.actions = payload.actions
   }
 
   event.waitUntil(self.registration.showNotification(title, options))

--- a/root/frontend/src/sw.ts
+++ b/root/frontend/src/sw.ts
@@ -1,0 +1,168 @@
+/// <reference lib="webworker" />
+
+import { cleanupOutdatedCaches, precacheAndRoute, createHandlerBoundToURL } from "workbox-precaching"
+import { clientsClaim } from "workbox-core"
+import { registerRoute, NavigationRoute } from "workbox-routing"
+import { StaleWhileRevalidate, CacheFirst } from "workbox-strategies"
+import { ExpirationPlugin } from "workbox-expiration"
+
+declare const self: ServiceWorkerGlobalScope & typeof globalThis
+
+const OFFLINE_URL = "/offline.html"
+const API_CACHE = "api-cache"
+const IMG_CACHE = "img-cache"
+
+cleanupOutdatedCaches()
+precacheAndRoute(self.__WB_MANIFEST)
+clientsClaim()
+void self.skipWaiting()
+
+self.addEventListener("message", (event) => {
+  if (event.data && typeof event.data === "object" && "type" in event.data) {
+    const type = (event.data as { type?: string }).type
+    if (type === "SKIP_WAITING") {
+      void self.skipWaiting()
+    }
+  }
+})
+
+const navigationHandler = createHandlerBoundToURL(OFFLINE_URL)
+
+registerRoute(
+  new NavigationRoute(async (options) => {
+    const { event, request, url } = options
+
+    if (!/^\/[^_].*/.test(url.pathname)) {
+      return fetch(request)
+    }
+
+    try {
+      const preload = await event.preloadResponse
+      if (preload) {
+        return preload
+      }
+
+      return await fetch(request)
+    } catch (error) {
+      return navigationHandler({ request, event })
+    }
+  }, { allowlist: [/^\/[^_].*/] })
+)
+
+registerRoute(
+  ({ url }) => /\/api\/(news|schedule)/.test(url.pathname),
+  new StaleWhileRevalidate({
+    cacheName: API_CACHE,
+    plugins: [
+      new ExpirationPlugin({ maxEntries: 100, maxAgeSeconds: 60 * 60 }),
+    ],
+  })
+)
+
+registerRoute(
+  ({ request }) => request.destination === "image",
+  new CacheFirst({
+    cacheName: IMG_CACHE,
+    plugins: [
+      new ExpirationPlugin({ maxEntries: 200, maxAgeSeconds: 7 * 24 * 60 * 60 }),
+    ],
+  })
+)
+
+type NotificationData = {
+  url?: string
+  [key: string]: unknown
+}
+
+type PushPayload = {
+  title?: string
+  body?: string
+  icon?: string
+  badge?: string
+  tag?: string
+  url?: string
+  data?: Record<string, unknown>
+  renotify?: boolean
+  requireInteraction?: boolean
+  silent?: boolean
+  timestamp?: number
+  vibrate?: number[]
+  actions?: NotificationAction[]
+}
+
+const DEFAULT_TITLE = "Экосистема ГУУ"
+const DEFAULT_ICON = "/maskable-icon-192.png"
+
+self.addEventListener("push", (event) => {
+  const payload = (() => {
+    if (!event.data) {
+      return {}
+    }
+    try {
+      return event.data.json() as PushPayload
+    } catch (error) {
+      return { body: event.data.text() } as PushPayload
+    }
+  })()
+
+  const title = payload.title || DEFAULT_TITLE
+  const data: NotificationData = {
+    url: payload.url || "/",
+    ...(payload.data ?? {}),
+  }
+
+  const options: NotificationOptions = {
+    body: payload.body,
+    icon: payload.icon || DEFAULT_ICON,
+    badge: payload.badge || payload.icon || DEFAULT_ICON,
+    tag: payload.tag,
+    data,
+    renotify: payload.renotify,
+    requireInteraction: payload.requireInteraction,
+    silent: payload.silent,
+    timestamp: payload.timestamp,
+    vibrate: payload.vibrate,
+    actions: payload.actions,
+  }
+
+  event.waitUntil(self.registration.showNotification(title, options))
+})
+
+self.addEventListener("notificationclick", (event) => {
+  event.notification.close()
+
+  const data = (event.notification.data || {}) as NotificationData
+  const targetUrl = typeof data.url === "string" && data.url ? data.url : "/"
+
+  event.waitUntil(
+    (async () => {
+      const allClients = await self.clients.matchAll({
+        type: "window",
+        includeUncontrolled: true,
+      })
+
+      const absoluteTarget = new URL(targetUrl, self.registration.scope).href
+
+      for (const client of allClients) {
+        const clientUrl = new URL(client.url, self.registration.scope).href
+        if (clientUrl === absoluteTarget) {
+          if ("focus" in client) {
+            return client.focus()
+          }
+          return
+        }
+        if (clientUrl.startsWith(self.registration.scope) && "navigate" in client) {
+          await client.navigate(absoluteTarget)
+          if ("focus" in client) {
+            return client.focus()
+          }
+          return
+        }
+      }
+
+      if (self.clients.openWindow) {
+        await self.clients.openWindow(absoluteTarget)
+      }
+    })()
+  )
+})

--- a/root/frontend/vite.config.mts
+++ b/root/frontend/vite.config.mts
@@ -89,41 +89,18 @@ export default defineConfig(({ mode }) => {
     VitePWA({
       registerType: "autoUpdate",
       injectRegister: "auto",
-      strategies: "generateSW",
+      strategies: "injectManifest",
+      srcDir: "src",
+      filename: "sw.ts",
       includeAssets: ["offline.html"],
       ...(manifest ? { manifest } : {}),
-      workbox: {
+      injectManifest: {
         globPatterns: ["**/*.{js,css,html,ico,png,svg,webp,json}"],
-        navigateFallback: "/offline.html",
-        navigateFallbackAllowlist: [/^\/[^_].*/],
-        navigationPreload: true,
-        cleanupOutdatedCaches: true,
-        skipWaiting: true,
-        clientsClaim: true,
-        runtimeCaching: [
-          {
-            urlPattern: /\/api\/(news|schedule)/,
-            handler: "StaleWhileRevalidate",
-            options: {
-              cacheName: "api-cache",
-              expiration: {
-                maxEntries: 100,
-                maxAgeSeconds: 3600,
-              },
-            },
-          },
-          {
-            urlPattern: ({ request }) => request.destination === "image",
-            handler: "CacheFirst",
-            options: {
-              cacheName: "img-cache",
-              expiration: {
-                maxEntries: 200,
-                maxAgeSeconds: 604800,
-              },
-            },
-          },
-        ],
+      },
+      devOptions: {
+        enabled: true,
+        suppressWarnings: true,
+        type: "module",
       },
     }),
     withStrictCspNonce(),


### PR DESCRIPTION
## Summary
- switch the PWA setup to Workbox injectManifest so a custom service worker can be used
- add a typed service worker that precaches assets, mirrors runtime caching, and handles push + notification click events

## Testing
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68e1b017b84c83278d744c6eab69d496