### PR TITLE
Add Lighthouse budget assertions to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,12 +273,23 @@ jobs:
         run: npx lhci collect --config=../.lighthouserc.js
       - name: Run Lighthouse assertions
         id: lighthouse_assert
-        continue-on-error: true
+        shell: bash
         run: |
+          set +e
           npx lhci assert \
             --config=../.lighthouserc.js \
             --preset=lighthouse:recommended \
             --budgetsFile=../budget.json
+          status=$?
+
+          if [ "$status" -ne 0 ]; then
+            echo "failed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "failed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          echo "exit_code=$status" >> "$GITHUB_OUTPUT"
+          exit 0
       - name: Generate Lighthouse reports
         run: npx lhci upload --config=../.lighthouserc.js
       - name: Build Lighthouse summary
@@ -459,7 +470,7 @@ jobs:
           path: root/frontend/.lighthouseci
           if-no-files-found: warn
       - name: Fail Lighthouse job on assertion errors
-        if: steps.lighthouse_assert.outcome == 'failure'
+        if: steps.lighthouse_assert.outputs.failed == 'true'
         run: |
           echo "::error::Lighthouse assertions failed. See logs above for details."
           exit 1
@@ -504,4 +515,8 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
       - name: Enforce Lighthouse thresholds
         if: steps.download_lighthouse_results.outcome == 'success'
-        run: npx lhci assert --config=../.lighthouserc.js
+        run: |
+          npx lhci assert \
+            --config=../.lighthouserc.js \
+            --preset=lighthouse:recommended \
+            --budgetsFile=../budget.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,23 +273,12 @@ jobs:
         run: npx lhci collect --config=../.lighthouserc.js
       - name: Run Lighthouse assertions
         id: lighthouse_assert
-        shell: bash
         run: |
-          set +e
           npx lhci assert \
             --config=../.lighthouserc.js \
             --preset=lighthouse:recommended \
             --budgetsFile=../budget.json
-          status=$?
-
-          if [ "$status" -ne 0 ]; then
-            echo "failed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "failed=false" >> "$GITHUB_OUTPUT"
-          fi
-
-          echo "exit_code=$status" >> "$GITHUB_OUTPUT"
-          exit 0
+        continue-on-error: true
       - name: Generate Lighthouse reports
         run: npx lhci upload --config=../.lighthouserc.js
       - name: Build Lighthouse summary
@@ -470,7 +459,7 @@ jobs:
           path: root/frontend/.lighthouseci
           if-no-files-found: warn
       - name: Fail Lighthouse job on assertion errors
-        if: steps.lighthouse_assert.outputs.failed == 'true'
+        if: steps.lighthouse_assert.outcome == 'failure'
         run: |
           echo "::error::Lighthouse assertions failed. See logs above for details."
           exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -459,7 +459,7 @@ jobs:
           path: root/frontend/.lighthouseci
           if-no-files-found: warn
       - name: Fail Lighthouse job on assertion errors
-        if: steps.lighthouse_assert.outcome == 'failure'
+        if: steps.lighthouse_assert.conclusion == 'failure'
         run: |
           echo "::error::Lighthouse assertions failed. See logs above for details."
           exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,6 +271,14 @@ jobs:
         run: npm ci
       - name: Collect Lighthouse metrics
         run: npx lhci collect --config=../.lighthouserc.js
+      - name: Run Lighthouse assertions
+        id: lighthouse_assert
+        continue-on-error: true
+        run: |
+          npx lhci assert \
+            --config=../.lighthouserc.js \
+            --preset=lighthouse:recommended \
+            --budgetsFile=../budget.json
       - name: Generate Lighthouse reports
         run: npx lhci upload --config=../.lighthouserc.js
       - name: Build Lighthouse summary
@@ -450,6 +458,11 @@ jobs:
           name: lighthouse-results
           path: root/frontend/.lighthouseci
           if-no-files-found: warn
+      - name: Fail Lighthouse job on assertion errors
+        if: steps.lighthouse_assert.outcome == 'failure'
+        run: |
+          echo "::error::Lighthouse assertions failed. See logs above for details."
+          exit 1
 
   performance-gate:
     name: Performance gate


### PR DESCRIPTION
## Summary
- run Lighthouse assertions during the Lighthouse CI job with the recommended preset
- point assertions to the shared performance budget so the job fails on bundle regressions
- surface assertion failures explicitly after uploading reports

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1b4852dec8327ac57f4b6f9593c3d