### PR TITLE
Add web push notification module and subscription schema

### DIFF
--- a/root/alembic/versions/f9d2b1f5e2d0_create_push_subscriptions_table.py
+++ b/root/alembic/versions/f9d2b1f5e2d0_create_push_subscriptions_table.py
@@ -3,6 +3,7 @@
 from typing import Sequence, Union
 
 import sqlalchemy as sa
+
 from alembic import op
 
 # revision identifiers, used by Alembic.
@@ -18,7 +19,12 @@ def upgrade() -> None:
     op.create_table(
         "push_subscriptions",
         sa.Column("id", sa.Integer(), primary_key=True),
-        sa.Column("user_id", sa.Integer(), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+        sa.Column(
+            "user_id",
+            sa.Integer(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
         sa.Column("endpoint", sa.Text(), nullable=False),
         sa.Column("p256dh", sa.String(length=200), nullable=False),
         sa.Column("auth", sa.String(length=200), nullable=False),
@@ -61,8 +67,16 @@ def upgrade() -> None:
 def downgrade() -> None:
     """Drop the push_subscriptions table."""
 
-    op.drop_index(op.f("ix_push_subscriptions_last_seen_at"), table_name="push_subscriptions")
-    op.drop_index(op.f("ix_push_subscriptions_created_at"), table_name="push_subscriptions")
-    op.drop_index(op.f("ix_push_subscriptions_user_id"), table_name="push_subscriptions")
-    op.drop_index(op.f("ix_push_subscriptions_endpoint"), table_name="push_subscriptions")
+    op.drop_index(
+        op.f("ix_push_subscriptions_last_seen_at"), table_name="push_subscriptions"
+    )
+    op.drop_index(
+        op.f("ix_push_subscriptions_created_at"), table_name="push_subscriptions"
+    )
+    op.drop_index(
+        op.f("ix_push_subscriptions_user_id"), table_name="push_subscriptions"
+    )
+    op.drop_index(
+        op.f("ix_push_subscriptions_endpoint"), table_name="push_subscriptions"
+    )
     op.drop_table("push_subscriptions")

--- a/root/alembic/versions/f9d2b1f5e2d0_create_push_subscriptions_table.py
+++ b/root/alembic/versions/f9d2b1f5e2d0_create_push_subscriptions_table.py
@@ -1,0 +1,68 @@
+"""create push_subscriptions table"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "f9d2b1f5e2d0"
+down_revision: Union[str, None] = "c8d0b5515f2d"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create the push_subscriptions table."""
+
+    op.create_table(
+        "push_subscriptions",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("user_id", sa.Integer(), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("endpoint", sa.Text(), nullable=False),
+        sa.Column("p256dh", sa.String(length=200), nullable=False),
+        sa.Column("auth", sa.String(length=200), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("user_agent", sa.String(length=512), nullable=True),
+        sa.Column("last_seen_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("topics", sa.JSON(), nullable=False, server_default=sa.text("'[]'")),
+    )
+    op.create_index(
+        op.f("ix_push_subscriptions_endpoint"),
+        "push_subscriptions",
+        ["endpoint"],
+        unique=True,
+    )
+    op.create_index(
+        op.f("ix_push_subscriptions_user_id"),
+        "push_subscriptions",
+        ["user_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_push_subscriptions_created_at"),
+        "push_subscriptions",
+        ["created_at"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_push_subscriptions_last_seen_at"),
+        "push_subscriptions",
+        ["last_seen_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Drop the push_subscriptions table."""
+
+    op.drop_index(op.f("ix_push_subscriptions_last_seen_at"), table_name="push_subscriptions")
+    op.drop_index(op.f("ix_push_subscriptions_created_at"), table_name="push_subscriptions")
+    op.drop_index(op.f("ix_push_subscriptions_user_id"), table_name="push_subscriptions")
+    op.drop_index(op.f("ix_push_subscriptions_endpoint"), table_name="push_subscriptions")
+    op.drop_table("push_subscriptions")

--- a/root/app/api/push.py
+++ b/root/app/api/push.py
@@ -141,9 +141,7 @@ async def broadcast(
 ):
     if user.role != "admin":
         raise HTTPException(status_code=403, detail="forbidden")
-    res = await session.execute(
-        select(PushSubscription)
-    )
+    res = await session.execute(select(PushSubscription))
     subs = res.scalars().all()
     for s in subs:
         bg.add_task(send_web_push, s, data.model_dump())

--- a/root/app/api/push.py
+++ b/root/app/api/push.py
@@ -1,6 +1,8 @@
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
+from datetime import UTC, datetime
+
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
 from pydantic import BaseModel
-from sqlalchemy import select, update
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps import get_current_user
@@ -35,12 +37,13 @@ class NotifyBody(BaseModel):
 
 @router.get("/public-key")
 async def public_key():
-    return {"key": settings.vapid_public_key}
+    return {"key": settings.VAPID_PUBLIC_KEY}
 
 
 @router.post("/subscribe")
 async def subscribe(
     payload: SubPayload,
+    request: Request,
     session: AsyncSession = Depends(get_db),
     user: User = Depends(get_current_user),
 ):
@@ -49,24 +52,33 @@ async def subscribe(
     auth = payload.keys.auth.strip()
     if not endpoint or not p256dh or not auth:
         raise HTTPException(status_code=400, detail="invalid subscription")
+    user_agent = (request.headers.get("user-agent") or "").strip()
+    if len(user_agent) > 512:
+        user_agent = user_agent[:512]
     res = await session.execute(
         select(PushSubscription).where(PushSubscription.endpoint == endpoint)
     )
     sub = res.scalar_one_or_none()
+    now = datetime.now(UTC)
     if sub:
-        await session.execute(
-            update(PushSubscription)
-            .where(PushSubscription.id == sub.id)
-            .values(active=True, p256dh=p256dh, auth=auth, user_id=user.id)
-        )
+        if sub.user_id != user.id:
+            raise HTTPException(status_code=409, detail="duplicate endpoint")
+        sub.p256dh = p256dh
+        sub.auth = auth
+        sub.user_id = user.id
+        sub.user_agent = user_agent or None
+        sub.last_seen_at = now
+        sub.topics = sub.topics or []
     else:
         session.add(
             PushSubscription(
                 endpoint=endpoint,
                 p256dh=p256dh,
                 auth=auth,
-                active=True,
                 user_id=user.id,
+                user_agent=user_agent or None,
+                last_seen_at=now,
+                topics=[],
             )
         )
     await session.commit()
@@ -80,12 +92,12 @@ async def unsubscribe(
     user: User = Depends(get_current_user),
 ):
     endpoint = payload.endpoint.strip()
+    if not endpoint:
+        raise HTTPException(status_code=400, detail="invalid subscription")
     await session.execute(
-        update(PushSubscription)
-        .where(
+        delete(PushSubscription).where(
             PushSubscription.endpoint == endpoint, PushSubscription.user_id == user.id
         )
-        .values(active=False)
     )
     await session.commit()
     return {"ok": True}
@@ -104,7 +116,6 @@ async def send_test(
     res = await session.execute(
         select(PushSubscription).where(
             PushSubscription.user_id == user.id,
-            PushSubscription.active.is_(True),
         )
     )
     subs = res.scalars().all()
@@ -131,7 +142,7 @@ async def broadcast(
     if user.role != "admin":
         raise HTTPException(status_code=403, detail="forbidden")
     res = await session.execute(
-        select(PushSubscription).where(PushSubscription.active.is_(True))
+        select(PushSubscription)
     )
     subs = res.scalars().all()
     for s in subs:

--- a/root/app/core/config.py
+++ b/root/app/core/config.py
@@ -152,6 +152,18 @@ class Settings(BaseSettings):
         return result
 
     @cached_property
+    def VAPID_PUBLIC_KEY(self) -> str:
+        return self.vapid_public_key
+
+    @cached_property
+    def VAPID_PRIVATE_KEY(self) -> str:
+        return self.vapid_private_key
+
+    @cached_property
+    def WEBPUSH_SUBJECT(self) -> str:
+        return self.vapid_subject or "mailto:no-reply@example.com"
+
+    @cached_property
     def cors_allow_origins_list(self) -> list[str]:
         allowed: list[str] = []
         seen: set[str] = set()

--- a/root/app/core/rate_limit.py
+++ b/root/app/core/rate_limit.py
@@ -229,7 +229,9 @@ class RateLimitExceeded(Exception):
         self.info = info
 
 
-async def _memory_rate_limit(key: str, limit: int, window_seconds: int) -> RateLimitInfo:
+async def _memory_rate_limit(
+    key: str, limit: int, window_seconds: int
+) -> RateLimitInfo:
     if limit <= 0 or window_seconds <= 0:
         return RateLimitInfo(True, max(limit, 0), 0)
     now = time.time()

--- a/root/app/core/rate_limit.py
+++ b/root/app/core/rate_limit.py
@@ -4,6 +4,7 @@ import asyncio
 import math
 import time
 import uuid
+from dataclasses import dataclass
 from typing import Callable, Optional
 
 from fastapi import Request
@@ -55,6 +56,12 @@ def _create_redis_pool(url: str) -> Redis:
 
 _RedisFactory = Callable[[str], Redis]
 _redis_factory: _RedisFactory = _create_redis_pool
+
+
+_shared_clients: dict[str, Redis] = {}
+_shared_client_locks: dict[str, asyncio.Lock] = {}
+_memory_buckets: dict[str, list[float]] = {}
+_memory_lock = asyncio.Lock()
 
 
 def set_rate_limit_client_factory(factory: Optional[_RedisFactory]) -> None:
@@ -186,3 +193,161 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
 
     def _redis_key(self, identifier: str) -> str:
         return f"rate-limit:{identifier}"
+
+
+async def _get_shared_client(redis_url: str) -> Redis:
+    client = _shared_clients.get(redis_url)
+    if client is not None:
+        return client
+    lock = _shared_client_locks.setdefault(redis_url, asyncio.Lock())
+    async with lock:
+        client = _shared_clients.get(redis_url)
+        if client is None:
+            client = _redis_factory(redis_url)
+            _shared_clients[redis_url] = client
+    return client
+
+
+def _compose_identifier(namespace: str, identifier: str) -> str:
+    ident = identifier.strip() or "unknown"
+    ns = namespace.strip()
+    return f"{ns}:{ident}" if ns else ident
+
+
+@dataclass(slots=True)
+class RateLimitInfo:
+    allowed: bool
+    remaining: int
+    retry_after: int
+
+
+class RateLimitExceeded(Exception):
+    """Raised when a manual rate limit check fails."""
+
+    def __init__(self, info: RateLimitInfo) -> None:
+        super().__init__("Rate limit exceeded")
+        self.info = info
+
+
+async def _memory_rate_limit(key: str, limit: int, window_seconds: int) -> RateLimitInfo:
+    if limit <= 0 or window_seconds <= 0:
+        return RateLimitInfo(True, max(limit, 0), 0)
+    now = time.time()
+    cutoff = now - window_seconds
+    async with _memory_lock:
+        bucket = _memory_buckets.get(key, [])
+        bucket = [timestamp for timestamp in bucket if timestamp > cutoff]
+        if len(bucket) >= limit:
+            retry_after = math.ceil(bucket[0] + window_seconds - now)
+            if retry_after < 0:
+                retry_after = 0
+            _memory_buckets[key] = bucket
+            return RateLimitInfo(False, 0, retry_after)
+        bucket.append(now)
+        _memory_buckets[key] = bucket
+        remaining = limit - len(bucket)
+    return RateLimitInfo(True, max(0, remaining), 0)
+
+
+async def _redis_rate_limit_fallback(
+    client: Redis,
+    redis_key: str,
+    window_ms: int,
+    limit: int,
+    now_ms: int,
+    member: str,
+) -> RateLimitInfo:
+    cutoff = now_ms - window_ms
+    await client.zremrangebyscore(redis_key, 0, cutoff)
+    count = await client.zcard(redis_key)
+    if count >= limit:
+        oldest = await client.zrange(redis_key, 0, 0, withscores=True)
+        retry_after_ms = 0
+        if oldest:
+            retry_after_ms = window_ms - (now_ms - int(float(oldest[0][1])))
+            if retry_after_ms < 0:
+                retry_after_ms = 0
+        retry_after = math.ceil(retry_after_ms / 1000)
+        return RateLimitInfo(False, 0, max(0, retry_after))
+    await client.zadd(redis_key, mapping={member: now_ms})
+    await client.pexpire(redis_key, window_ms)
+    remaining = limit - (count + 1)
+    return RateLimitInfo(True, max(0, remaining), 0)
+
+
+async def _redis_rate_limit(
+    redis_url: str, key: str, limit: int, window_seconds: int
+) -> RateLimitInfo:
+    if limit <= 0 or window_seconds <= 0:
+        return RateLimitInfo(True, max(limit, 0), 0)
+    client = await _get_shared_client(redis_url)
+    now_ms = int(time.time() * 1000)
+    window_ms = max(int(window_seconds * 1000), 1)
+    member = f"{now_ms}:{uuid.uuid4().hex}"
+    redis_key = f"rate-limit:{key}"
+    try:
+        result = await client.eval(
+            _RATE_LIMIT_SCRIPT,
+            1,
+            redis_key,
+            now_ms,
+            window_ms,
+            limit,
+            member,
+        )
+    except RedisError as exc:
+        if "unknown command" not in str(exc).lower():
+            raise
+        info = await _redis_rate_limit_fallback(
+            client, redis_key, window_ms, limit, now_ms, member
+        )
+        return info
+    allowed = bool(int(result[0]))
+    remaining = max(0, int(result[1]))
+    retry_after_ms = int(result[2])
+    retry_after = math.ceil(retry_after_ms / 1000)
+    if retry_after < 0:
+        retry_after = 0
+    return RateLimitInfo(allowed, remaining, retry_after)
+
+
+async def check_rate_limit(
+    *,
+    identifier: str,
+    namespace: str = "",
+    limit: int,
+    window_seconds: int,
+    redis_url: str | None = None,
+) -> RateLimitInfo:
+    """Check a rate limit for an arbitrary identifier."""
+
+    key = _compose_identifier(namespace, identifier)
+    redis_uri = (redis_url or "").strip()
+    if redis_uri.lower().startswith(("redis://", "rediss://")):
+        try:
+            return await _redis_rate_limit(redis_uri, key, limit, window_seconds)
+        except (RedisError, OSError):
+            pass
+    return await _memory_rate_limit(key, limit, window_seconds)
+
+
+async def enforce_rate_limit(
+    *,
+    identifier: str,
+    namespace: str = "",
+    limit: int,
+    window_seconds: int,
+    redis_url: str | None = None,
+) -> RateLimitInfo:
+    """Enforce a rate limit, raising :class:`RateLimitExceeded` if exceeded."""
+
+    info = await check_rate_limit(
+        identifier=identifier,
+        namespace=namespace,
+        limit=limit,
+        window_seconds=window_seconds,
+        redis_url=redis_url,
+    )
+    if not info.allowed:
+        raise RateLimitExceeded(info)
+    return info

--- a/root/app/main.py
+++ b/root/app/main.py
@@ -8,7 +8,6 @@ from fastapi.staticfiles import StaticFiles
 from sqlalchemy import text
 
 from app.api.notifications import router as notifications_router
-from app.api.push import router as push_router
 from app.api.routes import router as main_router
 from app.api.spotify import router as spotify_router
 from app.auth.auth import router as auth_router
@@ -18,6 +17,7 @@ from app.core.observability import configure_observability, shutdown_observabili
 from app.core.rate_limit import RateLimitMiddleware
 from app.core.security_headers import SecurityHeadersMiddleware
 from app.deps.cache import shutdown_cache
+from app.routers.notifications import router as webpush_router
 from app.routers.schedule import router as schedule_router
 from app.services.notifications import start_notifications_scheduler
 
@@ -101,6 +101,6 @@ async def ready():
 app.include_router(auth_router)
 app.include_router(spotify_router)
 app.include_router(notifications_router)
-app.include_router(push_router)
+app.include_router(webpush_router)
 app.include_router(schedule_router)
 app.include_router(main_router)

--- a/root/app/models/models.py
+++ b/root/app/models/models.py
@@ -8,6 +8,7 @@ from sqlalchemy import (
     ForeignKey,
     Index,
     Integer,
+    JSON,
     String,
     Text,
     UniqueConstraint,
@@ -264,17 +265,20 @@ class PushSubscription(Base):
     __tablename__ = "push_subscriptions"
 
     id = Column(Integer, primary_key=True)
+    user_id = Column(
+        Integer,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
     endpoint = Column(Text, unique=True, nullable=False, index=True)
     p256dh = Column(String(200), nullable=False)
     auth = Column(String(200), nullable=False)
-    user_id = Column(Integer, ForeignKey("users.id", ondelete="SET NULL"), index=True)
-    active = Column(Boolean, default=True, index=True)
-    created_at = Column(DateTime(timezone=True), server_default=func.now(), index=True)
-    updated_at = Column(
-        DateTime(timezone=True),
-        server_default=func.now(),
-        onupdate=func.now(),
-        index=True,
+    created_at = Column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False, index=True
     )
+    user_agent = Column(String(512))
+    last_seen_at = Column(DateTime(timezone=True), index=True)
+    topics = Column(JSON, nullable=False, default=list)
 
     user = relationship("User", back_populates="push_subscriptions")

--- a/root/app/models/models.py
+++ b/root/app/models/models.py
@@ -1,6 +1,7 @@
 import secrets
 
 from sqlalchemy import (
+    JSON,
     Boolean,
     CheckConstraint,
     Column,
@@ -8,7 +9,6 @@ from sqlalchemy import (
     ForeignKey,
     Index,
     Integer,
-    JSON,
     String,
     Text,
     UniqueConstraint,

--- a/root/app/routers/notifications.py
+++ b/root/app/routers/notifications.py
@@ -1,0 +1,305 @@
+"""Web push notification routes."""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from fastapi.concurrency import run_in_threadpool
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import get_current_user
+from app.core.config import settings
+from app.core.database import get_db
+from app.core.rate_limit import RateLimitExceeded, RateLimitInfo, enforce_rate_limit
+from app.models.models import PushSubscription, User
+from app.services.webpush import WebPushResult, send_web_push
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/webpush", tags=["webpush"])
+
+
+class PushSubscriptionKeys(BaseModel):
+    p256dh: str = Field(..., description="Base64-encoded public key")
+    auth: str = Field(..., description="Authentication secret")
+
+    @field_validator("p256dh", "auth", mode="before")
+    @classmethod
+    def _ensure_not_blank(cls, value: str) -> str:
+        if value is None:
+            return ""
+        return str(value).strip()
+
+
+class PushSubscriptionIn(BaseModel):
+    endpoint: str = Field(..., description="Push subscription endpoint URL")
+    keys: PushSubscriptionKeys
+    topics: list[str] | None = Field(default=None, description="Optional list of topics")
+    user_agent: str | None = Field(default=None, description="User agent override")
+
+    @field_validator("endpoint", mode="before")
+    @classmethod
+    def _normalize_endpoint(cls, value: str) -> str:
+        if value is None:
+            return ""
+        return str(value).strip()
+
+    @field_validator("topics", mode="before")
+    @classmethod
+    def _normalize_topics(cls, value: list[str] | None) -> list[str] | None:
+        if value is None:
+            return None
+        return [str(topic).strip() for topic in value if str(topic).strip()]
+
+
+class PushSubscriptionOut(BaseModel):
+    id: int
+    user_id: int
+    endpoint: str
+    p256dh: str
+    auth: str
+    created_at: datetime
+    user_agent: str | None = None
+    last_seen_at: datetime | None = None
+    topics: list[str] = Field(default_factory=list)
+
+    model_config = ConfigDict(from_attributes=True)
+
+    @field_validator("topics", mode="before")
+    @classmethod
+    def _topics_before(cls, value):
+        if not value:
+            return []
+        if isinstance(value, list):
+            return [str(topic) for topic in value if str(topic).strip()]
+        return value
+
+
+class PushSubscriptionDelete(BaseModel):
+    endpoint: str
+
+    @field_validator("endpoint", mode="before")
+    @classmethod
+    def _normalize_endpoint(cls, value: str) -> str:
+        if value is None:
+            return ""
+        return str(value).strip()
+
+
+class SendTestResponse(BaseModel):
+    sent: int
+    removed: int
+    failed: int
+    detail: str | None = None
+
+
+async def _validate_subscription_payload(data: PushSubscriptionIn) -> tuple[str, str, str]:
+    endpoint = data.endpoint.strip()
+    p256dh = data.keys.p256dh.strip()
+    auth = data.keys.auth.strip()
+    errors = []
+    if not endpoint:
+        errors.append({"field": "endpoint", "message": "Endpoint is required"})
+    if not p256dh:
+        errors.append({"field": "keys.p256dh", "message": "keys.p256dh must not be empty"})
+    if not auth:
+        errors.append({"field": "keys.auth", "message": "keys.auth must not be empty"})
+    if errors:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "error": "invalid_subscription",
+                "message": "Subscription payload validation failed",
+                "fields": errors,
+            },
+        )
+    return endpoint, p256dh, auth
+
+
+@router.get("/vapid-public-key")
+async def get_vapid_public_key() -> dict[str, str]:
+    """Return configured VAPID public key."""
+    return {"publicKey": settings.VAPID_PUBLIC_KEY}
+
+
+@router.post("/subscribe", response_model=PushSubscriptionOut)
+async def subscribe(
+    payload: PushSubscriptionIn,
+    request: Request,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    user: Annotated[User, Depends(get_current_user)],
+) -> PushSubscriptionOut:
+    endpoint, p256dh, auth = await _validate_subscription_payload(payload)
+    user_agent = payload.user_agent or request.headers.get("user-agent") or ""
+    user_agent = user_agent.strip()
+    if len(user_agent) > 512:
+        user_agent = user_agent[:512]
+
+    existing = (
+        await db.execute(select(PushSubscription).where(PushSubscription.endpoint == endpoint))
+    ).scalar_one_or_none()
+
+    def _resolve_topics() -> list[str]:
+        raw_topics = payload.topics
+        if raw_topics is None:
+            if existing and existing.topics:
+                return [str(topic).strip() for topic in existing.topics if str(topic).strip()]
+            return []
+        unique: list[str] = []
+        seen_local: set[str] = set()
+        for topic in raw_topics:
+            normalized = topic.strip()
+            if not normalized:
+                continue
+            key = normalized.lower()
+            if key in seen_local:
+                continue
+            seen_local.add(key)
+            unique.append(normalized)
+        return unique
+
+    now = datetime.now(UTC)
+    try:
+        if existing:
+            if existing.user_id != user.id:
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail={
+                        "error": "duplicate_endpoint",
+                        "message": "Subscription endpoint already registered",
+                    },
+                )
+            existing.p256dh = p256dh
+            existing.auth = auth
+            existing.user_agent = user_agent or None
+            existing.last_seen_at = now
+            existing.topics = _resolve_topics()
+            existing.user_id = user.id
+            await db.commit()
+            await db.refresh(existing)
+            subscription = existing
+        else:
+            subscription = PushSubscription(
+                endpoint=endpoint,
+                p256dh=p256dh,
+                auth=auth,
+                user_id=user.id,
+                user_agent=user_agent or None,
+                last_seen_at=now,
+                topics=_resolve_topics(),
+            )
+            db.add(subscription)
+            await db.commit()
+            await db.refresh(subscription)
+    except IntegrityError:
+        await db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "error": "duplicate_endpoint",
+                "message": "Subscription endpoint already exists",
+            },
+        )
+
+    return PushSubscriptionOut.model_validate(subscription)
+
+
+@router.delete("/subscribe", status_code=status.HTTP_204_NO_CONTENT)
+async def unsubscribe(
+    payload: PushSubscriptionDelete,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    user: Annotated[User, Depends(get_current_user)],
+) -> Response:
+    endpoint = payload.endpoint.strip()
+    if not endpoint:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "error": "invalid_subscription",
+                "message": "Endpoint is required",
+            },
+        )
+    existing = (
+        await db.execute(
+            select(PushSubscription).where(
+                PushSubscription.endpoint == endpoint, PushSubscription.user_id == user.id
+            )
+        )
+    ).scalar_one_or_none()
+    if not existing:
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
+    await db.delete(existing)
+    await db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.post("/send-test", response_model=SendTestResponse)
+async def send_test(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    user: Annotated[User, Depends(get_current_user)],
+) -> SendTestResponse:
+    if not settings.VAPID_PRIVATE_KEY or not settings.VAPID_PUBLIC_KEY:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Web push is not configured",
+        )
+
+    rate_identifier = f"user:{user.id}"
+    try:
+        await enforce_rate_limit(
+            identifier=rate_identifier,
+            namespace="webpush:test",
+            limit=3,
+            window_seconds=60,
+            redis_url=settings.rate_limit_storage_uri,
+        )
+    except RateLimitExceeded as exc:
+        info: RateLimitInfo = exc.info
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail={
+                "error": "rate_limited",
+                "message": "Too many test notifications",
+                "retry_after": info.retry_after,
+            },
+        )
+
+    subscriptions = (
+        await db.execute(
+            select(PushSubscription).where(PushSubscription.user_id == user.id)
+        )
+    ).scalars().all()
+    if not subscriptions:
+        return SendTestResponse(sent=0, removed=0, failed=0, detail="No subscriptions found")
+
+    payload = {
+        "title": "Тестовое веб-push уведомление",
+        "body": "Проверка доставки уведомлений",
+        "url": settings.app_base_url or "/",
+    }
+
+    sent = 0
+    removed = 0
+    failed = 0
+    for sub in subscriptions:
+        result: WebPushResult = await run_in_threadpool(send_web_push, sub, payload)
+        if result.status == "sent":
+            sent += 1
+        elif result.status == "gone":
+            removed += 1
+        else:
+            failed += 1
+    logger.info(
+        "webpush.send_test.summary",
+        extra={"user_id": user.id, "sent": sent, "removed": removed, "failed": failed},
+    )
+    detail = None
+    if failed and not sent:
+        detail = "Не удалось отправить тестовое уведомление"
+    return SendTestResponse(sent=sent, removed=removed, failed=failed, detail=detail)

--- a/root/app/routers/notifications.py
+++ b/root/app/routers/notifications.py
@@ -40,7 +40,9 @@ class PushSubscriptionKeys(BaseModel):
 class PushSubscriptionIn(BaseModel):
     endpoint: str = Field(..., description="Push subscription endpoint URL")
     keys: PushSubscriptionKeys
-    topics: list[str] | None = Field(default=None, description="Optional list of topics")
+    topics: list[str] | None = Field(
+        default=None, description="Optional list of topics"
+    )
     user_agent: str | None = Field(default=None, description="User agent override")
 
     @field_validator("endpoint", mode="before")
@@ -99,7 +101,9 @@ class SendTestResponse(BaseModel):
     detail: str | None = None
 
 
-async def _validate_subscription_payload(data: PushSubscriptionIn) -> tuple[str, str, str]:
+async def _validate_subscription_payload(
+    data: PushSubscriptionIn,
+) -> tuple[str, str, str]:
     endpoint = data.endpoint.strip()
     p256dh = data.keys.p256dh.strip()
     auth = data.keys.auth.strip()
@@ -107,7 +111,9 @@ async def _validate_subscription_payload(data: PushSubscriptionIn) -> tuple[str,
     if not endpoint:
         errors.append({"field": "endpoint", "message": "Endpoint is required"})
     if not p256dh:
-        errors.append({"field": "keys.p256dh", "message": "keys.p256dh must not be empty"})
+        errors.append(
+            {"field": "keys.p256dh", "message": "keys.p256dh must not be empty"}
+        )
     if not auth:
         errors.append({"field": "keys.auth", "message": "keys.auth must not be empty"})
     if errors:
@@ -142,14 +148,20 @@ async def subscribe(
         user_agent = user_agent[:512]
 
     existing = (
-        await db.execute(select(PushSubscription).where(PushSubscription.endpoint == endpoint))
+        await db.execute(
+            select(PushSubscription).where(PushSubscription.endpoint == endpoint)
+        )
     ).scalar_one_or_none()
 
     def _resolve_topics() -> list[str]:
         raw_topics = payload.topics
         if raw_topics is None:
             if existing and existing.topics:
-                return [str(topic).strip() for topic in existing.topics if str(topic).strip()]
+                return [
+                    str(topic).strip()
+                    for topic in existing.topics
+                    if str(topic).strip()
+                ]
             return []
         unique: list[str] = []
         seen_local: set[str] = set()
@@ -228,7 +240,8 @@ async def unsubscribe(
     existing = (
         await db.execute(
             select(PushSubscription).where(
-                PushSubscription.endpoint == endpoint, PushSubscription.user_id == user.id
+                PushSubscription.endpoint == endpoint,
+                PushSubscription.user_id == user.id,
             )
         )
     ).scalar_one_or_none()
@@ -271,12 +284,18 @@ async def send_test(
         )
 
     subscriptions = (
-        await db.execute(
-            select(PushSubscription).where(PushSubscription.user_id == user.id)
+        (
+            await db.execute(
+                select(PushSubscription).where(PushSubscription.user_id == user.id)
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     if not subscriptions:
-        return SendTestResponse(sent=0, removed=0, failed=0, detail="No subscriptions found")
+        return SendTestResponse(
+            sent=0, removed=0, failed=0, detail="No subscriptions found"
+        )
 
     payload = {
         "title": "Тестовое веб-push уведомление",

--- a/root/app/services/notifications.py
+++ b/root/app/services/notifications.py
@@ -43,9 +43,7 @@ async def create_notifications_for_users(
         subs = (
             (
                 await db.execute(
-                    select(PushSubscription).where(
-                        PushSubscription.user_id.in_(uids)
-                    )
+                    select(PushSubscription).where(PushSubscription.user_id.in_(uids))
                 )
             )
             .scalars()

--- a/root/app/services/notifications.py
+++ b/root/app/services/notifications.py
@@ -39,15 +39,12 @@ async def create_notifications_for_users(
     ]
     await db.execute(insert(Notification).values(rows))
     await db.commit()
-    if settings.vapid_private_key and settings.vapid_public_key:
+    if settings.VAPID_PRIVATE_KEY and settings.VAPID_PUBLIC_KEY:
         subs = (
             (
                 await db.execute(
                     select(PushSubscription).where(
-                        and_(
-                            PushSubscription.active.is_(True),
-                            PushSubscription.user_id.in_(uids),
-                        )
+                        PushSubscription.user_id.in_(uids)
                     )
                 )
             )

--- a/root/app/services/webpush.py
+++ b/root/app/services/webpush.py
@@ -1,12 +1,20 @@
+from __future__ import annotations
+
 import json
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Literal
 
 from pywebpush import WebPushException, webpush
-from sqlalchemy import create_engine, delete
+from sqlalchemy import create_engine, delete, update
 from sqlalchemy.engine import make_url
 from sqlalchemy.orm import sessionmaker
 
 from app.core.config import settings
 from app.models.models import PushSubscription
+
+logger = logging.getLogger(__name__)
 
 url = make_url(settings.database_url)
 if url.drivername.endswith("+asyncpg"):
@@ -19,7 +27,17 @@ def json_dumps(obj):
     return json.dumps(obj, ensure_ascii=False)
 
 
-def send_web_push(sub: PushSubscription, data: dict):
+@dataclass(slots=True)
+class WebPushResult:
+    subscription_id: int
+    endpoint: str
+    user_id: int
+    status: Literal["sent", "gone", "error"]
+    status_code: int | None = None
+    error: str | None = None
+
+
+def send_web_push(sub: PushSubscription, data: dict) -> WebPushResult:
     payload = {
         "title": data.get("title") or "Уведомление",
         "body": data.get("body") or "",
@@ -40,22 +58,90 @@ def send_web_push(sub: PushSubscription, data: dict):
         "endpoint": sub.endpoint,
         "keys": {"p256dh": sub.p256dh, "auth": sub.auth},
     }
+    user_id = getattr(sub, "user_id", None) or 0
     try:
         webpush(
             subscription_info=subscription_info,
             data=json_dumps(payload),
-            vapid_private_key=settings.vapid_private_key,
-            vapid_claims={
-                "sub": settings.vapid_subject or "mailto:no-reply@example.com"
-            },
+            vapid_private_key=settings.VAPID_PRIVATE_KEY,
+            vapid_claims={"sub": settings.WEBPUSH_SUBJECT},
             headers=headers,
             ttl=ttl if ttl is not None else 43200,
         )
-    except WebPushException as e:
-        status = getattr(getattr(e, "response", None), "status_code", None)
-        txt = str(e)
-        gone = status in (404, 410) or ("404" in txt or "410" in txt)
+    except WebPushException as exc:  # pragma: no cover - network errors hard to simulate
+        status_code = getattr(getattr(exc, "response", None), "status_code", None)
+        message = str(exc)
+        gone = False
+        if status_code in (404, 410):
+            gone = True
+        elif message:
+            gone = "404" in message or "410" in message
         if gone:
-            with _Session() as s:
-                s.execute(delete(PushSubscription).where(PushSubscription.id == sub.id))
-                s.commit()
+            with _Session() as session:
+                session.execute(
+                    delete(PushSubscription).where(PushSubscription.id == sub.id)
+                )
+                session.commit()
+            logger.info(
+                "webpush.send",
+                extra={
+                    "user_id": user_id,
+                    "endpoint": sub.endpoint,
+                    "status": "gone",
+                    "status_code": status_code,
+                },
+            )
+            return WebPushResult(
+                subscription_id=sub.id,
+                endpoint=sub.endpoint,
+                user_id=user_id,
+                status="gone",
+                status_code=status_code,
+                error=message or None,
+            )
+        logger.info(
+            "webpush.send",
+            extra={
+                "user_id": user_id,
+                "endpoint": sub.endpoint,
+                "status": "error",
+                "status_code": status_code,
+            },
+        )
+        return WebPushResult(
+            subscription_id=sub.id,
+            endpoint=sub.endpoint,
+            user_id=user_id,
+            status="error",
+            status_code=status_code,
+            error=message or None,
+        )
+    except Exception as exc:  # pragma: no cover - unexpected failure
+        logger.exception(
+            "webpush.send", extra={"user_id": user_id, "endpoint": sub.endpoint}
+        )
+        return WebPushResult(
+            subscription_id=sub.id,
+            endpoint=sub.endpoint,
+            user_id=user_id,
+            status="error",
+            error=str(exc),
+        )
+    now = datetime.now(UTC)
+    with _Session() as session:
+        session.execute(
+            update(PushSubscription)
+            .where(PushSubscription.id == sub.id)
+            .values(last_seen_at=now)
+        )
+        session.commit()
+    logger.info(
+        "webpush.send",
+        extra={"user_id": user_id, "endpoint": sub.endpoint, "status": "sent"},
+    )
+    return WebPushResult(
+        subscription_id=sub.id,
+        endpoint=sub.endpoint,
+        user_id=user_id,
+        status="sent",
+    )

--- a/root/app/services/webpush.py
+++ b/root/app/services/webpush.py
@@ -68,7 +68,9 @@ def send_web_push(sub: PushSubscription, data: dict) -> WebPushResult:
             headers=headers,
             ttl=ttl if ttl is not None else 43200,
         )
-    except WebPushException as exc:  # pragma: no cover - network errors hard to simulate
+    except (
+        WebPushException
+    ) as exc:  # pragma: no cover - network errors hard to simulate
         status_code = getattr(getattr(exc, "response", None), "status_code", None)
         message = str(exc)
         gone = False

--- a/root/requirements.txt
+++ b/root/requirements.txt
@@ -11,6 +11,7 @@ passlib[bcrypt]==1.7.4
 argon2-cffi>=23.1.0
 bcrypt==4.0.1
 python-jose[cryptography]>=3.3
+cryptography>=41
 email-validator>=2.0
 httpx>=0.27
 python-multipart>=0.0.7


### PR DESCRIPTION
## Summary
- add a dedicated /webpush router with subscription validation, test delivery, and rate limiting
- extend push subscription persistence with user agent, last seen, topics, and logging-backed webpush service updates
- expose VAPID configuration helpers, manual rate-limiter utilities, and create an Alembic migration for the push_subscriptions table

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e1cd0737708327bde0f8eb1014a4e6