### PR TITLE
feat: extend frontend notifications API

### DIFF
--- a/root/frontend/src/api/notifications.ts
+++ b/root/frontend/src/api/notifications.ts
@@ -1,14 +1,58 @@
-import axios from "@/api/client"
+import api from "@/api/client"
+import type {
+  PushSubscriptionResponse,
+  SendTestNotificationResponse,
+  VapidPublicKeyResponse,
+} from "@/types/notifications"
 
 export async function fetchNotifications(limit = 20, offset = 0) {
-  const r = await axios.get("/notifications", { params: { limit, offset } })
+  const r = await api.get("/notifications", { params: { limit, offset } })
   return r.data
 }
 
 export async function markRead(id: number) {
-  await axios.post("/notifications/mark-read", { id })
+  await api.post("/notifications/mark-read", { id })
 }
 
 export async function markAllRead() {
-  await axios.post("/notifications/mark-all-read", {})
+  await api.post("/notifications/mark-all-read", {})
+}
+
+export async function getVapidKey(): Promise<string> {
+  const { data } = await api.get<VapidPublicKeyResponse>("/webpush/vapid-public-key")
+  return data.publicKey
+}
+
+export async function saveSubscription(
+  sub: PushSubscriptionJSON,
+  topics?: string[]
+): Promise<PushSubscriptionResponse> {
+  const endpoint = sub.endpoint?.trim()
+  const p256dh = sub.keys?.p256dh?.trim()
+  const auth = sub.keys?.auth?.trim()
+  if (!endpoint || !p256dh || !auth) {
+    throw new Error("Invalid push subscription payload")
+  }
+
+  const userAgent =
+    typeof navigator !== "undefined" && navigator.userAgent ? navigator.userAgent : undefined
+
+  const payload = {
+    endpoint,
+    keys: { p256dh, auth },
+    topics,
+    user_agent: userAgent,
+  }
+
+  const { data } = await api.post<PushSubscriptionResponse>("/webpush/subscribe", payload)
+  return data
+}
+
+export async function deleteSubscription(endpoint: string): Promise<void> {
+  await api.delete("/webpush/subscribe", { data: { endpoint } })
+}
+
+export async function sendTest(): Promise<SendTestNotificationResponse> {
+  const { data } = await api.post<SendTestNotificationResponse>("/webpush/send-test")
+  return data
 }

--- a/root/frontend/src/types/notifications.ts
+++ b/root/frontend/src/types/notifications.ts
@@ -1,0 +1,22 @@
+export type VapidPublicKeyResponse = {
+  publicKey: string
+}
+
+export type PushSubscriptionResponse = {
+  id: number
+  user_id: number
+  endpoint: string
+  p256dh: string
+  auth: string
+  created_at: string
+  user_agent?: string | null
+  last_seen_at?: string | null
+  topics: string[]
+}
+
+export type SendTestNotificationResponse = {
+  sent: number
+  removed: number
+  failed: number
+  detail?: string | null
+}


### PR DESCRIPTION
## Summary
- add client helpers for web push VAPID key retrieval, subscription management, and test delivery
- introduce shared TypeScript definitions for notification API responses

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1d18546a483278a7fb821b728ef19