### PR TITLE
Support actionable web push notifications

### DIFF
--- a/root/app/api/push.py
+++ b/root/app/api/push.py
@@ -1,7 +1,8 @@
 from datetime import UTC, datetime
+from typing import Any
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, field_validator
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -24,15 +25,32 @@ class SubPayload(BaseModel):
     keys: SubKeys
 
 
+class NotificationAction(BaseModel):
+    action: str = Field(..., description="Notification action identifier")
+    title: str = Field(..., description="Action button title")
+    url: str | None = Field(default=None, description="Optional URL to open")
+    icon: str | None = Field(default=None, description="Optional icon URL")
+
+    @field_validator("action", "title", mode="before")
+    @classmethod
+    def _strip(cls, value: str) -> str:
+        if value is None:
+            return ""
+        return str(value).strip()
+
+
 class NotifyBody(BaseModel):
     title: str
     body: str | None = None
     url: str | None = None
     tag: str | None = None
+    badge: str | None = None
     type: str | None = None
     ttl: int | None = 43200
     urgency: str | None = "normal"
     topic: str | None = None
+    actions: list[NotificationAction] | None = None
+    data: dict[str, Any] | None = None
 
 
 @router.get("/public-key")
@@ -122,7 +140,7 @@ async def send_test(
     if not subs:
         return {"count": 0}
 
-    payload = (data.model_dump() if data else {}) | {
+    payload = (data.model_dump(exclude_none=True) if data else {}) | {
         "title": (data.title if data and data.title else "Тестовое уведомление"),
         "body": (data.body if data and data.body else "Проверка доставки"),
         "url": (data.url if data and data.url else "/"),

--- a/root/app/services/notifications.py
+++ b/root/app/services/notifications.py
@@ -1,7 +1,7 @@
 import asyncio
 import datetime as dt
 from datetime import UTC
-from typing import Awaitable, Callable, Optional, Sequence
+from typing import Any, Awaitable, Callable, Mapping, Optional, Sequence
 
 from sqlalchemy import and_, insert, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -19,6 +19,10 @@ async def create_notifications_for_users(
     body: Optional[str] = None,
     type: Optional[str] = None,
     url: Optional[str] = None,
+    badge: Optional[str] = None,
+    tag: Optional[str] = None,
+    actions: Optional[Sequence[Mapping[str, Any]]] = None,
+    payload_data: Optional[Mapping[str, Any]] = None,
     user_ids: Sequence[int],
 ) -> int:
     now = dt.datetime.now(UTC)
@@ -49,12 +53,33 @@ async def create_notifications_for_users(
             .scalars()
             .all()
         )
-        payload = {
+        payload: dict[str, Any] = {
             "title": title,
             "body": body or "",
             "url": url or "/",
             "type": type or None,
         }
+        if badge:
+            payload["badge"] = badge
+        if tag:
+            payload["tag"] = tag
+        if payload_data:
+            payload["data"] = dict(payload_data)
+        if actions:
+            normalized_actions: list[dict[str, Any]] = []
+            for action in actions:
+                if not isinstance(action, Mapping):
+                    continue
+                normalized = {
+                    key: value
+                    for key, value in action.items()
+                    if key in {"action", "title", "icon", "url"}
+                }
+                if not normalized.get("action") or not normalized.get("title"):
+                    continue
+                normalized_actions.append(normalized)
+            if normalized_actions:
+                payload["actions"] = normalized_actions
         for s in subs:
             asyncio.create_task(asyncio.to_thread(send_web_push, s, payload))
     return len(rows)
@@ -108,6 +133,14 @@ async def generate_schedule_reminders(
             body=body,
             type="lesson",
             url="/schedule",
+            tag=f"schedule-{sch.id}",
+            actions=[
+                {
+                    "action": "open-schedule",
+                    "title": "Открыть расписание",
+                    "url": "/schedule",
+                }
+            ],
             user_ids=to_notify,
         )
     return total_created

--- a/root/app/services/webpush.py
+++ b/root/app/services/webpush.py
@@ -4,7 +4,7 @@ import json
 import logging
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import Literal
+from typing import Any, Literal
 
 from pywebpush import WebPushException, webpush
 from sqlalchemy import create_engine, delete, update
@@ -37,14 +37,65 @@ class WebPushResult:
     error: str | None = None
 
 
+def _prepare_actions(raw_actions: Any) -> tuple[list[dict[str, str]], dict[str, str]]:
+    actions: list[dict[str, str]] = []
+    action_urls: dict[str, str] = {}
+    if not isinstance(raw_actions, list):
+        return actions, action_urls
+    for item in raw_actions:
+        if not isinstance(item, dict):
+            continue
+        action = str(item.get("action") or "").strip()
+        title = str(item.get("title") or "").strip()
+        if not action or not title:
+            continue
+        prepared: dict[str, str] = {"action": action, "title": title}
+        icon = item.get("icon")
+        if isinstance(icon, str) and icon.strip():
+            prepared["icon"] = icon.strip()
+        actions.append(prepared)
+        url = item.get("url")
+        if isinstance(url, str) and url.strip():
+            action_urls[action] = url.strip()
+    return actions, action_urls
+
+
 def send_web_push(sub: PushSubscription, data: dict) -> WebPushResult:
-    payload = {
+    payload: dict[str, Any] = {
         "title": data.get("title") or "Уведомление",
         "body": data.get("body") or "",
         "url": data.get("url") or "/",
         "tag": data.get("tag"),
         "type": data.get("type"),
     }
+    badge = data.get("badge")
+    if isinstance(badge, str) and badge.strip():
+        payload["badge"] = badge.strip()
+    icon = data.get("icon")
+    if isinstance(icon, str) and icon.strip():
+        payload["icon"] = icon.strip()
+    if "renotify" in data:
+        payload["renotify"] = bool(data.get("renotify"))
+    if "requireInteraction" in data:
+        payload["requireInteraction"] = bool(data.get("requireInteraction"))
+    if "silent" in data:
+        payload["silent"] = bool(data.get("silent"))
+    if "timestamp" in data:
+        try:
+            payload["timestamp"] = int(data.get("timestamp"))
+        except (TypeError, ValueError):
+            pass
+    if "vibrate" in data and isinstance(data.get("vibrate"), list):
+        payload["vibrate"] = [int(v) for v in data["vibrate"] if isinstance(v, (int, float))]
+    data_payload = data.get("data")
+    if isinstance(data_payload, dict):
+        payload["data"] = data_payload.copy()
+    actions, action_urls = _prepare_actions(data.get("actions"))
+    if actions:
+        payload["actions"] = actions
+        if action_urls:
+            payload.setdefault("data", {})
+            payload["data"]["actionUrls"] = action_urls
     ttl_val = data.get("ttl")
     ttl = int(ttl_val) if ttl_val is not None else None
     headers = {}

--- a/root/app/services/webpush.py
+++ b/root/app/services/webpush.py
@@ -86,7 +86,9 @@ def send_web_push(sub: PushSubscription, data: dict) -> WebPushResult:
         except (TypeError, ValueError):
             pass
     if "vibrate" in data and isinstance(data.get("vibrate"), list):
-        payload["vibrate"] = [int(v) for v in data["vibrate"] if isinstance(v, (int, float))]
+        payload["vibrate"] = [
+            int(v) for v in data["vibrate"] if isinstance(v, (int, float))
+        ]
     data_payload = data.get("data")
     if isinstance(data_payload, dict):
         payload["data"] = data_payload.copy()

--- a/root/frontend/src/sw.ts
+++ b/root/frontend/src/sw.ts
@@ -72,10 +72,18 @@ registerRoute(
 
 type NotificationData = {
   url?: string
+  actionUrls?: Record<string, string>
   [key: string]: unknown
 }
 
-type NotificationAction = {
+type NotificationActionPayload = {
+  action: string
+  title: string
+  icon?: string
+  url?: string
+}
+
+type NotificationActionOption = {
   action: string
   title: string
   icon?: string
@@ -94,7 +102,7 @@ type PushPayload = {
   silent?: boolean
   timestamp?: number
   vibrate?: number[]
-  actions?: NotificationAction[]
+  actions?: NotificationActionPayload[]
 }
 
 const DEFAULT_TITLE = "Экосистема ГУУ"
@@ -132,7 +140,7 @@ self.addEventListener("push", (event) => {
     renotify?: boolean
     timestamp?: number
     vibrate?: number[]
-    actions?: NotificationAction[]
+    actions?: NotificationActionOption[]
   }
 
   if (payload.renotify !== undefined) {
@@ -147,8 +155,29 @@ self.addEventListener("push", (event) => {
     extendedOptions.vibrate = payload.vibrate
   }
 
-  if (payload.actions) {
-    extendedOptions.actions = payload.actions
+  if (payload.actions?.length) {
+    const actionUrls: Record<string, string> = {}
+    const validActions: NotificationActionOption[] = []
+    for (const action of payload.actions) {
+      if (!action || typeof action !== "object") continue
+      const key = typeof action.action === "string" ? action.action.trim() : ""
+      const title = typeof action.title === "string" ? action.title.trim() : ""
+      if (!key || !title) continue
+      const entry: NotificationActionOption = { action: key, title }
+      if (action.icon && typeof action.icon === "string") {
+        entry.icon = action.icon
+      }
+      validActions.push(entry)
+      if (action.url && typeof action.url === "string" && action.url.trim()) {
+        actionUrls[key] = action.url
+      }
+    }
+    if (validActions.length) {
+      extendedOptions.actions = validActions
+      if (Object.keys(actionUrls).length) {
+        data.actionUrls = actionUrls
+      }
+    }
   }
 
   event.waitUntil(self.registration.showNotification(title, options))
@@ -158,7 +187,12 @@ self.addEventListener("notificationclick", (event) => {
   event.notification.close()
 
   const data = (event.notification.data || {}) as NotificationData
-  const targetUrl = typeof data.url === "string" && data.url ? data.url : "/"
+  const defaultUrl = typeof data.url === "string" && data.url ? data.url : "/"
+  const actionUrl =
+    event.action && data.actionUrls && typeof data.actionUrls === "object"
+      ? data.actionUrls[event.action]
+      : undefined
+  const targetUrl = typeof actionUrl === "string" && actionUrl ? actionUrl : defaultUrl
 
   event.waitUntil(
     (async () => {


### PR DESCRIPTION
## Summary
- allow push API payloads to include badge metadata, action buttons, and extra data
- enrich service worker handling to surface notification actions, badge/tag options, and open action URLs
- extend notification scheduler delivery to reuse tags and predefined "Open schedule" action buttons

## Testing
- npm run typecheck
- pytest tests/test_smoke.py

------
https://chatgpt.com/codex/tasks/task_e_68e26e33c4908327b9e2333587621f15