### PR TITLE
Add quiet hours do-not-disturb settings for notifications

### DIFF
--- a/root/alembic/versions/23d991e593b5_add_user_quiet_hours.py
+++ b/root/alembic/versions/23d991e593b5_add_user_quiet_hours.py
@@ -1,0 +1,36 @@
+"""add user quiet hours settings"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "23d991e593b5"
+down_revision: Union[str, None] = "2bc18c38157c"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "users",
+        sa.Column(
+            "dnd_enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.sql.expression.false(),
+        ),
+    )
+    op.add_column("users", sa.Column("dnd_start", sa.Time(), nullable=True))
+    op.add_column("users", sa.Column("dnd_end", sa.Time(), nullable=True))
+    op.alter_column("users", "dnd_enabled", server_default=None)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("users", "dnd_end")
+    op.drop_column("users", "dnd_start")
+    op.drop_column("users", "dnd_enabled")

--- a/root/alembic/versions/23d991e593b5_add_user_quiet_hours.py
+++ b/root/alembic/versions/23d991e593b5_add_user_quiet_hours.py
@@ -3,8 +3,8 @@
 from typing import Sequence, Union
 
 import sqlalchemy as sa
-from alembic import op
 
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "23d991e593b5"

--- a/root/app/api/push.py
+++ b/root/app/api/push.py
@@ -5,11 +5,13 @@ from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
 from pydantic import BaseModel, Field, field_validator
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from app.api.deps import get_current_user
 from app.core.config import settings
 from app.core.database import get_db
 from app.models.models import PushSubscription, User
+from app.services.notifications import prepare_push_payload_for_user
 from app.services.webpush import send_web_push
 
 router = APIRouter(prefix="/push", tags=["push"])
@@ -132,9 +134,9 @@ async def send_test(
         bg = BackgroundTasks()
 
     res = await session.execute(
-        select(PushSubscription).where(
-            PushSubscription.user_id == user.id,
-        )
+        select(PushSubscription)
+        .options(selectinload(PushSubscription.user))
+        .where(PushSubscription.user_id == user.id)
     )
     subs = res.scalars().all()
     if not subs:
@@ -145,8 +147,12 @@ async def send_test(
         "body": (data.body if data and data.body else "Проверка доставки"),
         "url": (data.url if data and data.url else "/"),
     }
+    now_time = datetime.now().astimezone().time()
     for s in subs:
-        bg.add_task(send_web_push, s, payload)
+        prepared = prepare_push_payload_for_user(
+            payload, getattr(s, "user", None), now_time=now_time
+        )
+        bg.add_task(send_web_push, s, prepared)
     return {"count": len(subs)}
 
 
@@ -159,8 +165,15 @@ async def broadcast(
 ):
     if user.role != "admin":
         raise HTTPException(status_code=403, detail="forbidden")
-    res = await session.execute(select(PushSubscription))
+    res = await session.execute(
+        select(PushSubscription).options(selectinload(PushSubscription.user))
+    )
     subs = res.scalars().all()
+    payload = data.model_dump()
+    now_time = datetime.now().astimezone().time()
     for s in subs:
-        bg.add_task(send_web_push, s, data.model_dump())
+        prepared = prepare_push_payload_for_user(
+            payload, getattr(s, "user", None), now_time=now_time
+        )
+        bg.add_task(send_web_push, s, prepared)
     return {"count": len(subs)}

--- a/root/app/models/models.py
+++ b/root/app/models/models.py
@@ -11,6 +11,7 @@ from sqlalchemy import (
     Integer,
     String,
     Text,
+    Time,
     UniqueConstraint,
     func,
 )
@@ -45,6 +46,10 @@ class User(Base):
     achievements = Column(String)
     department = Column(String)
     position = Column(String)
+
+    dnd_enabled = Column(Boolean, default=False, nullable=False)
+    dnd_start = Column(Time(timezone=False))
+    dnd_end = Column(Time(timezone=False))
 
     spotify_user_id = Column(String, unique=True, index=True)
     spotify_access_token = Column(String)

--- a/root/app/routers/notifications.py
+++ b/root/app/routers/notifications.py
@@ -12,12 +12,14 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from app.api.deps import get_current_user
 from app.core.config import settings
 from app.core.database import get_db
 from app.core.rate_limit import RateLimitExceeded, RateLimitInfo, enforce_rate_limit
 from app.models.models import PushSubscription, User
+from app.services.notifications import prepare_push_payload_for_user
 from app.services.webpush import WebPushResult, send_web_push
 
 logger = logging.getLogger(__name__)
@@ -286,7 +288,9 @@ async def send_test(
     subscriptions = (
         (
             await db.execute(
-                select(PushSubscription).where(PushSubscription.user_id == user.id)
+                select(PushSubscription)
+                .options(selectinload(PushSubscription.user))
+                .where(PushSubscription.user_id == user.id)
             )
         )
         .scalars()
@@ -306,8 +310,14 @@ async def send_test(
     sent = 0
     removed = 0
     failed = 0
+    now_time = datetime.now().astimezone().time()
     for sub in subscriptions:
-        result: WebPushResult = await run_in_threadpool(send_web_push, sub, payload)
+        prepared = prepare_push_payload_for_user(
+            payload, getattr(sub, "user", None), now_time=now_time
+        )
+        result: WebPushResult = await run_in_threadpool(
+            send_web_push, sub, prepared
+        )
         if result.status == "sent":
             sent += 1
         elif result.status == "gone":

--- a/root/app/routers/notifications.py
+++ b/root/app/routers/notifications.py
@@ -315,9 +315,7 @@ async def send_test(
         prepared = prepare_push_payload_for_user(
             payload, getattr(sub, "user", None), now_time=now_time
         )
-        result: WebPushResult = await run_in_threadpool(
-            send_web_push, sub, prepared
-        )
+        result: WebPushResult = await run_in_threadpool(send_web_push, sub, prepared)
         if result.status == "sent":
             sent += 1
         elif result.status == "gone":

--- a/root/app/schemas/schemas.py
+++ b/root/app/schemas/schemas.py
@@ -1,7 +1,7 @@
-from datetime import datetime
+from datetime import datetime, time
 from typing import List, Optional
 
-from pydantic import BaseModel, ConfigDict, EmailStr, Field
+from pydantic import BaseModel, ConfigDict, EmailStr, Field, model_validator
 
 
 class OrmModel(BaseModel):
@@ -42,6 +42,9 @@ class UserBase(BaseModel):
     position: Optional[str] = None
     spotify_connected: bool = False
     spotify_display_name: Optional[str] = None
+    dnd_enabled: bool = False
+    dnd_start: Optional[time] = None
+    dnd_end: Optional[time] = None
 
 
 class UserCreate(UserBase):
@@ -77,6 +80,20 @@ class UserProfileUpdate(BaseModel):
     achievements: Optional[str] = None
     department: Optional[str] = None
     position: Optional[str] = None
+    dnd_enabled: Optional[bool] = None
+    dnd_start: Optional[time] = None
+    dnd_end: Optional[time] = None
+
+    @model_validator(mode="after")
+    def _validate_dnd(cls, values: "UserProfileUpdate") -> "UserProfileUpdate":
+        enabled = values.dnd_enabled
+        start = values.dnd_start
+        end = values.dnd_end
+        if enabled and (start is None or end is None):
+            raise ValueError(
+                "Укажите время начала и окончания режима \"Не беспокоить\""
+            )
+        return values
 
 
 class GroupCreate(BaseModel):

--- a/root/app/schemas/schemas.py
+++ b/root/app/schemas/schemas.py
@@ -90,9 +90,7 @@ class UserProfileUpdate(BaseModel):
         start = values.dnd_start
         end = values.dnd_end
         if enabled and (start is None or end is None):
-            raise ValueError(
-                "Укажите время начала и окончания режима \"Не беспокоить\""
-            )
+            raise ValueError('Укажите время начала и окончания режима "Не беспокоить"')
         return values
 
 

--- a/root/app/services/notifications.py
+++ b/root/app/services/notifications.py
@@ -5,11 +5,59 @@ from typing import Any, Awaitable, Callable, Mapping, Optional, Sequence
 
 from sqlalchemy import and_, insert, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from app.core.config import settings
 from app.core.database import async_session
 from app.models.models import Notification, PushSubscription, Schedule, User
 from app.services.webpush import send_web_push
+
+
+def _current_local_time() -> dt.time:
+    return dt.datetime.now().astimezone().time()
+
+
+def is_user_in_quiet_hours(
+    user: User | None, *, now_time: dt.time | None = None
+) -> bool:
+    if not user or not getattr(user, "dnd_enabled", False):
+        return False
+    start = getattr(user, "dnd_start", None)
+    end = getattr(user, "dnd_end", None)
+    if now_time is None:
+        now_time = _current_local_time()
+    if start is None or end is None:
+        return True
+    if start == end:
+        return True
+    if start < end:
+        return start <= now_time < end
+    return now_time >= start or now_time < end
+
+
+def prepare_push_payload_for_user(
+    payload: Mapping[str, Any],
+    user: User | None,
+    *,
+    now_time: dt.time | None = None,
+) -> dict[str, Any]:
+    base: dict[str, Any] = dict(payload)
+    data_section = base.get("data")
+    if isinstance(data_section, Mapping):
+        base["data"] = dict(data_section)
+    if is_user_in_quiet_hours(user, now_time=now_time):
+        base["silent"] = True
+        base["vibrate"] = []
+        base["renotify"] = False
+        base["requireInteraction"] = False
+        data_payload = base.get("data")
+        if isinstance(data_payload, dict):
+            data_payload = dict(data_payload)
+        else:
+            data_payload = {}
+        data_payload["dnd_suppressed"] = True
+        base["data"] = data_payload
+    return base
 
 
 async def create_notifications_for_users(
@@ -47,24 +95,26 @@ async def create_notifications_for_users(
         subs = (
             (
                 await db.execute(
-                    select(PushSubscription).where(PushSubscription.user_id.in_(uids))
+                    select(PushSubscription)
+                    .options(selectinload(PushSubscription.user))
+                    .where(PushSubscription.user_id.in_(uids))
                 )
             )
             .scalars()
             .all()
         )
-        payload: dict[str, Any] = {
+        base_payload: dict[str, Any] = {
             "title": title,
             "body": body or "",
             "url": url or "/",
             "type": type or None,
         }
         if badge:
-            payload["badge"] = badge
+            base_payload["badge"] = badge
         if tag:
-            payload["tag"] = tag
+            base_payload["tag"] = tag
         if payload_data:
-            payload["data"] = dict(payload_data)
+            base_payload["data"] = dict(payload_data)
         if actions:
             normalized_actions: list[dict[str, Any]] = []
             for action in actions:
@@ -79,9 +129,15 @@ async def create_notifications_for_users(
                     continue
                 normalized_actions.append(normalized)
             if normalized_actions:
-                payload["actions"] = normalized_actions
+                base_payload["actions"] = normalized_actions
+        now_time = _current_local_time()
         for s in subs:
-            asyncio.create_task(asyncio.to_thread(send_web_push, s, payload))
+            prepared_payload = prepare_push_payload_for_user(
+                base_payload, getattr(s, "user", None), now_time=now_time
+            )
+            asyncio.create_task(
+                asyncio.to_thread(send_web_push, s, prepared_payload)
+            )
     return len(rows)
 
 

--- a/root/app/services/notifications.py
+++ b/root/app/services/notifications.py
@@ -135,9 +135,7 @@ async def create_notifications_for_users(
             prepared_payload = prepare_push_payload_for_user(
                 base_payload, getattr(s, "user", None), now_time=now_time
             )
-            asyncio.create_task(
-                asyncio.to_thread(send_web_push, s, prepared_payload)
-            )
+            asyncio.create_task(asyncio.to_thread(send_web_push, s, prepared_payload))
     return len(rows)
 
 

--- a/root/frontend/src/pages/Settings.tsx
+++ b/root/frontend/src/pages/Settings.tsx
@@ -1,4 +1,12 @@
-import { useEffect, useRef, useState, useCallback, ChangeEvent, useMemo } from "react";
+import {
+  useEffect,
+  useRef,
+  useState,
+  useCallback,
+  ChangeEvent,
+  FocusEvent,
+  useMemo
+} from "react";
 import { useAuth, currentUserQueryKey, fetchCurrentUser } from "@/contexts/AuthContext";
 import { useNavigate } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
@@ -34,6 +42,7 @@ import {
   FormHelperText
 } from "@mui/material";
 import { useColorScheme } from "@mui/material/styles";
+import TextField from "@mui/material/TextField";
 import SettingsIcon from "@mui/icons-material/Settings";
 import DarkModeIcon from "@mui/icons-material/DarkMode";
 import LightModeIcon from "@mui/icons-material/LightMode";
@@ -44,6 +53,8 @@ import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
 import ImageIcon from "@mui/icons-material/Image";
 import NotificationsActiveIcon from "@mui/icons-material/NotificationsActive";
 import NotificationsOffIcon from "@mui/icons-material/NotificationsOff";
+import DoNotDisturbOnIcon from "@mui/icons-material/DoNotDisturbOn";
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import defaultAvatar from "@/assets/default_avatar.png";
 import spotifyLogo from "@/assets/spotify_icon.png";
 import { resolveMediaUrl } from "@/utils/media";
@@ -73,6 +84,29 @@ const DEFAULT_NOTIFICATION_TOPICS: Record<NotificationTopicKey, boolean> = {
   system: true
 };
 
+const DEFAULT_DND_START = "22:00";
+const DEFAULT_DND_END = "07:00";
+
+const toInputTime = (value: unknown): string => {
+  if (!value) return "";
+  const str = String(value);
+  const match = str.match(/^(\d{2}:\d{2})/);
+  return match ? match[1] : "";
+};
+
+const toServerTime = (value: string | null): string | null => {
+  if (!value) return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  if (/^\d{2}:\d{2}$/.test(trimmed)) {
+    return `${trimmed}:00`;
+  }
+  if (/^\d{2}:\d{2}:\d{2}$/.test(trimmed)) {
+    return trimmed;
+  }
+  return trimmed;
+};
+
 export default function Settings() {
   const navigate = useNavigate();
   const { user, setUser, logout } = useAuth();
@@ -94,6 +128,19 @@ export default function Settings() {
   const [pushSubscription, setPushSubscription] = useState<PushSubscription | null>(null);
   const [pushBusy, setPushBusy] = useState(false);
   const [pushInitializing, setPushInitializing] = useState(true);
+  const [dndEnabled, setDndEnabled] = useState(false);
+  const [dndStart, setDndStart] = useState("");
+  const [dndEnd, setDndEnd] = useState("");
+  const [dndSaving, setDndSaving] = useState(false);
+
+  const syncDndFromUser = useCallback((value: any) => {
+    const enabled = Boolean(value?.dnd_enabled);
+    const start = toInputTime(value?.dnd_start);
+    const end = toInputTime(value?.dnd_end);
+    setDndEnabled(enabled);
+    setDndStart(start || (enabled ? DEFAULT_DND_START : ""));
+    setDndEnd(end || (enabled ? DEFAULT_DND_END : ""));
+  }, []);
 
   const selectedTopics = useMemo(() => {
     return topicKeys.filter(key => topicState[key]);
@@ -116,6 +163,113 @@ export default function Settings() {
   }, [selectedTopics]);
 
   const notificationsEnabled = !!pushSubscription;
+
+  const persistDnd = useCallback(
+    async (nextEnabled: boolean, nextStart: string | null, nextEnd: string | null) => {
+      if (dndSaving) return;
+      const normalizedStart = nextStart ? nextStart.trim() : null;
+      const normalizedEnd = nextEnd ? nextEnd.trim() : null;
+      const prevEnabled = Boolean((user as any)?.dnd_enabled);
+      const prevStart = toInputTime((user as any)?.dnd_start);
+      const prevEnd = toInputTime((user as any)?.dnd_end);
+      if (
+        nextEnabled === prevEnabled &&
+        (!nextEnabled ||
+          (normalizedStart && normalizedEnd && normalizedStart === prevStart && normalizedEnd === prevEnd))
+      ) {
+        return;
+      }
+      if (nextEnabled && (!normalizedStart || !normalizedEnd)) {
+        setSnack({ text: "Укажите время начала и окончания режима \"Не беспокоить\"", sev: "warning" });
+        syncDndFromUser(user);
+        return;
+      }
+      setDndSaving(true);
+      try {
+        const payload: Record<string, any> = { dnd_enabled: nextEnabled };
+        if (nextEnabled) {
+          payload.dnd_start = toServerTime(normalizedStart);
+          payload.dnd_end = toServerTime(normalizedEnd);
+        } else {
+          payload.dnd_start = null;
+          payload.dnd_end = null;
+        }
+        const res = await api.put("/users/me", payload);
+        setUser(res.data);
+        syncDndFromUser(res.data);
+        const wasEnabled = prevEnabled;
+        let message: string;
+        if (nextEnabled && !wasEnabled) message = 'Режим "Не беспокоить" включён';
+        else if (!nextEnabled && wasEnabled) message = 'Режим "Не беспокоить" выключен';
+        else message = 'Настройки режима "Не беспокоить" обновлены';
+        setSnack({ text: message, sev: "success" });
+      } catch (error: any) {
+        console.error("Failed to update quiet mode", error);
+        let message = 'Не удалось обновить настройки режима "Не беспокоить"';
+        const detail = error?.response?.data?.detail;
+        if (typeof detail === "string") message = detail;
+        else if (Array.isArray(detail)) {
+          const collected = detail
+            .map((item: any) => (item?.msg ? String(item.msg) : ""))
+            .filter(Boolean)
+            .join("; ");
+          if (collected) message = collected;
+        }
+        setSnack({ text: message, sev: "error" });
+        syncDndFromUser(user);
+      } finally {
+        setDndSaving(false);
+      }
+    },
+    [dndSaving, setUser, setSnack, syncDndFromUser, user]
+  );
+
+  const handleDndToggle = useCallback(
+    (_: ChangeEvent<HTMLInputElement>, checked: boolean) => {
+      if (dndSaving) return;
+      const nextStart = checked ? dndStart || DEFAULT_DND_START : dndStart;
+      const nextEnd = checked ? dndEnd || DEFAULT_DND_END : dndEnd;
+      if (checked) {
+        setDndStart(nextStart);
+        setDndEnd(nextEnd);
+      }
+      setDndEnabled(checked);
+      void persistDnd(checked, checked ? nextStart : null, checked ? nextEnd : null);
+    },
+    [dndSaving, dndEnd, dndStart, persistDnd]
+  );
+
+  const handleDndStartChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    setDndStart(event.target.value);
+  }, []);
+
+  const handleDndStartBlur = useCallback(
+    (event: FocusEvent<HTMLInputElement>) => {
+      if (!dndEnabled || dndSaving) return;
+      const value = (event.currentTarget.value || "").trim();
+      setDndStart(value);
+      void persistDnd(true, value || null, dndEnd || null);
+    },
+    [dndEnabled, dndEnd, dndSaving, persistDnd]
+  );
+
+  const handleDndEndChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    setDndEnd(event.target.value);
+  }, []);
+
+  const handleDndEndBlur = useCallback(
+    (event: FocusEvent<HTMLInputElement>) => {
+      if (!dndEnabled || dndSaving) return;
+      const value = (event.currentTarget.value || "").trim();
+      setDndEnd(value);
+      void persistDnd(true, dndStart || null, value || null);
+    },
+    [dndEnabled, dndSaving, dndStart, persistDnd]
+  );
+
+  useEffect(() => {
+    syncDndFromUser(user);
+  }, [syncDndFromUser, user]);
 
   const applyServerTopics = useCallback(
     (topics?: string[] | null) => {
@@ -666,6 +820,72 @@ export default function Settings() {
                       Разрешите уведомления в настройках браузера, чтобы получать оповещения.
                     </Alert>
                   )}
+
+                  <Divider sx={{ my: 1.2 }} />
+
+                  <Stack spacing={1.2}>
+                    <Stack direction="row" alignItems="center" spacing={1} sx={{ color: "var(--page-text)" }}>
+                      <DoNotDisturbOnIcon fontSize="small" />
+                      <Typography variant="subtitle1" sx={{ color: "var(--page-text)" }}>
+                        Режим «Не беспокоить»
+                      </Typography>
+                    </Stack>
+
+                    <FormControl component="fieldset" variant="standard">
+                      <FormGroup>
+                        <FormControlLabel
+                          control={
+                            <Switch checked={dndEnabled} onChange={handleDndToggle} disabled={dndSaving} />
+                          }
+                          label={<span style={{ color: "var(--page-text)" }}>Включить тихий период</span>}
+                        />
+                      </FormGroup>
+                      <FormHelperText sx={{ ml: 0, color: "var(--page-text)", mt: 0.5 }}>
+                        Уведомления будут доставляться без звука в указанный интервал.
+                      </FormHelperText>
+                    </FormControl>
+
+                    <Stack
+                      direction={{ xs: "column", sm: "row" }}
+                      spacing={1.5}
+                      alignItems={{ sm: "center" }}
+                    >
+                      <TextField
+                        type="time"
+                        label="С"
+                        value={dndStart}
+                        onChange={handleDndStartChange}
+                        onBlur={handleDndStartBlur}
+                        disabled={!dndEnabled || dndSaving}
+                        size="small"
+                        InputLabelProps={{ shrink: true }}
+                        sx={{ maxWidth: { xs: "100%", sm: 200 } }}
+                      />
+                      <TextField
+                        type="time"
+                        label="До"
+                        value={dndEnd}
+                        onChange={handleDndEndChange}
+                        onBlur={handleDndEndBlur}
+                        disabled={!dndEnabled || dndSaving}
+                        size="small"
+                        InputLabelProps={{ shrink: true }}
+                        sx={{ maxWidth: { xs: "100%", sm: 200 } }}
+                      />
+                    </Stack>
+
+                    <FormHelperText sx={{ ml: 0, color: "var(--page-text)" }}>
+                      Интервал задаётся в часовом поясе устройства и может пересекать полночь.
+                    </FormHelperText>
+
+                    <Stack direction="row" spacing={1} alignItems="flex-start" sx={{ color: "var(--page-text)" }}>
+                      <InfoOutlinedIcon fontSize="small" sx={{ mt: 0.3 }} />
+                      <Typography variant="body2" sx={{ color: "var(--page-text)" }}>
+                        На iOS при установке веб-приложения как PWA уведомления часто приходят без звука —
+                        это ограничение системы.
+                      </Typography>
+                    </Stack>
+                  </Stack>
 
                   <Typography variant="body2" sx={{ color: "var(--page-text)" }}>
                     {notificationsEnabled

--- a/root/tests/test_notifications_service.py
+++ b/root/tests/test_notifications_service.py
@@ -1,0 +1,41 @@
+import datetime as dt
+
+from app.models.models import User
+from app.services.notifications import (
+    is_user_in_quiet_hours,
+    prepare_push_payload_for_user,
+)
+
+
+def test_is_user_in_quiet_hours_crosses_midnight():
+    user = User(dnd_enabled=True, dnd_start=dt.time(22, 0), dnd_end=dt.time(7, 0))
+    assert is_user_in_quiet_hours(user, now_time=dt.time(23, 15)) is True
+    assert is_user_in_quiet_hours(user, now_time=dt.time(6, 45)) is True
+    assert is_user_in_quiet_hours(user, now_time=dt.time(12, 0)) is False
+
+
+def test_prepare_push_payload_applies_silent_mode():
+    payload = {"title": "Test", "data": {"foo": "bar"}}
+    user = User(dnd_enabled=True, dnd_start=dt.time(21, 0), dnd_end=dt.time(6, 0))
+
+    result = prepare_push_payload_for_user(payload, user, now_time=dt.time(22, 30))
+
+    assert result is not payload
+    assert result["silent"] is True
+    assert result["vibrate"] == []
+    assert result["renotify"] is False
+    assert result["requireInteraction"] is False
+    assert result["data"]["foo"] == "bar"
+    assert result["data"]["dnd_suppressed"] is True
+    assert "silent" not in payload
+
+
+def test_prepare_push_payload_keeps_original_when_outside_interval():
+    payload = {"title": "Test outside", "data": {"foo": "bar"}}
+    user = User(dnd_enabled=True, dnd_start=dt.time(22, 0), dnd_end=dt.time(7, 0))
+
+    result = prepare_push_payload_for_user(payload, user, now_time=dt.time(15, 0))
+
+    assert "silent" not in result
+    assert result["data"]["foo"] == "bar"
+    assert "dnd_suppressed" not in result["data"]

--- a/root/tests/test_schemas.py
+++ b/root/tests/test_schemas.py
@@ -1,3 +1,5 @@
+from datetime import time
+
 import pytest
 from pydantic import ValidationError
 
@@ -16,6 +18,20 @@ def test_user_profile_update_validates_email():
         schemas.UserProfileUpdate(email="not-an-email")
 
 
+def test_user_profile_update_requires_dnd_times():
+    with pytest.raises(ValidationError):
+        schemas.UserProfileUpdate(dnd_enabled=True)
+
+
+def test_user_profile_update_accepts_dnd_interval():
+    payload = schemas.UserProfileUpdate(
+        dnd_enabled=True,
+        dnd_start=time(22, 0),
+        dnd_end=time(7, 0),
+    )
+    assert payload.dnd_enabled is True
+
+
 async def test_user_out_contract(user_factory):
     user = await user_factory(
         full_name="Test User", spotify_is_connected=True, spotify_display_name="DJ Test"
@@ -27,4 +43,7 @@ async def test_user_out_contract(user_factory):
     assert data["email"] == user.email
     assert data["spotify_connected"] is True
     assert data["spotify_is_connected"] is True
+    assert data["dnd_enabled"] is False
+    assert data["dnd_start"] is None
+    assert data["dnd_end"] is None
     assert "hashed_password" not in data


### PR DESCRIPTION
## Summary
- add quiet hours fields and migration for user do-not-disturb preferences
- respect do-not-disturb intervals when delivering web push notifications across the API
- expose a "Не беспокоить" scheduler in settings with validation and an iOS PWA sound hint

## Testing
- pytest
- npm --prefix root/frontend test

------
https://chatgpt.com/codex/tasks/task_e_68e2722d4ec48327a23694f76af0f30d