### PR TITLE
Add subscription topic management for web push

### DIFF
--- a/root/app/api/push.py
+++ b/root/app/api/push.py
@@ -12,6 +12,7 @@ from app.core.config import settings
 from app.core.database import get_db
 from app.models.models import PushSubscription, User
 from app.services.notifications import prepare_push_payload_for_user
+from app.services.push_topics import normalize_topic, subscription_supports_topic
 from app.services.webpush import send_web_push
 
 router = APIRouter(prefix="/push", tags=["push"])
@@ -53,6 +54,11 @@ class NotifyBody(BaseModel):
     topic: str | None = None
     actions: list[NotificationAction] | None = None
     data: dict[str, Any] | None = None
+
+    @field_validator("topic", mode="before")
+    @classmethod
+    def _normalize_topic(cls, value):
+        return normalize_topic(value)
 
 
 @router.get("/public-key")
@@ -142,18 +148,25 @@ async def send_test(
     if not subs:
         return {"count": 0}
 
+    requested_topic = normalize_topic(getattr(data, "topic", None) if data else None)
     payload = (data.model_dump(exclude_none=True) if data else {}) | {
         "title": (data.title if data and data.title else "Тестовое уведомление"),
         "body": (data.body if data and data.body else "Проверка доставки"),
         "url": (data.url if data and data.url else "/"),
     }
+    if requested_topic:
+        payload["topic"] = requested_topic
     now_time = datetime.now().astimezone().time()
+    matched = 0
     for s in subs:
+        if not subscription_supports_topic(s, requested_topic):
+            continue
         prepared = prepare_push_payload_for_user(
             payload, getattr(s, "user", None), now_time=now_time
         )
         bg.add_task(send_web_push, s, prepared)
-    return {"count": len(subs)}
+        matched += 1
+    return {"count": matched}
 
 
 @router.post("/broadcast")
@@ -169,11 +182,20 @@ async def broadcast(
         select(PushSubscription).options(selectinload(PushSubscription.user))
     )
     subs = res.scalars().all()
+    topic = normalize_topic(data.topic)
     payload = data.model_dump()
+    if topic:
+        payload["topic"] = topic
+    else:
+        payload.pop("topic", None)
     now_time = datetime.now().astimezone().time()
+    matched = 0
     for s in subs:
+        if not subscription_supports_topic(s, topic):
+            continue
         prepared = prepare_push_payload_for_user(
             payload, getattr(s, "user", None), now_time=now_time
         )
         bg.add_task(send_web_push, s, prepared)
-    return {"count": len(subs)}
+        matched += 1
+    return {"count": matched}

--- a/root/app/routers/notifications.py
+++ b/root/app/routers/notifications.py
@@ -20,6 +20,12 @@ from app.core.database import get_db
 from app.core.rate_limit import RateLimitExceeded, RateLimitInfo, enforce_rate_limit
 from app.models.models import PushSubscription, User
 from app.services.notifications import prepare_push_payload_for_user
+from app.services.push_topics import (
+    normalize_topic,
+    normalize_topics,
+    resolve_topics,
+    subscription_supports_topic,
+)
 from app.services.webpush import WebPushResult, send_web_push
 
 logger = logging.getLogger(__name__)
@@ -59,7 +65,7 @@ class PushSubscriptionIn(BaseModel):
     def _normalize_topics(cls, value: list[str] | None) -> list[str] | None:
         if value is None:
             return None
-        return [str(topic).strip() for topic in value if str(topic).strip()]
+        return normalize_topics(value)
 
 
 class PushSubscriptionOut(BaseModel):
@@ -81,8 +87,27 @@ class PushSubscriptionOut(BaseModel):
         if not value:
             return []
         if isinstance(value, list):
-            return [str(topic) for topic in value if str(topic).strip()]
+            return normalize_topics(value)
         return value
+
+
+class PushSubscriptionTopicsUpdate(BaseModel):
+    endpoint: str
+    topics: list[str] = Field(default_factory=list)
+
+    @field_validator("endpoint", mode="before")
+    @classmethod
+    def _normalize_endpoint(cls, value: str) -> str:
+        if value is None:
+            return ""
+        return str(value).strip()
+
+    @field_validator("topics", mode="before")
+    @classmethod
+    def _normalize_topics(cls, value):
+        if value is None:
+            return []
+        return normalize_topics(value)
 
 
 class PushSubscriptionDelete(BaseModel):
@@ -156,27 +181,8 @@ async def subscribe(
     ).scalar_one_or_none()
 
     def _resolve_topics() -> list[str]:
-        raw_topics = payload.topics
-        if raw_topics is None:
-            if existing and existing.topics:
-                return [
-                    str(topic).strip()
-                    for topic in existing.topics
-                    if str(topic).strip()
-                ]
-            return []
-        unique: list[str] = []
-        seen_local: set[str] = set()
-        for topic in raw_topics:
-            normalized = topic.strip()
-            if not normalized:
-                continue
-            key = normalized.lower()
-            if key in seen_local:
-                continue
-            seen_local.add(key)
-            unique.append(normalized)
-        return unique
+        existing_topics = existing.topics if existing else None
+        return resolve_topics(payload.topics, existing_topics)
 
     now = datetime.now(UTC)
     try:
@@ -221,6 +227,46 @@ async def subscribe(
             },
         )
 
+    return PushSubscriptionOut.model_validate(subscription)
+
+
+@router.patch("/subscribe/topics", response_model=PushSubscriptionOut)
+async def update_subscription_topics(
+    payload: PushSubscriptionTopicsUpdate,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    user: Annotated[User, Depends(get_current_user)],
+) -> PushSubscriptionOut:
+    endpoint = payload.endpoint.strip()
+    if not endpoint:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "error": "invalid_subscription",
+                "message": "Endpoint is required",
+            },
+        )
+
+    subscription = (
+        await db.execute(
+            select(PushSubscription).where(
+                PushSubscription.endpoint == endpoint,
+                PushSubscription.user_id == user.id,
+            )
+        )
+    ).scalar_one_or_none()
+    if not subscription:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={
+                "error": "subscription_not_found",
+                "message": "Subscription not found",
+            },
+        )
+
+    subscription.topics = normalize_topics(payload.topics)
+    subscription.last_seen_at = datetime.now(UTC)
+    await db.commit()
+    await db.refresh(subscription)
     return PushSubscriptionOut.model_validate(subscription)
 
 
@@ -301,17 +347,22 @@ async def send_test(
             sent=0, removed=0, failed=0, detail="No subscriptions found"
         )
 
+    topic = normalize_topic("system")
     payload = {
         "title": "Тестовое веб-push уведомление",
         "body": "Проверка доставки уведомлений",
         "url": settings.app_base_url or "/",
     }
+    if topic:
+        payload["topic"] = topic
 
     sent = 0
     removed = 0
     failed = 0
     now_time = datetime.now().astimezone().time()
     for sub in subscriptions:
+        if not subscription_supports_topic(sub, topic):
+            continue
         prepared = prepare_push_payload_for_user(
             payload, getattr(sub, "user", None), now_time=now_time
         )

--- a/root/app/services/notifications.py
+++ b/root/app/services/notifications.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import selectinload
 from app.core.config import settings
 from app.core.database import async_session
 from app.models.models import Notification, PushSubscription, Schedule, User
+from app.services.push_topics import normalize_topic, subscription_supports_topic
 from app.services.webpush import send_web_push
 
 
@@ -72,6 +73,7 @@ async def create_notifications_for_users(
     actions: Optional[Sequence[Mapping[str, Any]]] = None,
     payload_data: Optional[Mapping[str, Any]] = None,
     user_ids: Sequence[int],
+    topic: Optional[str] = None,
 ) -> int:
     now = dt.datetime.now(UTC)
     uids = list({int(uid) for uid in user_ids})
@@ -109,6 +111,9 @@ async def create_notifications_for_users(
             "url": url or "/",
             "type": type or None,
         }
+        normalized_topic = normalize_topic(topic)
+        if normalized_topic:
+            base_payload["topic"] = normalized_topic
         if badge:
             base_payload["badge"] = badge
         if tag:
@@ -132,6 +137,8 @@ async def create_notifications_for_users(
                 base_payload["actions"] = normalized_actions
         now_time = _current_local_time()
         for s in subs:
+            if not subscription_supports_topic(s, normalized_topic):
+                continue
             prepared_payload = prepare_push_payload_for_user(
                 base_payload, getattr(s, "user", None), now_time=now_time
             )
@@ -196,6 +203,7 @@ async def generate_schedule_reminders(
                 }
             ],
             user_ids=to_notify,
+            topic="schedule",
         )
     return total_created
 

--- a/root/app/services/push_topics.py
+++ b/root/app/services/push_topics.py
@@ -67,4 +67,3 @@ def subscription_supports_topic(
     stored = getattr(subscription, "topics", None)
     normalized_existing = normalize_topics(stored)
     return normalized_topic in normalized_existing
-

--- a/root/app/services/push_topics.py
+++ b/root/app/services/push_topics.py
@@ -1,0 +1,70 @@
+"""Helpers for working with push notification topics."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - for type checking only
+    from app.models.models import PushSubscription
+
+ALLOWED_PUSH_TOPICS: set[str] = {"news", "schedule", "system"}
+
+
+def normalize_topic(value: str | None) -> str | None:
+    """Normalize a single topic value.
+
+    Returns the normalized topic (lowercase) if it is allowed, otherwise ``None``.
+    """
+
+    if value is None:
+        return None
+    normalized = str(value).strip().lower()
+    if not normalized:
+        return None
+    if normalized not in ALLOWED_PUSH_TOPICS:
+        return None
+    return normalized
+
+
+def normalize_topics(raw_topics: Iterable[str] | None) -> list[str]:
+    """Normalize and deduplicate an iterable of topics."""
+
+    result: list[str] = []
+    seen: set[str] = set()
+    if raw_topics is None:
+        return result
+    for raw in raw_topics:
+        normalized = normalize_topic(raw)
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        result.append(normalized)
+    return result
+
+
+def resolve_topics(
+    raw_topics: Iterable[str] | None,
+    existing: Sequence[str] | None = None,
+) -> list[str]:
+    """Resolve topics from a raw payload, falling back to existing values."""
+
+    if raw_topics is None:
+        return normalize_topics(existing or [])
+    return normalize_topics(raw_topics)
+
+
+def subscription_supports_topic(
+    subscription: PushSubscription | None, topic: str | None
+) -> bool:
+    """Check whether a subscription is interested in the provided topic."""
+
+    normalized_topic = normalize_topic(topic)
+    if normalized_topic is None:
+        return True
+    if subscription is None:
+        return False
+    stored = getattr(subscription, "topics", None)
+    normalized_existing = normalize_topics(stored)
+    return normalized_topic in normalized_existing
+

--- a/root/frontend/src/api/notifications.ts
+++ b/root/frontend/src/api/notifications.ts
@@ -52,6 +52,22 @@ export async function deleteSubscription(endpoint: string): Promise<void> {
   await api.delete("/webpush/subscribe", { data: { endpoint } })
 }
 
+export async function updateSubscriptionTopics(
+  endpoint: string,
+  topics: string[]
+): Promise<PushSubscriptionResponse> {
+  const normalizedEndpoint = endpoint?.trim()
+  if (!normalizedEndpoint) {
+    throw new Error("Endpoint is required")
+  }
+  const payload = { endpoint: normalizedEndpoint, topics }
+  const { data } = await api.patch<PushSubscriptionResponse>(
+    "/webpush/subscribe/topics",
+    payload
+  )
+  return data
+}
+
 export async function sendTest(): Promise<SendTestNotificationResponse> {
   const { data } = await api.post<SendTestNotificationResponse>("/webpush/send-test")
   return data

--- a/root/frontend/src/pages/Settings.tsx
+++ b/root/frontend/src/pages/Settings.tsx
@@ -64,7 +64,12 @@ import {
   setPushConsent,
   urlBase64ToUint8Array
 } from "@/push/subscribe";
-import { deleteSubscription, getVapidKey, saveSubscription } from "@/api/notifications";
+import {
+  deleteSubscription,
+  getVapidKey,
+  saveSubscription,
+  updateSubscriptionTopics
+} from "@/api/notifications";
 
 type ThemeMode = "system" | "light" | "dark";
 
@@ -425,7 +430,6 @@ export default function Settings() {
         if (!isPushSupported()) return;
         setPushBusy(true);
         const topicsToSend = topicKeys.filter(topic => nextState[topic]);
-        type Payload = Parameters<typeof saveSubscription>[0];
         (async () => {
           try {
             const registration = await navigator.serviceWorker.ready;
@@ -435,7 +439,11 @@ export default function Settings() {
               setPushConsent(false);
               return;
             }
-            const saved = await saveSubscription(sub.toJSON() as Payload, topicsToSend);
+            const endpoint = (sub.endpoint || "").trim();
+            type Payload = Parameters<typeof saveSubscription>[0];
+            const saved = endpoint
+              ? await updateSubscriptionTopics(endpoint, topicsToSend)
+              : await saveSubscription(sub.toJSON() as Payload, topicsToSend);
             applyServerTopics(saved?.topics ?? topicsToSend);
             setPushSubscription(sub);
           } catch (error) {
@@ -446,7 +454,16 @@ export default function Settings() {
           }
         })();
       },
-    [applyServerTopics, notificationsEnabled, pushBusy, topicKeys, topicState]
+    [
+      applyServerTopics,
+      notificationsEnabled,
+      pushBusy,
+      setPushConsent,
+      setPushSubscription,
+      setSnack,
+      topicKeys,
+      topicState
+    ]
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- normalize allowed push notification topics and reuse them across the backend
- add PATCH /webpush/subscribe/topics and ensure push senders respect selected topics
- update the settings page to patch topics through the new endpoint

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2775cf8e48327b329ae115fcc2253