### PR TITLE
feat: clean dead push subscriptions and automate weekly maintenance

### DIFF
--- a/.github/workflows/weekly-cleanup.yml
+++ b/.github/workflows/weekly-cleanup.yml
@@ -1,0 +1,43 @@
+name: Weekly cleanup
+
+on:
+  schedule:
+    - cron: '0 3 * * 1'
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    env:
+      OTEL_SDK_DISABLED: "true"
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      SECRET_KEY: ${{ secrets.SECRET_KEY }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: |
+            root/requirements.txt
+
+      - name: Install dependencies
+        working-directory: root
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run weekly cleanup
+        if: ${{ env.DATABASE_URL != '' && env.SECRET_KEY != '' }}
+        working-directory: root
+        run: |
+          python -m app.management.weekly_cleanup
+
+      - name: Report missing secrets
+        if: ${{ env.DATABASE_URL == '' || env.SECRET_KEY == '' }}
+        run: |
+          echo "Required secrets DATABASE_URL and SECRET_KEY are not configured; skipping cleanup."
+          exit 0

--- a/root/app/api/push.py
+++ b/root/app/api/push.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-from datetime import UTC, datetime
-
 import logging
+from datetime import UTC, datetime
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request

--- a/root/app/api/push.py
+++ b/root/app/api/push.py
@@ -1,7 +1,12 @@
+from __future__ import annotations
+
 from datetime import UTC, datetime
+
+import logging
 from typing import Any
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.concurrency import run_in_threadpool
 from pydantic import BaseModel, Field, field_validator
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -13,9 +18,11 @@ from app.core.database import get_db
 from app.models.models import PushSubscription, User
 from app.services.notifications import prepare_push_payload_for_user
 from app.services.push_topics import normalize_topic, subscription_supports_topic
-from app.services.webpush import send_web_push
+from app.services.webpush import WebPushResult, send_web_push
 
 router = APIRouter(prefix="/push", tags=["push"])
+
+logger = logging.getLogger(__name__)
 
 
 class SubKeys(BaseModel):
@@ -129,16 +136,42 @@ async def unsubscribe(
     return {"ok": True}
 
 
-@router.post("/test")
+class PushSendResponse(BaseModel):
+    total: int
+    sent: int
+    removed: int
+    failed: int
+    detail: str | None = None
+
+
+async def _deliver_to_subscription(
+    subscription: PushSubscription, payload: dict[str, Any]
+) -> WebPushResult:
+    return await run_in_threadpool(send_web_push, subscription, payload)
+
+
+def _aggregate_results(results: list[WebPushResult]) -> PushSendResponse:
+    sent = sum(1 for r in results if r.status == "sent")
+    removed = sum(1 for r in results if r.status == "gone")
+    failed = sum(1 for r in results if r.status == "error")
+    detail = None
+    if results and sent == 0 and failed:
+        detail = "Не удалось отправить уведомления"
+    return PushSendResponse(
+        total=len(results),
+        sent=sent,
+        removed=removed,
+        failed=failed,
+        detail=detail,
+    )
+
+
+@router.post("/test", response_model=PushSendResponse)
 async def send_test(
     data: NotifyBody | None = None,
-    bg: BackgroundTasks = None,
     session: AsyncSession = Depends(get_db),
     user: User = Depends(get_current_user),
-):
-    if bg is None:
-        bg = BackgroundTasks()
-
+) -> PushSendResponse:
     res = await session.execute(
         select(PushSubscription)
         .options(selectinload(PushSubscription.user))
@@ -146,7 +179,7 @@ async def send_test(
     )
     subs = res.scalars().all()
     if not subs:
-        return {"count": 0}
+        return PushSendResponse(total=0, sent=0, removed=0, failed=0)
 
     requested_topic = normalize_topic(getattr(data, "topic", None) if data else None)
     payload = (data.model_dump(exclude_none=True) if data else {}) | {
@@ -157,25 +190,35 @@ async def send_test(
     if requested_topic:
         payload["topic"] = requested_topic
     now_time = datetime.now().astimezone().time()
-    matched = 0
+    results: list[WebPushResult] = []
     for s in subs:
         if not subscription_supports_topic(s, requested_topic):
             continue
         prepared = prepare_push_payload_for_user(
             payload, getattr(s, "user", None), now_time=now_time
         )
-        bg.add_task(send_web_push, s, prepared)
-        matched += 1
-    return {"count": matched}
+        result = await _deliver_to_subscription(s, prepared)
+        results.append(result)
+    response = _aggregate_results(results)
+    logger.info(
+        "push.test.summary",
+        extra={
+            "user_id": user.id,
+            "total": response.total,
+            "sent": response.sent,
+            "removed": response.removed,
+            "failed": response.failed,
+        },
+    )
+    return response
 
 
-@router.post("/broadcast")
+@router.post("/broadcast", response_model=PushSendResponse)
 async def broadcast(
     data: NotifyBody,
-    bg: BackgroundTasks,
     session: AsyncSession = Depends(get_db),
     user: User = Depends(get_current_user),
-):
+) -> PushSendResponse:
     if user.role != "admin":
         raise HTTPException(status_code=403, detail="forbidden")
     res = await session.execute(
@@ -189,13 +232,23 @@ async def broadcast(
     else:
         payload.pop("topic", None)
     now_time = datetime.now().astimezone().time()
-    matched = 0
+    results: list[WebPushResult] = []
     for s in subs:
         if not subscription_supports_topic(s, topic):
             continue
         prepared = prepare_push_payload_for_user(
             payload, getattr(s, "user", None), now_time=now_time
         )
-        bg.add_task(send_web_push, s, prepared)
-        matched += 1
-    return {"count": matched}
+        results.append(await _deliver_to_subscription(s, prepared))
+    response = _aggregate_results(results)
+    logger.info(
+        "push.broadcast.summary",
+        extra={
+            "user_id": user.id,
+            "total": response.total,
+            "sent": response.sent,
+            "removed": response.removed,
+            "failed": response.failed,
+        },
+    )
+    return response

--- a/root/app/management/__init__.py
+++ b/root/app/management/__init__.py
@@ -1,0 +1,1 @@
+"""Management commands for maintenance tasks."""

--- a/root/app/management/weekly_cleanup.py
+++ b/root/app/management/weekly_cleanup.py
@@ -21,16 +21,21 @@ STALE_SUBSCRIPTION_DAYS = 180
 
 async def _delete_orphaned_subscriptions(session: AsyncSession) -> int:
     orphaned = (
-        await session.execute(
-            delete(PushSubscription)
-            .where(~PushSubscription.user_id.in_(select(User.id)))
-            .returning(PushSubscription.id)
+        (
+            await session.execute(
+                delete(PushSubscription)
+                .where(~PushSubscription.user_id.in_(select(User.id)))
+                .returning(PushSubscription.id)
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     if orphaned:
         await session.commit()
         logger.info(
-            "weekly_cleanup.deleted_orphaned_subscriptions", extra={"count": len(orphaned)}
+            "weekly_cleanup.deleted_orphaned_subscriptions",
+            extra={"count": len(orphaned)},
         )
     return len(orphaned)
 
@@ -38,15 +43,19 @@ async def _delete_orphaned_subscriptions(session: AsyncSession) -> int:
 async def _delete_stale_subscriptions(session: AsyncSession) -> int:
     cutoff = datetime.now(UTC) - timedelta(days=STALE_SUBSCRIPTION_DAYS)
     stale = (
-        await session.execute(
-            delete(PushSubscription)
-            .where(
-                (PushSubscription.last_seen_at.is_(None))
-                | (PushSubscription.last_seen_at < cutoff)
+        (
+            await session.execute(
+                delete(PushSubscription)
+                .where(
+                    (PushSubscription.last_seen_at.is_(None))
+                    | (PushSubscription.last_seen_at < cutoff)
+                )
+                .returning(PushSubscription.id)
             )
-            .returning(PushSubscription.id)
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     if stale:
         await session.commit()
         logger.info(

--- a/root/app/management/weekly_cleanup.py
+++ b/root/app/management/weekly_cleanup.py
@@ -1,0 +1,96 @@
+"""Weekly maintenance tasks for the platform."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy import delete, select, text
+from sqlalchemy.engine import make_url
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.core.database import async_session, engine
+from app.models.models import PushSubscription, User
+
+logger = logging.getLogger(__name__)
+
+STALE_SUBSCRIPTION_DAYS = 180
+
+
+async def _delete_orphaned_subscriptions(session: AsyncSession) -> int:
+    orphaned = (
+        await session.execute(
+            delete(PushSubscription)
+            .where(~PushSubscription.user_id.in_(select(User.id)))
+            .returning(PushSubscription.id)
+        )
+    ).scalars().all()
+    if orphaned:
+        await session.commit()
+        logger.info(
+            "weekly_cleanup.deleted_orphaned_subscriptions", extra={"count": len(orphaned)}
+        )
+    return len(orphaned)
+
+
+async def _delete_stale_subscriptions(session: AsyncSession) -> int:
+    cutoff = datetime.now(UTC) - timedelta(days=STALE_SUBSCRIPTION_DAYS)
+    stale = (
+        await session.execute(
+            delete(PushSubscription)
+            .where(
+                (PushSubscription.last_seen_at.is_(None))
+                | (PushSubscription.last_seen_at < cutoff)
+            )
+            .returning(PushSubscription.id)
+        )
+    ).scalars().all()
+    if stale:
+        await session.commit()
+        logger.info(
+            "weekly_cleanup.deleted_stale_subscriptions", extra={"count": len(stale)}
+        )
+    return len(stale)
+
+
+async def _reindex_database() -> None:
+    url = make_url(settings.database_url)
+    database_name = url.database
+    if not database_name:
+        logger.warning("Skipping database reindex: database name is empty")
+        return
+    quoted_db_name = database_name.replace('"', '""')
+    async with engine.connect() as conn:
+        await conn.execution_options(isolation_level="AUTOCOMMIT").execute(
+            text(f'REINDEX DATABASE "{quoted_db_name}"')
+        )
+    logger.info("weekly_cleanup.reindex_completed", extra={"database": database_name})
+
+
+async def run_weekly_cleanup() -> dict[str, int | None]:
+    """Perform database reindexing and cleanup stale push subscriptions."""
+
+    removed_orphaned = 0
+    removed_stale = 0
+    async with async_session() as session:
+        removed_orphaned = await _delete_orphaned_subscriptions(session)
+        removed_stale = await _delete_stale_subscriptions(session)
+    await _reindex_database()
+    stats = {
+        "subscriptions_removed": removed_orphaned + removed_stale,
+        "subscriptions_orphaned": removed_orphaned,
+        "subscriptions_stale": removed_stale,
+    }
+    logger.info("weekly_cleanup.completed", extra=stats)
+    return stats
+
+
+def main() -> None:
+    stats = asyncio.run(run_weekly_cleanup())
+    print("Weekly cleanup finished:", stats)
+
+
+if __name__ == "__main__":
+    main()

--- a/root/tests/test_push_api.py
+++ b/root/tests/test_push_api.py
@@ -1,0 +1,109 @@
+import pytest
+
+from app.api.push import NotifyBody, broadcast, send_test
+from app.models.models import PushSubscription
+from app.services.webpush import WebPushResult
+
+
+@pytest.mark.anyio
+async def test_push_test_returns_aggregated_stats(
+    db_session,
+    user_factory,
+    monkeypatch,
+) -> None:
+    user = await user_factory()
+    subscriptions = [
+        PushSubscription(
+            endpoint=f"https://example.com/sub-{idx}",
+            p256dh=f"key-{idx}",
+            auth=f"auth-{idx}",
+            user_id=user.id,
+            topics=["system"],
+        )
+        for idx in range(3)
+    ]
+    db_session.add_all(subscriptions)
+    await db_session.commit()
+
+    results = iter(
+        [
+            WebPushResult(
+                subscription_id=subscriptions[0].id,
+                endpoint=subscriptions[0].endpoint,
+                user_id=user.id,
+                status="sent",
+            ),
+            WebPushResult(
+                subscription_id=subscriptions[1].id,
+                endpoint=subscriptions[1].endpoint,
+                user_id=user.id,
+                status="gone",
+                status_code=410,
+            ),
+            WebPushResult(
+                subscription_id=subscriptions[2].id,
+                endpoint=subscriptions[2].endpoint,
+                user_id=user.id,
+                status="error",
+                status_code=500,
+                error="boom",
+            ),
+        ]
+    )
+
+    async def _fake_deliver(*args, **kwargs):
+        return next(results)
+
+    monkeypatch.setattr("app.api.push._deliver_to_subscription", _fake_deliver)
+
+    response = await send_test(data=None, session=db_session, user=user)
+    assert response.model_dump() == {
+        "total": 3,
+        "sent": 1,
+        "removed": 1,
+        "failed": 1,
+        "detail": None,
+    }
+
+
+@pytest.mark.anyio
+async def test_push_broadcast_reports_failures(
+    db_session,
+    user_factory,
+    monkeypatch,
+) -> None:
+    admin = await user_factory(role="admin")
+    subs = [
+        PushSubscription(
+            endpoint=f"https://example.com/admin-{idx}",
+            p256dh=f"key-{idx}",
+            auth=f"auth-{idx}",
+            user_id=admin.id,
+            topics=["news"],
+        )
+        for idx in range(2)
+    ]
+    db_session.add_all(subs)
+    await db_session.commit()
+
+    async def _fail_deliver(*args, **kwargs):
+        return WebPushResult(
+            subscription_id=subs[0].id,
+            endpoint=subs[0].endpoint,
+            user_id=admin.id,
+            status="error",
+            status_code=503,
+            error="Service Unavailable",
+        )
+
+    monkeypatch.setattr("app.api.push._deliver_to_subscription", _fail_deliver)
+
+    payload = NotifyBody(title="System", body="Maintenance", url="/")
+    response = await broadcast(data=payload, session=db_session, user=admin)
+    assert response.model_dump() == {
+        "total": 2,
+        "sent": 0,
+        "removed": 0,
+        "failed": 2,
+        "detail": "Не удалось отправить уведомления",
+    }


### PR DESCRIPTION
## Summary
- add aggregated delivery statistics and logging to the push API endpoints when web push delivery is attempted
- add a management command and scheduled GitHub Action to reindex the database and remove stale or orphaned subscriptions each week
- cover the new delivery aggregation behaviour with unit tests

## Testing
- pytest tests/test_push_api.py

------
https://chatgpt.com/codex/tasks/task_e_68e279ec7fa48327bb2a88d0b2465b6b