### PR TITLE
feat: improve notification permission ux

### DIFF
--- a/root/frontend/src/components/InstallPrompt.tsx
+++ b/root/frontend/src/components/InstallPrompt.tsx
@@ -1,15 +1,30 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import type { ChangeEvent } from "react"
 import CloseIcon from "@mui/icons-material/Close"
+import NotificationsActiveIcon from "@mui/icons-material/NotificationsActive"
+import NotificationsOffIcon from "@mui/icons-material/NotificationsOff"
 import {
   Alert,
   Button,
+  Divider,
+  FormControl,
+  FormControlLabel,
+  FormGroup,
+  FormHelperText,
   IconButton,
+  Link,
   Paper,
   Slide,
   Snackbar,
   Stack,
+  Switch,
   Typography,
 } from "@mui/material"
+import {
+  usePushPreferences,
+  NOTIFICATION_TOPIC_LABELS,
+  type NotificationToast,
+} from "@/hooks/usePushPreferences"
 import { PWA_REFRESH_EVENT, type ServiceWorkerUpdateEventDetail } from "../app/pwaEvents"
 
 interface BeforeInstallPromptEvent extends Event {
@@ -65,10 +80,28 @@ export default function InstallPrompt() {
   const [visible, setVisible] = useState(false)
   const [installing, setInstalling] = useState(false)
   const [updateToastOpen, setUpdateToastOpen] = useState(false)
+  const [feedback, setFeedback] = useState<NotificationToast | null>(null)
   const suppressUntilRef = useRef<number>(0)
   const pendingUpdateRef = useRef<ServiceWorkerUpdateEventDetail["update"] | null>(null)
 
   const isEligible = useMemo(() => !isStandalone(), [])
+
+  const {
+    topicKeys,
+    topicState,
+    pushSupported,
+    notificationPermission,
+    notificationsEnabled,
+    pushBusy,
+    pushInitializing,
+    permissionText,
+    selectedTopicsDescription,
+    enableNotifications,
+    disableNotifications,
+    handleTopicToggle,
+    safariIOS,
+    safariGuideUrl,
+  } = usePushPreferences({ onNotify: setFeedback })
 
   useEffect(() => {
     const handleServiceWorkerUpdate = (event: Event) => {
@@ -120,6 +153,14 @@ export default function InstallPrompt() {
     return () => window.removeEventListener("appinstalled", onAppInstalled)
   }, [isEligible])
 
+  useEffect(() => {
+    if (!pushSupported) return
+    if (notificationPermission === "granted") return
+    const now = Date.now()
+    if (suppressUntilRef.current && now < suppressUntilRef.current) return
+    setVisible(true)
+  }, [notificationPermission, pushSupported])
+
   const handleInstall = useCallback(async () => {
     if (!deferredPrompt) return
     setInstalling(true)
@@ -146,11 +187,24 @@ export default function InstallPrompt() {
     }
   }, [deferredPrompt])
 
+  const handleNotificationsToggle = useCallback(
+    (_: ChangeEvent<HTMLInputElement>, checked: boolean) => {
+      if (pushBusy || pushInitializing) return
+      if (checked) void enableNotifications()
+      else void disableNotifications()
+    },
+    [disableNotifications, enableNotifications, pushBusy, pushInitializing],
+  )
+
   const handleClose = useCallback(() => {
     suppressUntilRef.current = Date.now() + DISMISS_TTL
     rememberDismiss()
     setVisible(false)
     setDeferredPrompt(null)
+  }, [])
+
+  const handleFeedbackClose = useCallback(() => {
+    setFeedback(null)
   }, [])
 
   const handleUpdateReload = useCallback(() => {
@@ -168,7 +222,12 @@ export default function InstallPrompt() {
 
   return (
     <>
-      <Slide direction="up" in={visible && Boolean(deferredPrompt)} mountOnEnter unmountOnExit>
+      <Slide
+        direction="up"
+        in={visible && (Boolean(deferredPrompt) || (pushSupported && notificationPermission !== "granted"))}
+        mountOnEnter
+        unmountOnExit
+      >
         <Paper
           elevation={8}
           role="dialog"
@@ -188,35 +247,183 @@ export default function InstallPrompt() {
                 : "0px 18px 45px rgba(11, 99, 244, 0.16)",
           }}
         >
-          <Stack spacing={2} alignItems="flex-start">
+          <Stack spacing={2.5} alignItems="flex-start">
             <Stack direction="row" spacing={1.5} alignItems="flex-start" sx={{ width: "100%" }}>
               <Typography component="h2" variant="h6" sx={{ flex: 1, fontWeight: 700 }}>
-                Установить «Экосистема ГУУ»
+                {deferredPrompt ? "Установить «Экосистема ГУУ»" : "Экосистема ГУУ"}
               </Typography>
               <IconButton aria-label="Скрыть предложение" onClick={handleClose} size="small">
                 <CloseIcon fontSize="small" />
               </IconButton>
             </Stack>
-            <Typography variant="body2" sx={{ opacity: 0.85 }}>
-              Добавьте приложение на главный экран, чтобы открывать профиль, расписание и новости без браузера.
-            </Typography>
-            <Stack direction="row" spacing={1.5} sx={{ width: "100%" }}>
-              <Button
-                variant="contained"
-                color="primary"
-                onClick={handleInstall}
-                disabled={!deferredPrompt || installing}
-                sx={{ flexGrow: 1 }}
-              >
-                Установить
-              </Button>
-              <Button variant="text" color="inherit" onClick={handleClose}>
-                Позже
-              </Button>
-            </Stack>
+            {deferredPrompt ? (
+              <>
+                <Typography variant="body2" sx={{ opacity: 0.85 }}>
+                  Добавьте приложение на главный экран, чтобы открывать профиль, расписание и новости без браузера.
+                </Typography>
+                <Stack direction="row" spacing={1.5} sx={{ width: "100%" }}>
+                  <Button
+                    variant="contained"
+                    color="primary"
+                    onClick={handleInstall}
+                    disabled={!deferredPrompt || installing}
+                    sx={{ flexGrow: 1 }}
+                  >
+                    Установить
+                  </Button>
+                  <Button variant="text" color="inherit" onClick={handleClose}>
+                    Позже
+                  </Button>
+                </Stack>
+              </>
+            ) : (
+              <Typography variant="body2" sx={{ opacity: 0.85 }}>
+                Управляйте уведомлениями, чтобы не пропускать важные обновления.
+              </Typography>
+            )}
+            {(pushSupported || notificationPermission !== "granted") && (
+              <>
+                <Divider sx={{ width: "100%" }} />
+                <Stack spacing={1.2} sx={{ width: "100%" }}>
+                  <Typography variant="subtitle2" sx={{ fontWeight: 700, color: "var(--page-text)" }}>
+                    Уведомления
+                  </Typography>
+                  {!pushSupported ? (
+                    <Alert severity="warning" variant="outlined">
+                      Push-уведомления недоступны в этом браузере.
+                    </Alert>
+                  ) : notificationPermission === "denied" ? (
+                    <Stack spacing={1}>
+                      <Alert severity="error" variant="outlined">
+                        Включите уведомления для «Экосистема ГУУ» в настройках браузера, затем нажмите «Проверить».
+                      </Alert>
+                      {safariIOS && (
+                        <Alert severity="info" variant="outlined">
+                          Установите приложение на Домой, затем разрешите уведомления. {" "}
+                          <Link href={safariGuideUrl} target="_blank" rel="noreferrer noopener">
+                            Инструкция
+                          </Link>
+                          .
+                        </Alert>
+                      )}
+                      <Stack direction="row" spacing={1} alignItems="center">
+                        <Button
+                          variant="contained"
+                          size="small"
+                          onClick={() => void enableNotifications()}
+                          disabled={pushBusy}
+                        >
+                          Проверить
+                        </Button>
+                        <Typography variant="caption" sx={{ color: "var(--page-text)" }}>
+                          Состояние: {permissionText}.
+                        </Typography>
+                      </Stack>
+                    </Stack>
+                  ) : notificationPermission === "default" ? (
+                    <Stack spacing={1}>
+                      <Typography variant="body2" sx={{ color: "var(--page-text)" }}>
+                        Разрешите уведомления, чтобы получать новости, расписание и важные напоминания.
+                      </Typography>
+                      <Stack direction="row" spacing={1} alignItems="center">
+                        <Button
+                          variant="contained"
+                          size="small"
+                          onClick={() => void enableNotifications()}
+                          disabled={pushBusy || pushInitializing}
+                        >
+                          Разрешить
+                        </Button>
+                        <Typography variant="caption" sx={{ color: "var(--page-text)" }}>
+                          Состояние: {permissionText}.
+                        </Typography>
+                      </Stack>
+                      {safariIOS && (
+                        <Alert severity="info" variant="outlined">
+                          Установите приложение на Домой, затем разрешите уведомления. {" "}
+                          <Link href={safariGuideUrl} target="_blank" rel="noreferrer noopener">
+                            Инструкция
+                          </Link>
+                          .
+                        </Alert>
+                      )}
+                    </Stack>
+                  ) : (
+                    <Stack spacing={1.5}>
+                      <FormControl component="fieldset" variant="standard">
+                        <FormGroup>
+                          <FormControlLabel
+                            control={
+                              <Switch
+                                checked={notificationsEnabled}
+                                onChange={handleNotificationsToggle}
+                                disabled={pushBusy || pushInitializing}
+                              />
+                            }
+                            label={
+                              <Stack direction="row" spacing={1} alignItems="center" sx={{ color: "var(--page-text)" }}>
+                                {notificationsEnabled ? <NotificationsActiveIcon fontSize="small" /> : <NotificationsOffIcon fontSize="small" />}
+                                <span>Уведомления</span>
+                              </Stack>
+                            }
+                          />
+                        </FormGroup>
+                        <FormHelperText sx={{ ml: 0, color: "var(--page-text)", mt: 0.5 }}>
+                          Разрешение браузера: {permissionText}
+                        </FormHelperText>
+                      </FormControl>
+                      <FormControl
+                        component="fieldset"
+                        variant="standard"
+                        disabled={!notificationsEnabled || pushBusy || pushInitializing}
+                        sx={{ opacity: notificationsEnabled ? 1 : 0.6 }}
+                      >
+                        <FormGroup>
+                          {topicKeys.map(key => (
+                            <FormControlLabel
+                              key={key}
+                              control={
+                                <Switch
+                                  // Keys originate from a predefined list
+                                  // eslint-disable-next-line security/detect-object-injection
+                                  checked={topicState[key]}
+                                  onChange={handleTopicToggle(key)}
+                                  disabled={!notificationsEnabled || pushBusy || pushInitializing}
+                                />
+                              }
+                              label={
+                                <span style={{ color: "var(--page-text)" }}>{NOTIFICATION_TOPIC_LABELS[key]}</span>
+                              }
+                            />
+                          ))}
+                        </FormGroup>
+                        <FormHelperText sx={{ ml: 0, color: "var(--page-text)", mt: 0.5 }}>
+                          Активные темы: {selectedTopicsDescription}
+                        </FormHelperText>
+                      </FormControl>
+                    </Stack>
+                  )}
+                </Stack>
+              </>
+            )}
           </Stack>
         </Paper>
       </Slide>
+      <Snackbar
+        open={Boolean(feedback)}
+        autoHideDuration={4000}
+        onClose={handleFeedbackClose}
+        anchorOrigin={{ vertical: "top", horizontal: "center" }}
+      >
+        <Alert
+          severity={feedback?.sev ?? "info"}
+          variant="filled"
+          onClose={handleFeedbackClose}
+          sx={{ alignItems: "center" }}
+        >
+          {feedback?.text}
+        </Alert>
+      </Snackbar>
       <Snackbar
         open={updateToastOpen}
         onClose={handleCloseUpdateToast}

--- a/root/frontend/src/hooks/usePushPreferences.ts
+++ b/root/frontend/src/hooks/usePushPreferences.ts
@@ -1,0 +1,365 @@
+import { useCallback, useEffect, useMemo, useState } from "react"
+import type { ChangeEvent } from "react"
+import {
+  getExistingPushSubscription,
+  isPushSupported,
+  setPushConsent,
+  urlBase64ToUint8Array,
+} from "@/push/subscribe"
+import {
+  deleteSubscription,
+  getVapidKey,
+  saveSubscription,
+  updateSubscriptionTopics,
+} from "@/api/notifications"
+import { isSafariIOS } from "@/utils/browser"
+
+export type NotificationTopicKey = "news" | "schedule" | "system"
+
+export const NOTIFICATION_TOPIC_LABELS: Record<NotificationTopicKey, string> = {
+  news: "Новости",
+  schedule: "Расписание",
+  system: "Системные",
+}
+
+export const DEFAULT_NOTIFICATION_TOPICS: Record<NotificationTopicKey, boolean> = {
+  news: true,
+  schedule: true,
+  system: true,
+}
+
+export type NotificationToast = {
+  text: string
+  sev?: "success" | "info" | "warning" | "error"
+}
+
+export type UsePushPreferencesOptions = {
+  onNotify?: (toast: NotificationToast) => void
+}
+
+const SAFARI_IOS_GUIDE_URL = "https://support.apple.com/ru-ru/guide/iphone/iph42ab2f3a7/ios"
+
+export function usePushPreferences(options?: UsePushPreferencesOptions) {
+  const { onNotify } = options ?? {}
+
+  const topicKeys = useMemo(
+    () => Object.keys(NOTIFICATION_TOPIC_LABELS) as NotificationTopicKey[],
+    [],
+  )
+  const [topicState, setTopicState] = useState<Record<NotificationTopicKey, boolean>>(
+    DEFAULT_NOTIFICATION_TOPICS,
+  )
+  const [pushSupported, setPushSupported] = useState(() => isPushSupported())
+  const [notificationPermission, setNotificationPermission] = useState<NotificationPermission>(() => {
+    if (typeof window === "undefined" || typeof Notification === "undefined") return "default"
+    return Notification.permission
+  })
+  const [pushSubscription, setPushSubscription] = useState<PushSubscription | null>(null)
+  const [pushBusy, setPushBusy] = useState(false)
+  const [pushInitializing, setPushInitializing] = useState(true)
+  const [safariIOS] = useState(() => isSafariIOS())
+
+  const notify = useCallback(
+    (toast: NotificationToast) => {
+      onNotify?.(toast)
+    },
+    [onNotify],
+  )
+
+  const selectedTopics = useMemo(() => topicKeys.filter(key => topicState[key]), [topicKeys, topicState])
+
+  const notificationsEnabled = !!pushSubscription
+
+  const permissionText = useMemo(() => {
+    switch (notificationPermission) {
+      case "granted":
+        return "разрешено"
+      case "denied":
+        return "запрещено"
+      default:
+        return "не запрошено"
+    }
+  }, [notificationPermission])
+
+  const selectedTopicsDescription = useMemo(() => {
+    if (!selectedTopics.length) return "Темы не выбраны"
+    return selectedTopics.map(key => NOTIFICATION_TOPIC_LABELS[key]).join(", ")
+  }, [selectedTopics])
+
+  const applyServerTopics = useCallback(
+    (topics?: string[] | null) => {
+      if (topics == null) return
+      const next: Record<NotificationTopicKey, boolean> = {} as Record<NotificationTopicKey, boolean>
+      for (const key of topicKeys) {
+        next[key] = false
+      }
+      for (const raw of topics) {
+        if (!raw) continue
+        const normalized = raw.toString().trim().toLowerCase() as NotificationTopicKey
+        if ((topicKeys as string[]).includes(normalized)) {
+          next[normalized as NotificationTopicKey] = true
+        }
+      }
+      setTopicState(next)
+    },
+    [topicKeys],
+  )
+
+  const enableNotifications = useCallback(async () => {
+    if (!isPushSupported()) {
+      setPushSupported(false)
+      notify({ text: "Ваш браузер не поддерживает push-уведомления", sev: "warning" })
+      return
+    }
+    if (typeof Notification === "undefined") {
+      notify({ text: "Браузер не поддерживает уведомления", sev: "warning" })
+      return
+    }
+    setPushBusy(true)
+    try {
+      const permission = await Notification.requestPermission()
+      setNotificationPermission(permission)
+      if (permission !== "granted") {
+        notify({ text: "Разрешите уведомления в настройках браузера", sev: "info" })
+        return
+      }
+
+      if (!("serviceWorker" in navigator)) {
+        notify({ text: "Сервис-воркеры недоступны", sev: "error" })
+        return
+      }
+
+      const registration = await navigator.serviceWorker.ready
+      let sub = await registration.pushManager.getSubscription()
+
+      if (!sub) {
+        let vapidKey = ""
+        try {
+          vapidKey = (await getVapidKey())?.trim() || ""
+        } catch (error) {
+          console.error("Failed to load VAPID key", error)
+        }
+        if (!vapidKey) {
+          notify({ text: "Не удалось получить ключ уведомлений", sev: "error" })
+          return
+        }
+        const applicationServerKey = urlBase64ToUint8Array(vapidKey)
+        sub = await registration.pushManager.subscribe({
+          userVisibleOnly: true,
+          applicationServerKey,
+        })
+      }
+
+      if (!sub) {
+        notify({ text: "Не удалось активировать подписку", sev: "error" })
+        return
+      }
+
+      type Payload = Parameters<typeof saveSubscription>[0]
+      const saved = await saveSubscription(sub.toJSON() as Payload, selectedTopics)
+      applyServerTopics(saved?.topics ?? selectedTopics)
+      setPushSubscription(sub)
+      setPushConsent(true)
+      notify({ text: "Уведомления включены", sev: "success" })
+    } catch (error) {
+      console.error("Failed to enable notifications", error)
+      notify({ text: "Не удалось включить уведомления", sev: "error" })
+    } finally {
+      setPushBusy(false)
+      setPushInitializing(false)
+    }
+  }, [applyServerTopics, notify, selectedTopics])
+
+  const disableNotifications = useCallback(async () => {
+    if (!isPushSupported()) {
+      setPushSubscription(null)
+      setPushConsent(false)
+      return
+    }
+    setPushBusy(true)
+    try {
+      const registration = await navigator.serviceWorker.ready
+      const sub = await registration.pushManager.getSubscription()
+      if (!sub) {
+        setPushSubscription(null)
+        setPushConsent(false)
+        notify({ text: "Уведомления выключены", sev: "success" })
+        return
+      }
+      const endpoint = sub.endpoint
+      let unsubscribed = false
+      try {
+        unsubscribed = await sub.unsubscribe()
+      } catch (error) {
+        console.error("Failed to unsubscribe push", error)
+      }
+      if (endpoint) {
+        try {
+          await deleteSubscription(endpoint)
+        } catch (error) {
+          console.warn("Не удалось удалить подписку на сервере", error)
+        }
+      }
+      setPushSubscription(null)
+      setPushConsent(false)
+      if (unsubscribed || !endpoint) {
+        notify({ text: "Уведомления выключены", sev: "success" })
+      } else {
+        notify({ text: "Уведомления отключены локально", sev: "info" })
+      }
+    } catch (error) {
+      console.error("Failed to disable notifications", error)
+      notify({ text: "Не удалось выключить уведомления", sev: "error" })
+    } finally {
+      setPushBusy(false)
+    }
+  }, [notify])
+
+  const handleTopicToggle = useCallback(
+    (key: NotificationTopicKey) =>
+      async (_: ChangeEvent<HTMLInputElement>, checked: boolean) => {
+        const nextState = { ...topicState, [key]: checked }
+        setTopicState(nextState)
+        if (!notificationsEnabled || pushBusy) return
+        if (!isPushSupported()) return
+        setPushBusy(true)
+        const topicsToSend = topicKeys.filter(topic => nextState[topic])
+        try {
+          const registration = await navigator.serviceWorker.ready
+          const sub = await registration.pushManager.getSubscription()
+          if (!sub) {
+            setPushSubscription(null)
+            setPushConsent(false)
+            return
+          }
+          const endpoint = (sub.endpoint || "").trim()
+          type Payload = Parameters<typeof saveSubscription>[0]
+          const saved = endpoint
+            ? await updateSubscriptionTopics(endpoint, topicsToSend)
+            : await saveSubscription(sub.toJSON() as Payload, topicsToSend)
+          applyServerTopics(saved?.topics ?? topicsToSend)
+          setPushSubscription(sub)
+        } catch (error) {
+          console.error("Failed to update topics", error)
+          notify({ text: "Не удалось обновить настройки уведомлений", sev: "error" })
+        } finally {
+          setPushBusy(false)
+        }
+      },
+    [applyServerTopics, notificationsEnabled, pushBusy, topicKeys, topicState, notify],
+  )
+
+  useEffect(() => {
+    setPushSupported(isPushSupported())
+  }, [])
+
+  useEffect(() => {
+    let cancelled = false
+    let removeListener: (() => void) | undefined
+
+    const syncPermission = () => {
+      if (typeof Notification === "undefined") {
+        setNotificationPermission("default")
+        return
+      }
+      setNotificationPermission(Notification.permission)
+    }
+    syncPermission()
+
+    if (typeof navigator !== "undefined" && (navigator as any).permissions?.query) {
+      ;(navigator as any)
+        .permissions.query({ name: "notifications" as PermissionName })
+        .then((status: PermissionStatus) => {
+          if (cancelled) return
+          const handler = () => {
+            if (cancelled) return
+            const state = status.state
+            if (state === "prompt") setNotificationPermission("default")
+            else setNotificationPermission(state as NotificationPermission)
+          }
+          handler()
+          if (typeof status.addEventListener === "function") {
+            status.addEventListener("change", handler)
+            removeListener = () => {
+              try {
+                status.removeEventListener("change", handler)
+              } catch {}
+            }
+          } else {
+            const statusWithOnChange = status as PermissionStatus & { onchange?: (() => void) | null }
+            statusWithOnChange.onchange = handler
+            removeListener = () => {
+              if (statusWithOnChange.onchange === handler) {
+                statusWithOnChange.onchange = null
+              }
+            }
+          }
+        })
+        .catch(() => {})
+    }
+
+    return () => {
+      cancelled = true
+      removeListener?.()
+    }
+  }, [])
+
+  useEffect(() => {
+    let active = true
+    const detectSubscription = async () => {
+      try {
+        const supported = isPushSupported()
+        if (!active) return
+        setPushSupported(supported)
+        if (!supported) {
+          setPushSubscription(null)
+          return
+        }
+        setPushInitializing(true)
+        const sub = await getExistingPushSubscription()
+        if (!active) return
+        setPushSubscription(sub)
+        if (sub) {
+          setPushConsent(true)
+          type Payload = Parameters<typeof saveSubscription>[0]
+          try {
+            const saved = await saveSubscription(sub.toJSON() as Payload)
+            if (!active) return
+            applyServerTopics(saved?.topics ?? [])
+          } catch (error) {
+            console.warn("Не удалось получить настройки подписки", error)
+          }
+        }
+      } catch (error) {
+        if (active) {
+          console.warn("Не удалось определить подписку на push", error)
+        }
+      } finally {
+        if (active) setPushInitializing(false)
+      }
+    }
+    void detectSubscription()
+    return () => {
+      active = false
+    }
+  }, [applyServerTopics])
+
+  return {
+    topicKeys,
+    topicState,
+    setTopicState,
+    pushSupported,
+    notificationPermission,
+    pushSubscription,
+    notificationsEnabled,
+    pushBusy,
+    pushInitializing,
+    permissionText,
+    selectedTopicsDescription,
+    enableNotifications,
+    disableNotifications,
+    handleTopicToggle,
+    safariIOS,
+    safariGuideUrl: SAFARI_IOS_GUIDE_URL,
+  }
+}

--- a/root/frontend/src/pages/Settings.tsx
+++ b/root/frontend/src/pages/Settings.tsx
@@ -1,16 +1,9 @@
-import {
-  useEffect,
-  useRef,
-  useState,
-  useCallback,
-  ChangeEvent,
-  FocusEvent,
-  useMemo
-} from "react";
+import { useEffect, useRef, useState, useCallback, ChangeEvent, FocusEvent } from "react";
 import { useAuth, currentUserQueryKey, fetchCurrentUser } from "@/contexts/AuthContext";
 import { useNavigate } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
 import { useNotifications } from "@/hooks/useNotifications";
+import { usePushPreferences, NOTIFICATION_TOPIC_LABELS } from "@/hooks/usePushPreferences";
 import api from "../api/client";
 import {
   Box,
@@ -39,7 +32,8 @@ import {
   Switch,
   FormGroup,
   FormControl,
-  FormHelperText
+  FormHelperText,
+  Link
 } from "@mui/material";
 import { useColorScheme } from "@mui/material/styles";
 import TextField from "@mui/material/TextField";
@@ -58,36 +52,10 @@ import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import defaultAvatar from "@/assets/default_avatar.png";
 import spotifyLogo from "@/assets/spotify_icon.png";
 import { resolveMediaUrl } from "@/utils/media";
-import {
-  getExistingPushSubscription,
-  isPushSupported,
-  setPushConsent,
-  urlBase64ToUint8Array
-} from "@/push/subscribe";
-import {
-  deleteSubscription,
-  getVapidKey,
-  saveSubscription,
-  updateSubscriptionTopics
-} from "@/api/notifications";
 
 type ThemeMode = "system" | "light" | "dark";
 
 const BACKEND_ORIGIN = import.meta.env.VITE_BACKEND_ORIGIN || "";
-
-type NotificationTopicKey = "news" | "schedule" | "system";
-
-const NOTIFICATION_TOPIC_LABELS: Record<NotificationTopicKey, string> = {
-  news: "Новости",
-  schedule: "Расписание",
-  system: "Системные"
-};
-
-const DEFAULT_NOTIFICATION_TOPICS: Record<NotificationTopicKey, boolean> = {
-  news: true,
-  schedule: true,
-  system: true
-};
 
 const DEFAULT_DND_START = "22:00";
 const DEFAULT_DND_END = "07:00";
@@ -123,16 +91,22 @@ export default function Settings() {
   const { mode: storedMode, setMode } = useColorScheme();
   const theme = (storedMode ?? "system") as ThemeMode;
 
-  const topicKeys = useMemo(() => Object.keys(NOTIFICATION_TOPIC_LABELS) as NotificationTopicKey[], []);
-  const [topicState, setTopicState] = useState<Record<NotificationTopicKey, boolean>>(DEFAULT_NOTIFICATION_TOPICS);
-  const [pushSupported, setPushSupported] = useState(() => isPushSupported());
-  const [notificationPermission, setNotificationPermission] = useState<NotificationPermission>(() => {
-    if (typeof window === "undefined" || typeof Notification === "undefined") return "default";
-    return Notification.permission;
-  });
-  const [pushSubscription, setPushSubscription] = useState<PushSubscription | null>(null);
-  const [pushBusy, setPushBusy] = useState(false);
-  const [pushInitializing, setPushInitializing] = useState(true);
+  const {
+    topicKeys,
+    topicState,
+    pushSupported,
+    notificationPermission,
+    notificationsEnabled,
+    pushBusy,
+    pushInitializing,
+    permissionText,
+    selectedTopicsDescription,
+    enableNotifications,
+    disableNotifications,
+    handleTopicToggle,
+    safariIOS,
+    safariGuideUrl
+  } = usePushPreferences({ onNotify: setSnack });
   const [dndEnabled, setDndEnabled] = useState(false);
   const [dndStart, setDndStart] = useState("");
   const [dndEnd, setDndEnd] = useState("");
@@ -146,28 +120,6 @@ export default function Settings() {
     setDndStart(start || (enabled ? DEFAULT_DND_START : ""));
     setDndEnd(end || (enabled ? DEFAULT_DND_END : ""));
   }, []);
-
-  const selectedTopics = useMemo(() => {
-    return topicKeys.filter(key => topicState[key]);
-  }, [topicKeys, topicState]);
-
-  const permissionText = useMemo(() => {
-    switch (notificationPermission) {
-      case "granted":
-        return "разрешено";
-      case "denied":
-        return "запрещено";
-      default:
-        return "не запрошено";
-    }
-  }, [notificationPermission]);
-
-  const selectedTopicsDescription = useMemo(() => {
-    if (!selectedTopics.length) return "Темы не выбраны";
-    return selectedTopics.map(key => NOTIFICATION_TOPIC_LABELS[key]).join(", ");
-  }, [selectedTopics]);
-
-  const notificationsEnabled = !!pushSubscription;
 
   const persistDnd = useCallback(
     async (nextEnabled: boolean, nextStart: string | null, nextEnd: string | null) => {
@@ -276,196 +228,6 @@ export default function Settings() {
     syncDndFromUser(user);
   }, [syncDndFromUser, user]);
 
-  const applyServerTopics = useCallback(
-    (topics?: string[] | null) => {
-      if (topics == null) return;
-      const next: Record<NotificationTopicKey, boolean> = {} as Record<NotificationTopicKey, boolean>;
-      for (const key of topicKeys) {
-        next[key] = false;
-      }
-      for (const rawTopic of topics) {
-        if (!rawTopic) continue;
-        const normalized = rawTopic.toString().trim().toLowerCase() as NotificationTopicKey;
-        if ((topicKeys as string[]).includes(normalized)) {
-          next[normalized as NotificationTopicKey] = true;
-        }
-      }
-      setTopicState(next);
-    },
-    [topicKeys]
-  );
-
-  const handleThemeChange = useCallback(
-    (_: ChangeEvent<HTMLInputElement>, value: string) => {
-      setMode(value as ThemeMode);
-    },
-    [setMode]
-  );
-
-  const enableNotifications = useCallback(async () => {
-    if (!isPushSupported()) {
-      setPushSupported(false);
-      setSnack({ text: "Ваш браузер не поддерживает push-уведомления", sev: "warning" });
-      return;
-    }
-    if (typeof Notification === "undefined") {
-      setSnack({ text: "Браузер не поддерживает уведомления", sev: "warning" });
-      return;
-    }
-    setPushBusy(true);
-    try {
-      const permission = await Notification.requestPermission();
-      setNotificationPermission(permission);
-      if (permission !== "granted") {
-        setSnack({ text: "Разрешите уведомления в настройках браузера", sev: "info" });
-        return;
-      }
-
-      if (!("serviceWorker" in navigator)) {
-        setSnack({ text: "Сервис-воркеры недоступны", sev: "error" });
-        return;
-      }
-
-      const registration = await navigator.serviceWorker.ready;
-      let sub = await registration.pushManager.getSubscription();
-
-      if (!sub) {
-        let vapidKey = "";
-        try {
-          vapidKey = (await getVapidKey())?.trim() || "";
-        } catch (error) {
-          console.error("Failed to load VAPID key", error);
-        }
-        if (!vapidKey) {
-          setSnack({ text: "Не удалось получить ключ уведомлений", sev: "error" });
-          return;
-        }
-        const applicationServerKey = urlBase64ToUint8Array(vapidKey);
-        sub = await registration.pushManager.subscribe({
-          userVisibleOnly: true,
-          applicationServerKey
-        });
-      }
-
-      if (!sub) {
-        setSnack({ text: "Не удалось активировать подписку", sev: "error" });
-        return;
-      }
-
-      type Payload = Parameters<typeof saveSubscription>[0];
-      const saved = await saveSubscription(sub.toJSON() as Payload, selectedTopics);
-      applyServerTopics(saved?.topics ?? selectedTopics);
-      setPushSubscription(sub);
-      setPushConsent(true);
-      setSnack({ text: "Уведомления включены", sev: "success" });
-    } catch (error) {
-      console.error("Failed to enable notifications", error);
-      setSnack({ text: "Не удалось включить уведомления", sev: "error" });
-    } finally {
-      setPushBusy(false);
-      setPushInitializing(false);
-    }
-  }, [applyServerTopics, selectedTopics]);
-
-  const disableNotifications = useCallback(async () => {
-    if (!isPushSupported()) {
-      setPushSubscription(null);
-      setPushConsent(false);
-      return;
-    }
-    setPushBusy(true);
-    try {
-      const registration = await navigator.serviceWorker.ready;
-      const sub = await registration.pushManager.getSubscription();
-      if (!sub) {
-        setPushSubscription(null);
-        setPushConsent(false);
-        setSnack({ text: "Уведомления выключены", sev: "success" });
-        return;
-      }
-      const endpoint = sub.endpoint;
-      let unsubscribed = false;
-      try {
-        unsubscribed = await sub.unsubscribe();
-      } catch (error) {
-        console.error("Failed to unsubscribe push", error);
-      }
-      if (endpoint) {
-        try {
-          await deleteSubscription(endpoint);
-        } catch (error) {
-          console.warn("Не удалось удалить подписку на сервере", error);
-        }
-      }
-      setPushSubscription(null);
-      setPushConsent(false);
-      if (unsubscribed || !endpoint) {
-        setSnack({ text: "Уведомления выключены", sev: "success" });
-      } else {
-        setSnack({ text: "Уведомления отключены локально", sev: "info" });
-      }
-    } catch (error) {
-      console.error("Failed to disable notifications", error);
-      setSnack({ text: "Не удалось выключить уведомления", sev: "error" });
-    } finally {
-      setPushBusy(false);
-    }
-  }, []);
-
-  const handleNotificationsToggle = useCallback(
-    (_: ChangeEvent<HTMLInputElement>, checked: boolean) => {
-      if (pushBusy || pushInitializing) return;
-      if (checked) void enableNotifications();
-      else void disableNotifications();
-    },
-    [disableNotifications, enableNotifications, pushBusy, pushInitializing]
-  );
-
-  const handleTopicToggle = useCallback(
-    (key: NotificationTopicKey) =>
-      (_: ChangeEvent<HTMLInputElement>, checked: boolean) => {
-        const nextState = { ...topicState, [key]: checked };
-        setTopicState(nextState);
-        if (!notificationsEnabled || pushBusy) return;
-        if (!isPushSupported()) return;
-        setPushBusy(true);
-        const topicsToSend = topicKeys.filter(topic => nextState[topic]);
-        (async () => {
-          try {
-            const registration = await navigator.serviceWorker.ready;
-            const sub = await registration.pushManager.getSubscription();
-            if (!sub) {
-              setPushSubscription(null);
-              setPushConsent(false);
-              return;
-            }
-            const endpoint = (sub.endpoint || "").trim();
-            type Payload = Parameters<typeof saveSubscription>[0];
-            const saved = endpoint
-              ? await updateSubscriptionTopics(endpoint, topicsToSend)
-              : await saveSubscription(sub.toJSON() as Payload, topicsToSend);
-            applyServerTopics(saved?.topics ?? topicsToSend);
-            setPushSubscription(sub);
-          } catch (error) {
-            console.error("Failed to update topics", error);
-            setSnack({ text: "Не удалось обновить настройки уведомлений", sev: "error" });
-          } finally {
-            setPushBusy(false);
-          }
-        })();
-      },
-    [
-      applyServerTopics,
-      notificationsEnabled,
-      pushBusy,
-      setPushConsent,
-      setPushSubscription,
-      setSnack,
-      topicKeys,
-      topicState
-    ]
-  );
-
   useEffect(() => {
     const sp = new URLSearchParams(window.location.search);
     const s = sp.get("spotify");
@@ -478,100 +240,21 @@ export default function Settings() {
     }
   }, []);
 
-  useEffect(() => {
-    setPushSupported(isPushSupported());
-  }, []);
+  const handleThemeChange = useCallback(
+    (_: ChangeEvent<HTMLInputElement>, value: string) => {
+      setMode(value as ThemeMode);
+    },
+    [setMode]
+  );
 
-  useEffect(() => {
-    let cancelled = false;
-    let removeListener: (() => void) | undefined;
-
-    const syncPermission = () => {
-      if (typeof Notification === "undefined") {
-        setNotificationPermission("default");
-        return;
-      }
-      setNotificationPermission(Notification.permission);
-    };
-    syncPermission();
-
-    if (typeof navigator !== "undefined" && (navigator as any).permissions?.query) {
-      (navigator as any)
-        .permissions.query({ name: "notifications" as PermissionName })
-        .then((status: PermissionStatus) => {
-          if (cancelled) return;
-          const handler = () => {
-            if (cancelled) return;
-            const state = status.state;
-            if (state === "prompt") setNotificationPermission("default");
-            else setNotificationPermission(state as NotificationPermission);
-          };
-          handler();
-          if (typeof status.addEventListener === "function") {
-            status.addEventListener("change", handler);
-            removeListener = () => {
-              try {
-                status.removeEventListener("change", handler);
-              } catch {}
-            };
-          } else {
-            const statusWithOnChange = status as PermissionStatus & { onchange?: (() => void) | null };
-            statusWithOnChange.onchange = handler;
-            removeListener = () => {
-              if (statusWithOnChange.onchange === handler) {
-                statusWithOnChange.onchange = null;
-              }
-            };
-          }
-        })
-        .catch(() => {});
-    }
-
-    return () => {
-      cancelled = true;
-      removeListener?.();
-    };
-  }, []);
-
-  useEffect(() => {
-    let active = true;
-    const detectSubscription = async () => {
-      try {
-        const supported = isPushSupported();
-        if (!active) return;
-        setPushSupported(supported);
-        if (!supported) {
-          setPushSubscription(null);
-          return;
-        }
-        setPushInitializing(true);
-        const sub = await getExistingPushSubscription();
-        if (!active) return;
-        setPushSubscription(sub);
-        if (sub) {
-          setPushConsent(true);
-          type Payload = Parameters<typeof saveSubscription>[0];
-          try {
-            const saved = await saveSubscription(sub.toJSON() as Payload);
-            if (!active) return;
-            applyServerTopics(saved?.topics ?? []);
-          } catch (error) {
-            console.warn("Не удалось получить настройки подписки", error);
-          }
-        }
-      } catch (error) {
-        if (active) {
-          console.warn("Не удалось определить подписку на push", error);
-        }
-      } finally {
-        if (active) setPushInitializing(false);
-      }
-    };
-    void detectSubscription();
-    return () => {
-      active = false;
-    };
-  }, [applyServerTopics]);
+  const handleNotificationsToggle = useCallback(
+    (_: ChangeEvent<HTMLInputElement>, checked: boolean) => {
+      if (pushBusy || pushInitializing) return;
+      if (checked) void enableNotifications();
+      else void disableNotifications();
+    },
+    [disableNotifications, enableNotifications, pushBusy, pushInitializing]
+  );
 
   const spotifyConnected = Boolean((user as any)?.spotify_connected || (user as any)?.spotify_is_connected);
   const spotifyName = (user as any)?.spotify_display_name || "";
@@ -781,134 +464,192 @@ export default function Settings() {
                 </Alert>
               ) : (
                 <Stack spacing={1.8}>
-                  <FormControl component="fieldset" variant="standard">
-                    <FormGroup>
-                      <FormControlLabel
-                        control={
-                          <Switch
-                            checked={notificationsEnabled}
-                            onChange={handleNotificationsToggle}
-                            disabled={pushBusy || pushInitializing}
-                          />
-                        }
-                        label={
-                          <Stack direction="row" alignItems="center" spacing={1} sx={{ color: "var(--page-text)" }}>
-                            {notificationsEnabled ? <NotificationsActiveIcon /> : <NotificationsOffIcon />}
-                            <span>Включить уведомления</span>
-                          </Stack>
-                        }
-                      />
-                    </FormGroup>
-                    <FormHelperText sx={{ ml: 0, color: "var(--page-text)", mt: 0.5 }}>
-                      Разрешение браузера: {permissionText}
-                    </FormHelperText>
-                  </FormControl>
-
-                  <FormControl
-                    component="fieldset"
-                    variant="standard"
-                    disabled={!notificationsEnabled || pushBusy || pushInitializing}
-                    sx={{ opacity: notificationsEnabled ? 1 : 0.6 }}
-                  >
-                    <FormGroup>
-                      {topicKeys.map(key => (
-                        <FormControlLabel
-                          key={key}
-                          control={
-                            <Switch
-                              checked={topicState[key]}
-                              onChange={handleTopicToggle(key)}
-                              disabled={!notificationsEnabled || pushBusy || pushInitializing}
-                            />
-                          }
-                          label={
-                            <span style={{ color: "var(--page-text)" }}>{NOTIFICATION_TOPIC_LABELS[key]}</span>
-                          }
-                        />
-                      ))}
-                    </FormGroup>
-                    <FormHelperText sx={{ ml: 0, color: "var(--page-text)", mt: 0.5 }}>
-                      Активные темы: {selectedTopicsDescription}
-                    </FormHelperText>
-                  </FormControl>
-
-                  {notificationPermission === "denied" && (
-                    <Alert severity="error" variant="outlined">
-                      Разрешите уведомления в настройках браузера, чтобы получать оповещения.
-                    </Alert>
-                  )}
-
-                  <Divider sx={{ my: 1.2 }} />
-
-                  <Stack spacing={1.2}>
-                    <Stack direction="row" alignItems="center" spacing={1} sx={{ color: "var(--page-text)" }}>
-                      <DoNotDisturbOnIcon fontSize="small" />
-                      <Typography variant="subtitle1" sx={{ color: "var(--page-text)" }}>
-                        Режим «Не беспокоить»
-                      </Typography>
-                    </Stack>
-
-                    <FormControl component="fieldset" variant="standard">
-                      <FormGroup>
-                        <FormControlLabel
-                          control={
-                            <Switch checked={dndEnabled} onChange={handleDndToggle} disabled={dndSaving} />
-                          }
-                          label={<span style={{ color: "var(--page-text)" }}>Включить тихий период</span>}
-                        />
-                      </FormGroup>
-                      <FormHelperText sx={{ ml: 0, color: "var(--page-text)", mt: 0.5 }}>
-                        Уведомления будут доставляться без звука в указанный интервал.
-                      </FormHelperText>
-                    </FormControl>
-
-                    <Stack
-                      direction={{ xs: "column", sm: "row" }}
-                      spacing={1.5}
-                      alignItems={{ sm: "center" }}
-                    >
-                      <TextField
-                        type="time"
-                        label="С"
-                        value={dndStart}
-                        onChange={handleDndStartChange}
-                        onBlur={handleDndStartBlur}
-                        disabled={!dndEnabled || dndSaving}
-                        size="small"
-                        InputLabelProps={{ shrink: true }}
-                        sx={{ maxWidth: { xs: "100%", sm: 200 } }}
-                      />
-                      <TextField
-                        type="time"
-                        label="До"
-                        value={dndEnd}
-                        onChange={handleDndEndChange}
-                        onBlur={handleDndEndBlur}
-                        disabled={!dndEnabled || dndSaving}
-                        size="small"
-                        InputLabelProps={{ shrink: true }}
-                        sx={{ maxWidth: { xs: "100%", sm: 200 } }}
-                      />
-                    </Stack>
-
-                    <FormHelperText sx={{ ml: 0, color: "var(--page-text)" }}>
-                      Интервал задаётся в часовом поясе устройства и может пересекать полночь.
-                    </FormHelperText>
-
-                    <Stack direction="row" spacing={1} alignItems="flex-start" sx={{ color: "var(--page-text)" }}>
-                      <InfoOutlinedIcon fontSize="small" sx={{ mt: 0.3 }} />
+                  {notificationPermission === "denied" ? (
+                    <Stack spacing={1.5}>
+                      <Alert severity="error" variant="outlined">
+                        Уведомления запрещены в браузере. Откройте настройки сайта и включите уведомления для
+                        «Экосистема ГУУ».
+                      </Alert>
                       <Typography variant="body2" sx={{ color: "var(--page-text)" }}>
-                        На iOS при установке веб-приложения как PWA уведомления часто приходят без звука —
-                        это ограничение системы.
+                        После изменения настроек браузера нажмите «Проверить разрешение», чтобы обновить статус.
                       </Typography>
+                      {safariIOS && (
+                        <Alert severity="info" variant="outlined">
+                          Установите приложение на Домой, затем разрешите уведомления. {" "}
+                          <Link href={safariGuideUrl} target="_blank" rel="noreferrer noopener">
+                            Инструкция
+                          </Link>
+                          .
+                        </Alert>
+                      )}
+                      <Stack direction={{ xs: "column", sm: "row" }} spacing={1.2} alignItems={{ sm: "center" }}>
+                        <Button
+                          variant="contained"
+                          onClick={() => void enableNotifications()}
+                          disabled={pushBusy}
+                        >
+                          Проверить разрешение
+                        </Button>
+                        <Typography variant="body2" sx={{ color: "var(--page-text)" }}>
+                          Текущее состояние: {permissionText}.
+                        </Typography>
+                      </Stack>
                     </Stack>
-                  </Stack>
+                  ) : notificationPermission === "default" ? (
+                    <Stack spacing={1.5}>
+                      <Typography variant="body2" sx={{ color: "var(--page-text)" }}>
+                        Включите уведомления, чтобы первым узнавать о расписании, новостях и важных изменениях.
+                      </Typography>
+                      <Stack direction={{ xs: "column", sm: "row" }} spacing={1.2} alignItems={{ sm: "center" }}>
+                        <Button
+                          variant="contained"
+                          onClick={() => void enableNotifications()}
+                          disabled={pushBusy || pushInitializing}
+                        >
+                          Разрешить уведомления
+                        </Button>
+                        <Typography variant="body2" sx={{ color: "var(--page-text)" }}>
+                          Текущее состояние: {permissionText}.
+                        </Typography>
+                      </Stack>
+                      {safariIOS && (
+                        <Alert severity="info" variant="outlined">
+                          Установите приложение на Домой, затем разрешите уведомления. {" "}
+                          <Link href={safariGuideUrl} target="_blank" rel="noreferrer noopener">
+                            Инструкция
+                          </Link>
+                          .
+                        </Alert>
+                      )}
+                    </Stack>
+                  ) : (
+                    <>
+                      <FormControl component="fieldset" variant="standard">
+                        <FormGroup>
+                          <FormControlLabel
+                            control={
+                              <Switch
+                                checked={notificationsEnabled}
+                                onChange={handleNotificationsToggle}
+                                disabled={pushBusy || pushInitializing}
+                              />
+                            }
+                            label={
+                              <Stack direction="row" alignItems="center" spacing={1} sx={{ color: "var(--page-text)" }}>
+                                {notificationsEnabled ? <NotificationsActiveIcon /> : <NotificationsOffIcon />}
+                                <span>Включить уведомления</span>
+                              </Stack>
+                            }
+                          />
+                        </FormGroup>
+                        <FormHelperText sx={{ ml: 0, color: "var(--page-text)", mt: 0.5 }}>
+                          Разрешение браузера: {permissionText}
+                        </FormHelperText>
+                      </FormControl>
 
-                  <Typography variant="body2" sx={{ color: "var(--page-text)" }}>
-                    {notificationsEnabled
-                      ? `Непрочитанные: ${unreadCount}.`
-                      : "Уведомления сейчас отключены."}
-                  </Typography>
+                      <FormControl
+                        component="fieldset"
+                        variant="standard"
+                        disabled={!notificationsEnabled || pushBusy || pushInitializing}
+                        sx={{ opacity: notificationsEnabled ? 1 : 0.6 }}
+                      >
+                        <FormGroup>
+                          {topicKeys.map(key => (
+                            <FormControlLabel
+                              key={key}
+                              control={
+                                <Switch
+                                  // Keys originate from a predefined list
+                                  // eslint-disable-next-line security/detect-object-injection
+                                  checked={topicState[key]}
+                                  onChange={handleTopicToggle(key)}
+                                  disabled={!notificationsEnabled || pushBusy || pushInitializing}
+                                />
+                              }
+                              label={
+                                <span style={{ color: "var(--page-text)" }}>{NOTIFICATION_TOPIC_LABELS[key]}</span>
+                              }
+                            />
+                          ))}
+                        </FormGroup>
+                        <FormHelperText sx={{ ml: 0, color: "var(--page-text)", mt: 0.5 }}>
+                          Активные темы: {selectedTopicsDescription}
+                        </FormHelperText>
+                      </FormControl>
+
+                      <Divider sx={{ my: 1.2 }} />
+
+                      <Stack spacing={1.2}>
+                        <Stack direction="row" alignItems="center" spacing={1} sx={{ color: "var(--page-text)" }}>
+                          <DoNotDisturbOnIcon fontSize="small" />
+                          <Typography variant="subtitle1" sx={{ color: "var(--page-text)" }}>
+                            Режим «Не беспокоить»
+                          </Typography>
+                        </Stack>
+
+                        <FormControl component="fieldset" variant="standard">
+                          <FormGroup>
+                            <FormControlLabel
+                              control={
+                                <Switch checked={dndEnabled} onChange={handleDndToggle} disabled={dndSaving} />
+                              }
+                              label={<span style={{ color: "var(--page-text)" }}>Включить тихий период</span>}
+                            />
+                          </FormGroup>
+                          <FormHelperText sx={{ ml: 0, color: "var(--page-text)", mt: 0.5 }}>
+                            Уведомления будут доставляться без звука в указанный интервал.
+                          </FormHelperText>
+                        </FormControl>
+
+                        <Stack
+                          direction={{ xs: "column", sm: "row" }}
+                          spacing={1.5}
+                          alignItems={{ sm: "center" }}
+                        >
+                          <TextField
+                            type="time"
+                            label="С"
+                            value={dndStart}
+                            onChange={handleDndStartChange}
+                            onBlur={handleDndStartBlur}
+                            disabled={!dndEnabled || dndSaving}
+                            size="small"
+                            InputLabelProps={{ shrink: true }}
+                            sx={{ maxWidth: { xs: "100%", sm: 200 } }}
+                          />
+                          <TextField
+                            type="time"
+                            label="До"
+                            value={dndEnd}
+                            onChange={handleDndEndChange}
+                            onBlur={handleDndEndBlur}
+                            disabled={!dndEnabled || dndSaving}
+                            size="small"
+                            InputLabelProps={{ shrink: true }}
+                            sx={{ maxWidth: { xs: "100%", sm: 200 } }}
+                          />
+                        </Stack>
+
+                        <FormHelperText sx={{ ml: 0, color: "var(--page-text)" }}>
+                          Интервал задаётся в часовом поясе устройства и может пересекать полночь.
+                        </FormHelperText>
+
+                        <Stack direction="row" spacing={1} alignItems="flex-start" sx={{ color: "var(--page-text)" }}>
+                          <InfoOutlinedIcon fontSize="small" sx={{ mt: 0.3 }} />
+                          <Typography variant="body2" sx={{ color: "var(--page-text)" }}>
+                            На iOS при установке веб-приложения как PWA уведомления часто приходят без звука — это
+                            ограничение системы.
+                          </Typography>
+                        </Stack>
+                      </Stack>
+
+                      <Typography variant="body2" sx={{ color: "var(--page-text)" }}>
+                        {notificationsEnabled
+                          ? `Непрочитанные: ${unreadCount}.`
+                          : "Уведомления сейчас отключены."}
+                      </Typography>
+                    </>
+                  )}
                 </Stack>
               )}
             </Box>

--- a/root/frontend/src/utils/browser.ts
+++ b/root/frontend/src/utils/browser.ts
@@ -1,0 +1,24 @@
+export function isIOS(): boolean {
+  if (typeof navigator === "undefined") return false
+  const platform = navigator.platform || ""
+  const userAgent = navigator.userAgent || ""
+  const iosPlatforms = ["iPad", "iPhone", "iPod"]
+  if (iosPlatforms.includes(platform)) return true
+  // iPadOS 13+ returns MacIntel, so additionally check for touch support
+  if (platform === "MacIntel" && (navigator as any).maxTouchPoints > 1) return true
+  return /iPad|iPhone|iPod/.test(userAgent)
+}
+
+export function isSafari(): boolean {
+  if (typeof navigator === "undefined") return false
+  const ua = navigator.userAgent || ""
+  const vendor = navigator.vendor || ""
+  const isSafariVendor = /Apple Computer/.test(vendor)
+  const isSafariUA = /Safari/.test(ua)
+  const isExcluded = /CriOS|FxiOS|OPiOS|EdgiOS|Chrome|Firefox|OPR|Edg/.test(ua)
+  return isSafariUA && isSafariVendor && !isExcluded
+}
+
+export function isSafariIOS(): boolean {
+  return isIOS() && isSafari()
+}


### PR DESCRIPTION
## Summary
- add a shared `usePushPreferences` hook to centralise push-permission state, safari detection and subscription management
- update Settings notifications UI to handle denied/default/granted states with Safari iOS tips and topic toggles behind granted permission
- extend the install prompt to surface the same permission states and quick topic switches when notifications are available

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e27faf2c6c8327a500746507b0c22d