### PR TITLE
feat: add live in-app push toasts

### DIFF
--- a/root/frontend/src/App.tsx
+++ b/root/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import MobileBottomNav from "./components/MobileBottomNav"
 import BackToTop from "./components/BackToTop"
 import ErrorBoundary from "./app/ErrorBoundary"
 import InstallPrompt from "./components/InstallPrompt"
+import LivePushToasts from "./components/LivePushToasts"
 import { useQueryClient } from "@tanstack/react-query"
 import { nowPlayingQueryKey } from "./hooks/useNowPlaying"
 
@@ -130,6 +131,7 @@ function AppContent() {
       {!hideNavbar && <BackToTop />}
       {!hideNavbar && <Footer />}
       {!hideNavbar && <MobileBottomNav />}
+      <LivePushToasts />
       {!hideNavbar && <InstallPrompt />}
     </>
   )

--- a/root/frontend/src/components/LivePushToasts.tsx
+++ b/root/frontend/src/components/LivePushToasts.tsx
@@ -1,0 +1,142 @@
+import { useCallback, useEffect, useState, type SyntheticEvent } from "react"
+import { Alert, Button, Snackbar, Stack, Typography } from "@mui/material"
+import type { SnackbarCloseReason } from "@mui/material/Snackbar"
+
+type SnackbarSeverity = "success" | "info" | "warning" | "error"
+
+type ToastPayload = {
+  id?: string
+  title?: string
+  body?: string
+  url?: string
+  icon?: string
+  tag?: string
+  data?: Record<string, unknown>
+  timestamp?: number
+}
+
+type ActiveToast = Required<Pick<ToastPayload, "id">> & ToastPayload
+
+type ServiceWorkerMessage = {
+  type?: string
+  toast?: ToastPayload
+}
+
+const DEFAULT_SEVERITY: SnackbarSeverity = "info"
+const VALID_SEVERITIES: readonly SnackbarSeverity[] = ["success", "info", "warning", "error"] as const
+
+const resolveSeverity = (toast: ActiveToast | null): SnackbarSeverity => {
+  if (!toast?.data || typeof toast.data !== "object") return DEFAULT_SEVERITY
+  const rawSeverity = (toast.data as { severity?: unknown }).severity
+  if (typeof rawSeverity !== "string") return DEFAULT_SEVERITY
+  const normalized = rawSeverity.trim().toLowerCase()
+  const match = VALID_SEVERITIES.find((value) => value === normalized)
+  return match ?? DEFAULT_SEVERITY
+}
+
+const buildToastId = (toast: ToastPayload) => {
+  if (toast.id && toast.id.trim()) return toast.id
+  if (toast.tag && toast.tag.trim()) return toast.tag
+  if (toast.timestamp && Number.isFinite(toast.timestamp)) return String(toast.timestamp)
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}`
+}
+
+export default function LivePushToasts() {
+  const [queue, setQueue] = useState<ActiveToast[]>([])
+  const [current, setCurrent] = useState<ActiveToast | null>(null)
+  const [open, setOpen] = useState(false)
+
+  const enqueue = useCallback((toast: ToastPayload) => {
+    const hasContent = Boolean(toast.title?.trim() || toast.body?.trim())
+    if (!hasContent) return
+    setQueue((prev) => [...prev, { ...toast, id: buildToastId(toast) }])
+  }, [])
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+    if (!("serviceWorker" in navigator)) return
+
+    const handleMessage = (event: MessageEvent<ServiceWorkerMessage>) => {
+      const { data } = event
+      if (!data || typeof data !== "object") return
+      if (data.type !== "PUSH_NOTIFICATION") return
+      if (!data.toast) return
+      if (typeof document !== "undefined" && document.visibilityState !== "visible") return
+      enqueue(data.toast)
+    }
+
+    navigator.serviceWorker.addEventListener("message", handleMessage)
+    return () => navigator.serviceWorker.removeEventListener("message", handleMessage)
+  }, [enqueue])
+
+  useEffect(() => {
+    if (current || queue.length === 0) return
+    setCurrent(queue[0])
+    setQueue((prev) => prev.slice(1))
+    setOpen(true)
+  }, [current, queue])
+
+  const handleClose = useCallback(
+    (_event?: Event | SyntheticEvent, reason?: SnackbarCloseReason) => {
+      if (reason === "clickaway") return
+      setOpen(false)
+      setCurrent(null)
+    },
+    [],
+  )
+
+  const handleAction = useCallback(() => {
+    if (!current?.url) return
+    try {
+      const resolved = new URL(current.url, window.location.href)
+      const sameOrigin = resolved.origin === window.location.origin
+      window.open(resolved.href, sameOrigin ? "_self" : "_blank", sameOrigin ? undefined : "noopener,noreferrer")
+    } catch (error) {
+      console.error("Failed to open toast link", error)
+      window.open(current.url, "_blank", "noopener,noreferrer")
+    }
+    setOpen(false)
+    setCurrent(null)
+  }, [current])
+
+  const severity = resolveSeverity(current)
+  const title = current?.title?.trim()
+  const body = current?.body?.trim()
+
+  return (
+    <Snackbar
+      key={current?.id}
+      open={open && Boolean(current)}
+      autoHideDuration={6000}
+      onClose={handleClose}
+      anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+    >
+      <Alert
+        severity={severity}
+        variant="filled"
+        onClose={handleClose}
+        sx={{ alignItems: "flex-start", width: "100%", gap: 0.5, minWidth: { xs: 280, sm: 320 } }}
+        action={
+          current?.url ? (
+            <Button color="inherit" size="small" onClick={handleAction}>
+              Открыть
+            </Button>
+          ) : null
+        }
+      >
+        <Stack spacing={0.5}>
+          {title ? (
+            <Typography component="span" variant="subtitle2" sx={{ fontWeight: 700 }}>
+              {title}
+            </Typography>
+          ) : null}
+          {body ? (
+            <Typography component="span" variant="body2">
+              {body}
+            </Typography>
+          ) : null}
+        </Stack>
+      </Alert>
+    </Snackbar>
+  )
+}

--- a/root/frontend/src/sw.ts
+++ b/root/frontend/src/sw.ts
@@ -109,78 +109,120 @@ const DEFAULT_TITLE = "Экосистема ГУУ"
 const DEFAULT_ICON = "/maskable-icon-192.png"
 
 self.addEventListener("push", (event) => {
-  const payload = (() => {
-    if (!event.data) {
-      return {}
-    }
-    try {
-      return event.data.json() as PushPayload
-    } catch (error) {
-      return { body: event.data.text() } as PushPayload
-    }
-  })()
-
-  const title = payload.title || DEFAULT_TITLE
-  const data: NotificationData = {
-    url: payload.url || "/",
-    ...(payload.data ?? {}),
-  }
-
-  const options: NotificationOptions = {
-    body: payload.body,
-    icon: payload.icon || DEFAULT_ICON,
-    badge: payload.badge || payload.icon || DEFAULT_ICON,
-    tag: payload.tag,
-    data,
-    requireInteraction: payload.requireInteraction,
-    silent: payload.silent,
-  }
-
-  const extendedOptions = options as NotificationOptions & {
-    renotify?: boolean
-    timestamp?: number
-    vibrate?: number[]
-    actions?: NotificationActionOption[]
-  }
-
-  if (payload.renotify !== undefined) {
-    extendedOptions.renotify = payload.renotify
-  }
-
-  if (payload.timestamp !== undefined) {
-    extendedOptions.timestamp = payload.timestamp
-  }
-
-  if (payload.vibrate) {
-    extendedOptions.vibrate = payload.vibrate
-  }
-
-  if (payload.actions?.length) {
-    const actionUrls: Record<string, string> = {}
-    const validActions: NotificationActionOption[] = []
-    for (const action of payload.actions) {
-      if (!action || typeof action !== "object") continue
-      const key = typeof action.action === "string" ? action.action.trim() : ""
-      const title = typeof action.title === "string" ? action.title.trim() : ""
-      if (!key || !title) continue
-      const entry: NotificationActionOption = { action: key, title }
-      if (action.icon && typeof action.icon === "string") {
-        entry.icon = action.icon
+  const handlePush = async () => {
+    const payload = (() => {
+      if (!event.data) {
+        return {}
       }
-      validActions.push(entry)
-      if (action.url && typeof action.url === "string" && action.url.trim()) {
-        actionUrls[key] = action.url
+      try {
+        return event.data.json() as PushPayload
+      } catch (error) {
+        return { body: event.data.text() } as PushPayload
+      }
+    })()
+
+    const rawData =
+      payload.data && typeof payload.data === "object" ? (payload.data as Record<string, unknown>) : undefined
+
+    const title = payload.title || DEFAULT_TITLE
+    const data: NotificationData = {
+      url: payload.url || "/",
+      ...(rawData ?? {}),
+    }
+
+    const options: NotificationOptions = {
+      body: payload.body,
+      icon: payload.icon || DEFAULT_ICON,
+      badge: payload.badge || payload.icon || DEFAULT_ICON,
+      tag: payload.tag,
+      data,
+      requireInteraction: payload.requireInteraction,
+      silent: payload.silent,
+    }
+
+    const extendedOptions = options as NotificationOptions & {
+      renotify?: boolean
+      timestamp?: number
+      vibrate?: number[]
+      actions?: NotificationActionOption[]
+    }
+
+    if (payload.renotify !== undefined) {
+      extendedOptions.renotify = payload.renotify
+    }
+
+    if (payload.timestamp !== undefined) {
+      extendedOptions.timestamp = payload.timestamp
+    }
+
+    if (payload.vibrate) {
+      extendedOptions.vibrate = payload.vibrate
+    }
+
+    if (payload.actions?.length) {
+      const actionUrls: Record<string, string> = {}
+      const validActions: NotificationActionOption[] = []
+      for (const action of payload.actions) {
+        if (!action || typeof action !== "object") continue
+        const key = typeof action.action === "string" ? action.action.trim() : ""
+        const actionTitle = typeof action.title === "string" ? action.title.trim() : ""
+        if (!key || !actionTitle) continue
+        const entry: NotificationActionOption = { action: key, title: actionTitle }
+        if (action.icon && typeof action.icon === "string") {
+          entry.icon = action.icon
+        }
+        validActions.push(entry)
+        if (action.url && typeof action.url === "string" && action.url.trim()) {
+          actionUrls[key] = action.url
+        }
+      }
+      if (validActions.length) {
+        extendedOptions.actions = validActions
+        if (Object.keys(actionUrls).length) {
+          data.actionUrls = actionUrls
+        }
       }
     }
-    if (validActions.length) {
-      extendedOptions.actions = validActions
-      if (Object.keys(actionUrls).length) {
-        data.actionUrls = actionUrls
+
+    const payloadType = (() => {
+      const rawType = rawData && typeof rawData.type === "string" ? rawData.type.trim() : undefined
+      return rawType || undefined
+    })()
+
+    if (payloadType === "in-app") {
+      const windowClients = (await self.clients.matchAll({
+        type: "window",
+        includeUncontrolled: true,
+      })) as WindowClient[]
+
+      const hasVisibleClient = windowClients.some((client) => client.visibilityState === "visible")
+
+      if (hasVisibleClient) {
+        const toastMessage = {
+          type: "PUSH_NOTIFICATION",
+          toast: {
+            title,
+            body: payload.body,
+            url: typeof data.url === "string" ? data.url : undefined,
+            icon: options.icon,
+            tag: options.tag,
+            data,
+            timestamp: extendedOptions.timestamp ?? Date.now(),
+          },
+        }
+
+        for (const client of windowClients) {
+          client.postMessage(toastMessage)
+        }
+
+        return
       }
     }
+
+    await self.registration.showNotification(title, options)
   }
 
-  event.waitUntil(self.registration.showNotification(title, options))
+  event.waitUntil(handlePush())
 })
 
 self.addEventListener("notificationclick", (event) => {


### PR DESCRIPTION
## Summary
- add a LivePushToasts component that listens for service worker messages and renders in-app Snackbar alerts
- update the service worker to emit toast messages for `in-app` pushes instead of system notifications when a window is visible
- mount the toast container in the main app shell so users see live push content without duplicated OS alerts

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e28d89d7f08327814d208d27e19d81