### PR TITLE
feat: add app badge updates to notifications center

### DIFF
--- a/root/frontend/src/pages/Notifications.tsx
+++ b/root/frontend/src/pages/Notifications.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 import Layout from "../components/Layout"
 import {
   Avatar,
@@ -29,6 +29,41 @@ import { useNavigate } from "react-router-dom"
 import { useNotifications, type AppNotification } from "@/hooks/useNotifications"
 
 const rtf = new Intl.RelativeTimeFormat("ru-RU", { numeric: "auto" })
+
+type NavigatorWithBadge = Navigator & {
+  setAppBadge?: (count?: number) => Promise<void> | void
+  clearAppBadge?: () => Promise<void> | void
+}
+
+function updateAppBadge(unread: number) {
+  if (typeof navigator === "undefined") return
+  const nav = navigator as NavigatorWithBadge
+  const hasBadgeApi = typeof nav.setAppBadge === "function" || typeof nav.clearAppBadge === "function"
+  if (!hasBadgeApi) return
+
+  const swallow = (result: void | Promise<void> | undefined) => {
+    if (result && typeof (result as PromiseLike<void>).catch === "function") {
+      ;(result as PromiseLike<void>).catch(() => {})
+    }
+  }
+
+  try {
+    if (unread > 0) {
+      swallow(nav.setAppBadge?.(unread))
+      return
+    }
+
+    if (typeof nav.clearAppBadge === "function") {
+      swallow(nav.clearAppBadge())
+    } else {
+      swallow(nav.setAppBadge?.(0))
+    }
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.debug("Failed to update app badge", error)
+    }
+  }
+}
 
 function timeAgo(dateIso: string): string {
   const date = new Date(dateIso)
@@ -207,6 +242,10 @@ function NotificationsCenter() {
   } = useNotifications()
   const [filter, setFilter] = useState<FilterValue>("all")
   const [refreshing, setRefreshing] = useState(false)
+
+  useEffect(() => {
+    updateAppBadge(unreadCount)
+  }, [unreadCount])
 
   const filteredItems = useMemo(() => {
     if (filter === "all") return items

--- a/root/frontend/src/pages/Notifications.tsx
+++ b/root/frontend/src/pages/Notifications.tsx
@@ -42,8 +42,11 @@ function updateAppBadge(unread: number) {
   if (!hasBadgeApi) return
 
   const swallow = (result: void | Promise<void> | undefined) => {
-    if (result && typeof (result as PromiseLike<void>).catch === "function") {
-      ;(result as PromiseLike<void>).catch(() => {})
+    if (
+      result &&
+      typeof (result as PromiseLike<void>).then === "function"
+    ) {
+      ;(result as PromiseLike<void>).then(undefined, () => {})
     }
   }
 


### PR DESCRIPTION
## Summary
- add a helper to update the PWA app badge with the current unread notification count
- invoke the badge helper when the notification center opens so unread changes update the badge with graceful fallback handling

## Testing
- npm --prefix root/frontend run lint
- npm --prefix root/frontend run lint:all *(fails: pre-existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e2917daff48327a42f5781dd1c6101