### PR TITLE
Add webpush helper API for payload templates and dispatch

### DIFF
--- a/root/app/services/webpush.py
+++ b/root/app/services/webpush.py
@@ -1,18 +1,24 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
+from collections.abc import Mapping
+from copy import deepcopy
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, time
 from typing import Any, Literal
 
 from pywebpush import WebPushException, webpush
-from sqlalchemy import create_engine, delete, update
+from sqlalchemy import create_engine, delete, select, update
 from sqlalchemy.engine import make_url
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import selectinload, sessionmaker
 
 from app.core.config import settings
+from app.core.database import async_session
+from app.core.rate_limit import RateLimitExceeded, RateLimitInfo, enforce_rate_limit
 from app.models.models import PushSubscription
+from app.services.push_topics import normalize_topic, subscription_supports_topic
 
 logger = logging.getLogger(__name__)
 
@@ -22,9 +28,66 @@ if url.drivername.endswith("+asyncpg"):
 _sync_engine = create_engine(str(url), pool_pre_ping=True, future=True)
 _Session = sessionmaker(bind=_sync_engine, autocommit=False, autoflush=False)
 
+_OPTION_KEYS: set[str] = {
+    "actions",
+    "badge",
+    "body",
+    "dir",
+    "icon",
+    "image",
+    "lang",
+    "renotify",
+    "requireInteraction",
+    "silent",
+    "tag",
+    "timestamp",
+    "vibrate",
+}
+_META_KEYS: set[str] = {"ttl", "topic", "urgency"}
+
+_USER_RATE_LIMIT = 60
+_TOPIC_RATE_LIMIT = 300
+_RATE_LIMIT_WINDOW_SECONDS = 60
+
 
 def json_dumps(obj):
     return json.dumps(obj, ensure_ascii=False)
+
+
+def _log_event(event: str, *, level: int = logging.INFO, **fields: Any) -> None:
+    extra = {key: value for key, value in fields.items() if value is not None}
+    extra["event"] = event
+    logger.log(level, "webpush.%s", event, extra=extra)
+
+
+def _current_local_time() -> time:
+    return datetime.now().astimezone().time()
+
+
+def _is_user_in_quiet_hours(user: Any | None, *, now_time: time | None = None) -> bool:
+    if not user or not getattr(user, "dnd_enabled", False):
+        return False
+    start = getattr(user, "dnd_start", None)
+    end = getattr(user, "dnd_end", None)
+    if now_time is None:
+        now_time = _current_local_time()
+    if start is None or end is None:
+        return True
+    if start == end:
+        return True
+    if start < end:
+        return start <= now_time < end
+    return now_time >= start or now_time < end
+
+
+def _sanitize_vibrate(raw: Any) -> list[int]:
+    if not isinstance(raw, (list, tuple)):
+        return []
+    cleaned: list[int] = []
+    for item in raw:
+        if isinstance(item, (int, float)):
+            cleaned.append(int(item))
+    return cleaned
 
 
 @dataclass(slots=True)
@@ -60,53 +123,264 @@ def _prepare_actions(raw_actions: Any) -> tuple[list[dict[str, str]], dict[str, 
     return actions, action_urls
 
 
-def send_web_push(sub: PushSubscription, data: dict) -> WebPushResult:
-    payload: dict[str, Any] = {
-        "title": data.get("title") or "Уведомление",
-        "body": data.get("body") or "",
-        "url": data.get("url") or "/",
-        "tag": data.get("tag"),
-        "type": data.get("type"),
-    }
-    badge = data.get("badge")
-    if isinstance(badge, str) and badge.strip():
-        payload["badge"] = badge.strip()
-    icon = data.get("icon")
-    if isinstance(icon, str) and icon.strip():
-        payload["icon"] = icon.strip()
-    if "renotify" in data:
-        payload["renotify"] = bool(data.get("renotify"))
-    if "requireInteraction" in data:
-        payload["requireInteraction"] = bool(data.get("requireInteraction"))
-    if "silent" in data:
-        payload["silent"] = bool(data.get("silent"))
-    if "timestamp" in data:
+def _normalize_payload(
+    raw: Mapping[str, Any] | None,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    if not isinstance(raw, Mapping):
+        raw = {}
+    payload_options: dict[str, Any]
+    payload_data: dict[str, Any]
+    if isinstance(raw.get("options"), Mapping):
+        payload_options = {
+            key: deepcopy(value)
+            for key, value in raw["options"].items()
+            if value is not None
+        }
+    else:
+        payload_options = {}
+    if isinstance(raw.get("data"), Mapping):
+        payload_data = {
+            key: deepcopy(value) for key, value in raw["data"].items()
+        }
+    else:
+        payload_data = {}
+    meta: dict[str, Any] = {}
+    meta_source = raw.get("_meta") if isinstance(raw.get("_meta"), Mapping) else {}
+    for key in _META_KEYS:
+        value = None
+        if isinstance(meta_source, Mapping):
+            value = meta_source.get(key)
+        if value is None and key in raw and raw.get(key) is not None:
+            value = raw.get(key)
+        if value is None:
+            continue
+        if key == "ttl":
+            try:
+                meta[key] = int(value)
+            except (TypeError, ValueError):
+                continue
+        else:
+            meta[key] = value
+    if not payload_options:
+        actions, action_urls = _prepare_actions(raw.get("actions"))
+        if actions:
+            payload_options["actions"] = actions
+            if action_urls:
+                payload_data.setdefault("actionUrls", action_urls)
+        for key in _OPTION_KEYS - {"actions", "vibrate", "body"}:
+            if key not in raw:
+                continue
+            value = raw.get(key)
+            if value is None:
+                continue
+            payload_options[key] = value
+        vibrate = _sanitize_vibrate(raw.get("vibrate"))
+        if vibrate:
+            payload_options["vibrate"] = vibrate
+        body_value = raw.get("body")
+        payload_options.setdefault("body", str(body_value or ""))
+    else:
+        meta_from_options = {
+            key: payload_options.pop(key)
+            for key in list(payload_options)
+            if key in _META_KEYS
+        }
+        for key, value in meta_from_options.items():
+            if value is None or key in meta:
+                continue
+            if key == "ttl":
+                try:
+                    meta[key] = int(value)
+                except (TypeError, ValueError):
+                    continue
+            else:
+                meta[key] = value
+        actions, action_urls = _prepare_actions(payload_options.get("actions"))
+        if actions:
+            payload_options["actions"] = actions
+            if action_urls:
+                payload_data.setdefault("actionUrls", action_urls)
+        else:
+            payload_options.pop("actions", None)
+        if "vibrate" in payload_options:
+            vibrate = _sanitize_vibrate(payload_options.get("vibrate"))
+            if vibrate:
+                payload_options["vibrate"] = vibrate
+            else:
+                payload_options.pop("vibrate", None)
+        if "body" in payload_options:
+            payload_options["body"] = str(payload_options["body"] or "")
+    for flag in ("renotify", "requireInteraction", "silent"):
+        if flag in payload_options:
+            payload_options[flag] = bool(payload_options[flag])
+    if "timestamp" in payload_options:
         try:
-            payload["timestamp"] = int(data.get("timestamp"))
+            payload_options["timestamp"] = int(payload_options["timestamp"])
+        except (TypeError, ValueError):
+            payload_options.pop("timestamp", None)
+    if "body" not in payload_options:
+        payload_options["body"] = ""
+    cleaned_options: dict[str, Any] = {}
+    for key, value in payload_options.items():
+        if key not in _OPTION_KEYS:
+            continue
+        if key == "actions" and not value:
+            continue
+        cleaned_options[key] = value
+    payload_options = cleaned_options
+    for string_key in ("badge", "icon", "image", "tag", "dir", "lang"):
+        if string_key in payload_options:
+            payload_options[string_key] = str(payload_options[string_key])
+    url = raw.get("url")
+    if isinstance(url, str) and url.strip():
+        payload_data.setdefault("url", url.strip())
+    if "type" in raw and raw.get("type") is not None:
+        payload_data.setdefault("type", str(raw.get("type")))
+    topic = meta.get("topic")
+    if topic and isinstance(topic, str):
+        payload_data.setdefault("topic", topic)
+    title = str(raw.get("title") or "Уведомление")
+    payload = {
+        "title": title,
+        "options": payload_options,
+        "data": payload_data,
+    }
+    return payload, meta
+
+
+def _compose_payload(payload: Mapping[str, Any], meta: Mapping[str, Any] | None) -> dict[str, Any]:
+    result = {
+        "title": str(payload.get("title") or "Уведомление"),
+        "options": deepcopy(payload.get("options", {})),
+        "data": deepcopy(payload.get("data", {})),
+    }
+    clean_meta = (
+        {key: value for key, value in (meta or {}).items() if value is not None}
+        if meta
+        else {}
+    )
+    if clean_meta:
+        result["_meta"] = clean_meta
+    return result
+
+
+def _apply_quiet_mode(payload: dict[str, Any]) -> None:
+    options = payload.setdefault("options", {})
+    options["silent"] = True
+    options["renotify"] = False
+    options["requireInteraction"] = False
+    options["vibrate"] = []
+    data_payload = payload.setdefault("data", {})
+    data_payload["dnd_suppressed"] = True
+
+
+def _prepare_delivery_payload(
+    payload: Mapping[str, Any] | None,
+    *,
+    topic: str | None,
+    user: Any | None,
+) -> dict[str, Any]:
+    normalized, meta = _normalize_payload(payload)
+    normalized_topic = normalize_topic(topic) or normalize_topic(meta.get("topic"))
+    if normalized_topic:
+        meta["topic"] = normalized_topic
+        normalized.setdefault("data", {})
+        normalized["data"].setdefault("topic", normalized_topic)
+    if user and _is_user_in_quiet_hours(user):
+        _apply_quiet_mode(normalized)
+    return _compose_payload(normalized, meta)
+
+
+async def _check_rate_limit(
+    identifier: str,
+    *,
+    namespace: str,
+    limit: int,
+) -> RateLimitInfo:
+    if limit <= 0 or not settings.rate_limit_enabled:
+        return RateLimitInfo(True, max(limit, 0), 0)
+    try:
+        return await enforce_rate_limit(
+            identifier=identifier,
+            namespace=namespace,
+            limit=limit,
+            window_seconds=_RATE_LIMIT_WINDOW_SECONDS,
+            redis_url=settings.rate_limit_storage_uri,
+        )
+    except RateLimitExceeded as exc:
+        return exc.info
+
+
+def build_payload(notification_type: str, data: Mapping[str, Any] | None) -> dict[str, Any]:
+    source: Mapping[str, Any]
+    if isinstance(data, Mapping):
+        source = data
+    else:
+        source = {}
+    title = str(source.get("title") or "Уведомление")
+    payload_data: dict[str, Any] = {}
+    if isinstance(source.get("data"), Mapping):
+        payload_data.update({
+            key: deepcopy(value) for key, value in source["data"].items()
+        })
+    url = source.get("url")
+    if isinstance(url, str) and url.strip():
+        payload_data.setdefault("url", url.strip())
+    if notification_type is not None:
+        payload_data.setdefault("type", str(notification_type))
+    options: dict[str, Any] = {}
+    for key in ("badge", "icon", "image", "tag", "dir", "lang"):
+        value = source.get(key)
+        if value is not None:
+            options[key] = str(value)
+    actions, action_urls = _prepare_actions(source.get("actions"))
+    if actions:
+        options["actions"] = actions
+    if action_urls:
+        payload_data.setdefault("actionUrls", action_urls)
+    vibrate = _sanitize_vibrate(source.get("vibrate"))
+    if vibrate:
+        options["vibrate"] = vibrate
+    options["body"] = str(source.get("body") or "")
+    if "renotify" in source:
+        options["renotify"] = bool(source.get("renotify"))
+    if "requireInteraction" in source:
+        options["requireInteraction"] = bool(source.get("requireInteraction"))
+    if "silent" in source:
+        options["silent"] = bool(source.get("silent"))
+    if "timestamp" in source:
+        try:
+            options["timestamp"] = int(source.get("timestamp"))
         except (TypeError, ValueError):
             pass
-    if "vibrate" in data and isinstance(data.get("vibrate"), list):
-        payload["vibrate"] = [
-            int(v) for v in data["vibrate"] if isinstance(v, (int, float))
-        ]
-    data_payload = data.get("data")
-    if isinstance(data_payload, dict):
-        payload["data"] = data_payload.copy()
-    actions, action_urls = _prepare_actions(data.get("actions"))
-    if actions:
-        payload["actions"] = actions
-        if action_urls:
-            payload.setdefault("data", {})
-            payload["data"]["actionUrls"] = action_urls
-    ttl_val = data.get("ttl")
-    ttl = int(ttl_val) if ttl_val is not None else None
+    meta: dict[str, Any] = {}
+    for key in _META_KEYS:
+        value = source.get(key)
+        if value is None:
+            continue
+        if key == "ttl":
+            try:
+                meta[key] = int(value)
+            except (TypeError, ValueError):
+                continue
+        else:
+            meta[key] = value
+    payload = {"title": title, "options": options, "data": payload_data}
+    if meta:
+        payload["_meta"] = meta
+    return payload
+
+
+def send_web_push(sub: PushSubscription, data: dict) -> WebPushResult:
+    normalized_payload, meta = _normalize_payload(data)
+    ttl = meta.get("ttl") if isinstance(meta.get("ttl"), int) else None
     headers = {}
-    urgency = data.get("urgency")
+    urgency = meta.get("urgency")
     if urgency:
-        headers["Urgency"] = urgency
-    topic = data.get("topic")
+        headers["Urgency"] = str(urgency)
+    topic = meta.get("topic")
     if topic:
-        headers["Topic"] = topic
+        headers["Topic"] = str(topic)
     subscription_info = {
         "endpoint": sub.endpoint,
         "keys": {"p256dh": sub.p256dh, "auth": sub.auth},
@@ -115,7 +389,7 @@ def send_web_push(sub: PushSubscription, data: dict) -> WebPushResult:
     try:
         webpush(
             subscription_info=subscription_info,
-            data=json_dumps(payload),
+            data=json_dumps(normalized_payload),
             vapid_private_key=settings.VAPID_PRIVATE_KEY,
             vapid_claims={"sub": settings.WEBPUSH_SUBJECT},
             headers=headers,
@@ -137,14 +411,8 @@ def send_web_push(sub: PushSubscription, data: dict) -> WebPushResult:
                     delete(PushSubscription).where(PushSubscription.id == sub.id)
                 )
                 session.commit()
-            logger.info(
-                "webpush.send",
-                extra={
-                    "user_id": user_id,
-                    "endpoint": sub.endpoint,
-                    "status": "gone",
-                    "status_code": status_code,
-                },
+            _log_event(
+                "send", user_id=user_id, endpoint=sub.endpoint, status="gone", status_code=status_code
             )
             return WebPushResult(
                 subscription_id=sub.id,
@@ -154,14 +422,12 @@ def send_web_push(sub: PushSubscription, data: dict) -> WebPushResult:
                 status_code=status_code,
                 error=message or None,
             )
-        logger.info(
-            "webpush.send",
-            extra={
-                "user_id": user_id,
-                "endpoint": sub.endpoint,
-                "status": "error",
-                "status_code": status_code,
-            },
+        _log_event(
+            "send",
+            user_id=user_id,
+            endpoint=sub.endpoint,
+            status="error",
+            status_code=status_code,
         )
         return WebPushResult(
             subscription_id=sub.id,
@@ -172,9 +438,14 @@ def send_web_push(sub: PushSubscription, data: dict) -> WebPushResult:
             error=message or None,
         )
     except Exception as exc:  # pragma: no cover - unexpected failure
-        logger.exception(
-            "webpush.send", extra={"user_id": user_id, "endpoint": sub.endpoint}
+        _log_event(
+            "send",
+            level=logging.ERROR,
+            user_id=user_id,
+            endpoint=sub.endpoint,
+            status="error",
         )
+        logger.exception("webpush.send", extra={"user_id": user_id, "endpoint": sub.endpoint})
         return WebPushResult(
             subscription_id=sub.id,
             endpoint=sub.endpoint,
@@ -190,13 +461,141 @@ def send_web_push(sub: PushSubscription, data: dict) -> WebPushResult:
             .values(last_seen_at=now)
         )
         session.commit()
-    logger.info(
-        "webpush.send",
-        extra={"user_id": user_id, "endpoint": sub.endpoint, "status": "sent"},
-    )
+    _log_event("send", user_id=user_id, endpoint=sub.endpoint, status="sent")
     return WebPushResult(
         subscription_id=sub.id,
         endpoint=sub.endpoint,
         user_id=user_id,
         status="sent",
     )
+
+
+async def send_to_user(
+    user_id: int,
+    payload: Mapping[str, Any] | None,
+    topic: str | None = None,
+) -> list[WebPushResult]:
+    normalized_topic = normalize_topic(topic) if topic is not None else None
+    if topic and normalized_topic is None:
+        _log_event(
+            "dispatch",
+            level=logging.WARNING,
+            user_id=user_id,
+            topic=topic,
+            status="invalid_topic",
+        )
+    _, payload_meta = _normalize_payload(payload)
+    payload_topic = normalize_topic(payload_meta.get("topic"))
+    effective_topic = normalized_topic or payload_topic
+    rate_info = await _check_rate_limit(
+        f"user:{user_id}", namespace="webpush:user", limit=_USER_RATE_LIMIT
+    )
+    if not rate_info.allowed:
+        _log_event(
+            "dispatch",
+            level=logging.WARNING,
+            user_id=user_id,
+            topic=effective_topic or normalized_topic or topic,
+            status="rate_limited",
+            retry_after=rate_info.retry_after,
+        )
+        return []
+    async with async_session() as session:
+        result = await session.execute(
+            select(PushSubscription)
+            .options(selectinload(PushSubscription.user))
+            .where(PushSubscription.user_id == user_id)
+        )
+        subscriptions = result.scalars().all()
+    if not subscriptions:
+        _log_event(
+            "dispatch",
+            user_id=user_id,
+            topic=effective_topic or normalized_topic or topic,
+            status="no_subscriptions",
+        )
+        return []
+    tasks = []
+    for sub in subscriptions:
+        if not subscription_supports_topic(sub, effective_topic):
+            continue
+        prepared = _prepare_delivery_payload(
+            payload, topic=normalized_topic or payload_topic, user=getattr(sub, "user", None)
+        )
+        tasks.append(asyncio.to_thread(send_web_push, sub, prepared))
+    if not tasks:
+        _log_event(
+            "dispatch",
+            user_id=user_id,
+            topic=effective_topic or normalized_topic or topic,
+            status="no_matching_topics",
+        )
+        return []
+    results = await asyncio.gather(*tasks)
+    _log_event(
+        "dispatch",
+        user_id=user_id,
+        topic=effective_topic or normalized_topic or topic,
+        status="sent",
+        delivered=len(results),
+    )
+    return list(results)
+
+
+async def broadcast_to_topic(
+    topic: str,
+    payload: Mapping[str, Any] | None,
+) -> list[WebPushResult]:
+    normalized_topic = normalize_topic(topic)
+    if not normalized_topic:
+        _log_event(
+            "broadcast",
+            level=logging.WARNING,
+            topic=topic,
+            status="invalid_topic",
+        )
+        return []
+    rate_info = await _check_rate_limit(
+        f"topic:{normalized_topic}",
+        namespace="webpush:topic",
+        limit=_TOPIC_RATE_LIMIT,
+    )
+    if not rate_info.allowed:
+        _log_event(
+            "broadcast",
+            level=logging.WARNING,
+            topic=normalized_topic,
+            status="rate_limited",
+            retry_after=rate_info.retry_after,
+        )
+        return []
+    async with async_session() as session:
+        result = await session.execute(
+            select(PushSubscription)
+            .options(selectinload(PushSubscription.user))
+            .where(PushSubscription.topics.contains([normalized_topic]))
+        )
+        subscriptions = result.scalars().all()
+    if not subscriptions:
+        _log_event(
+            "broadcast",
+            topic=normalized_topic,
+            status="no_subscribers",
+        )
+        return []
+    tasks = []
+    for sub in subscriptions:
+        prepared = _prepare_delivery_payload(
+            payload,
+            topic=normalized_topic,
+            user=getattr(sub, "user", None),
+        )
+        tasks.append(asyncio.to_thread(send_web_push, sub, prepared))
+    results = await asyncio.gather(*tasks)
+    _log_event(
+        "broadcast",
+        topic=normalized_topic,
+        status="sent",
+        delivered=len(results),
+    )
+    return list(results)

--- a/root/app/services/webpush.py
+++ b/root/app/services/webpush.py
@@ -139,9 +139,7 @@ def _normalize_payload(
     else:
         payload_options = {}
     if isinstance(raw.get("data"), Mapping):
-        payload_data = {
-            key: deepcopy(value) for key, value in raw["data"].items()
-        }
+        payload_data = {key: deepcopy(value) for key, value in raw["data"].items()}
     else:
         payload_data = {}
     meta: dict[str, Any] = {}
@@ -248,7 +246,9 @@ def _normalize_payload(
     return payload, meta
 
 
-def _compose_payload(payload: Mapping[str, Any], meta: Mapping[str, Any] | None) -> dict[str, Any]:
+def _compose_payload(
+    payload: Mapping[str, Any], meta: Mapping[str, Any] | None
+) -> dict[str, Any]:
     result = {
         "title": str(payload.get("title") or "Уведомление"),
         "options": deepcopy(payload.get("options", {})),
@@ -311,7 +311,9 @@ async def _check_rate_limit(
         return exc.info
 
 
-def build_payload(notification_type: str, data: Mapping[str, Any] | None) -> dict[str, Any]:
+def build_payload(
+    notification_type: str, data: Mapping[str, Any] | None
+) -> dict[str, Any]:
     source: Mapping[str, Any]
     if isinstance(data, Mapping):
         source = data
@@ -320,9 +322,9 @@ def build_payload(notification_type: str, data: Mapping[str, Any] | None) -> dic
     title = str(source.get("title") or "Уведомление")
     payload_data: dict[str, Any] = {}
     if isinstance(source.get("data"), Mapping):
-        payload_data.update({
-            key: deepcopy(value) for key, value in source["data"].items()
-        })
+        payload_data.update(
+            {key: deepcopy(value) for key, value in source["data"].items()}
+        )
     url = source.get("url")
     if isinstance(url, str) and url.strip():
         payload_data.setdefault("url", url.strip())
@@ -412,7 +414,11 @@ def send_web_push(sub: PushSubscription, data: dict) -> WebPushResult:
                 )
                 session.commit()
             _log_event(
-                "send", user_id=user_id, endpoint=sub.endpoint, status="gone", status_code=status_code
+                "send",
+                user_id=user_id,
+                endpoint=sub.endpoint,
+                status="gone",
+                status_code=status_code,
             )
             return WebPushResult(
                 subscription_id=sub.id,
@@ -445,7 +451,9 @@ def send_web_push(sub: PushSubscription, data: dict) -> WebPushResult:
             endpoint=sub.endpoint,
             status="error",
         )
-        logger.exception("webpush.send", extra={"user_id": user_id, "endpoint": sub.endpoint})
+        logger.exception(
+            "webpush.send", extra={"user_id": user_id, "endpoint": sub.endpoint}
+        )
         return WebPushResult(
             subscription_id=sub.id,
             endpoint=sub.endpoint,
@@ -520,7 +528,9 @@ async def send_to_user(
         if not subscription_supports_topic(sub, effective_topic):
             continue
         prepared = _prepare_delivery_payload(
-            payload, topic=normalized_topic or payload_topic, user=getattr(sub, "user", None)
+            payload,
+            topic=normalized_topic or payload_topic,
+            user=getattr(sub, "user", None),
         )
         tasks.append(asyncio.to_thread(send_web_push, sub, prepared))
     if not tasks:


### PR DESCRIPTION
## Summary
- normalize webpush payload handling with reusable helpers and consistent logging
- add async utilities to build payloads and dispatch to users or topics with rate limiting and quiet hours awareness

## Testing
- python -m compileall root/app/services/webpush.py

------
https://chatgpt.com/codex/tasks/task_e_68e2ebf2044483278a2e053942be003e