### PR TITLE
Adjust web push TTL based on urgency

### DIFF
--- a/root/app/api/push.py
+++ b/root/app/api/push.py
@@ -55,7 +55,7 @@ class NotifyBody(BaseModel):
     tag: str | None = None
     badge: str | None = None
     type: str | None = None
-    ttl: int | None = 43200
+    ttl: int | None = None
     urgency: str | None = "normal"
     topic: str | None = None
     actions: list[NotificationAction] | None = None

--- a/root/app/services/webpush.py
+++ b/root/app/services/webpush.py
@@ -45,6 +45,14 @@ _OPTION_KEYS: set[str] = {
 }
 _META_KEYS: set[str] = {"ttl", "topic", "urgency"}
 
+_DEFAULT_TTL_SECONDS = 60 * 60  # 1 hour
+_TTL_BY_URGENCY: dict[str, int] = {
+    "high": 5 * 60,
+    "normal": 60 * 60,
+    "low": 12 * 60 * 60,
+    "very-low": 24 * 60 * 60,
+}
+
 _USER_RATE_LIMIT = 60
 _TOPIC_RATE_LIMIT = 300
 _RATE_LIMIT_WINDOW_SECONDS = 60
@@ -246,6 +254,25 @@ def _normalize_payload(
     return payload, meta
 
 
+def _resolve_ttl(meta: Mapping[str, Any]) -> int:
+    raw_ttl = meta.get("ttl")
+    ttl_value: int | None = None
+    if isinstance(raw_ttl, int):
+        ttl_value = raw_ttl
+    elif raw_ttl is not None:
+        try:
+            ttl_value = int(raw_ttl)
+        except (TypeError, ValueError):
+            ttl_value = None
+    if ttl_value is not None and ttl_value > 0:
+        return ttl_value
+    urgency = str(meta.get("urgency") or "").strip().lower()
+    mapped_ttl = _TTL_BY_URGENCY.get(urgency)
+    if mapped_ttl is not None and mapped_ttl > 0:
+        return mapped_ttl
+    return _DEFAULT_TTL_SECONDS
+
+
 def _compose_payload(
     payload: Mapping[str, Any], meta: Mapping[str, Any] | None
 ) -> dict[str, Any]:
@@ -375,8 +402,8 @@ def build_payload(
 
 def send_web_push(sub: PushSubscription, data: dict) -> WebPushResult:
     normalized_payload, meta = _normalize_payload(data)
-    ttl = meta.get("ttl") if isinstance(meta.get("ttl"), int) else None
-    headers = {}
+    ttl = _resolve_ttl(meta)
+    headers = {"TTL": str(ttl)}
     urgency = meta.get("urgency")
     if urgency:
         headers["Urgency"] = str(urgency)
@@ -395,7 +422,7 @@ def send_web_push(sub: PushSubscription, data: dict) -> WebPushResult:
             vapid_private_key=settings.VAPID_PRIVATE_KEY,
             vapid_claims={"sub": settings.WEBPUSH_SUBJECT},
             headers=headers,
-            ttl=ttl if ttl is not None else 43200,
+            ttl=ttl,
         )
     except (
         WebPushException

--- a/root/tests/test_webpush_ttl.py
+++ b/root/tests/test_webpush_ttl.py
@@ -1,0 +1,92 @@
+import pytest
+
+from app.models.models import PushSubscription
+from app.services import webpush as webpush_module
+
+
+class _DummySession:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def execute(self, *args, **kwargs):
+        return None
+
+    def commit(self):
+        return None
+
+
+@pytest.fixture(autouse=True)
+def _stub_session(monkeypatch):
+    monkeypatch.setattr(webpush_module, "_Session", lambda: _DummySession())
+
+
+@pytest.fixture(autouse=True)
+def _stub_settings(monkeypatch):
+    class _Settings:
+        VAPID_PRIVATE_KEY = "test-private"
+        WEBPUSH_SUBJECT = "mailto:test@example.com"
+
+    monkeypatch.setattr(webpush_module, "settings", _Settings())
+
+
+def _make_subscription() -> PushSubscription:
+    subscription = PushSubscription(
+        endpoint="https://example.com/subscription",
+        p256dh="p256dh-key",
+        auth="auth-key",
+        user_id=1,
+        topics=[],
+    )
+    subscription.id = 1
+    return subscription
+
+
+@pytest.mark.parametrize(
+    ("urgency", "expected_ttl"),
+    [
+        ("high", 5 * 60),
+        ("normal", 60 * 60),
+        ("low", 12 * 60 * 60),
+        ("very-low", 24 * 60 * 60),
+        (None, 60 * 60),
+    ],
+)
+def test_send_web_push_sets_ttl_based_on_urgency(monkeypatch, urgency, expected_ttl):
+    captured: dict[str, object] = {}
+
+    def _capture_webpush(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(webpush_module, "webpush", _capture_webpush)
+    payload: dict[str, object] = {"title": "Test"}
+    if urgency is not None:
+        payload["urgency"] = urgency
+    result = webpush_module.send_web_push(_make_subscription(), payload)
+
+    assert result.status == "sent"
+    assert captured["ttl"] == expected_ttl
+    assert captured["headers"]["TTL"] == str(expected_ttl)
+    if urgency:
+        assert captured["headers"]["Urgency"] == urgency
+    else:
+        assert "Urgency" not in captured["headers"]
+
+
+def test_send_web_push_prefers_explicit_ttl(monkeypatch):
+    captured: dict[str, object] = {}
+
+    def _capture_webpush(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(webpush_module, "webpush", _capture_webpush)
+    payload = {"title": "Test", "ttl": 900, "urgency": "high"}
+
+    result = webpush_module.send_web_push(_make_subscription(), payload)
+
+    assert result.status == "sent"
+    assert captured["ttl"] == 900
+    assert captured["headers"]["TTL"] == "900"
+    assert captured["headers"]["Urgency"] == "high"


### PR DESCRIPTION
## Summary
- derive the TTL for outgoing web push notifications from the urgency metadata and send it as a header
- stop defaulting the API payload TTL to 12 hours so the automatic calculation can take effect
- cover the new TTL behaviour with dedicated tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2ef4cd1408327b1fa35b9e088392f