### PR TITLE
Harden web push configuration and admin controls

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,3 +26,12 @@ Our FastAPI middleware enables a strict set of transport and browser security he
 - Existing headers remain in place: `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy: no-referrer`, and `Permissions-Policy: geolocation=(), microphone=(), camera=()`.
 
 Cross-Origin Resource Sharing (CORS) is also tightened: wildcard origins are rejected, non-local HTTP origins are ignored in strict mode, and cookies/credentials are only permitted for HTTPS origins or localhost during development/testing. Configure additional trusted origins via `FRONTEND_ORIGINS` if external dashboards need access.
+
+## Push Subscription Hygiene
+
+- VAPID `subject` **must** be configured as a valid `mailto:` address or HTTPS URL. Invalid values will raise a configuration error at startup; use `VAPID_SUBJECT=mailto:security@example.com` (or an HTTPS URL under your control) in production. Plain HTTP origins are only accepted for local development hosts (`localhost`, `127.0.0.1`).
+- Subscription identifiers are masked in logs and cryptographic keys are never logged to avoid leaking Web Push credentials.
+- To revoke all push subscriptions for a user (e.g., during account deletion or in response to a compromise):
+  1. Authenticate as an administrator.
+  2. Call `POST /push/admin/disable-user` with the target `user_id`. The endpoint removes every `PushSubscription` row for that account and returns the number of deleted entries.
+  3. Confirm the user no longer has active subscriptions before finalising account removal.

--- a/root/app/api/push.py
+++ b/root/app/api/push.py
@@ -68,7 +68,9 @@ class NotifyBody(BaseModel):
 
 
 class DisableUserPushRequest(BaseModel):
-    user_id: int = Field(..., ge=1, description="ID пользователя, для которого нужно отключить push")
+    user_id: int = Field(
+        ..., ge=1, description="ID пользователя, для которого нужно отключить push"
+    )
 
 
 @router.get("/public-key")
@@ -181,10 +183,14 @@ async def disable_user_push(
     if not target:
         raise HTTPException(status_code=404, detail="user_not_found")
     existing = (
-        await session.execute(
-            select(PushSubscription.id).where(PushSubscription.user_id == target.id)
+        (
+            await session.execute(
+                select(PushSubscription.id).where(PushSubscription.user_id == target.id)
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     if not existing:
         return {"ok": True, "removed": 0}
     await session.execute(
@@ -193,7 +199,11 @@ async def disable_user_push(
     await session.commit()
     logger.info(
         "push.admin.disable_all",
-        extra={"user_id": user.id, "target_user_id": target.id, "removed": len(existing)},
+        extra={
+            "user_id": user.id,
+            "target_user_id": target.id,
+            "removed": len(existing),
+        },
     )
     return {"ok": True, "removed": len(existing)}
 

--- a/root/app/api/push.py
+++ b/root/app/api/push.py
@@ -67,6 +67,10 @@ class NotifyBody(BaseModel):
         return normalize_topic(value)
 
 
+class DisableUserPushRequest(BaseModel):
+    user_id: int = Field(..., ge=1, description="ID пользователя, для которого нужно отключить push")
+
+
 @router.get("/public-key")
 async def public_key():
     return {"key": settings.VAPID_PUBLIC_KEY}
@@ -163,6 +167,35 @@ def _aggregate_results(results: list[WebPushResult]) -> PushSendResponse:
         failed=failed,
         detail=detail,
     )
+
+
+@router.post("/admin/disable-user")
+async def disable_user_push(
+    payload: DisableUserPushRequest,
+    session: AsyncSession = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    if user.role != "admin":
+        raise HTTPException(status_code=403, detail="forbidden")
+    target = await session.get(User, payload.user_id)
+    if not target:
+        raise HTTPException(status_code=404, detail="user_not_found")
+    existing = (
+        await session.execute(
+            select(PushSubscription.id).where(PushSubscription.user_id == target.id)
+        )
+    ).scalars().all()
+    if not existing:
+        return {"ok": True, "removed": 0}
+    await session.execute(
+        delete(PushSubscription).where(PushSubscription.user_id == target.id)
+    )
+    await session.commit()
+    logger.info(
+        "push.admin.disable_all",
+        extra={"user_id": user.id, "target_user_id": target.id, "removed": len(existing)},
+    )
+    return {"ok": True, "removed": len(existing)}
 
 
 @router.post("/test", response_model=PushSendResponse)

--- a/root/app/core/config.py
+++ b/root/app/core/config.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
+from email.utils import parseaddr
 from functools import cached_property
 from pathlib import Path
 from typing import Iterable
 from urllib.parse import urlparse
-
-from email.utils import parseaddr
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -53,7 +52,9 @@ def _validate_webpush_subject(value: str) -> str:
     if scheme == "http":
         hostname = (parsed.hostname or "").lower()
         if hostname not in {"localhost", "127.0.0.1"}:
-            raise ValueError("Insecure http scheme is only allowed for localhost testing")
+            raise ValueError(
+                "Insecure http scheme is only allowed for localhost testing"
+            )
     return normalized
 
 

--- a/root/app/core/config.py
+++ b/root/app/core/config.py
@@ -5,6 +5,8 @@ from pathlib import Path
 from typing import Iterable
 from urllib.parse import urlparse
 
+from email.utils import parseaddr
+
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 _PROJECT_ROOT = Path(__file__).resolve().parents[2]
@@ -30,6 +32,29 @@ def _coerce_str_list(values: Iterable[str] | str | None) -> list[str]:
     else:
         items = [str(item).strip() for item in values]
     return [item for item in items if item]
+
+
+def _validate_webpush_subject(value: str) -> str:
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError("WEBPUSH_SUBJECT must not be empty")
+    lower = normalized.lower()
+    if lower.startswith("mailto:"):
+        _, address = parseaddr(normalized[7:])
+        if address and "@" in address:
+            return f"mailto:{address.lower()}"
+        raise ValueError("WEBPUSH_SUBJECT mailto: value must contain a valid email")
+    parsed = urlparse(normalized)
+    scheme = parsed.scheme.lower()
+    if scheme not in {"https", "http"}:
+        raise ValueError("WEBPUSH_SUBJECT URL must use https or http scheme")
+    if not parsed.netloc:
+        raise ValueError("WEBPUSH_SUBJECT URL must include a host")
+    if scheme == "http":
+        hostname = (parsed.hostname or "").lower()
+        if hostname not in {"localhost", "127.0.0.1"}:
+            raise ValueError("Insecure http scheme is only allowed for localhost testing")
+    return normalized
 
 
 class Settings(BaseSettings):
@@ -88,7 +113,11 @@ class Settings(BaseSettings):
         "img-src 'self' data: https:; "
         "script-src 'self' 'nonce-{nonce}' 'strict-dynamic'; "
         "style-src 'self' 'unsafe-inline'; "
-        "connect-src 'self' https://api.spotify.com https://*.push.service; "
+        "connect-src 'self' https://api.spotify.com https://fcm.googleapis.com "
+        "https://fcmregistrations.googleapis.com https://*.push.services.mozilla.com "
+        "https://updates.push.services.mozilla.com https://*.push.apple.com; "
+        "worker-src 'self' blob:; "
+        "manifest-src 'self'; "
         "font-src 'self' data:; "
         "trusted-types dompurify-news; "
         "require-trusted-types-for 'script'; "
@@ -161,7 +190,11 @@ class Settings(BaseSettings):
 
     @cached_property
     def WEBPUSH_SUBJECT(self) -> str:
-        return self.vapid_subject or "mailto:no-reply@example.com"
+        raw_subject = (self.vapid_subject or "").strip()
+        if not raw_subject:
+            return "mailto:no-reply@example.com"
+        subject = _validate_webpush_subject(raw_subject)
+        return subject
 
     @cached_property
     def cors_allow_origins_list(self) -> list[str]:

--- a/root/app/core/security_headers.py
+++ b/root/app/core/security_headers.py
@@ -54,18 +54,7 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
 
     def _apply_csp(self, response: Response, *, nonce: str | None) -> None:
         headers = response.headers
-        policy_template = (
-            "default-src 'self'; "
-            "base-uri 'self'; "
-            "object-src 'none'; "
-            "frame-ancestors 'none'; "
-            "img-src 'self' data: https:; "
-            "script-src 'self' 'nonce-{nonce}' 'strict-dynamic'; "
-            "style-src 'self' 'unsafe-inline'; "
-            "connect-src 'self' https://api.spotify.com https://*.push.service; "
-            "font-src 'self' data:; "
-            "upgrade-insecure-requests"
-        )
+        policy_template = self._settings.strict_security_csp
         policy = policy_template
         if nonce:
             policy = policy.replace("{nonce}", nonce)
@@ -76,12 +65,21 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
                 .replace(" ;", ";")
                 .strip(" ;")
             )
-        report_uri = self._settings.security_csp_report_uri.strip()
-        if report_uri:
-            policy = f"{policy}; report-uri {report_uri}".strip(" ;")
-        headers["Content-Security-Policy"] = policy
+        header_name = "Content-Security-Policy"
+        if self._settings.security_csp_report_only:
+            header_name = "Content-Security-Policy-Report-Only"
+            try:
+                del headers["Content-Security-Policy"]
+            except KeyError:
+                pass
+        headers[header_name] = policy
+        other_header = (
+            "Content-Security-Policy"
+            if header_name == "Content-Security-Policy-Report-Only"
+            else "Content-Security-Policy-Report-Only"
+        )
         try:
-            del headers["Content-Security-Policy-Report-Only"]
+            del headers[other_header]
         except KeyError:
             pass
 

--- a/root/app/services/webpush.py
+++ b/root/app/services/webpush.py
@@ -7,7 +7,9 @@ from collections.abc import Mapping
 from copy import deepcopy
 from dataclasses import dataclass
 from datetime import UTC, datetime, time
+from hashlib import sha256
 from typing import Any, Literal
+from urllib.parse import urlparse
 
 from pywebpush import WebPushException, webpush
 from sqlalchemy import create_engine, delete, select, update
@@ -62,8 +64,26 @@ def json_dumps(obj):
     return json.dumps(obj, ensure_ascii=False)
 
 
+def _mask_endpoint(endpoint: str | None) -> str | None:
+    if not endpoint:
+        return None
+    value = endpoint.strip()
+    if not value:
+        return None
+    digest = sha256(value.encode("utf-8")).hexdigest()[:10]
+    try:
+        parsed = urlparse(value)
+    except ValueError:
+        parsed = None
+    if parsed and parsed.scheme and parsed.netloc:
+        return f"{parsed.scheme}://{parsed.netloc}/…#{digest}"
+    return f"…#{digest}"
+
+
 def _log_event(event: str, *, level: int = logging.INFO, **fields: Any) -> None:
     extra = {key: value for key, value in fields.items() if value is not None}
+    if "endpoint" in extra:
+        extra["endpoint"] = _mask_endpoint(str(extra["endpoint"]))
     extra["event"] = event
     logger.log(level, "webpush.%s", event, extra=extra)
 
@@ -479,7 +499,8 @@ def send_web_push(sub: PushSubscription, data: dict) -> WebPushResult:
             status="error",
         )
         logger.exception(
-            "webpush.send", extra={"user_id": user_id, "endpoint": sub.endpoint}
+            "webpush.send",
+            extra={"user_id": user_id, "endpoint": _mask_endpoint(sub.endpoint)},
         )
         return WebPushResult(
             subscription_id=sub.id,

--- a/root/tests/test_push_api.py
+++ b/root/tests/test_push_api.py
@@ -1,6 +1,14 @@
 import pytest
+from fastapi import HTTPException
+from sqlalchemy import select
 
-from app.api.push import NotifyBody, broadcast, send_test
+from app.api.push import (
+    DisableUserPushRequest,
+    NotifyBody,
+    broadcast,
+    disable_user_push,
+    send_test,
+)
 from app.models.models import PushSubscription
 from app.services.webpush import WebPushResult
 
@@ -107,3 +115,68 @@ async def test_push_broadcast_reports_failures(
         "failed": 2,
         "detail": "Не удалось отправить уведомления",
     }
+
+
+@pytest.mark.anyio
+async def test_admin_disable_user_push_removes_subscriptions(
+    db_session, user_factory
+) -> None:
+    admin = await user_factory(role="admin")
+    target = await user_factory()
+    other_user = await user_factory()
+    subscriptions = [
+        PushSubscription(
+            endpoint=f"https://example.com/target-{idx}",
+            p256dh=f"key-{idx}",
+            auth=f"auth-{idx}",
+            user_id=target.id,
+            topics=["news"],
+        )
+        for idx in range(2)
+    ] + [
+        PushSubscription(
+            endpoint="https://example.com/other",
+            p256dh="key-other",
+            auth="auth-other",
+            user_id=other_user.id,
+            topics=["news"],
+        )
+    ]
+    db_session.add_all(subscriptions)
+    await db_session.commit()
+
+    payload = DisableUserPushRequest(user_id=target.id)
+    response = await disable_user_push(payload=payload, session=db_session, user=admin)
+
+    assert response == {"ok": True, "removed": 2}
+    remaining = (
+        await db_session.execute(
+            select(PushSubscription).where(PushSubscription.user_id == target.id)
+        )
+    ).scalars().all()
+    assert remaining == []
+    others = (
+        await db_session.execute(
+            select(PushSubscription).where(PushSubscription.user_id == other_user.id)
+        )
+    ).scalars().all()
+    assert len(others) == 1
+
+
+@pytest.mark.anyio
+async def test_admin_disable_user_push_requires_admin(db_session, user_factory) -> None:
+    requester = await user_factory()
+    target = await user_factory()
+    payload = DisableUserPushRequest(user_id=target.id)
+    with pytest.raises(HTTPException) as exc:
+        await disable_user_push(payload=payload, session=db_session, user=requester)
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_admin_disable_user_push_missing_user(db_session, user_factory) -> None:
+    admin = await user_factory(role="admin")
+    payload = DisableUserPushRequest(user_id=9999)
+    with pytest.raises(HTTPException) as exc:
+        await disable_user_push(payload=payload, session=db_session, user=admin)
+    assert exc.value.status_code == 404

--- a/root/tests/test_push_api.py
+++ b/root/tests/test_push_api.py
@@ -150,16 +150,26 @@ async def test_admin_disable_user_push_removes_subscriptions(
 
     assert response == {"ok": True, "removed": 2}
     remaining = (
-        await db_session.execute(
-            select(PushSubscription).where(PushSubscription.user_id == target.id)
+        (
+            await db_session.execute(
+                select(PushSubscription).where(PushSubscription.user_id == target.id)
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert remaining == []
     others = (
-        await db_session.execute(
-            select(PushSubscription).where(PushSubscription.user_id == other_user.id)
+        (
+            await db_session.execute(
+                select(PushSubscription).where(
+                    PushSubscription.user_id == other_user.id
+                )
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert len(others) == 1
 
 

--- a/root/tests/test_security_headers.py
+++ b/root/tests/test_security_headers.py
@@ -56,7 +56,12 @@ async def test_strict_security_headers_enabled(monkeypatch):
     assert "img-src 'self' data:" in csp
     assert "script-src 'self' 'nonce-" in csp
     assert "style-src 'self' 'unsafe-inline'" in csp
-    assert "connect-src 'self' https://api.spotify.com https://*.push.service" in csp
+    assert "https://api.spotify.com" in csp
+    assert "https://fcm.googleapis.com" in csp
+    assert "https://fcmregistrations.googleapis.com" in csp
+    assert "https://*.push.services.mozilla.com" in csp
+    assert "worker-src 'self' blob:" in csp
+    assert "manifest-src 'self'" in csp
     assert "Content-Security-Policy-Report-Only" not in headers
 
 

--- a/root/tests/test_webpush_config.py
+++ b/root/tests/test_webpush_config.py
@@ -1,0 +1,44 @@
+import pytest
+
+from app.core.config import Settings, _validate_webpush_subject
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("mailto:Admin@example.com", "mailto:admin@example.com"),
+        ("https://example.com", "https://example.com"),
+        ("http://localhost:8000", "http://localhost:8000"),
+    ],
+)
+def test_validate_webpush_subject_accepts_supported_values(value, expected):
+    assert _validate_webpush_subject(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "",  # empty
+        "mailto:",  # missing address
+        "mailto:not-an-email",  # missing @
+        "ws://example.com",  # unsupported scheme
+        "https://",  # missing host
+        "http://example.com",  # insecure host
+    ],
+)
+def test_validate_webpush_subject_rejects_invalid_values(value):
+    with pytest.raises(ValueError):
+        _validate_webpush_subject(value)
+
+
+def test_settings_webpush_subject_defaults(monkeypatch):
+    monkeypatch.delenv("VAPID_SUBJECT", raising=False)
+    settings = Settings(vapid_subject="")
+    assert settings.WEBPUSH_SUBJECT == "mailto:no-reply@example.com"
+
+
+def test_settings_webpush_subject_invalid(monkeypatch):
+    monkeypatch.setenv("VAPID_SUBJECT", "invalid-subject")
+    settings = Settings()
+    with pytest.raises(ValueError):
+        _ = settings.WEBPUSH_SUBJECT

--- a/root/tests/test_webpush_ttl.py
+++ b/root/tests/test_webpush_ttl.py
@@ -90,3 +90,13 @@ def test_send_web_push_prefers_explicit_ttl(monkeypatch):
     assert captured["ttl"] == 900
     assert captured["headers"]["TTL"] == "900"
     assert captured["headers"]["Urgency"] == "high"
+
+
+def test_log_event_masks_endpoint(caplog):
+    caplog.set_level("INFO", logger="app.services.webpush")
+    webpush_module._log_event(
+        "send", endpoint="https://example.com/private/token-123", user_id=1
+    )
+    record = caplog.records[-1]
+    assert record.endpoint.startswith("https://example.com/…#")
+    assert "token-123" not in record.endpoint


### PR DESCRIPTION
## Summary
- validate the configured VAPID subject, mask subscription endpoints in logs, and cover the behaviour with unit tests
- add an admin-only endpoint to purge a user’s push subscriptions and document the revocation workflow in SECURITY.md
- refresh the strict Content Security Policy so service workers and push transports work while keeping automated coverage in place

## Testing
- pytest
- pytest tests/test_push_api.py
- pytest tests/test_security_headers.py

------
https://chatgpt.com/codex/tasks/task_e_68e2f6caf0a0832783c7610b4cc48081