### PR TITLE
Add tests for push notification preferences

### DIFF
--- a/root/frontend/src/pages/__tests__/Settings.notifications.test.tsx
+++ b/root/frontend/src/pages/__tests__/Settings.notifications.test.tsx
@@ -1,0 +1,271 @@
+import { act, renderHook, waitFor } from "@testing-library/react"
+import type { ChangeEvent } from "react"
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest"
+import { usePushPreferences } from "@/hooks/usePushPreferences"
+
+const hoistedMocks = vi.hoisted(() => ({
+  getVapidKeyMock: vi.fn(),
+  saveSubscriptionMock: vi.fn(),
+  deleteSubscriptionMock: vi.fn(),
+  updateSubscriptionTopicsMock: vi.fn(),
+  setPushConsentMock: vi.fn(),
+  getExistingPushSubscriptionMock: vi.fn(),
+  isPushSupportedMock: vi.fn(() => true),
+  requestPermissionMock: vi.fn(),
+})) as {
+  getVapidKeyMock: ReturnType<typeof vi.fn>
+  saveSubscriptionMock: ReturnType<typeof vi.fn>
+  deleteSubscriptionMock: ReturnType<typeof vi.fn>
+  updateSubscriptionTopicsMock: ReturnType<typeof vi.fn>
+  setPushConsentMock: ReturnType<typeof vi.fn>
+  getExistingPushSubscriptionMock: ReturnType<typeof vi.fn>
+  isPushSupportedMock: ReturnType<typeof vi.fn>
+  requestPermissionMock: ReturnType<typeof vi.fn>
+}
+
+vi.mock("@/api/notifications", async () => {
+  const actual = await vi.importActual<typeof import("@/api/notifications")>("@/api/notifications")
+  return {
+    ...actual,
+    getVapidKey: hoistedMocks.getVapidKeyMock,
+    saveSubscription: hoistedMocks.saveSubscriptionMock,
+    deleteSubscription: hoistedMocks.deleteSubscriptionMock,
+    updateSubscriptionTopics: hoistedMocks.updateSubscriptionTopicsMock,
+  }
+})
+
+vi.mock("@/push/subscribe", async () => {
+  const actual = await vi.importActual<typeof import("@/push/subscribe")>("@/push/subscribe")
+  return {
+    ...actual,
+    setPushConsent: hoistedMocks.setPushConsentMock,
+    getExistingPushSubscription: hoistedMocks.getExistingPushSubscriptionMock,
+    isPushSupported: hoistedMocks.isPushSupportedMock,
+  }
+})
+
+const {
+  getVapidKeyMock,
+  saveSubscriptionMock,
+  deleteSubscriptionMock,
+  updateSubscriptionTopicsMock,
+  setPushConsentMock,
+  getExistingPushSubscriptionMock,
+  isPushSupportedMock,
+  requestPermissionMock,
+} = hoistedMocks
+
+class MockNotification {
+  static permission: NotificationPermission = "default"
+
+  static requestPermission = requestPermissionMock
+}
+
+type MutableSubscription = PushSubscription & {
+  toJSON: () => PushSubscriptionJSON
+  unsubscribe: () => Promise<boolean>
+  __payload: PushSubscriptionJSON
+}
+
+const createMockSubscription = (): MutableSubscription => {
+  const payload: PushSubscriptionJSON = {
+    endpoint: "https://example.com/sub",
+    keys: { p256dh: "p256", auth: "auth" },
+  }
+  return {
+    endpoint: payload.endpoint!,
+    options: { applicationServerKey: new Uint8Array([1, 2, 3]) } as any,
+    toJSON: vi.fn(() => payload),
+    unsubscribe: vi.fn(async () => true),
+    __payload: payload,
+  } as MutableSubscription
+}
+
+type MockRegistration = ServiceWorkerRegistration & {
+  pushManager: {
+    getSubscription: ReturnType<typeof vi.fn>
+    subscribe: ReturnType<typeof vi.fn>
+  }
+}
+
+let registration: MockRegistration
+
+const ensureAtob = () => {
+  if (typeof globalThis.atob !== "function") {
+    globalThis.atob = (value: string) => Buffer.from(value, "base64").toString("binary")
+  }
+}
+
+ensureAtob()
+
+beforeEach(() => {
+  requestPermissionMock.mockReset()
+  MockNotification.permission = "default"
+  Object.defineProperty(globalThis, "Notification", {
+    value: MockNotification,
+    configurable: true,
+    writable: true,
+  })
+
+  const pushManager = {
+    getSubscription: vi.fn(),
+    subscribe: vi.fn(),
+  }
+
+  registration = {
+    pushManager,
+    showNotification: vi.fn(),
+  } as unknown as MockRegistration
+
+  const ready = Promise.resolve(registration)
+
+  Object.defineProperty(navigator, "serviceWorker", {
+    value: {
+      ready,
+      getRegistration: vi.fn(async () => registration),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    },
+    configurable: true,
+  })
+
+  Object.defineProperty(window, "PushManager", {
+    value: function MockPushManager() {},
+    configurable: true,
+  })
+
+  getExistingPushSubscriptionMock.mockReset()
+  getExistingPushSubscriptionMock.mockResolvedValue(null)
+  setPushConsentMock.mockReset()
+  isPushSupportedMock.mockReset()
+  isPushSupportedMock.mockReturnValue(true)
+  getVapidKeyMock.mockReset()
+  saveSubscriptionMock.mockReset()
+  deleteSubscriptionMock.mockReset()
+  updateSubscriptionTopicsMock.mockReset()
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+  delete (navigator as any).serviceWorker
+  delete (window as any).PushManager
+})
+
+describe("usePushPreferences notifications flow", () => {
+  it("requests permission and enables notifications", async () => {
+    const subscription = createMockSubscription()
+    registration.pushManager.getSubscription.mockResolvedValueOnce(null)
+    registration.pushManager.subscribe.mockResolvedValue(subscription)
+
+    requestPermissionMock.mockImplementation(async () => {
+      MockNotification.permission = "granted"
+      return "granted"
+    })
+
+    getVapidKeyMock.mockResolvedValue("BElq1234ABCD5678")
+    saveSubscriptionMock.mockResolvedValue({ topics: ["news", "schedule"] })
+
+    const onNotify = vi.fn()
+    const { result } = renderHook(() => usePushPreferences({ onNotify }))
+
+    await act(async () => {
+      await result.current.enableNotifications()
+    })
+
+    expect(requestPermissionMock).toHaveBeenCalled()
+    await waitFor(() => expect(result.current.notificationsEnabled).toBe(true))
+
+    expect(registration.pushManager.subscribe).toHaveBeenCalledWith(
+      expect.objectContaining({ userVisibleOnly: true }),
+    )
+    expect(saveSubscriptionMock).toHaveBeenCalledWith(subscription.__payload, [
+      "news",
+      "schedule",
+      "system",
+    ])
+    expect(setPushConsentMock).toHaveBeenCalledWith(true)
+    expect(onNotify).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "Уведомления включены", sev: "success" }),
+    )
+    expect(result.current.topicState).toMatchObject({ news: true, schedule: true, system: false })
+  })
+
+  it("disables notifications and removes subscription", async () => {
+    const subscription = createMockSubscription()
+    registration.pushManager.getSubscription.mockResolvedValue(subscription)
+    getExistingPushSubscriptionMock.mockResolvedValue(subscription)
+    saveSubscriptionMock.mockResolvedValue({ topics: ["news", "schedule", "system"] })
+
+    const onNotify = vi.fn()
+    const { result } = renderHook(() => usePushPreferences({ onNotify }))
+
+    await waitFor(() => expect(result.current.notificationsEnabled).toBe(true))
+
+    await act(async () => {
+      await result.current.disableNotifications()
+    })
+
+    expect(subscription.unsubscribe).toHaveBeenCalled()
+    expect(deleteSubscriptionMock).toHaveBeenCalledWith(subscription.endpoint)
+    expect(setPushConsentMock).toHaveBeenCalledWith(false)
+    expect(onNotify).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "Уведомления выключены", sev: "success" }),
+    )
+    await waitFor(() => expect(result.current.notificationsEnabled).toBe(false))
+  })
+
+  it("updates topics when toggles change", async () => {
+    const subscription = createMockSubscription()
+    registration.pushManager.getSubscription.mockResolvedValue(subscription)
+    getExistingPushSubscriptionMock.mockResolvedValue(subscription)
+    saveSubscriptionMock.mockResolvedValue({ topics: ["news", "schedule", "system"] })
+    updateSubscriptionTopicsMock.mockResolvedValue({ topics: ["news", "schedule"] })
+
+    const { result } = renderHook(() => usePushPreferences())
+
+    await waitFor(() => expect(result.current.notificationsEnabled).toBe(true))
+
+    const handler = result.current.handleTopicToggle("system")
+    await act(async () => {
+      await handler({} as ChangeEvent<HTMLInputElement>, false)
+    })
+
+    expect(updateSubscriptionTopicsMock).toHaveBeenCalledWith(subscription.endpoint, [
+      "news",
+      "schedule",
+    ])
+    expect(result.current.topicState.system).toBe(false)
+  })
+
+  it("notifies user when permission is denied", async () => {
+    registration.pushManager.getSubscription.mockResolvedValue(null)
+
+    requestPermissionMock.mockImplementation(async () => {
+      MockNotification.permission = "denied"
+      return "denied"
+    })
+
+    const onNotify = vi.fn()
+    const { result } = renderHook(() => usePushPreferences({ onNotify }))
+
+    await act(async () => {
+      await result.current.enableNotifications()
+    })
+
+    expect(requestPermissionMock).toHaveBeenCalled()
+    expect(getVapidKeyMock).not.toHaveBeenCalled()
+    expect(saveSubscriptionMock).not.toHaveBeenCalled()
+    expect(onNotify).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "Разрешите уведомления в настройках браузера", sev: "info" }),
+    )
+    expect(result.current.notificationsEnabled).toBe(false)
+    expect(result.current.notificationPermission).toBe("denied")
+  })
+})

--- a/root/frontend/src/pages/__tests__/Settings.notifications.test.tsx
+++ b/root/frontend/src/pages/__tests__/Settings.notifications.test.tsx
@@ -81,11 +81,16 @@ const createMockSubscription = (): MutableSubscription => {
   }
   return {
     endpoint: payload.endpoint!,
-    options: { applicationServerKey: new Uint8Array([1, 2, 3]) } as any,
+    expirationTime: null,
+    options: {
+      applicationServerKey: new Uint8Array([1, 2, 3]),
+      userVisibleOnly: true,
+    },
     toJSON: vi.fn(() => payload),
     unsubscribe: vi.fn(async () => true),
+    getKey: vi.fn(() => new ArrayBuffer(0)),
     __payload: payload,
-  } as MutableSubscription
+  } as unknown as MutableSubscription
 }
 
 type MockRegistration = ServiceWorkerRegistration & {

--- a/root/frontend/src/push/__tests__/notification-helpers.test.ts
+++ b/root/frontend/src/push/__tests__/notification-helpers.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest"
+import {
+  DEFAULT_ICON,
+  DEFAULT_TITLE,
+  buildNotificationDetails,
+  parsePushEventData,
+} from "../notification-helpers"
+
+describe("parsePushEventData", () => {
+  it("returns empty payload when data is missing", () => {
+    expect(parsePushEventData(undefined)).toEqual({})
+    expect(parsePushEventData(null)).toEqual({})
+  })
+
+  it("parses JSON payloads", () => {
+    const payload = { title: "Hello", body: "World" }
+    const data = {
+      json: () => payload,
+      text: () => JSON.stringify(payload),
+    }
+    expect(parsePushEventData(data)).toEqual(payload)
+  })
+
+  it("falls back to text body when JSON parsing fails", () => {
+    const data = {
+      json: () => {
+        throw new Error("bad json")
+      },
+      text: () => "raw-body",
+    }
+    expect(parsePushEventData(data)).toEqual({ body: "raw-body" })
+  })
+})
+
+describe("buildNotificationDetails", () => {
+  it("applies defaults for title and icon", () => {
+    const result = buildNotificationDetails({})
+    expect(result.title).toBe(DEFAULT_TITLE)
+    expect(result.options.icon).toBe(DEFAULT_ICON)
+    expect(result.options.badge).toBe(DEFAULT_ICON)
+    expect(result.data.url).toBe("/")
+  })
+
+  it("maps payload data and returns payload type", () => {
+    const result = buildNotificationDetails({
+      title: "Custom",
+      body: "Message",
+      icon: "/icon.png",
+      badge: "/badge.png",
+      tag: "tag-id",
+      url: "/path",
+      data: { foo: "bar", type: " system  " },
+      vibrate: [100],
+      timestamp: 123,
+      renotify: true,
+    })
+
+    expect(result.title).toBe("Custom")
+    expect(result.options.body).toBe("Message")
+    expect(result.options.icon).toBe("/icon.png")
+    expect(result.options.badge).toBe("/badge.png")
+    expect(result.options.vibrate).toEqual([100])
+    expect(result.options.timestamp).toBe(123)
+    expect(result.options.renotify).toBe(true)
+    expect(result.options.data).toMatchObject({ foo: "bar", type: " system  " })
+    expect(result.payloadType).toBe("system")
+    expect(result.data.url).toBe("/path")
+  })
+
+  it("normalizes actions and collects action URLs", () => {
+    const result = buildNotificationDetails({
+      actions: [
+        { action: " open ", title: "Open", icon: "icon.svg", url: "/open" },
+        { action: "", title: "", url: "" },
+        // @ts-expect-error intentionally invalid payload
+        null,
+      ],
+    })
+
+    expect(result.options.actions).toEqual([{ action: "open", title: "Open", icon: "icon.svg" }])
+    expect(result.data.actionUrls).toEqual({ open: "/open" })
+  })
+})

--- a/root/frontend/src/push/notification-helpers.ts
+++ b/root/frontend/src/push/notification-helpers.ts
@@ -1,0 +1,143 @@
+export type NotificationData = {
+  url?: string
+  actionUrls?: Record<string, string>
+  // Allow arbitrary additional payload data from the server.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any
+}
+
+export type NotificationActionPayload = {
+  action: string
+  title: string
+  icon?: string
+  url?: string
+}
+
+export type NotificationActionOption = {
+  action: string
+  title: string
+  icon?: string
+}
+
+export type PushPayload = {
+  title?: string
+  body?: string
+  icon?: string
+  badge?: string
+  tag?: string
+  url?: string
+  data?: Record<string, unknown>
+  renotify?: boolean
+  requireInteraction?: boolean
+  silent?: boolean
+  timestamp?: number
+  vibrate?: number[]
+  actions?: NotificationActionPayload[]
+}
+
+export const DEFAULT_TITLE = "Экосистема ГУУ"
+export const DEFAULT_ICON = "/maskable-icon-192.png"
+
+export type ExtendedNotificationOptions = NotificationOptions & {
+  renotify?: boolean
+  timestamp?: number
+  vibrate?: number[]
+  actions?: NotificationActionOption[]
+}
+
+export function parsePushEventData(
+  data: { json: () => unknown; text: () => string } | null | undefined,
+): PushPayload {
+  if (!data) {
+    return {}
+  }
+
+  try {
+    const parsed = data.json()
+    if (parsed && typeof parsed === "object") {
+      return parsed as PushPayload
+    }
+    return {}
+  } catch (error) {
+    try {
+      const text = data.text()
+      if (!text) return {}
+      return { body: text }
+    } catch {
+      return {}
+    }
+  }
+}
+
+export function buildNotificationDetails(payload: PushPayload): {
+  title: string
+  options: ExtendedNotificationOptions
+  data: NotificationData
+  payloadType?: string
+} {
+  const rawData =
+    payload.data && typeof payload.data === "object"
+      ? (payload.data as Record<string, unknown>)
+      : undefined
+
+  const title = payload.title || DEFAULT_TITLE
+
+  const data: NotificationData = {
+    url: payload.url || "/",
+    ...(rawData ?? {}),
+  }
+
+  const options: ExtendedNotificationOptions = {
+    body: payload.body,
+    icon: payload.icon || DEFAULT_ICON,
+    badge: payload.badge || payload.icon || DEFAULT_ICON,
+    tag: payload.tag,
+    data,
+    requireInteraction: payload.requireInteraction,
+    silent: payload.silent,
+  }
+
+  if (payload.renotify !== undefined) {
+    options.renotify = payload.renotify
+  }
+
+  if (payload.timestamp !== undefined) {
+    options.timestamp = payload.timestamp
+  }
+
+  if (payload.vibrate) {
+    options.vibrate = payload.vibrate
+  }
+
+  if (payload.actions?.length) {
+    const actionUrls: Record<string, string> = {}
+    const validActions: NotificationActionOption[] = []
+    for (const action of payload.actions) {
+      if (!action || typeof action !== "object") continue
+      const key = typeof action.action === "string" ? action.action.trim() : ""
+      const actionTitle = typeof action.title === "string" ? action.title.trim() : ""
+      if (!key || !actionTitle) continue
+      const entry: NotificationActionOption = { action: key, title: actionTitle }
+      if (action.icon && typeof action.icon === "string") {
+        entry.icon = action.icon
+      }
+      validActions.push(entry)
+      if (action.url && typeof action.url === "string" && action.url.trim()) {
+        actionUrls[key] = action.url
+      }
+    }
+    if (validActions.length) {
+      options.actions = validActions
+      if (Object.keys(actionUrls).length) {
+        data.actionUrls = actionUrls
+      }
+    }
+  }
+
+  const payloadType = (() => {
+    const rawType = rawData && typeof rawData.type === "string" ? rawData.type.trim() : undefined
+    return rawType || undefined
+  })()
+
+  return { title, options, data, payloadType }
+}

--- a/root/frontend/src/sw.ts
+++ b/root/frontend/src/sw.ts
@@ -5,6 +5,11 @@ import { clientsClaim } from "workbox-core"
 import { registerRoute, NavigationRoute } from "workbox-routing"
 import { StaleWhileRevalidate, CacheFirst } from "workbox-strategies"
 import { ExpirationPlugin } from "workbox-expiration"
+import {
+  NotificationData,
+  buildNotificationDetails,
+  parsePushEventData,
+} from "@/push/notification-helpers"
 
 declare const self: ServiceWorkerGlobalScope & typeof globalThis
 
@@ -70,124 +75,10 @@ registerRoute(
   })
 )
 
-type NotificationData = {
-  url?: string
-  actionUrls?: Record<string, string>
-  [key: string]: unknown
-}
-
-type NotificationActionPayload = {
-  action: string
-  title: string
-  icon?: string
-  url?: string
-}
-
-type NotificationActionOption = {
-  action: string
-  title: string
-  icon?: string
-}
-
-type PushPayload = {
-  title?: string
-  body?: string
-  icon?: string
-  badge?: string
-  tag?: string
-  url?: string
-  data?: Record<string, unknown>
-  renotify?: boolean
-  requireInteraction?: boolean
-  silent?: boolean
-  timestamp?: number
-  vibrate?: number[]
-  actions?: NotificationActionPayload[]
-}
-
-const DEFAULT_TITLE = "Экосистема ГУУ"
-const DEFAULT_ICON = "/maskable-icon-192.png"
-
 self.addEventListener("push", (event) => {
   const handlePush = async () => {
-    const payload = (() => {
-      if (!event.data) {
-        return {}
-      }
-      try {
-        return event.data.json() as PushPayload
-      } catch (error) {
-        return { body: event.data.text() } as PushPayload
-      }
-    })()
-
-    const rawData =
-      payload.data && typeof payload.data === "object" ? (payload.data as Record<string, unknown>) : undefined
-
-    const title = payload.title || DEFAULT_TITLE
-    const data: NotificationData = {
-      url: payload.url || "/",
-      ...(rawData ?? {}),
-    }
-
-    const options: NotificationOptions = {
-      body: payload.body,
-      icon: payload.icon || DEFAULT_ICON,
-      badge: payload.badge || payload.icon || DEFAULT_ICON,
-      tag: payload.tag,
-      data,
-      requireInteraction: payload.requireInteraction,
-      silent: payload.silent,
-    }
-
-    const extendedOptions = options as NotificationOptions & {
-      renotify?: boolean
-      timestamp?: number
-      vibrate?: number[]
-      actions?: NotificationActionOption[]
-    }
-
-    if (payload.renotify !== undefined) {
-      extendedOptions.renotify = payload.renotify
-    }
-
-    if (payload.timestamp !== undefined) {
-      extendedOptions.timestamp = payload.timestamp
-    }
-
-    if (payload.vibrate) {
-      extendedOptions.vibrate = payload.vibrate
-    }
-
-    if (payload.actions?.length) {
-      const actionUrls: Record<string, string> = {}
-      const validActions: NotificationActionOption[] = []
-      for (const action of payload.actions) {
-        if (!action || typeof action !== "object") continue
-        const key = typeof action.action === "string" ? action.action.trim() : ""
-        const actionTitle = typeof action.title === "string" ? action.title.trim() : ""
-        if (!key || !actionTitle) continue
-        const entry: NotificationActionOption = { action: key, title: actionTitle }
-        if (action.icon && typeof action.icon === "string") {
-          entry.icon = action.icon
-        }
-        validActions.push(entry)
-        if (action.url && typeof action.url === "string" && action.url.trim()) {
-          actionUrls[key] = action.url
-        }
-      }
-      if (validActions.length) {
-        extendedOptions.actions = validActions
-        if (Object.keys(actionUrls).length) {
-          data.actionUrls = actionUrls
-        }
-      }
-    }
-
-    const payloadType = (() => {
-      const rawType = rawData && typeof rawData.type === "string" ? rawData.type.trim() : undefined
-      return rawType || undefined
-    })()
+    const payload = parsePushEventData(event.data)
+    const { title, options, data, payloadType } = buildNotificationDetails(payload)
 
     if (payloadType === "in-app") {
       const windowClients = (await self.clients.matchAll({
@@ -207,7 +98,7 @@ self.addEventListener("push", (event) => {
             icon: options.icon,
             tag: options.tag,
             data,
-            timestamp: extendedOptions.timestamp ?? Date.now(),
+            timestamp: options.timestamp ?? Date.now(),
           },
         }
 


### PR DESCRIPTION
## Summary
- add Vitest coverage for push notification enable/disable flows on the Settings page using service worker and Notification mocks
- extract service worker payload parsing helpers and cover them with unit tests to verify parsing and option building
- update the service worker to consume the new helpers when showing notifications

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2fd24bb4883278f8b7caed65faf61