### PR TITLE
Sync push subscriptions on auth transitions

### DIFF
--- a/root/frontend/src/contexts/AuthContext.tsx
+++ b/root/frontend/src/contexts/AuthContext.tsx
@@ -1,6 +1,7 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from "react"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { isAxiosError } from "axios"
+import { softSyncPushSubscription, unsubscribePush } from "@/push/subscribe"
 import api, { API_UNAUTHORIZED_EVENT, setAuthToken } from "../api/client"
 
 type SetUserArg = any | ((prev: any) => any)
@@ -179,12 +180,30 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       applyToken(nextToken)
       await queryClient.cancelQueries({ queryKey: currentUserQueryKey })
       await queryClient.fetchQuery({ queryKey: currentUserQueryKey, queryFn: fetchCurrentUser })
+      if (typeof window !== "undefined" && typeof Notification !== "undefined") {
+        if (Notification.permission === "granted") {
+          await softSyncPushSubscription()
+        }
+      }
     },
     [applyToken, queryClient]
   )
 
   const logout = useCallback(() => {
-    handleUnauthorized()
+    if (typeof window === "undefined") {
+      handleUnauthorized()
+      return
+    }
+
+    void (async () => {
+      try {
+        await unsubscribePush({ preserveConsent: true })
+      } catch (error) {
+        console.error("Failed to unsubscribe push subscription on logout", error)
+      } finally {
+        handleUnauthorized()
+      }
+    })()
   }, [handleUnauthorized])
 
   const value = useMemo(

--- a/root/frontend/src/push/subscribe.ts
+++ b/root/frontend/src/push/subscribe.ts
@@ -9,6 +9,26 @@ const PUSH_TOPICS_STORAGE_KEY = "push:last_topics"
 
 const ensureLocks = new Map<string, Promise<PushSubscription | null>>()
 
+type NormalizedTopics = string[] | undefined
+
+function parseStoredTopics(raw: string | null): NormalizedTopics {
+  if (!raw) return undefined
+  try {
+    const parsed = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return undefined
+    const topics: string[] = []
+    for (const entry of parsed) {
+      if (typeof entry !== "string") continue
+      const normalized = entry.trim()
+      if (!normalized) continue
+      topics.push(normalized)
+    }
+    return topics.length ? topics : []
+  } catch {
+    return undefined
+  }
+}
+
 function sleep(ms: number) {
   return new Promise<void>(resolve => setTimeout(resolve, ms))
 }
@@ -202,9 +222,14 @@ export async function ensurePushSubscription(
   }
 }
 
-export async function unsubscribePush() {
+type UnsubscribePushOptions = {
+  registration?: ServiceWorkerRegistration
+  preserveConsent?: boolean
+}
+
+export async function unsubscribePush(options?: UnsubscribePushOptions) {
   if (!("serviceWorker" in navigator)) return false
-  const reg = await navigator.serviceWorker.ready
+  const reg = options?.registration ?? (await navigator.serviceWorker.ready)
   const sub = await reg.pushManager.getSubscription()
   if (!sub) return true
   const endpoint = sub.endpoint
@@ -218,9 +243,11 @@ export async function unsubscribePush() {
     }
   }
   const ok = await sub.unsubscribe()
-  try {
-    localStorage.removeItem(PUSH_CONSENT_STORAGE_KEY)
-  } catch {}
+  if (!options?.preserveConsent) {
+    try {
+      localStorage.removeItem(PUSH_CONSENT_STORAGE_KEY)
+    } catch {}
+  }
   removeStoredValue(PUSH_LAST_SYNC_STORAGE_KEY)
   removeStoredValue(PUSH_SUB_STORAGE_KEY)
   removeStoredValue(PUSH_TOPICS_STORAGE_KEY)
@@ -245,6 +272,33 @@ export async function getExistingPushSubscription(
     const sub = await reg.pushManager.getSubscription()
     return sub
   } catch {
+    return null
+  }
+}
+
+type SoftSyncOptions = {
+  registration?: ServiceWorkerRegistration
+  vapidPublicKey?: string
+  topics?: string[]
+}
+
+export async function softSyncPushSubscription(
+  options?: SoftSyncOptions
+): Promise<PushSubscription | null> {
+  if (!isPushSupported()) return null
+  if (typeof Notification === "undefined") return null
+  if (Notification.permission !== "granted") return null
+
+  const storedTopics = options?.topics ?? parseStoredTopics(getStoredValue(PUSH_TOPICS_STORAGE_KEY))
+  try {
+    const subscription = await ensurePushSubscription(
+      options?.vapidPublicKey,
+      options?.registration,
+      storedTopics,
+    )
+    return subscription
+  } catch (error) {
+    console.error("Failed to soft sync push subscription", error)
     return null
   }
 }


### PR DESCRIPTION
## Summary
- trigger a push subscription soft-sync after a successful login when notifications are already granted
- unsubscribe from push notifications on logout and notify the backend before clearing auth state
- add utilities to read stored topics, preserve consent on unsubscribe, and expose a soft-sync helper for reuse

## Testing
- npm --prefix root/frontend run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e30f12b27483279b9c2ed09580d4fc