### PR TITLE
Fix Spotify now playing and media uploads

### DIFF
--- a/root/alembic/env.py
+++ b/root/alembic/env.py
@@ -1,9 +1,11 @@
+import asyncio
 import os
 import sys
 from logging.config import fileConfig
 
 from sqlalchemy import engine_from_config, pool
 from sqlalchemy.engine import make_url
+from sqlalchemy.ext.asyncio import async_engine_from_config
 
 from alembic import context
 
@@ -40,20 +42,47 @@ def run_migrations_offline() -> None:
         context.run_migrations()
 
 
-def run_migrations_online() -> None:
-    connectable = engine_from_config(
-        {"sqlalchemy.url": get_url()},
-        prefix="sqlalchemy.",
-        poolclass=pool.NullPool,
+def _configure_context(connection) -> None:
+    context.configure(
+        connection=connection,
+        target_metadata=target_metadata,
+        compare_type=True,
     )
-    with connectable.connect() as connection:
-        context.configure(
-            connection=connection,
-            target_metadata=target_metadata,
-            compare_type=True,
-        )
+
+
+def run_migrations_online() -> None:
+    url = get_url()
+    config_options = {"sqlalchemy.url": url}
+    url_obj = make_url(url)
+
+    def run_sync_migrations(connection) -> None:
+        _configure_context(connection)
         with context.begin_transaction():
             context.run_migrations()
+
+    if url_obj.get_dialect().is_async:
+        connectable = async_engine_from_config(
+            config_options,
+            prefix="sqlalchemy.",
+            poolclass=pool.NullPool,
+        )
+
+        async def async_run_migrations() -> None:
+            async with connectable.connect() as connection:
+                await connection.run_sync(run_sync_migrations)
+
+        try:
+            asyncio.run(async_run_migrations())
+        finally:
+            asyncio.run(connectable.dispose())
+    else:
+        connectable = engine_from_config(
+            config_options,
+            prefix="sqlalchemy.",
+            poolclass=pool.NullPool,
+        )
+        with connectable.connect() as connection:
+            run_sync_migrations(connection)
 
 
 if context.is_offline_mode():

--- a/root/frontend/src/contexts/AuthContext.tsx
+++ b/root/frontend/src/contexts/AuthContext.tsx
@@ -9,7 +9,7 @@ type SetUserArg = any | ((prev: any) => any)
 type AuthContextType = {
   isAuth: boolean
   login: (token: string) => Promise<void>
-  logout: () => void
+  logout: () => Promise<void>
   user: any
   loading: boolean
   setUser: (user: SetUserArg) => void
@@ -18,7 +18,7 @@ type AuthContextType = {
 export const AuthContext = createContext<AuthContextType>({
   isAuth: false,
   login: async () => {},
-  logout: () => {},
+  logout: async () => {},
   user: null,
   loading: false,
   setUser: () => {},
@@ -189,13 +189,19 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     [applyToken, queryClient]
   )
 
-  const logout = useCallback(() => {
+  const logout = useCallback(async () => {
     if (typeof window === "undefined") {
       handleUnauthorized()
       return
     }
 
-    void (async () => {
+    try {
+      await api.post("/auth/logout")
+    } catch (error) {
+      if (import.meta.env.DEV) {
+        console.warn("Logout request failed", error)
+      }
+    } finally {
       try {
         await unsubscribePush({ preserveConsent: true })
       } catch (error) {
@@ -203,7 +209,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       } finally {
         handleUnauthorized()
       }
-    })()
+    }
   }, [handleUnauthorized])
 
   const value = useMemo(

--- a/root/frontend/src/contexts/__tests__/AuthContext.test.tsx
+++ b/root/frontend/src/contexts/__tests__/AuthContext.test.tsx
@@ -1,14 +1,20 @@
 import { PropsWithChildren } from 'react';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { QueryClientProvider } from '@tanstack/react-query';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createQueryClient } from '@/app/queryClient';
 import { AuthProvider, currentUserQueryKey, useAuth } from '@/contexts/AuthContext';
 import { testUser } from '@/tests/mocks/handlers';
+import api from '@/api/client';
 
 describe('AuthProvider caching', () => {
   beforeEach(() => {
     localStorage.clear();
+    vi.spyOn(api, 'post').mockResolvedValue({ data: {} } as any);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   const setup = () => {
@@ -41,8 +47,8 @@ describe('AuthProvider caching', () => {
 
     await waitFor(() => expect(result.current.user).toBeTruthy());
 
-    act(() => {
-      result.current.logout();
+    await act(async () => {
+      await result.current.logout();
     });
 
     await waitFor(() => expect(result.current.user).toBeNull());

--- a/root/frontend/src/hooks/__tests__/useNowPlaying.test.tsx
+++ b/root/frontend/src/hooks/__tests__/useNowPlaying.test.tsx
@@ -1,0 +1,150 @@
+import { QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import type { ReactNode } from "react";
+import { createQueryClient } from "@/app/queryClient";
+import api from "@/api/client";
+import { fetchNowPlaying, useNowPlaying } from "@/hooks/useNowPlaying";
+import type { NowPlaying } from "@/types/spotify";
+
+const STORAGE_KEY = "spotify:now-playing:last";
+
+afterEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+beforeEach(() => {
+  vi.useRealTimers();
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => "visible",
+  });
+});
+
+describe("fetchNowPlaying", () => {
+  it("normalizes a playing track", async () => {
+    vi.spyOn(api, "get").mockResolvedValue({
+      status: 200,
+      data: {
+        is_playing: true,
+        track_id: " 42 ",
+        track_name: "Nightcall",
+        artists: ["Kavinsky", " "],
+        album_name: "Drive",
+        album_image_url: "/media/cover.jpg",
+        track_url: "https://open.spotify.com/track/42",
+        duration_ms: 180000,
+        progress_ms: 45000,
+      },
+    } as any);
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-01T00:00:00Z"));
+
+    try {
+      const result = await fetchNowPlaying();
+
+      expect(result).toMatchObject({
+        is_playing: true,
+        track_id: "42",
+        track_name: "Nightcall",
+        artists: ["Kavinsky"],
+        album_name: "Drive",
+        album_image_url: "/media/cover.jpg",
+        track_url: "https://open.spotify.com/track/42",
+        duration_ms: 180000,
+        progress_ms: 45000,
+      });
+      expect(typeof result?.fetched_at).toBe("string");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("returns null for 204 responses", async () => {
+    vi.spyOn(api, "get").mockResolvedValue({ status: 204, data: null } as any);
+    const result = await fetchNowPlaying();
+    expect(result).toBeNull();
+  });
+});
+
+describe("useNowPlaying", () => {
+  const wrapper = ({ children }: { children: ReactNode }) => {
+    const client = createQueryClient();
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  };
+
+  it("exposes paused track data and stores it in cache", async () => {
+    const payload: Partial<NowPlaying> = {
+      is_playing: false,
+      track_id: "xyz",
+      track_name: "Lo-fi Study",
+      artists: ["Various"],
+      album_name: "Lo-fi",
+      album_image_url: "https://cdn.example/lofi.jpg",
+      track_url: "https://open.spotify.com/track/xyz",
+      duration_ms: 210000,
+      progress_ms: 120000,
+    };
+
+    vi.spyOn(api, "get").mockResolvedValue({ status: 200, data: payload } as any);
+
+    const { result } = renderHook(() => useNowPlaying(true), { wrapper });
+
+    await waitFor(() =>
+      expect(result.current.data).toMatchObject({
+        is_playing: false,
+        track_id: "xyz",
+        track_name: "Lo-fi Study",
+        artists: ["Various"],
+        duration_ms: 210000,
+        progress_ms: 120000,
+      }),
+    );
+
+    const stored = localStorage.getItem(STORAGE_KEY);
+    expect(stored).toBeTruthy();
+  });
+
+  it("falls back to cached value before network resolves", async () => {
+    const cached: NowPlaying = {
+      is_playing: true,
+      track_id: "cached",
+      track_name: "Cached Song",
+      artists: ["Cache"],
+      album_name: null,
+      album_image_url: null,
+      track_url: null,
+      duration_ms: 100000,
+      progress_ms: 50000,
+      fetched_at: "2024-01-01T00:00:00.000Z",
+    };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(cached));
+
+    vi.spyOn(api, "get").mockImplementation(() =>
+      new Promise((resolve) => {
+        setTimeout(() => {
+          resolve({ status: 204, data: null } as any);
+        }, 50);
+      }),
+    );
+
+    const { result } = renderHook(() => useNowPlaying(true), { wrapper });
+
+    expect(result.current.data).toMatchObject({ track_id: "cached", track_name: "Cached Song" });
+
+    await act(async () => {
+      await result.current.refetch();
+    });
+
+    await waitFor(() => expect(result.current.data).toBeNull());
+  });
+});

--- a/root/frontend/src/hooks/useNowPlaying.ts
+++ b/root/frontend/src/hooks/useNowPlaying.ts
@@ -1,20 +1,69 @@
-import { useEffect } from "react"
+import { useEffect, useMemo } from "react"
 import { useQuery } from "@tanstack/react-query"
 import api from "@/api/client"
 import type { NowPlaying } from "@/types/spotify"
 
 export const nowPlayingQueryKey = ["spotify", "now-playing"] as const
 
-const isTestEnv = typeof process !== "undefined" && process.env.NODE_ENV === "test"
+const isTestEnv = typeof import.meta !== "undefined" && import.meta.env.MODE === "test"
 
 const STORAGE_KEY = "spotify:now-playing:last"
+
+type RawNowPlaying = Partial<NowPlaying> | null | undefined
+
+const toNullableString = (value: unknown) => {
+  if (value == null) return null
+  const str = String(value).trim()
+  return str.length > 0 ? str : null
+}
+
+const toNullableNumber = (value: unknown) => {
+  if (value == null) return null
+  const num = Number(value)
+  if (!Number.isFinite(num)) return null
+  return Math.max(0, num)
+}
+
+const normalizeNowPlaying = (input: RawNowPlaying): NowPlaying | null => {
+  if (!input) return null
+
+  const artists = Array.isArray(input.artists)
+    ? input.artists
+        .map((artist) => toNullableString(artist))
+        .filter((artist): artist is string => Boolean(artist))
+    : []
+
+  const durationMs = toNullableNumber(input.duration_ms)
+  const progressMs = toNullableNumber(input.progress_ms)
+
+  const payload: NowPlaying = {
+    is_playing: Boolean(input.is_playing),
+    track_id: toNullableString(input.track_id),
+    track_name: toNullableString(input.track_name),
+    artists,
+    album_name: toNullableString(input.album_name),
+    album_image_url: toNullableString(input.album_image_url),
+    track_url: toNullableString(input.track_url),
+    duration_ms: durationMs,
+    progress_ms:
+      durationMs != null && progressMs != null
+        ? Math.min(Math.max(0, progressMs), durationMs)
+        : progressMs,
+    fetched_at: input.fetched_at ?? new Date().toISOString(),
+  }
+
+  const hasContent = payload.track_id || payload.track_name || payload.artists.length > 0
+  if (!hasContent) return null
+
+  return payload
+}
 
 const readCachedNowPlaying = (): NowPlaying | null | undefined => {
   if (typeof window === "undefined") return undefined
   try {
     const raw = window.localStorage.getItem(STORAGE_KEY)
     if (!raw) return undefined
-    return JSON.parse(raw) as NowPlaying | null
+    return normalizeNowPlaying(JSON.parse(raw) as RawNowPlaying)
   } catch {
     return undefined
   }
@@ -30,46 +79,66 @@ const persistNowPlaying = (value: NowPlaying | null) => {
 }
 
 export const fetchNowPlaying = async () => {
-  const res = await api.get<NowPlaying>("/spotify/now-playing")
-  return res.data
+  const res = await api.get<RawNowPlaying>("/spotify/now-playing", {
+    validateStatus: (status) => status === 204 || (status >= 200 && status < 300),
+  })
+
+  if (res.status === 204) return null
+  return normalizeNowPlaying(res.data)
 }
 
-const computeInterval = (data?: NowPlaying | null) => {
-  if (!data) return 15000
-  if (data.is_playing && data.duration_ms && data.progress_ms != null) {
-    const remain = Math.max(0, data.duration_ms - data.progress_ms)
-    return Math.min(remain + 400, 20000)
+const computeInterval = (data: NowPlaying | null) => {
+  if (!data || !data.is_playing) return 75_000
+  if (data.duration_ms != null && data.progress_ms != null) {
+    const remaining = Math.max(0, data.duration_ms - data.progress_ms)
+    const padded = remaining + 5_000
+    return Math.min(Math.max(padded, 15_000), 20_000)
   }
-  return 15000
+  return 18_000
 }
 
 export const useNowPlaying = (enabled: boolean) => {
+  const cached = useMemo(() => readCachedNowPlaying(), [])
+
   const query = useQuery<NowPlaying | null, Error, NowPlaying | null, typeof nowPlayingQueryKey>({
     queryKey: nowPlayingQueryKey,
     queryFn: fetchNowPlaying,
     enabled,
-    placeholderData: previous => {
+    initialData: cached,
+    placeholderData: (previous) => {
       if (previous !== undefined) return previous ?? null
-      const cached = readCachedNowPlaying()
       return cached ?? null
     },
     staleTime: 60_000,
     gcTime: 5 * 60_000,
     networkMode: "online",
     retry: 1,
-    refetchOnWindowFocus: enabled,
-    refetchInterval: (query: { state: { data: NowPlaying | null | undefined } }) => {
+    refetchOnWindowFocus: false,
+    refetchInterval: ({ state }) => {
       if (!enabled || isTestEnv) return false
-      const data = query.state.data ?? null
-      return computeInterval(data)
+      if (typeof document !== "undefined" && document.visibilityState === "hidden") return false
+      return computeInterval(state.data ?? null)
     },
     refetchIntervalInBackground: true,
   })
 
+  const { data, isSuccess, refetch } = query
+
   useEffect(() => {
-    if (!query.isSuccess) return
-    persistNowPlaying(query.data ?? null)
-  }, [query.data, query.isSuccess])
+    if (!isSuccess) return
+    persistNowPlaying(data ?? null)
+  }, [data, isSuccess])
+
+  useEffect(() => {
+    if (!enabled || typeof document === "undefined") return
+    const listener = () => {
+      if (document.visibilityState === "visible") {
+        void refetch()
+      }
+    }
+    document.addEventListener("visibilitychange", listener)
+    return () => document.removeEventListener("visibilitychange", listener)
+  }, [enabled, refetch])
 
   return query
 }

--- a/root/frontend/src/main.tsx
+++ b/root/frontend/src/main.tsx
@@ -60,7 +60,7 @@ async function bootstrap() {
   function BodyColorSchemeSync() {
     const { mode, systemMode } = useColorScheme()
     useEffect(() => {
-      const resolved = mode === "system" ? systemMode ?? "light" : mode ?? "light"
+      const resolved = mode === "system" ? (systemMode ?? "light") : (mode ?? "light")
       document.body.dataset.colorScheme = resolved
       document.body.classList.toggle("dark", resolved === "dark")
       return () => {
@@ -76,7 +76,12 @@ async function bootstrap() {
   ReactDOMMod.default.createRoot(document.getElementById("root")!).render(
     <StrictMode>
       <QueryClientProvider client={queryClient}>
-        <CssVarsProvider theme={theme} defaultMode="system" modeStorageKey="theme" disableTransitionOnChange>
+        <CssVarsProvider
+          theme={theme}
+          defaultMode="system"
+          modeStorageKey="theme"
+          disableTransitionOnChange
+        >
           <CssBaseline enableColorScheme />
           <BodyColorSchemeSync />
           <ErrorBoundary>

--- a/root/frontend/src/pages/Profile.tsx
+++ b/root/frontend/src/pages/Profile.tsx
@@ -42,6 +42,7 @@ import { QRCodeSVG } from "qrcode.react";
 import { motion, useReducedMotion } from "framer-motion";
 import { useNowPlaying } from "@/hooks/useNowPlaying";
 import type { NowPlaying } from "@/types/spotify";
+import { addVersionParam, resolveMediaUrl } from "@/utils/media";
 
 const BACKEND_ORIGIN = import.meta.env.VITE_BACKEND_ORIGIN || "";
 
@@ -62,87 +63,59 @@ const onlinePulse = keyframes`
 `;
 
 const MotionPaper = motion.create(Paper);
-const isTest = process.env.NODE_ENV === "test";
+const isTest = typeof import.meta !== "undefined" && import.meta.env.MODE === "test";
 
-const safeEncode = (seg: string) => {
-  try {
-    return encodeURIComponent(decodeURIComponent(seg));
-  } catch {
-    return encodeURIComponent(seg);
-  }
-};
-
-const buildMediaUrl = (raw?: string): string | undefined => {
-  if (!raw) return undefined;
-  const origin =
-    BACKEND_ORIGIN ||
-    (typeof window !== "undefined" ? window.location.origin : "");
-  const cleaned = String(raw).trim().replace(/^\/+/, match => (match ? "/" : ""));
-  try {
-    const base = origin ? new URL(origin) : undefined;
-    const u = new URL(cleaned, base?.toString());
-    const parts = u.pathname.split("/").map(safeEncode).join("/");
-    u.pathname = parts.replace(/\/{2,}/g, "/");
-    return u.toString();
-  } catch {
-    const path = `/${cleaned}`;
-    const encoded = path
-      .split("/")
-      .map(safeEncode)
-      .join("/")
-      .replace(/\/{2,}/g, "/");
-    return `${origin.replace(/\/$/, "")}${encoded}`;
-  }
-};
-
-const addVersionParam = (url: string | undefined, v: number): string | undefined => {
-  if (!url) return undefined;
-  try {
-    const u = new URL(url);
-    u.searchParams.set("v", String(v));
-    return u.toString();
-  } catch {
-    const sep = url.includes("?") ? "&" : "?";
-    return `${url}${sep}v=${v}`;
-  }
-};
-
-const NowPlayingCard = memo(function NowPlayingCard({ data }: { data: NowPlaying }) {
-  const [progress, setProgress] = useState<number>(data.progress_ms ?? 0);
-  const startRef = useRef<number>(Date.now() - (data.progress_ms ?? 0));
-  const rafRef = useRef<number | null>(null);
+export const NowPlayingCard = memo(function NowPlayingCard({ data }: { data: NowPlaying }) {
   const theme = useTheme();
   const prefersReduce = useMediaQuery("(prefers-reduced-motion: reduce)");
   const reduced = useReducedMotion();
   const isDark = theme.palette.mode === "dark";
   const borderCol = isDark ? alpha(theme.palette.common.white, 0.14) : alpha(theme.palette.common.black, 0.12);
   const textSecondary = theme.palette.text.secondary;
+  const duration = data.duration_ms ?? 0;
+
+  const clampProgress = useCallback(
+    (value: number | null | undefined) => {
+      if (value == null) return 0;
+      if (!Number.isFinite(value)) return 0;
+      if (!duration || duration <= 0) return Math.max(0, value);
+      return Math.min(Math.max(0, value), duration);
+    },
+    [duration]
+  );
+
+  const [progress, setProgress] = useState<number>(() => clampProgress(data.progress_ms));
+  const startRef = useRef<number>(Date.now() - clampProgress(data.progress_ms));
+  const rafRef = useRef<number | null>(null);
 
   useEffect(() => {
-    startRef.current = Date.now() - (data.progress_ms ?? 0);
-    setProgress(data.progress_ms ?? 0);
-  }, [data.track_id, data.progress_ms, data.duration_ms, data.is_playing]);
+    const next = clampProgress(data.progress_ms);
+    startRef.current = Date.now() - next;
+    setProgress(next);
+  }, [clampProgress, data.progress_ms, data.duration_ms, data.track_id, data.is_playing]);
+
+  const shouldAnimate = !isTest && data.is_playing && !prefersReduce && !reduced && duration > 0;
 
   useEffect(() => {
-    if (isTest || !data.is_playing || !data.duration_ms) return;
+    if (!shouldAnimate) return;
     const loop = () => {
-      const p = Math.min(data.duration_ms!, Date.now() - startRef.current);
-      setProgress(p);
+      const elapsed = Date.now() - startRef.current;
+      setProgress(clampProgress(elapsed));
       rafRef.current = requestAnimationFrame(loop);
     };
     rafRef.current = requestAnimationFrame(loop);
     return () => {
       if (rafRef.current) cancelAnimationFrame(rafRef.current);
     };
-  }, [data.is_playing, data.duration_ms, data.track_id]);
+  }, [clampProgress, shouldAnimate]);
 
-  const pct = data.duration_ms ? Math.max(0, Math.min(100, (progress / data.duration_ms) * 100)) : 0;
-  const fmt = (ms?: number) => {
+  const pct = duration > 0 ? Math.max(0, Math.min(100, (progress / duration) * 100)) : 0;
+  const fmt = (ms: number | null | undefined) => {
     if (ms == null) return "0:00";
-    const s = Math.max(0, Math.floor(ms / 1000));
-    const m = Math.floor(s / 60);
-    const ss = String(s % 60).padStart(2, "0");
-    return `${m}:${ss}`;
+    const seconds = Math.max(0, Math.floor(ms / 1000));
+    const minutes = Math.floor(seconds / 60);
+    const rest = String(seconds % 60).padStart(2, "0");
+    return `${minutes}:${rest}`;
   };
 
   const href = data.track_url || "https://open.spotify.com";
@@ -154,19 +127,15 @@ const NowPlayingCard = memo(function NowPlayingCard({ data }: { data: NowPlaying
       target="_blank"
       rel="noopener noreferrer"
       aria-label={data.track_name ? `Открыть в Spotify: ${data.track_name}` : "Открыть Spotify"}
-      sx={{
-        display: "block",
-        textDecoration: "none",
-        width: "100%"
-      }}
+      sx={{ display: "block", textDecoration: "none", width: "100%" }}
     >
       <MotionPaper
         elevation={0}
         className="nowplaying--spotify"
-        initial={isTest ? false : { y: reduced ? 0 : 12, opacity: reduced ? 1 : 0.94, scale: 1 }}
+        initial={isTest || prefersReduce || reduced ? false : { y: 12, opacity: 0.94, scale: 1 }}
         animate={{ y: 0, opacity: 1, scale: 1 }}
-        whileHover={reduced ? {} : { y: -1, scale: 1.002 }}
-        whileTap={reduced ? {} : { scale: 0.997 }}
+        whileHover={prefersReduce || reduced ? {} : { y: -1, scale: 1.002 }}
+        whileTap={prefersReduce || reduced ? {} : { scale: 0.997 }}
         transition={isTest ? { duration: 0 } : { type: "spring", stiffness: 520, damping: 36, mass: 0.9 }}
         sx={{
           width: "100%",
@@ -197,30 +166,50 @@ const NowPlayingCard = memo(function NowPlayingCard({ data }: { data: NowPlaying
           }}
         >
           <Avatar
-            src={data.album_image_url || ""}
+            src={data.album_image_url ?? ""}
             variant="rounded"
             alt={data.album_name || data.track_name || "Обложка альбома"}
             sx={{
               width: "100%",
               height: "100%",
               borderRadius: 2,
-              transform: prefersReduce ? "none" : "scale(1.012)",
-              transition: prefersReduce ? "none" : "transform 900ms cubic-bezier(.22,.61,.36,1)",
-              "&:hover": prefersReduce ? undefined : { transform: "scale(1.02)" }
+              transform: prefersReduce || reduced ? "none" : "scale(1.012)",
+              transition:
+                prefersReduce || reduced ? "none" : "transform 900ms cubic-bezier(.22,.61,.36,1)",
+              "&:hover": prefersReduce || reduced ? undefined : { transform: "scale(1.02)" }
             }}
           />
         </Box>
-        <Box sx={{ minWidth: 0, display: "flex", flexDirection: "column", gap: 0.75 }}>
-          <Typography className="np-title" variant="body1" sx={{ fontWeight: 800, lineHeight: 1.2, letterSpacing: "-.01em" }}>
+        <Box sx={{ minWidth: 0, display: "flex", flexDirection: "column", gap: 0.75 }} aria-live="polite">
+          <Typography
+            className="np-title"
+            variant="body1"
+            sx={{ fontWeight: 800, lineHeight: 1.2, letterSpacing: "-.01em" }}
+          >
             {data.track_name || "—"}
           </Typography>
           <Typography className="np-art" variant="body2" sx={{ opacity: 0.9 }}>
-            {(data.artists || []).join(", ")}
+            {data.artists.join(", ")}
           </Typography>
+          {!data.is_playing && (
+            <Chip
+              size="small"
+              label="Пауза"
+              color="default"
+              sx={{ alignSelf: "flex-start", textTransform: "uppercase", fontWeight: 700 }}
+              aria-hidden
+            />
+          )}
           <Box sx={{ display: "flex", alignItems: "center", gap: 1, width: "100%" }}>
-            <LinearProgress className="progress" variant="determinate" value={pct} sx={{ flex: 1, height: 6, borderRadius: 999 }} />
+            <LinearProgress
+              className="progress"
+              variant="determinate"
+              value={pct}
+              aria-label="Прогресс трека"
+              sx={{ flex: 1, height: 6, borderRadius: 999 }}
+            />
             <Typography className="np-time" variant="caption" sx={{ color: textSecondary, whiteSpace: "nowrap" }}>
-              {fmt(progress)} / {fmt(data.duration_ms)}
+              {fmt(progress)} / {fmt(duration)}
             </Typography>
           </Box>
         </Box>
@@ -228,6 +217,7 @@ const NowPlayingCard = memo(function NowPlayingCard({ data }: { data: NowPlaying
     </Box>
   );
 });
+
 
 const DetailRow = ({ label, value }: { label: string; value?: React.ReactNode }) => {
   const theme = useTheme();
@@ -287,33 +277,11 @@ export default function Profile() {
   const spotifyConnected = Boolean(user?.spotify_connected || user?.spotify_is_connected);
   const nowPlayingQuery = useNowPlaying(spotifyConnected);
   const nowPlaying = nowPlayingQuery.data ?? null;
-  const [npFallback, setNpFallback] = useState<NowPlaying | null>(null);
-
-  useEffect(() => {
-    let stop = false;
-    let timer: number | null = null;
-    const load = async () => {
-      try {
-        const r = await api.get<NowPlaying | null>("/spotify/now-playing", { validateStatus: () => true });
-        if (stop) return;
-        if (r.status === 200 && r.data && (r.data as any).track_id) setNpFallback(r.data as NowPlaying);
-        else setNpFallback(null);
-      } catch {
-        if (!stop) setNpFallback(null);
-      } finally {
-        if (!stop) timer = window.setTimeout(load, 8000);
-      }
-    };
-    if (spotifyConnected) load();
-    else setNpFallback(null);
-    return () => {
-      stop = true;
-      if (timer) window.clearTimeout(timer);
-    };
-  }, [spotifyConnected]);
-
-  const effectiveNowPlaying = nowPlaying || npFallback;
-
+  const showNowPlaying = Boolean(
+    spotifyConnected &&
+      nowPlaying &&
+      (nowPlaying.track_id || nowPlaying.track_name || nowPlaying.artists.length > 0)
+  );
   const location = useLocation();
   const navigate = useNavigate();
 
@@ -401,7 +369,7 @@ export default function Profile() {
       affiliation: user.institute || user.department || "",
       url: typeof window !== "undefined" ? window.location.href : "",
       image: (() => {
-        const media = buildMediaUrl(user.avatar_url || "");
+        const media = resolveMediaUrl(user.avatar_url || "", BACKEND_ORIGIN);
         const withV = addVersionParam(media, avatarVersion);
         return withV || "";
       })()
@@ -423,12 +391,12 @@ export default function Profile() {
     );
 
   const getAvatarSrc = () => {
-    const media = buildMediaUrl(user?.avatar_url || "");
-    return addVersionParam(media, avatarVersion);
+    const media = resolveMediaUrl(user?.avatar_url || "", BACKEND_ORIGIN);
+    return addVersionParam(media, avatarVersion) || undefined;
   };
 
   const getCoverSrc = () => {
-    const media = buildMediaUrl(user?.cover_url || "");
+    const media = resolveMediaUrl(user?.cover_url || "", BACKEND_ORIGIN);
     return media || "https://mui.com/static/images/cards/cover1.jpg";
   };
 
@@ -898,13 +866,13 @@ export default function Profile() {
                     </Stack>
                   </Paper>
 
-                  {spotifyConnected && effectiveNowPlaying && (
+                  {showNowPlaying && nowPlaying && (
                     <Fade in timeout={isTest || reduced ? 0 : 720}>
                       <Stack spacing={1.4}>
                         <Typography variant="overline" sx={{ letterSpacing: 2.2, color: textSecondary }}>
                           Сейчас играет
                         </Typography>
-                        <NowPlayingCard data={effectiveNowPlaying} />
+                        <NowPlayingCard data={nowPlaying} />
                       </Stack>
                     </Fade>
                   )}

--- a/root/frontend/src/pages/Settings.tsx
+++ b/root/frontend/src/pages/Settings.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState, useCallback, ChangeEvent, FocusEvent } from "react";
+import { isAxiosError } from "axios";
 import { useAuth, currentUserQueryKey, fetchCurrentUser } from "@/contexts/AuthContext";
 import { useNavigate } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
@@ -51,7 +52,7 @@ import DoNotDisturbOnIcon from "@mui/icons-material/DoNotDisturbOn";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import defaultAvatar from "@/assets/default_avatar.png";
 import spotifyLogo from "@/assets/spotify_icon.png";
-import { resolveMediaUrl } from "@/utils/media";
+import { addVersionParam, resolveMediaUrl } from "@/utils/media";
 
 type ThemeMode = "system" | "light" | "dark";
 
@@ -115,8 +116,6 @@ export default function Settings() {
 
   const [avatarVersion, setAvatarVersion] = useState(Date.now());
   const [coverVersion, setCoverVersion] = useState(Date.now());
-
-  const withV = (url: string | undefined, v: number) => (url ? `${url}${url.includes("?") ? "&" : "?"}v=${v}` : url);
 
   const syncDndFromUser = useCallback((value: any) => {
     const enabled = Boolean(value?.dnd_enabled);
@@ -300,7 +299,7 @@ export default function Settings() {
   const getAvatarSrc = useCallback(() => {
     if ((user as any)?.avatar_url) {
       const url = resolveMediaUrl((user as any).avatar_url, BACKEND_ORIGIN);
-      return withV(url, avatarVersion) || defaultAvatar;
+      return addVersionParam(url, avatarVersion) || defaultAvatar;
     }
     return defaultAvatar;
   }, [user, avatarVersion]);
@@ -308,7 +307,7 @@ export default function Settings() {
   const getCoverSrc = useCallback(() => {
     if ((user as any)?.cover_url) {
       const url = resolveMediaUrl((user as any).cover_url, BACKEND_ORIGIN);
-      return withV(url || "", coverVersion);
+      return addVersionParam(url || "", coverVersion) || "";
     }
     return "";
   }, [user, coverVersion]);
@@ -316,11 +315,30 @@ export default function Settings() {
   const triggerAvatarPick = () => avatarInputRef.current?.click();
   const triggerCoverPick = () => coverInputRef.current?.click();
 
-  const refreshMe = async () => {
-    const meResp = await fetch("/api/users/me", { credentials: "include" });
-    const me = await meResp.json();
-    setUser(me);
-  };
+  const refreshMe = useCallback(async () => {
+    const fresh = await queryClient.fetchQuery({
+      queryKey: currentUserQueryKey,
+      queryFn: fetchCurrentUser,
+      staleTime: 0,
+    });
+    setUser(fresh);
+    return fresh;
+  }, [queryClient, setUser]);
+
+  const resolveDetailMessage = useCallback((error: unknown, fallback: string) => {
+    if (isAxiosError(error)) {
+      const detail = (error.response?.data as any)?.detail;
+      if (typeof detail === "string") return detail;
+      if (Array.isArray(detail)) {
+        const combined = detail
+          .map((item) => (item && typeof item === "object" && "msg" in item ? String(item.msg) : ""))
+          .filter(Boolean)
+          .join("; ");
+        if (combined) return combined;
+      }
+    }
+    return fallback;
+  }, []);
 
   const uploadAvatar = async (file: File) => {
     if (!isImage(file)) return setSnack({ text: "Поддерживаются PNG/JPG/WebP/AVIF/GIF", sev: "warning" });
@@ -329,13 +347,14 @@ export default function Settings() {
       setAvatarBusy(true);
       const fd = new FormData();
       fd.append("file", file);
-      const r = await fetch("/api/users/me/avatar", { method: "POST", body: fd, credentials: "include" });
-      if (!r.ok) throw new Error();
+      await api.post("/users/me/avatar", fd, {
+        headers: { "Content-Type": "multipart/form-data" },
+      });
       await refreshMe();
       setAvatarVersion(Date.now());
       setSnack({ text: "Аватар обновлён", sev: "success" });
-    } catch {
-      setSnack({ text: "Не удалось загрузить аватар", sev: "error" });
+    } catch (error) {
+      setSnack({ text: resolveDetailMessage(error, "Не удалось загрузить аватар"), sev: "error" });
     } finally {
       setAvatarBusy(false);
       if (avatarInputRef.current) avatarInputRef.current.value = "";
@@ -345,13 +364,12 @@ export default function Settings() {
   const removeAvatar = async () => {
     try {
       setAvatarBusy(true);
-      const r = await fetch("/api/users/me/avatar", { method: "DELETE", credentials: "include" });
-      if (!r.ok) throw new Error();
+      await api.delete("/users/me/avatar");
       await refreshMe();
       setAvatarVersion(Date.now());
       setSnack({ text: "Аватар удалён", sev: "success" });
-    } catch {
-      setSnack({ text: "Не удалось удалить аватар", sev: "error" });
+    } catch (error) {
+      setSnack({ text: resolveDetailMessage(error, "Не удалось удалить аватар"), sev: "error" });
     } finally {
       setAvatarBusy(false);
     }
@@ -364,13 +382,14 @@ export default function Settings() {
       setCoverBusy(true);
       const fd = new FormData();
       fd.append("file", file);
-      const r = await fetch("/api/users/me/cover", { method: "POST", body: fd, credentials: "include" });
-      if (!r.ok) throw new Error();
+      await api.post("/users/me/cover", fd, {
+        headers: { "Content-Type": "multipart/form-data" },
+      });
       await refreshMe();
       setCoverVersion(Date.now());
       setSnack({ text: "Обложка обновлена", sev: "success" });
-    } catch {
-      setSnack({ text: "Не удалось загрузить обложку", sev: "error" });
+    } catch (error) {
+      setSnack({ text: resolveDetailMessage(error, "Не удалось загрузить обложку"), sev: "error" });
     } finally {
       setCoverBusy(false);
       if (coverInputRef.current) coverInputRef.current.value = "";
@@ -714,6 +733,7 @@ export default function Settings() {
               >
                 <ListItemAvatar sx={{ mr: 1.25 }}>
                   <Box
+                    data-testid="settings-cover-preview"
                     sx={{
                       width: 120,
                       height: 52,
@@ -756,7 +776,10 @@ export default function Settings() {
                     variant="text"
                     color="error"
                     startIcon={<LogoutIcon />}
-                    onClick={async () => { setConfirmLogout(false); try { await fetch("/auth/logout", { method: "POST", credentials: "include" }); } finally { logout(); } }}
+                    onClick={async () => {
+                      setConfirmLogout(false);
+                      await logout();
+                    }}
                     sx={{ px: 0 }}
                   >
                     Выйти
@@ -799,7 +822,15 @@ export default function Settings() {
         </DialogContent>
         <DialogActions>
           <Button onClick={() => setConfirmLogout(false)}>Отмена</Button>
-          <Button color="error" onClick={async () => { setConfirmLogout(false); try { await fetch("/auth/logout", { method: "POST", credentials: "include" }); } finally { logout(); } }}>Выйти</Button>
+          <Button
+            color="error"
+            onClick={async () => {
+              setConfirmLogout(false);
+              await logout();
+            }}
+          >
+            Выйти
+          </Button>
         </DialogActions>
       </Dialog>
 

--- a/root/frontend/src/pages/__tests__/Profile.nowPlaying.test.tsx
+++ b/root/frontend/src/pages/__tests__/Profile.nowPlaying.test.tsx
@@ -51,7 +51,7 @@ describe("NowPlayingCard", () => {
 
     const advanced: NowPlaying = {
       ...baseTrack,
-      progress_ms: baseTrack.progress_ms + 15000,
+      progress_ms: (baseTrack.progress_ms ?? 0) + 15000,
       fetched_at: "2024-01-01T00:00:15.000Z",
     };
 

--- a/root/frontend/src/pages/__tests__/Profile.nowPlaying.test.tsx
+++ b/root/frontend/src/pages/__tests__/Profile.nowPlaying.test.tsx
@@ -1,0 +1,69 @@
+import { ThemeProvider, createTheme } from "@mui/material/styles";
+import { render, act } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { NowPlayingCard } from "@/pages/Profile";
+import type { NowPlaying } from "@/types/spotify";
+
+vi.mock("framer-motion", async () => {
+  const actual = await vi.importActual<typeof import("framer-motion")>("framer-motion");
+  return { ...actual, useReducedMotion: () => false };
+});
+
+const theme = createTheme();
+
+const baseTrack: NowPlaying = {
+  is_playing: true,
+  track_id: "play-1",
+  track_name: "Test Track",
+  artists: ["Tester"],
+  album_name: "Album",
+  album_image_url: "https://example.com/cover.jpg",
+  track_url: "https://open.spotify.com/track/play-1",
+  duration_ms: 180000,
+  progress_ms: 30000,
+  fetched_at: "2024-01-01T00:00:00.000Z",
+};
+
+const renderWithTheme = (track: NowPlaying) =>
+  render(
+    <ThemeProvider theme={theme}>
+      <NowPlayingCard data={track} />
+    </ThemeProvider>,
+  );
+
+describe("NowPlayingCard", () => {
+  it("matches snapshot when playing", () => {
+    const { container } = renderWithTheme(baseTrack);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it("matches snapshot when paused", () => {
+    const paused: NowPlaying = { ...baseTrack, is_playing: false };
+    const { container, getByText } = renderWithTheme(paused);
+    expect(getByText("Пауза")).toBeInTheDocument();
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it("reflects updated progress when data changes", () => {
+    const { getByRole, rerender } = renderWithTheme(baseTrack);
+    const progressBar = getByRole("progressbar");
+    const initial = Number(progressBar.getAttribute("aria-valuenow"));
+
+    const advanced: NowPlaying = {
+      ...baseTrack,
+      progress_ms: baseTrack.progress_ms + 15000,
+      fetched_at: "2024-01-01T00:00:15.000Z",
+    };
+
+    act(() => {
+      rerender(
+        <ThemeProvider theme={theme}>
+          <NowPlayingCard data={advanced} />
+        </ThemeProvider>,
+      );
+    });
+
+    const updated = Number(progressBar.getAttribute("aria-valuenow"));
+    expect(updated).toBeGreaterThan(initial);
+  });
+});

--- a/root/frontend/src/pages/__tests__/Settings.media.test.tsx
+++ b/root/frontend/src/pages/__tests__/Settings.media.test.tsx
@@ -1,0 +1,175 @@
+import { QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor, act } from "@testing-library/react";
+import { Experimental_CssVarsProvider as CssVarsProvider } from "@mui/material/styles";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import api from "@/api/client";
+import { createQueryClient } from "@/app/queryClient";
+import { AuthContext } from "@/contexts/AuthContext";
+import Settings from "@/pages/Settings";
+
+vi.mock("@/hooks/useNotifications", () => ({
+  useNotifications: () => ({ unreadCount: 0 }),
+}));
+
+vi.mock("@/hooks/usePushPreferences", () => ({
+  usePushPreferences: () => ({
+    topicKeys: [],
+    topicState: {},
+    pushSupported: false,
+    notificationPermission: "default" as NotificationPermission,
+    notificationsEnabled: false,
+    pushBusy: false,
+    pushInitializing: false,
+    permissionText: "",
+    selectedTopicsDescription: "",
+    enableNotifications: vi.fn(),
+    disableNotifications: vi.fn(),
+    handleTopicToggle: () => () => {},
+    safariIOS: false,
+    safariGuideUrl: "#",
+  }),
+  NOTIFICATION_TOPIC_LABELS: {},
+}));
+
+const baseUser = {
+  id: 1,
+  full_name: "Test User",
+  email: "test@example.com",
+  role: "student",
+  avatar_url: "/media/avatars/original.png",
+  cover_url: "/media/covers/original.jpg",
+  spotify_connected: false,
+  spotify_is_connected: false,
+};
+
+const renderSettings = () => {
+  const queryClient = createQueryClient();
+  const mockSetUser = vi.fn();
+  const mockLogout = vi.fn().mockResolvedValue(undefined);
+
+  const utils = render(
+    <MemoryRouter initialEntries={["/settings"]}>
+      <QueryClientProvider client={queryClient}>
+        <CssVarsProvider>
+          <AuthContext.Provider
+            value={{
+              user: baseUser,
+              setUser: mockSetUser,
+              logout: mockLogout,
+              login: vi.fn(),
+              isAuth: true,
+              loading: false,
+            }}
+          >
+            <Settings />
+          </AuthContext.Provider>
+        </CssVarsProvider>
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+
+  return { ...utils, mockSetUser };
+};
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("Settings media actions", () => {
+  it("uploads avatar and refreshes the profile", async () => {
+    const updatedUser = { ...baseUser, avatar_url: "/media/avatars/new.png" };
+    const postSpy = vi.spyOn(api, "post").mockResolvedValue({ data: updatedUser } as any);
+    const getSpy = vi.spyOn(api, "get").mockResolvedValue({ data: updatedUser } as any);
+
+    const { mockSetUser } = renderSettings();
+
+    fireEvent.click(screen.getByRole("tab", { name: "Аккаунт" }));
+
+    await waitFor(() => expect(document.querySelectorAll("input[type='file']").length).toBeGreaterThan(1));
+    const fileInputs = document.querySelectorAll<HTMLInputElement>("input[type='file']");
+
+    const avatar = await screen.findByAltText(baseUser.full_name);
+    const initialSrc = avatar.getAttribute("src");
+
+    const file = new File(["avatar"], "avatar.png", { type: "image/png" });
+
+    await act(async () => {
+      fireEvent.change(fileInputs[0], { target: { files: [file] } });
+      await new Promise((resolve) => setTimeout(resolve, 15));
+    });
+
+    await waitFor(() => expect(postSpy).toHaveBeenCalled());
+
+    const formData = postSpy.mock.calls[0][1] as FormData;
+    expect(formData.get("file")).toBe(file);
+
+    await waitFor(() => expect(getSpy).toHaveBeenCalledWith("/users/me"));
+    await waitFor(() => expect(mockSetUser).toHaveBeenCalledWith(updatedUser));
+
+    const updatedSrc = avatar.getAttribute("src");
+    expect(updatedSrc).toContain("v=");
+    expect(updatedSrc).not.toEqual(initialSrc);
+  });
+
+  it("shows an error when avatar upload fails", async () => {
+    vi.spyOn(api, "post").mockRejectedValue({ response: { data: { detail: "Ошибка загрузки" } } });
+
+    renderSettings();
+    fireEvent.click(screen.getByRole("tab", { name: "Аккаунт" }));
+    await waitFor(() => expect(document.querySelector("input[type='file']")).toBeTruthy());
+    const fileInputs = document.querySelectorAll<HTMLInputElement>("input[type='file']");
+    const file = new File(["avatar"], "avatar.png", { type: "image/png" });
+
+    await act(async () => {
+      fireEvent.change(fileInputs[0], { target: { files: [file] } });
+    });
+
+    await waitFor(() => expect(api.post).toHaveBeenCalled());
+
+    expect(await screen.findByText("Не удалось загрузить аватар", {}, { timeout: 3000 })).toBeInTheDocument();
+  });
+
+  it("uploads cover and updates preview", async () => {
+    const updatedUser = { ...baseUser, cover_url: "/media/covers/new.jpg" };
+    vi.spyOn(api, "post").mockImplementation((url: string) => {
+      if (url === "/users/me/cover") {
+        return Promise.resolve({ data: updatedUser } as any);
+      }
+      return Promise.resolve({ data: updatedUser } as any);
+    });
+    vi.spyOn(api, "get").mockResolvedValue({ data: updatedUser } as any);
+
+    const { mockSetUser } = renderSettings();
+
+    fireEvent.click(screen.getByRole("tab", { name: "Аккаунт" }));
+
+    await waitFor(() => expect(document.querySelectorAll("input[type='file']").length).toBeGreaterThan(1));
+    const fileInputs = document.querySelectorAll<HTMLInputElement>("input[type='file']");
+
+    const coverLabel = await screen.findByText("Обложка профиля");
+    const coverItem = coverLabel.closest("li") as HTMLElement;
+    const preview = coverItem.querySelector<HTMLElement>("[data-testid='settings-cover-preview']");
+    expect(preview).toBeTruthy();
+    const initialBackground = window.getComputedStyle(preview!).backgroundImage;
+
+    const file = new File(["cover"], "cover.png", { type: "image/png" });
+    await act(async () => {
+      fireEvent.change(fileInputs[1], { target: { files: [file] } });
+      await new Promise((resolve) => setTimeout(resolve, 15));
+    });
+
+    await waitFor(() => expect(api.post).toHaveBeenCalled());
+
+    await waitFor(() => expect(mockSetUser).toHaveBeenCalledWith(updatedUser));
+
+    const updatedBackground = window.getComputedStyle(preview!).backgroundImage;
+    expect(updatedBackground).toContain("v=");
+    expect(updatedBackground).not.toEqual(initialBackground);
+  });
+});

--- a/root/frontend/src/pages/__tests__/__snapshots__/Profile.nowPlaying.test.tsx.snap
+++ b/root/frontend/src/pages/__tests__/__snapshots__/Profile.nowPlaying.test.tsx.snap
@@ -1,0 +1,149 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`NowPlayingCard > matches snapshot when paused 1`] = `
+<a
+  aria-label="Открыть в Spotify: Test Track"
+  class="MuiBox-root css-1wokdvp"
+  href="https://open.spotify.com/track/play-1"
+  rel="noopener noreferrer"
+  target="_blank"
+>
+  <div
+    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 nowplaying--spotify css-1wy2kwt-MuiPaper-root"
+    style="--Paper-shadow: none; opacity: 1; transform: none;"
+    tabindex="0"
+  >
+    <div
+      class="MuiBox-root css-spixek"
+    >
+      <div
+        class="MuiAvatar-root MuiAvatar-rounded css-abauh4-MuiAvatar-root"
+      >
+        <img
+          alt="Album"
+          class="MuiAvatar-img css-1su80sj-MuiAvatar-img"
+          src="https://example.com/cover.jpg"
+        />
+      </div>
+    </div>
+    <div
+      aria-live="polite"
+      class="MuiBox-root css-wr3v6d"
+    >
+      <p
+        class="MuiTypography-root MuiTypography-body1 np-title css-7yakwh-MuiTypography-root"
+      >
+        Test Track
+      </p>
+      <p
+        class="MuiTypography-root MuiTypography-body2 np-art css-3ya38w-MuiTypography-root"
+      >
+        Tester
+      </p>
+      <div
+        aria-hidden="true"
+        class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorDefault MuiChip-filledDefault css-k6o8te-MuiChip-root"
+      >
+        <span
+          class="MuiChip-label MuiChip-labelSmall css-eccknh-MuiChip-label"
+        >
+          Пауза
+        </span>
+      </div>
+      <div
+        class="MuiBox-root css-1gj2vl9"
+      >
+        <span
+          aria-label="Прогресс трека"
+          aria-valuemax="100"
+          aria-valuemin="0"
+          aria-valuenow="17"
+          class="MuiLinearProgress-root MuiLinearProgress-colorPrimary MuiLinearProgress-determinate progress css-3yrdhv-MuiLinearProgress-root"
+          role="progressbar"
+        >
+          <span
+            class="MuiLinearProgress-bar MuiLinearProgress-bar1 MuiLinearProgress-barColorPrimary MuiLinearProgress-bar1Determinate css-l16vtb-MuiLinearProgress-bar1"
+            style="transform: translateX(-83.33333333333334%);"
+          />
+        </span>
+        <span
+          class="MuiTypography-root MuiTypography-caption np-time css-1qfol84-MuiTypography-root"
+        >
+          0:30
+           / 
+          3:00
+        </span>
+      </div>
+    </div>
+  </div>
+</a>
+`;
+
+exports[`NowPlayingCard > matches snapshot when playing 1`] = `
+<a
+  aria-label="Открыть в Spotify: Test Track"
+  class="MuiBox-root css-1wokdvp"
+  href="https://open.spotify.com/track/play-1"
+  rel="noopener noreferrer"
+  target="_blank"
+>
+  <div
+    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 nowplaying--spotify css-1wy2kwt-MuiPaper-root"
+    style="--Paper-shadow: none; opacity: 1; transform: none;"
+    tabindex="0"
+  >
+    <div
+      class="MuiBox-root css-spixek"
+    >
+      <div
+        class="MuiAvatar-root MuiAvatar-rounded css-abauh4-MuiAvatar-root"
+      >
+        <img
+          alt="Album"
+          class="MuiAvatar-img css-1su80sj-MuiAvatar-img"
+          src="https://example.com/cover.jpg"
+        />
+      </div>
+    </div>
+    <div
+      aria-live="polite"
+      class="MuiBox-root css-wr3v6d"
+    >
+      <p
+        class="MuiTypography-root MuiTypography-body1 np-title css-7yakwh-MuiTypography-root"
+      >
+        Test Track
+      </p>
+      <p
+        class="MuiTypography-root MuiTypography-body2 np-art css-3ya38w-MuiTypography-root"
+      >
+        Tester
+      </p>
+      <div
+        class="MuiBox-root css-1gj2vl9"
+      >
+        <span
+          aria-label="Прогресс трека"
+          aria-valuemax="100"
+          aria-valuemin="0"
+          aria-valuenow="17"
+          class="MuiLinearProgress-root MuiLinearProgress-colorPrimary MuiLinearProgress-determinate progress css-3yrdhv-MuiLinearProgress-root"
+          role="progressbar"
+        >
+          <span
+            class="MuiLinearProgress-bar MuiLinearProgress-bar1 MuiLinearProgress-barColorPrimary MuiLinearProgress-bar1Determinate css-l16vtb-MuiLinearProgress-bar1"
+            style="transform: translateX(-83.33333333333334%);"
+          />
+        </span>
+        <span
+          class="MuiTypography-root MuiTypography-caption np-time css-1qfol84-MuiTypography-root"
+        >
+          0:30
+           / 
+          3:00
+        </span>
+      </div>
+    </div>
+  </div>
+</a>
+`;

--- a/root/frontend/src/types/spotify.ts
+++ b/root/frontend/src/types/spotify.ts
@@ -1,13 +1,12 @@
 export type NowPlaying = {
   is_playing: boolean
-  progress_ms?: number
-  duration_ms?: number
-  track_id?: string
-  track_name?: string
-  artists?: string[]
-  album_name?: string
-  album_image_url?: string
-  track_url?: string
-  preview_url?: string
-  fetched_at: string | number | Date
+  track_id: string | null
+  track_name: string | null
+  artists: string[]
+  album_name: string | null
+  album_image_url: string | null
+  track_url: string | null
+  duration_ms: number | null
+  progress_ms: number | null
+  fetched_at?: string | number | Date | null
 }

--- a/root/frontend/src/utils/media.ts
+++ b/root/frontend/src/utils/media.ts
@@ -1,17 +1,58 @@
+const ABSOLUTE_PATTERN = /^(data:|blob:|https?:\/\/)/i
+
+const ensureOrigin = (origin?: string) => origin?.replace(/\/+$/, "") ?? ""
+
+const encodePath = (value: string) => {
+  return value
+    .split("/")
+    .map((segment) => {
+      if (!segment) return segment
+      try {
+        return encodeURIComponent(decodeURIComponent(segment))
+      } catch {
+        return encodeURIComponent(segment)
+      }
+    })
+    .join("/")
+    .replace(/\/{2,}/g, "/")
+}
+
 export function resolveMediaUrl(input?: string, backendOrigin = ""): string {
   if (!input) return ""
   const raw = String(input).trim()
-  if (/^(data:|blob:|https?:\/\/)/i.test(raw)) return raw
-  const base = backendOrigin || (typeof window !== "undefined" ? window.location.origin : "")
-  if (!base) return raw
-  if (/^\/(static|media)\//i.test(raw)) return base.replace(/\/+$/, "") + raw
+  if (!raw) return ""
+  if (ABSOLUTE_PATTERN.test(raw)) return raw
+
+  const origin = ensureOrigin(
+    backendOrigin || (typeof window !== "undefined" ? window.location.origin : "")
+  )
+
+  if (!origin) {
+    const normalized = raw.startsWith("/") ? raw : `/${raw}`
+    return encodePath(normalized)
+  }
+
   try {
-    const u = new URL(raw, base)
-    if (u.pathname.startsWith("/static/") || u.pathname.startsWith("/media/")) {
-      return u.origin + u.pathname + u.search
-    }
-    return u.toString()
+    const resolved = new URL(raw, `${origin}/`)
+    resolved.pathname = encodePath(resolved.pathname)
+    return resolved.toString()
   } catch {
-    return raw
+    const normalized = raw.replace(/^\/+/, "")
+    return `${origin}/${encodePath(normalized)}`
+  }
+}
+
+export function addVersionParam(
+  url: string | undefined,
+  version: number | string
+): string | undefined {
+  if (!url) return undefined
+  try {
+    const parsed = new URL(url)
+    parsed.searchParams.set("v", String(version))
+    return parsed.toString()
+  } catch {
+    const sep = url.includes("?") ? "&" : "?"
+    return `${url}${sep}v=${encodeURIComponent(String(version))}`
   }
 }

--- a/root/frontend/src/utils/trustedTypes.ts
+++ b/root/frontend/src/utils/trustedTypes.ts
@@ -38,9 +38,10 @@ const ensureSanitizePolicy = (win: TrustedTypesWindow): TrustedTypePolicy | null
   if (win.__ttSanitizePolicy === false) return null
   if (win.__ttSanitizePolicy) return win.__ttSanitizePolicy
   try {
-    win.__ttSanitizePolicy = win.trustedTypes.createPolicy(SANITIZE_POLICY_NAME, {
+    const policy = win.trustedTypes.createPolicy(SANITIZE_POLICY_NAME, {
       createHTML: (input: string) => DOMPurify.sanitize(input, DEFAULT_SANITIZE_CONFIG),
-    })
+    }) as TrustedTypePolicy
+    win.__ttSanitizePolicy = policy
   } catch {
     win.__ttSanitizePolicy = false
   }
@@ -54,7 +55,7 @@ const ensureAppPolicy = (win: TrustedTypesWindow): TrustedTypePolicy | null => {
   const location = win.location
   const allowed = getAllowedScriptOrigins(location)
   try {
-    win.__ttAppPolicy = win.trustedTypes.createPolicy(APP_POLICY_NAME, {
+    const policy = win.trustedTypes.createPolicy(APP_POLICY_NAME, {
       createScriptURL: (value: string) => {
         const resolved = new URL(value, location.href)
         if (!allowed.has(resolved.origin)) {
@@ -62,7 +63,8 @@ const ensureAppPolicy = (win: TrustedTypesWindow): TrustedTypePolicy | null => {
         }
         return resolved.toString()
       },
-    })
+    }) as TrustedTypePolicy
+    win.__ttAppPolicy = policy
   } catch {
     win.__ttAppPolicy = false
   }

--- a/root/frontend/vite.config.mts
+++ b/root/frontend/vite.config.mts
@@ -149,10 +149,16 @@ export default defineConfig(({ mode }) => {
           manualChunks(id) {
             const normalizedId = toPosix(id)
             for (const chunk of routeChunks) {
-              if (chunk.patterns.some((pattern) => normalizedId.startsWith(pattern))) return chunk.name
+              if (chunk.patterns.some((pattern) => normalizedId.startsWith(pattern)))
+                return chunk.name
             }
             if (!normalizedId.includes("node_modules")) return
-            const uiMatchers = [/[/\\]react(?:-dom)?[/\\]/, /[/\\]scheduler[/\\]/, /@emotion/, /@mui/] as const
+            const uiMatchers = [
+              /[/\\]react(?:-dom)?[/\\]/,
+              /[/\\]scheduler[/\\]/,
+              /@emotion/,
+              /@mui/,
+            ] as const
             if (uiMatchers.some((pattern) => pattern.test(normalizedId))) return "ui"
             if (normalizedId.includes("@tanstack")) return "react-query"
             if (normalizedId.includes("framer-motion")) return "motion"

--- a/root/frontend/vite.config.mts
+++ b/root/frontend/vite.config.mts
@@ -62,6 +62,8 @@ export default defineConfig(({ mode }) => {
   const mk = (rewrite = false) => ({
     target,
     changeOrigin: true,
+    secure: false,
+    ws: true,
     ...(rewrite ? { rewrite: (p: string) => p.replace(/^\/api/, "") } : {}),
   })
 

--- a/root/tests/test_migrations_runtime.py
+++ b/root/tests/test_migrations_runtime.py
@@ -121,8 +121,8 @@ def test_alembic_upgrade_from_multiple_heads(tmp_path):
     engine = _inspect(sync_url)
     with engine.begin() as conn:
         rows = conn.execute(version.select()).fetchall()
-    assert {row[0] for row in rows} == {"5a9d1c0a9bc1"}
-    engine.dispose()
-
     script = ScriptDirectory.from_config(config)
-    assert len(script.get_heads()) == 1
+    heads = script.get_heads()
+    assert len(heads) == 1
+    assert {row[0] for row in rows} == set(heads)
+    engine.dispose()


### PR DESCRIPTION
## Summary
- normalize Spotify now playing responses, persist cache, and refresh the profile card rendering
- harden media URL helpers and settings flows to refresh avatar/cover immediately after upload
- expand automated coverage for now playing hook, profile card, settings media actions, and auth logout

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e43cfcd9a08327b1b98f0dda9a39df