### PR TITLE
Refine navbar notifications popover

### DIFF
--- a/root/frontend/src/components/Navbar.tsx
+++ b/root/frontend/src/components/Navbar.tsx
@@ -137,7 +137,6 @@ const Navbar = () => {
       { to: "/dashboard", label: "Главная" },
       { to: "/news", label: "Новости" },
       { to: "/schedule", label: "Расписание" },
-      { to: "/notifications", label: "Уведомления" },
       { to: "/events", label: "Мероприятия" },
       { to: "/activity", label: "Активность" },
       { to: "/map", label: "Карта" }

--- a/root/frontend/src/components/NotificationsBell.tsx
+++ b/root/frontend/src/components/NotificationsBell.tsx
@@ -1,54 +1,117 @@
-import { useEffect, useMemo, useRef, useState, memo, useCallback } from "react";
-import { Badge, Box, Button, CircularProgress, Divider, IconButton, List, ListItemButton, ListItemIcon, ListItemText, Popover, Stack, Typography, Avatar, Tooltip } from "@mui/material";
-import NotificationsNoneIcon from "@mui/icons-material/NotificationsNone";
-import DoneAllIcon from "@mui/icons-material/DoneAll";
-import OpenInNewIcon from "@mui/icons-material/OpenInNew";
-import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
-import EventNoteIcon from "@mui/icons-material/EventNote";
-import ArticleIcon from "@mui/icons-material/Article";
-import FiberManualRecordIcon from "@mui/icons-material/FiberManualRecord";
-import { useNotifications } from "@/hooks/useNotifications";
-import { useNavigate } from "react-router-dom";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react"
+import {
+  Avatar,
+  Badge,
+  Box,
+  Button,
+  CircularProgress,
+  Divider,
+  IconButton,
+  List,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  Popover,
+  Stack,
+  Typography,
+} from "@mui/material"
+import NotificationsNoneIcon from "@mui/icons-material/NotificationsNone"
+import DoneAllIcon from "@mui/icons-material/DoneAll"
+import TaskAltIcon from "@mui/icons-material/TaskAlt"
+import OpenInNewIcon from "@mui/icons-material/OpenInNew"
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined"
+import EventNoteIcon from "@mui/icons-material/EventNote"
+import ArticleIcon from "@mui/icons-material/Article"
+import FiberManualRecordIcon from "@mui/icons-material/FiberManualRecord"
+import SettingsIcon from "@mui/icons-material/Settings"
+import NotificationsActiveIcon from "@mui/icons-material/NotificationsActive"
+import { useNotifications } from "@/hooks/useNotifications"
+import { usePushPreferences } from "@/hooks/usePushPreferences"
+import { useNavigate } from "react-router-dom"
 
-const rtf = new Intl.RelativeTimeFormat("ru-RU", { numeric: "auto" });
+type Notif = {
+  id: string | number
+  title: string
+  body?: string
+  type?: string
+  url?: string
+  created_at: string
+  read?: boolean
+  avatar_url?: string
+  icon?: string
+}
+
+const rtf = new Intl.RelativeTimeFormat("ru-RU", { numeric: "auto" })
 function formatRelTime(iso: string, nowMs: number) {
-  const ts = new Date(iso).getTime();
-  const diffSec = Math.round((ts - nowMs) / 1000);
-  const abs = Math.abs(diffSec);
-  if (abs < 60) return rtf.format(Math.sign(diffSec) * Math.round(abs), "second");
-  if (abs < 3600) return rtf.format(Math.sign(diffSec) * Math.round(abs / 60), "minute");
-  if (abs < 86400) return rtf.format(Math.sign(diffSec) * Math.round(abs / 3600), "hour");
-  return rtf.format(Math.sign(diffSec) * Math.round(abs / 86400), "day");
+  const ts = new Date(iso).getTime()
+  const diffSec = Math.round((ts - nowMs) / 1000)
+  const abs = Math.abs(diffSec)
+  if (abs < 60) return rtf.format(Math.sign(diffSec) * Math.round(abs), "second")
+  if (abs < 3600) return rtf.format(Math.sign(diffSec) * Math.round(abs / 60), "minute")
+  if (abs < 86400) return rtf.format(Math.sign(diffSec) * Math.round(abs / 3600), "hour")
+  return rtf.format(Math.sign(diffSec) * Math.round(abs / 86400), "day")
 }
 
 function pickIcon(t?: string) {
-  if (t === "event") return <EventNoteIcon fontSize="small" />;
-  if (t === "news") return <ArticleIcon fontSize="small" />;
-  return <InfoOutlinedIcon fontSize="small" />;
+  if (t === "event") return <EventNoteIcon fontSize="small" />
+  if (t === "news") return <ArticleIcon fontSize="small" />
+  return <InfoOutlinedIcon fontSize="small" />
 }
 
-type Notif = { id: string | number; title: string; body?: string; type?: string; url?: string; created_at: string; read?: boolean; avatar_url?: string; icon?: string; };
-
 const TimeAgo = memo(function TimeAgo({ date }: { date: string }) {
-  const [, setTick] = useState(0);
+  const [, setTick] = useState(0)
   useEffect(() => {
-    const id = setInterval(() => setTick((x) => x + 1), 30000);
-    return () => clearInterval(id);
-  }, []);
-  const now = Date.now();
-  return <>{formatRelTime(date, now)}</>;
-});
+    const id = setInterval(() => setTick((x) => x + 1), 30000)
+    return () => clearInterval(id)
+  }, [])
+  const now = Date.now()
+  return <>{formatRelTime(date, now)}</>
+})
 
-const NotificationItem = memo(function NotificationItem({ n, onOpen }: { n: Notif; onOpen: (n: Notif, e: React.MouseEvent | React.KeyboardEvent) => void; }) {
-  const unreadDot = !n.read ? <FiberManualRecordIcon sx={{ fontSize: 10, color: "var(--nav-link)" }} /> : null;
-  const leading = n.avatar_url ? <Avatar src={n.avatar_url} alt="" imgProps={{ loading: "lazy", referrerPolicy: "no-referrer" }} sx={{ width: 28, height: 28 }} /> : pickIcon(n.type);
+const NotificationItem = memo(function NotificationItem({
+  n,
+  onOpen,
+  onFocus,
+  isActive,
+}: {
+  n: Notif
+  onOpen: (n: Notif, e: React.MouseEvent | React.KeyboardEvent) => void
+  onFocus: (n: Notif) => void
+  isActive: boolean
+}) {
+  const unreadDot = !n.read ? <FiberManualRecordIcon sx={{ fontSize: 10, color: "var(--nav-link)" }} /> : null
+  const leading = n.avatar_url ? (
+    <Avatar src={n.avatar_url} alt="" imgProps={{ loading: "lazy", referrerPolicy: "no-referrer" }} sx={{ width: 28, height: 28 }} />
+  ) : (
+    pickIcon(n.type)
+  )
+
   return (
     <ListItemButton
       role="listitem"
+      data-notification-id={String(n.id)}
       onClick={(e) => onOpen(n, e)}
-      onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onOpen(n, e); } }}
-      selected={!n.read}
-      sx={{ alignItems: "flex-start", gap: 1, py: 1, opacity: n.read ? 0.75 : 1, "&:hover": { opacity: 1 } }}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault()
+          onOpen(n, e)
+        }
+      }}
+      onFocus={() => onFocus(n)}
+      onMouseEnter={() => onFocus(n)}
+      selected={isActive}
+      sx={(theme) => ({
+        alignItems: "flex-start",
+        gap: 1,
+        py: 1,
+        opacity: n.read ? 0.78 : 1,
+        backgroundColor: !n.read ? theme.palette.action.hover : undefined,
+        "&:hover": { opacity: 1 },
+        "&.Mui-selected": {
+          backgroundColor: theme.palette.action.selected,
+          opacity: 1,
+        },
+      })}
       aria-label={n.title}
     >
       <ListItemIcon sx={{ minWidth: 34, mt: 0.2 }}>{leading}</ListItemIcon>
@@ -61,93 +124,242 @@ const NotificationItem = memo(function NotificationItem({ n, onOpen }: { n: Noti
         }
         secondary={
           <Stack direction="row" spacing={1} alignItems="center">
-            {n.body && <Typography variant="body2" color="text.secondary" sx={{ display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden" }}>{n.body}</Typography>}
+            {n.body && (
+              <Typography
+                variant="body2"
+                color="text.secondary"
+                sx={{ display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden" }}
+              >
+                {n.body}
+              </Typography>
+            )}
             {n.url && <OpenInNewIcon fontSize="inherit" />}
           </Stack>
         }
       />
-      <Typography variant="caption" sx={{ whiteSpace: "nowrap", ml: 1 }} title={new Date(n.created_at).toLocaleString()}><TimeAgo date={n.created_at} /></Typography>
+      <Typography variant="caption" sx={{ whiteSpace: "nowrap", ml: 1 }} title={new Date(n.created_at).toLocaleString()}>
+        <TimeAgo date={n.created_at} />
+      </Typography>
     </ListItemButton>
-  );
-});
+  )
+})
+
+function PushSettingsPreview({ onOpenSettings }: { onOpenSettings: () => void }) {
+  const {
+    pushSupported,
+    notificationsEnabled,
+    pushBusy,
+    pushInitializing,
+    permissionText,
+    enableNotifications,
+    disableNotifications,
+  } = usePushPreferences()
+
+  const busy = pushBusy || pushInitializing
+
+  const statusText = useMemo(() => {
+    if (!pushSupported) return "Веб push-уведомления недоступны в этом браузере."
+    if (notificationsEnabled) return "Пуш-уведомления включены."
+    return `Разрешение браузера: ${permissionText}.`
+  }, [notificationsEnabled, permissionText, pushSupported])
+
+  const hintText = useMemo(() => {
+    if (!pushSupported) {
+      return "Попробуйте открыть Экосистему ГУУ в другом браузере или установите приложение."
+    }
+    if (notificationsEnabled) {
+      return "Отключить уведомления можно здесь или в настройках браузера."
+    }
+    return "Разрешите уведомления, чтобы получать новости и изменения сразу."
+  }, [notificationsEnabled, pushSupported])
+
+  const handleToggle = useCallback(async () => {
+    if (!pushSupported) return
+    if (notificationsEnabled) {
+      await disableNotifications()
+    } else {
+      await enableNotifications()
+    }
+  }, [disableNotifications, enableNotifications, notificationsEnabled, pushSupported])
+
+  return (
+    <Stack spacing={1.2}>
+      <Stack direction="row" alignItems="center" spacing={1}>
+        <NotificationsActiveIcon fontSize="small" color={notificationsEnabled ? "primary" : "disabled"} />
+        <Typography variant="subtitle2" fontWeight={700} component="h3">
+          Настройки пушей
+        </Typography>
+      </Stack>
+      <Typography variant="body2" color="text.secondary">
+        {statusText}
+      </Typography>
+      <Typography variant="caption" color="text.secondary">
+        {hintText}
+      </Typography>
+      <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
+        {pushSupported && (
+          <Button
+            size="small"
+            variant={notificationsEnabled ? "outlined" : "contained"}
+            onClick={() => {
+              void handleToggle()
+            }}
+            disabled={busy}
+            startIcon={busy ? <CircularProgress size={16} sx={{ color: "inherit" }} /> : undefined}
+          >
+            {notificationsEnabled ? "Выключить" : "Включить"}
+          </Button>
+        )}
+        <Button
+          size="small"
+          variant="text"
+          onClick={onOpenSettings}
+          startIcon={<SettingsIcon fontSize="small" />}
+        >
+          Подробнее
+        </Button>
+      </Stack>
+    </Stack>
+  )
+}
 
 export default function NotificationsBell({ iconColor = "inherit" }: { iconColor?: string }) {
-  const { items, loading, unreadCount, hasMore, loadMore, markRead, markAllRead } = useNotifications();
-  const [open, setOpen] = useState(false);
-  const anchorRef = useRef<HTMLButtonElement | null>(null);
-  const listRef = useRef<HTMLUListElement | null>(null);
-  const scrollBoxRef = useRef<HTMLDivElement | null>(null);
-  const navigate = useNavigate();
-  const [loadingMore, setLoadingMore] = useState(false);
-  const popoverId = "notifications-popover";
-  const titleId = "notifications-title";
-  const sentinelRef = useRef<HTMLDivElement | null>(null);
+  const {
+    items,
+    loading,
+    unreadCount,
+    hasMore,
+    loadMore,
+    markRead,
+    markAllRead,
+    loadingMore,
+  } = useNotifications()
+  const [open, setOpen] = useState(false)
+  const [selectedId, setSelectedId] = useState<number | string | null>(null)
+  const anchorRef = useRef<HTMLButtonElement | null>(null)
+  const listRef = useRef<HTMLUListElement | null>(null)
+  const scrollBoxRef = useRef<HTMLDivElement | null>(null)
+  const sentinelRef = useRef<HTMLDivElement | null>(null)
+  const navigate = useNavigate()
+  const popoverId = "notifications-popover"
+  const titleId = "notifications-title"
 
   useEffect(() => {
-    if (!open) return;
-    if (!hasMore) return;
-    const el = sentinelRef.current;
-    if (!el) return;
+    if (!open) return
+    if (!hasMore) return
+    const el = sentinelRef.current
+    if (!el) return
     const io = new IntersectionObserver(
       (entries) => {
-        const vis = entries.some((e) => e.isIntersecting);
-        if (vis && !loadingMore) {
-          setLoadingMore(true);
-          Promise.resolve(loadMore()).finally(() => setLoadingMore(false));
-        }
+        const vis = entries.some((entry) => entry.isIntersecting)
+        if (!vis || loadingMore) return
+        void loadMore()
       },
-      { root: scrollBoxRef.current, rootMargin: "100px 0px", threshold: 0.01 }
-    );
-    io.observe(el);
-    return () => io.disconnect();
-  }, [open, hasMore, loadMore, loadingMore]);
+      { root: scrollBoxRef.current, rootMargin: "120px 0px", threshold: 0.01 },
+    )
+    io.observe(el)
+    return () => io.disconnect()
+  }, [open, hasMore, loadMore, loadingMore])
 
   useEffect(() => {
-    if (!open) return;
-    const t = setTimeout(() => {
-      const first = listRef.current?.querySelector<HTMLElement>('[role="button"],[tabindex],button,a,[href],input,select,textarea');
-      first?.focus();
-    }, 10);
-    return () => clearTimeout(t);
-  }, [open]);
+    if (!open) return
+    const timer = setTimeout(() => {
+      const first = listRef.current?.querySelector<HTMLElement>("[data-notification-id]")
+      first?.focus()
+    }, 20)
+    return () => clearTimeout(timer)
+  }, [open, items.length])
 
   useEffect(() => {
-    const sw = navigator.serviceWorker;
-    if (!sw) return;
-    const onMsg = (e: MessageEvent) => {
-      const data = e.data || {};
-      if (data.type === "NOTIFICATION_MARK_READ" && data.id != null) {
-        try { markRead(data.id); } catch {}
-      }
-      if (data.type === "PUSH_NOTIFICATION") {
-        try { if ("setAppBadge" in navigator && typeof (navigator as any).setAppBadge === "function") {} } catch {}
-      }
-    };
-    sw.addEventListener("message", onMsg);
-    return () => sw.removeEventListener("message", onMsg);
-  }, [markRead]);
-
-  const handleOpenItem = useCallback((n: Notif, e: React.MouseEvent | React.KeyboardEvent) => {
-    markRead(n.id);
-    if (!n.url) { setOpen(false); return; }
-    const isExternal = /^https?:\/\//i.test(n.url);
-    const mouse = e as React.MouseEvent;
-    const kb = e as React.KeyboardEvent;
-    const isMiddle = (mouse as any).button === 1;
-    const newTab = mouse.ctrlKey || mouse.metaKey || isMiddle;
-    if (isExternal) {
-      if (newTab) window.open(n.url, "_blank", "noopener,noreferrer");
-      else window.open(n.url, "_self");
-    } else {
-      if (newTab) window.open(n.url, "_blank");
-      else navigate(n.url);
+    if (!open) {
+      setSelectedId(null)
+      return
     }
-    setOpen(false);
-  }, [markRead, navigate]);
+    setSelectedId((prev) => {
+      if (prev != null && items.some((item) => item.id === prev)) return prev
+      const next = items.find((item) => !item.read) ?? items[0]
+      return next?.id ?? null
+    })
+  }, [items, open])
 
-  const content = useMemo(() => {
+  const handleOpenItem = useCallback(
+    (n: Notif, e: React.MouseEvent | React.KeyboardEvent) => {
+      void markRead(n.id)
+      if (!n.url) {
+        setOpen(false)
+        return
+      }
+      const isExternal = /^https?:\/\//i.test(n.url)
+      const mouse = e as React.MouseEvent
+      const isMiddle = (mouse as any).button === 1
+      const newTab = mouse.ctrlKey || mouse.metaKey || isMiddle
+      if (isExternal) {
+        if (newTab) window.open(n.url, "_blank", "noopener,noreferrer")
+        else window.open(n.url, "_self")
+      } else {
+        if (newTab) window.open(n.url, "_blank")
+        else navigate(n.url)
+      }
+      setOpen(false)
+    },
+    [markRead, navigate],
+  )
+
+  const handleFocusItem = useCallback((n: Notif) => {
+    setSelectedId(n.id)
+  }, [])
+
+  const handleListKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLUListElement>) => {
+      if (event.key !== "ArrowDown" && event.key !== "ArrowUp") return
+      if (!items.length) return
+      event.preventDefault()
+      const dir = event.key === "ArrowDown" ? 1 : -1
+      const currentIndex = selectedId != null ? items.findIndex((item) => item.id === selectedId) : -1
+      let nextIndex = currentIndex + dir
+      if (nextIndex < 0) nextIndex = items.length - 1
+      if (nextIndex >= items.length) nextIndex = 0
+      const next = items[nextIndex]
+      if (next) {
+        setSelectedId(next.id)
+        const el = listRef.current?.querySelector<HTMLElement>(`[data-notification-id="${next.id}"]`)
+        el?.focus()
+      }
+    },
+    [items, selectedId],
+  )
+
+  const selectedNotification = useMemo(() => {
+    if (selectedId == null) return undefined
+    return items.find((item) => item.id === selectedId)
+  }, [items, selectedId])
+
+  const handleMarkSelected = useCallback(() => {
+    if (!selectedNotification || selectedNotification.read) return
+    void markRead(selectedNotification.id)
+  }, [markRead, selectedNotification])
+
+  const handleMarkAll = useCallback(() => {
+    void markAllRead()
+  }, [markAllRead])
+
+  const handleOpenSettings = useCallback(() => {
+    setOpen(false)
+    navigate("/settings")
+  }, [navigate])
+
+  const handleOpenCenter = useCallback(() => {
+    setOpen(false)
+    navigate("/notifications")
+  }, [navigate])
+
+  const renderList = () => {
     if (loading && !items.length) {
-      return <Stack alignItems="center" justifyContent="center" sx={{ py: 3 }}><CircularProgress size={26} /></Stack>;
+      return (
+        <Stack alignItems="center" justifyContent="center" sx={{ py: 3 }}>
+          <CircularProgress size={26} />
+        </Stack>
+      )
     }
     if (items.length === 0) {
       return (
@@ -155,28 +367,39 @@ export default function NotificationsBell({ iconColor = "inherit" }: { iconColor
           <NotificationsNoneIcon />
           <Typography mt={1}>Здесь пока пусто</Typography>
         </Stack>
-      );
+      )
     }
     return (
       <>
-        <List ref={listRef} disablePadding role="list" aria-labelledby={titleId} sx={{ py: 0 }}>
+        <List
+          ref={listRef}
+          disablePadding
+          role="list"
+          aria-labelledby={titleId}
+          sx={{ py: 0 }}
+          onKeyDown={handleListKeyDown}
+        >
           {items.map((n) => (
-            <NotificationItem key={n.id} n={n} onOpen={handleOpenItem} />
+            <NotificationItem key={n.id} n={n} onOpen={handleOpenItem} onFocus={handleFocusItem} isActive={selectedId === n.id} />
           ))}
         </List>
         {(hasMore || loadingMore) && (
           <Box sx={{ p: 1.2 }}>
             {loadingMore ? (
-              <Stack alignItems="center" sx={{ py: 1 }}><CircularProgress size={22} /></Stack>
+              <Stack alignItems="center" sx={{ py: 1 }}>
+                <CircularProgress size={22} />
+              </Stack>
             ) : (
-              <Button fullWidth variant="outlined" onClick={loadMore} aria-busy={loadingMore}>Показать ещё</Button>
+              <Button fullWidth variant="outlined" onClick={() => void loadMore()} aria-busy={loadingMore}>
+                Показать ещё
+              </Button>
             )}
             <div ref={sentinelRef} aria-hidden="true" style={{ height: 1 }} />
           </Box>
         )}
       </>
-    );
-  }, [items, loading, hasMore, loadingMore, loadMore, handleOpenItem]);
+    )
+  }
 
   return (
     <>
@@ -201,37 +424,78 @@ export default function NotificationsBell({ iconColor = "inherit" }: { iconColor
         anchorEl={anchorRef.current}
         anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
         transformOrigin={{ vertical: "top", horizontal: "center" }}
-        PaperProps={{ role: "dialog", "aria-modal": "true", "aria-labelledby": titleId, sx: { width: 380, maxWidth: "92vw", bgcolor: "var(--card-bg)" } }}
+        PaperProps={{
+          role: "dialog",
+          "aria-modal": "true",
+          "aria-labelledby": titleId,
+          sx: { width: 400, maxWidth: "92vw", bgcolor: "var(--card-bg)" },
+        }}
         disableRestoreFocus={false}
       >
-        <Box sx={{ p: 1.2 }}>
-          <Stack direction="row" alignItems="center" justifyContent="space-between">
-            <Typography id={titleId} fontWeight={800}>Уведомления</Typography>
-            <Tooltip title="Отметить все как прочитанные">
-              <span>
-                <Button size="small" startIcon={<DoneAllIcon />} onClick={markAllRead} disabled={!unreadCount} aria-disabled={!unreadCount}>
-                  Прочитаны
-                </Button>
-              </span>
-            </Tooltip>
+        <Box sx={{ p: 1.5 }}>
+          <Stack spacing={0.5}>
+            <Typography id={titleId} fontWeight={800} fontSize="1rem">
+              Уведомления
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              {unreadCount > 0 ? `Непрочитанных: ${unreadCount}` : "Все уведомления прочитаны."}
+            </Typography>
           </Stack>
         </Box>
         <Divider />
-        <Box ref={scrollBoxRef} sx={{ maxHeight: 444, overflow: "auto" }}>{content}</Box>
+        <Box sx={{ px: 1.5, py: 1 }}>
+          <Stack direction={{ xs: "column", sm: "row" }} spacing={1} alignItems={{ sm: "stretch" }}>
+            <Button
+              variant="outlined"
+              size="small"
+              startIcon={<TaskAltIcon fontSize="small" />}
+              onClick={handleMarkSelected}
+              disabled={!selectedNotification || selectedNotification.read}
+            >
+              Пометить прочитанным
+            </Button>
+            <Button
+              variant="outlined"
+              size="small"
+              startIcon={<DoneAllIcon fontSize="small" />}
+              onClick={handleMarkAll}
+              disabled={unreadCount === 0}
+            >
+              Пометить все прочитанными
+            </Button>
+            <Button
+              variant="outlined"
+              size="small"
+              startIcon={<SettingsIcon fontSize="small" />}
+              onClick={handleOpenSettings}
+            >
+              Открыть настройки уведомлений
+            </Button>
+          </Stack>
+        </Box>
+        <Divider />
+        <Box ref={scrollBoxRef} sx={{ maxHeight: 444, overflow: "auto" }}>
+          {renderList()}
+        </Box>
         <Divider />
         <Box sx={{ p: 1 }}>
           <Button
             fullWidth
             variant="text"
-            onClick={() => {
-              setOpen(false)
-              navigate("/notifications")
-            }}
+            onClick={handleOpenCenter}
           >
             Открыть центр уведомлений
           </Button>
         </Box>
+        {open && (
+          <>
+            <Divider />
+            <Box sx={{ px: 1.5, py: 1.5 }}>
+              <PushSettingsPreview onOpenSettings={handleOpenSettings} />
+            </Box>
+          </>
+        )}
       </Popover>
     </>
-  );
+  )
 }

--- a/root/frontend/src/hooks/useNotifications.ts
+++ b/root/frontend/src/hooks/useNotifications.ts
@@ -1,27 +1,37 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo } from "react"
+import {
+  type InfiniteData,
+  useInfiniteQuery,
+  useMutation,
+  useQueryClient,
+} from "@tanstack/react-query"
 import {
   fetchNotifications,
   markAllNotificationsRead,
   markNotificationRead,
   type NotificationListResponse,
-} from "@/api/notifications";
+} from "@/api/notifications"
 
 export type AppNotification = {
-  id: number | string;
-  title: string;
-  body?: string;
-  type?: string;
-  url?: string;
-  created_at: string;
-  read: boolean;
-  read_at?: string;
-  avatar_url?: string;
-  icon?: string;
-};
+  id: number | string
+  title: string
+  body?: string
+  type?: string
+  url?: string
+  created_at: string
+  read: boolean
+  read_at?: string
+  avatar_url?: string
+  icon?: string
+}
 
-const PAGE_SIZE = 20;
+const PAGE_SIZE = 20
 
-type LoadMode = "reset" | "append";
+export const notificationsQueryKey = ["notifications", "list"] as const
+
+type NotificationsInfiniteData = InfiniteData<NotificationListResponse, string | null>
+
+type LoadMode = "reset" | "append"
 
 function normalizeItem(item: NotificationListResponse["items"][number]): AppNotification {
   return {
@@ -33,168 +43,265 @@ function normalizeItem(item: NotificationListResponse["items"][number]): AppNoti
     created_at: item.created_at,
     read: Boolean(item.read),
     read_at: item.read_at ?? undefined,
-  };
+  }
+}
+
+function markItemReadInCache(
+  data: NotificationsInfiniteData | undefined,
+  id: number | string,
+  iso: string,
+): NotificationsInfiniteData | undefined {
+  if (!data) return data
+
+  let mutated = false
+  let decremented = false
+
+  const pages = data.pages.map(page => {
+    const index = page.items.findIndex(item => item.id === Number(id))
+    if (index === -1) return page
+
+    const original = page.items[index]
+    const wasUnread = !original.read
+    const nextItem = {
+      ...original,
+      read: true,
+      read_at: original.read_at ?? iso,
+    }
+
+    const unread_count =
+      wasUnread && !decremented ? Math.max(0, (page.unread_count ?? 0) - 1) : page.unread_count
+    if (wasUnread && !decremented) decremented = true
+
+    mutated = mutated || wasUnread || original.read_at == null
+
+    const nextItems = page.items.slice()
+    nextItems[index] = nextItem
+
+    return {
+      ...page,
+      unread_count,
+      items: nextItems,
+    }
+  })
+
+  if (!mutated) return data
+
+  return {
+    ...data,
+    pages,
+  }
+}
+
+function markAllReadInCache(
+  data: NotificationsInfiniteData | undefined,
+  iso: string,
+): NotificationsInfiniteData | undefined {
+  if (!data) return data
+
+  let mutated = false
+
+  const pages = data.pages.map(page => {
+    let changed = false
+    const nextItems = page.items.map(item => {
+      if (!item.read || !item.read_at) {
+        changed = true
+        return {
+          ...item,
+          read: true,
+          read_at: item.read_at ?? iso,
+        }
+      }
+      return item
+    })
+
+    if (!changed && (page.unread_count ?? 0) === 0) {
+      return page
+    }
+
+    mutated = mutated || changed || (page.unread_count ?? 0) > 0
+
+    return {
+      ...page,
+      unread_count: 0,
+      items: changed ? nextItems : page.items,
+    }
+  })
+
+  if (!mutated) return data
+
+  return {
+    ...data,
+    pages,
+  }
 }
 
 export function useNotifications() {
-  const [items, setItems] = useState<AppNotification[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [fetching, setFetching] = useState(false);
-  const [initialized, setInitialized] = useState(false);
-  const [hasMore, setHasMore] = useState(false);
-  const unreadFromServer = useRef(0);
-  const seenIds = useRef<Set<string | number>>(new Set());
-  const nextCursorRef = useRef<string | null>(null);
-  const loadingRef = useRef(false);
-  const hasMoreRef = useRef(false);
-  const initializedRef = useRef(false);
+  const queryClient = useQueryClient()
+
+  const query = useInfiniteQuery({
+    queryKey: notificationsQueryKey,
+    queryFn: async ({ pageParam }) =>
+      fetchNotifications({ limit: PAGE_SIZE, cursor: pageParam ?? null }),
+    initialPageParam: null as string | null,
+    getNextPageParam: lastPage =>
+      lastPage.has_more ? lastPage.next_cursor ?? undefined : undefined,
+  })
+
+  const {
+    data,
+    isLoading,
+    isFetching,
+    isFetchingNextPage,
+    hasNextPage,
+    fetchNextPage,
+    refetch,
+  } = query
+
+  const items = useMemo(() => {
+    if (!data) return [] as AppNotification[]
+    return data.pages.flatMap(page => page.items.map(normalizeItem))
+  }, [data])
 
   const unreadCount = useMemo(() => {
-    const local = items.reduce((acc, n) => acc + (n.read ? 0 : 1), 0);
-    return Math.max(local, unreadFromServer.current);
-  }, [items]);
+    const fromItems = items.reduce((acc, item) => acc + (item.read ? 0 : 1), 0)
+    const fromServer =
+      data?.pages.reduce((max, page) => Math.max(max, page.unread_count ?? 0), 0) ?? 0
+    return Math.max(fromItems, fromServer)
+  }, [data, items])
 
-  const load = useCallback(async (mode: LoadMode = "reset") => {
-    if (mode === "append" && (loadingRef.current || !hasMoreRef.current)) {
-      return;
-    }
-
-    loadingRef.current = true;
-    setFetching(true);
-    const showLoader = !initializedRef.current || mode === "reset";
-    if (showLoader) {
-      setLoading(true);
-    }
-
-    try {
-      const cursor = mode === "append" ? nextCursorRef.current : null;
-      const page = await fetchNotifications({ limit: PAGE_SIZE, cursor });
-      unreadFromServer.current = page.unread_count ?? 0;
-      setHasMore(Boolean(page.has_more));
-      hasMoreRef.current = Boolean(page.has_more);
-      nextCursorRef.current = page.next_cursor ?? null;
-
-      const mapped = page.items.map(normalizeItem);
-
-      setItems(prev => {
-        if (mode === "reset") {
-          seenIds.current = new Set();
-        }
-
-        const map = new Map<string | number, AppNotification>();
-        if (mode !== "reset") {
-          for (const it of prev) {
-            map.set(it.id, it);
-          }
-        }
-
-        for (const it of mapped) {
-          map.set(it.id, it);
-          seenIds.current.add(it.id);
-        }
-
-        const next = Array.from(map.values());
-        next.sort((a, b) => {
-          const diff = new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
-          if (diff !== 0) return diff;
-          const aId = typeof a.id === "number" ? a.id : Number.parseInt(String(a.id), 10);
-          const bId = typeof b.id === "number" ? b.id : Number.parseInt(String(b.id), 10);
-          if (Number.isFinite(aId) && Number.isFinite(bId)) return bId - aId;
-          return String(b.id).localeCompare(String(a.id));
-        });
-        return next;
-      });
-    } catch (error) {
-      console.error("Failed to load notifications", error);
+  const load = useCallback(
+    async (mode: LoadMode = "reset") => {
       if (mode === "append") {
-        setHasMore(false);
-        hasMoreRef.current = false;
+        if (!hasNextPage) return
+        await fetchNextPage()
+        return
       }
-    } finally {
-      loadingRef.current = false;
-      setFetching(false);
-      if (showLoader) {
-        setLoading(false);
-      }
-      if (!initializedRef.current) {
-        initializedRef.current = true;
-        setInitialized(true);
-      }
-    }
-  }, []);
+      await refetch()
+    },
+    [fetchNextPage, hasNextPage, refetch],
+  )
 
-  const loadMore = useCallback(async () => {
-    await load("append");
-  }, [load]);
+  const markReadMutation = useMutation({
+    mutationFn: async ({ id }: { id: number; iso: string }) => {
+      await markNotificationRead(id)
+    },
+    onMutate: async ({ id, iso }: { id: number; iso: string }) => {
+      await queryClient.cancelQueries({ queryKey: notificationsQueryKey })
+      const previous = queryClient.getQueryData<NotificationsInfiniteData>(notificationsQueryKey)
 
-  const markRead = useCallback(async (id: number | string) => {
-    const nowIso = new Date().toISOString();
-    setItems(prev =>
-      prev.map(n => (n.id === id ? { ...n, read: true, read_at: n.read_at ?? nowIso } : n))
-    );
-    if (unreadFromServer.current > 0) unreadFromServer.current -= 1;
-    if (typeof id === "number") {
-      try {
-        await markNotificationRead(id);
-      } catch (error) {
-        console.error("Failed to mark notification read", error);
+      queryClient.setQueryData(
+        notificationsQueryKey,
+        (current: NotificationsInfiniteData | undefined) => markItemReadInCache(current, id, iso),
+      )
+
+      return { previous }
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(notificationsQueryKey, context.previous)
       }
-    }
-  }, []);
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: notificationsQueryKey })
+    },
+  })
+
+  const markAllMutation = useMutation({
+    mutationFn: async () => {
+      await markAllNotificationsRead()
+    },
+    onMutate: async () => {
+      await queryClient.cancelQueries({ queryKey: notificationsQueryKey })
+      const previous = queryClient.getQueryData<NotificationsInfiniteData>(notificationsQueryKey)
+      const iso = new Date().toISOString()
+      queryClient.setQueryData(
+        notificationsQueryKey,
+        (current: NotificationsInfiniteData | undefined) => markAllReadInCache(current, iso),
+      )
+      return { previous }
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(notificationsQueryKey, context.previous)
+      }
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: notificationsQueryKey })
+    },
+  })
+
+  const markRead = useCallback(
+    async (id: number | string) => {
+      const parsed = Number(id)
+      const iso = new Date().toISOString()
+
+      if (Number.isFinite(parsed)) {
+        await markReadMutation.mutateAsync({ id: parsed, iso })
+      } else {
+        queryClient.setQueryData(
+          notificationsQueryKey,
+          (current: NotificationsInfiniteData | undefined) => markItemReadInCache(current, id, iso),
+        )
+        void queryClient.invalidateQueries({ queryKey: notificationsQueryKey })
+      }
+    },
+    [markReadMutation, queryClient],
+  )
 
   const markAllRead = useCallback(async () => {
-    const nowIso = new Date().toISOString();
-    setItems(prev => prev.map(n => ({ ...n, read: true, read_at: n.read_at ?? nowIso })));
-    unreadFromServer.current = 0;
-    try {
-      await markAllNotificationsRead();
-    } catch (error) {
-      console.error("Failed to mark all notifications read", error);
-    }
-  }, []);
+    await markAllMutation.mutateAsync()
+  }, [markAllMutation])
+
+  const loadMore = useCallback(async () => {
+    await load("append")
+  }, [load])
 
   const refresh = useCallback(async () => {
-    await load("reset");
-  }, [load]);
+    await load("reset")
+  }, [load])
 
   useEffect(() => {
-    void load("reset");
-  }, [load]);
+    if (!("serviceWorker" in navigator)) return
 
-  useEffect(() => {
-    if ("setAppBadge" in navigator) {
-      try {
-        const nav: any = navigator;
-        if (unreadCount > 0) nav.setAppBadge(unreadCount);
-        else nav.clearAppBadge?.();
-      } catch {}
-    }
-  }, [unreadCount]);
-
-  useEffect(() => {
-    if (!("serviceWorker" in navigator)) return;
-    const onMsg = (e: MessageEvent) => {
-      const msg: any = e.data ?? {};
+    const onMessage = (event: MessageEvent) => {
+      const msg: any = event.data ?? {}
       if (msg?.type === "PUSH_NOTIFICATION") {
-        void refresh();
+        void queryClient.invalidateQueries({ queryKey: notificationsQueryKey })
+        return
       }
       if (msg?.type === "NOTIFICATION_MARK_READ" && msg.id != null) {
-        void markRead(msg.id);
+        const iso = new Date().toISOString()
+        queryClient.setQueryData(
+          notificationsQueryKey,
+          (current: NotificationsInfiniteData | undefined) => markItemReadInCache(current, msg.id, iso),
+        )
+        return
       }
-    };
-    navigator.serviceWorker.addEventListener("message", onMsg);
-    return () => navigator.serviceWorker.removeEventListener("message", onMsg);
-  }, [markRead, refresh]);
+    }
+
+    navigator.serviceWorker.addEventListener("message", onMessage)
+    return () => navigator.serviceWorker.removeEventListener("message", onMessage)
+  }, [queryClient])
+
+  useEffect(() => {
+    if (!("setAppBadge" in navigator)) return
+    try {
+      const nav: any = navigator
+      if (unreadCount > 0) nav.setAppBadge?.(unreadCount)
+      else nav.clearAppBadge?.()
+    } catch {}
+  }, [unreadCount])
 
   return {
     items,
-    loading: loading && !initialized,
+    loading: isLoading,
     unreadCount,
-    hasMore,
+    hasMore: Boolean(hasNextPage),
     loadMore,
     markRead,
     markAllRead,
     refresh,
-    fetching,
-  };
+    fetching: isFetching,
+    loadingMore: isFetchingNextPage,
+  }
 }


### PR DESCRIPTION
## Summary
- migrate the notifications hook to TanStack Query with optimistic updates and cache invalidation
- redesign the navbar bell popover with inline actions, push settings preview, and remove the old notifications menu link
- keep unread counts in sync across the bell, badge, and actions while preserving infinite scroll behaviour

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e45f52f0208327995466fa70d80a48