### PR TITLE
Complete end-to-end web push integration

### DIFF
--- a/root/app/main.py
+++ b/root/app/main.py
@@ -17,7 +17,8 @@ from app.core.observability import configure_observability, shutdown_observabili
 from app.core.rate_limit import RateLimitMiddleware
 from app.core.security_headers import SecurityHeadersMiddleware
 from app.deps.cache import shutdown_cache
-from app.routers.notifications import router as webpush_router
+from app.routers.notifications import legacy_router as legacy_push_router
+from app.routers.notifications import router as push_router
 from app.routers.schedule import router as schedule_router
 from app.services.notifications import start_notifications_scheduler
 
@@ -111,6 +112,7 @@ async def ready():
 app.include_router(auth_router)
 app.include_router(spotify_router)
 app.include_router(notifications_router)
-app.include_router(webpush_router)
+app.include_router(push_router)
+app.include_router(legacy_push_router)
 app.include_router(schedule_router)
 app.include_router(main_router)

--- a/root/app/routers/notifications.py
+++ b/root/app/routers/notifications.py
@@ -15,6 +15,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.api.deps import get_current_user
+from app.api.push import NotifyBody
 from app.core.config import settings
 from app.core.database import get_db
 from app.core.rate_limit import RateLimitExceeded, RateLimitInfo, enforce_rate_limit
@@ -30,7 +31,8 @@ from app.services.webpush import WebPushResult, send_web_push
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/webpush", tags=["webpush"])
+router = APIRouter(prefix="/push", tags=["push"])
+legacy_router = APIRouter(prefix="/webpush", tags=["webpush"])
 
 
 class PushSubscriptionKeys(BaseModel):
@@ -77,6 +79,7 @@ class PushSubscriptionOut(BaseModel):
     created_at: datetime
     user_agent: str | None = None
     last_seen_at: datetime | None = None
+    updated_at: datetime | None = None
     topics: list[str] = Field(default_factory=list)
 
     model_config = ConfigDict(from_attributes=True)
@@ -89,6 +92,23 @@ class PushSubscriptionOut(BaseModel):
         if isinstance(value, list):
             return normalize_topics(value)
         return value
+
+
+def _serialize_subscription(subscription: PushSubscription) -> PushSubscriptionOut:
+    topics = normalize_topics(subscription.topics or [])
+    data = {
+        "id": subscription.id,
+        "user_id": subscription.user_id,
+        "endpoint": subscription.endpoint,
+        "p256dh": subscription.p256dh,
+        "auth": subscription.auth,
+        "created_at": subscription.created_at,
+        "user_agent": subscription.user_agent,
+        "last_seen_at": subscription.last_seen_at,
+        "updated_at": subscription.last_seen_at,
+        "topics": topics,
+    }
+    return PushSubscriptionOut.model_validate(data)
 
 
 class PushSubscriptionTopicsUpdate(BaseModel):
@@ -126,6 +146,23 @@ class SendTestResponse(BaseModel):
     removed: int
     failed: int
     detail: str | None = None
+
+
+class PushTestRequest(NotifyBody):
+    user_id: int | None = Field(
+        default=None, description="Target user id for testing", ge=1
+    )
+    title: str = Field(
+        default="Тестовое веб-push уведомление",
+        description="Notification title",
+    )
+    body: str | None = Field(
+        default="Проверка доставки уведомлений",
+        description="Notification body",
+    )
+    url: str | None = Field(
+        default=None, description="URL to open when clicking the notification"
+    )
 
 
 async def _validate_subscription_payload(
@@ -169,6 +206,35 @@ async def subscribe(
     user: Annotated[User, Depends(get_current_user)],
 ) -> PushSubscriptionOut:
     endpoint, p256dh, auth = await _validate_subscription_payload(payload)
+
+    client_host = request.client.host if request.client else None
+    try:
+        await enforce_rate_limit(
+            identifier=f"user:{user.id}",
+            namespace="push:subscribe:user",
+            limit=20,
+            window_seconds=60,
+            redis_url=settings.rate_limit_storage_uri,
+        )
+        if client_host:
+            await enforce_rate_limit(
+                identifier=f"ip:{client_host}",
+                namespace="push:subscribe:ip",
+                limit=60,
+                window_seconds=60,
+                redis_url=settings.rate_limit_storage_uri,
+            )
+    except RateLimitExceeded as exc:
+        info: RateLimitInfo = exc.info
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail={
+                "error": "rate_limited",
+                "message": "Слишком много запросов подписки. Попробуйте позже.",
+                "retry_after": info.retry_after,
+            },
+        ) from None
+
     user_agent = payload.user_agent or request.headers.get("user-agent") or ""
     user_agent = user_agent.strip()
     if len(user_agent) > 512:
@@ -197,10 +263,10 @@ async def subscribe(
                 )
             existing.p256dh = p256dh
             existing.auth = auth
+            existing.user_id = user.id
             existing.user_agent = user_agent or None
             existing.last_seen_at = now
             existing.topics = _resolve_topics()
-            existing.user_id = user.id
             await db.commit()
             await db.refresh(existing)
             subscription = existing
@@ -227,7 +293,7 @@ async def subscribe(
             },
         )
 
-    return PushSubscriptionOut.model_validate(subscription)
+    return _serialize_subscription(subscription)
 
 
 @router.patch("/subscribe/topics", response_model=PushSubscriptionOut)
@@ -267,15 +333,16 @@ async def update_subscription_topics(
     subscription.last_seen_at = datetime.now(UTC)
     await db.commit()
     await db.refresh(subscription)
-    return PushSubscriptionOut.model_validate(subscription)
+    return _serialize_subscription(subscription)
 
 
-@router.delete("/subscribe", status_code=status.HTTP_204_NO_CONTENT)
+@router.post("/unsubscribe")
 async def unsubscribe(
     payload: PushSubscriptionDelete,
+    request: Request,
     db: Annotated[AsyncSession, Depends(get_db)],
     user: Annotated[User, Depends(get_current_user)],
-) -> Response:
+) -> dict[str, bool]:
     endpoint = payload.endpoint.strip()
     if not endpoint:
         raise HTTPException(
@@ -285,6 +352,35 @@ async def unsubscribe(
                 "message": "Endpoint is required",
             },
         )
+
+    client_host = request.client.host if request.client else None
+    try:
+        await enforce_rate_limit(
+            identifier=f"user:{user.id}",
+            namespace="push:unsubscribe:user",
+            limit=20,
+            window_seconds=60,
+            redis_url=settings.rate_limit_storage_uri,
+        )
+        if client_host:
+            await enforce_rate_limit(
+                identifier=f"ip:{client_host}",
+                namespace="push:unsubscribe:ip",
+                limit=60,
+                window_seconds=60,
+                redis_url=settings.rate_limit_storage_uri,
+            )
+    except RateLimitExceeded as exc:
+        info: RateLimitInfo = exc.info
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail={
+                "error": "rate_limited",
+                "message": "Слишком много попыток отключить уведомления.",
+                "retry_after": info.retry_after,
+            },
+        ) from None
+
     existing = (
         await db.execute(
             select(PushSubscription).where(
@@ -294,32 +390,49 @@ async def unsubscribe(
         )
     ).scalar_one_or_none()
     if not existing:
-        return Response(status_code=status.HTTP_204_NO_CONTENT)
+        return {"ok": True, "removed": False}
+
     await db.delete(existing)
     await db.commit()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
+    return {"ok": True, "removed": True}
 
 
-@router.post("/send-test", response_model=SendTestResponse)
+@router.post("/test", response_model=SendTestResponse)
 async def send_test(
+    request: Request,
     db: Annotated[AsyncSession, Depends(get_db)],
     user: Annotated[User, Depends(get_current_user)],
+    payload: PushTestRequest | None = None,
 ) -> SendTestResponse:
+    if user.role != "admin":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={"error": "forbidden", "message": "Admin access required"},
+        )
+
     if not settings.VAPID_PRIVATE_KEY or not settings.VAPID_PUBLIC_KEY:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Web push is not configured",
         )
 
-    rate_identifier = f"user:{user.id}"
+    client_host = request.client.host if request and request.client else None
     try:
         await enforce_rate_limit(
-            identifier=rate_identifier,
-            namespace="webpush:test",
-            limit=3,
+            identifier=f"user:{user.id}",
+            namespace="push:test:user",
+            limit=5,
             window_seconds=60,
             redis_url=settings.rate_limit_storage_uri,
         )
+        if client_host:
+            await enforce_rate_limit(
+                identifier=f"ip:{client_host}",
+                namespace="push:test:ip",
+                limit=15,
+                window_seconds=60,
+                redis_url=settings.rate_limit_storage_uri,
+            )
     except RateLimitExceeded as exc:
         info: RateLimitInfo = exc.info
         raise HTTPException(
@@ -331,12 +444,20 @@ async def send_test(
             },
         )
 
+    target_id = payload.user_id if payload and payload.user_id else user.id
+    target = await db.get(User, target_id)
+    if not target:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"error": "user_not_found", "message": "Target user not found"},
+        )
+
     subscriptions = (
         (
             await db.execute(
                 select(PushSubscription)
                 .options(selectinload(PushSubscription.user))
-                .where(PushSubscription.user_id == user.id)
+                .where(PushSubscription.user_id == target.id)
             )
         )
         .scalars()
@@ -347,24 +468,34 @@ async def send_test(
             sent=0, removed=0, failed=0, detail="No subscriptions found"
         )
 
-    topic = normalize_topic("system")
-    payload = {
-        "title": "Тестовое веб-push уведомление",
-        "body": "Проверка доставки уведомлений",
-        "url": settings.app_base_url or "/",
+    normalized_topic = normalize_topic(payload.topic if payload else None) or "system"
+    base_url = payload.url if payload and payload.url else settings.app_base_url or "/"
+    body = payload.body if payload else None
+    title = payload.title if payload else "Тестовое веб-push уведомление"
+    message = {
+        "title": title,
+        "body": body or "Проверка доставки уведомлений",
+        "url": base_url,
     }
-    if topic:
-        payload["topic"] = topic
+    if normalized_topic:
+        message["topic"] = normalized_topic
+
+    optional_fields = ("tag", "badge", "ttl", "urgency", "actions", "data")
+    if payload:
+        for field in optional_fields:
+            value = getattr(payload, field, None)
+            if value is not None:
+                message[field] = value
 
     sent = 0
     removed = 0
     failed = 0
     now_time = datetime.now().astimezone().time()
     for sub in subscriptions:
-        if not subscription_supports_topic(sub, topic):
+        if not subscription_supports_topic(sub, normalized_topic):
             continue
         prepared = prepare_push_payload_for_user(
-            payload, getattr(sub, "user", None), now_time=now_time
+            message, getattr(sub, "user", None), now_time=now_time
         )
         result: WebPushResult = await run_in_threadpool(send_web_push, sub, prepared)
         if result.status == "sent":
@@ -374,10 +505,46 @@ async def send_test(
         else:
             failed += 1
     logger.info(
-        "webpush.send_test.summary",
-        extra={"user_id": user.id, "sent": sent, "removed": removed, "failed": failed},
+        "push.test.summary",
+        extra={
+            "user_id": user.id,
+            "target_user_id": target.id,
+            "sent": sent,
+            "removed": removed,
+            "failed": failed,
+        },
     )
     detail = None
     if failed and not sent:
         detail = "Не удалось отправить тестовое уведомление"
     return SendTestResponse(sent=sent, removed=removed, failed=failed, detail=detail)
+
+
+legacy_router.add_api_route(
+    "/vapid-public-key",
+    get_vapid_public_key,
+    methods=["GET"],
+)
+legacy_router.add_api_route(
+    "/subscribe",
+    subscribe,
+    methods=["POST"],
+    response_model=PushSubscriptionOut,
+)
+legacy_router.add_api_route(
+    "/subscribe/topics",
+    update_subscription_topics,
+    methods=["PATCH"],
+    response_model=PushSubscriptionOut,
+)
+legacy_router.add_api_route(
+    "/unsubscribe",
+    unsubscribe,
+    methods=["POST"],
+)
+legacy_router.add_api_route(
+    "/send-test",
+    send_test,
+    methods=["POST"],
+    response_model=SendTestResponse,
+)

--- a/root/frontend/src/api/notifications.ts
+++ b/root/frontend/src/api/notifications.ts
@@ -1,9 +1,5 @@
 import api from "@/api/client"
-import type {
-  PushSubscriptionResponse,
-  SendTestNotificationResponse,
-  VapidPublicKeyResponse,
-} from "@/types/notifications"
+import type { PushSubscriptionResponse, SendTestNotificationResponse } from "@/types/notifications"
 
 export type NotificationListResponse = {
   items: Array<{
@@ -42,11 +38,6 @@ export async function markAllNotificationsRead(): Promise<void> {
   await api.post("/notifications/read-all")
 }
 
-export async function getVapidKey(): Promise<string> {
-  const { data } = await api.get<VapidPublicKeyResponse>("/webpush/vapid-public-key")
-  return data.publicKey
-}
-
 export async function saveSubscription(
   sub: PushSubscriptionJSON,
   topics?: string[]
@@ -68,31 +59,15 @@ export async function saveSubscription(
     user_agent: userAgent,
   }
 
-  const { data } = await api.post<PushSubscriptionResponse>("/webpush/subscribe", payload)
+  const { data } = await api.post<PushSubscriptionResponse>("/push/subscribe", payload)
   return data
 }
 
 export async function deleteSubscription(endpoint: string): Promise<void> {
-  await api.delete("/webpush/subscribe", { data: { endpoint } })
-}
-
-export async function updateSubscriptionTopics(
-  endpoint: string,
-  topics: string[]
-): Promise<PushSubscriptionResponse> {
-  const normalizedEndpoint = endpoint?.trim()
-  if (!normalizedEndpoint) {
-    throw new Error("Endpoint is required")
-  }
-  const payload = { endpoint: normalizedEndpoint, topics }
-  const { data } = await api.patch<PushSubscriptionResponse>(
-    "/webpush/subscribe/topics",
-    payload
-  )
-  return data
+  await api.post("/push/unsubscribe", { endpoint })
 }
 
 export async function sendTest(): Promise<SendTestNotificationResponse> {
-  const { data } = await api.post<SendTestNotificationResponse>("/webpush/send-test")
+  const { data } = await api.post<SendTestNotificationResponse>("/push/test")
   return data
 }

--- a/root/frontend/src/components/NotificationsBell.tsx
+++ b/root/frontend/src/components/NotificationsBell.tsx
@@ -1,10 +1,14 @@
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { memo, useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent } from "react"
 import {
+  Alert,
   Avatar,
   Badge,
   Box,
   Button,
+  Checkbox,
   CircularProgress,
+  FormControlLabel,
+  FormGroup,
   Divider,
   IconButton,
   List,
@@ -13,6 +17,7 @@ import {
   ListItemText,
   Popover,
   Stack,
+  Switch,
   Typography,
 } from "@mui/material"
 import NotificationsNoneIcon from "@mui/icons-material/NotificationsNone"
@@ -26,7 +31,7 @@ import FiberManualRecordIcon from "@mui/icons-material/FiberManualRecord"
 import SettingsIcon from "@mui/icons-material/Settings"
 import NotificationsActiveIcon from "@mui/icons-material/NotificationsActive"
 import { useNotifications } from "@/hooks/useNotifications"
-import { usePushPreferences } from "@/hooks/usePushPreferences"
+import { usePushPreferences, NOTIFICATION_TOPIC_LABELS } from "@/hooks/usePushPreferences"
 import { useNavigate } from "react-router-dom"
 
 type Notif = {
@@ -151,74 +156,151 @@ function PushSettingsPreview({ onOpenSettings }: { onOpenSettings: () => void })
     pushBusy,
     pushInitializing,
     permissionText,
+    notificationPermission,
     enableNotifications,
     disableNotifications,
+    topicKeys,
+    topicState,
+    handleTopicToggle,
+    selectedTopicsDescription,
+    safariIOS,
+    safariGuideUrl,
   } = usePushPreferences()
 
   const busy = pushBusy || pushInitializing
 
   const statusText = useMemo(() => {
     if (!pushSupported) return "Веб push-уведомления недоступны в этом браузере."
-    if (notificationsEnabled) return "Пуш-уведомления включены."
-    return `Разрешение браузера: ${permissionText}.`
-  }, [notificationsEnabled, permissionText, pushSupported])
-
-  const hintText = useMemo(() => {
-    if (!pushSupported) {
-      return "Попробуйте открыть Экосистему ГУУ в другом браузере или установите приложение."
-    }
     if (notificationsEnabled) {
-      return "Отключить уведомления можно здесь или в настройках браузера."
+      return `Подписка активна. Темы: ${selectedTopicsDescription}.`
     }
-    return "Разрешите уведомления, чтобы получать новости и изменения сразу."
-  }, [notificationsEnabled, pushSupported])
+    if (notificationPermission === "denied") {
+      return "Уведомления заблокированы. Разрешите их в настройках браузера."
+    }
+    if (notificationPermission === "default") {
+      return "Нажмите переключатель, чтобы разрешить уведомления."
+    }
+    return `Уведомления выключены. Разрешение: ${permissionText}.`
+  }, [
+    notificationPermission,
+    notificationsEnabled,
+    permissionText,
+    pushSupported,
+    selectedTopicsDescription,
+  ])
 
-  const handleToggle = useCallback(async () => {
-    if (!pushSupported) return
-    if (notificationsEnabled) {
-      await disableNotifications()
-    } else {
-      await enableNotifications()
-    }
-  }, [disableNotifications, enableNotifications, notificationsEnabled, pushSupported])
+  const handleSwitchChange = useCallback(
+    (_event: ChangeEvent<HTMLInputElement>, checked: boolean) => {
+      if (!pushSupported) return
+      if (checked) void enableNotifications()
+      else void disableNotifications()
+    },
+    [disableNotifications, enableNotifications, pushSupported],
+  )
+
+  const safariHint = useMemo(() => {
+    if (!safariIOS) return null
+    return (
+      <Alert severity="info" variant="outlined">
+        <Stack spacing={0.5}>
+          <Typography variant="body2" fontWeight={600} component="p">
+            Safari / iOS
+          </Typography>
+          <Typography variant="caption" component="p">
+            Добавьте Экосистему на Домой: поделиться → На экран Домой.
+          </Typography>
+          <Typography variant="caption" component="p">
+            Разрешите уведомления в Настройки → Уведомления → Экосистема ГУУ.
+          </Typography>
+          <Typography variant="caption" component="p">
+            На iOS звук push-уведомлений может отсутствовать — это ограничение системы.
+          </Typography>
+          <Typography variant="caption" component="p">
+            <a href={safariGuideUrl} target="_blank" rel="noreferrer">
+              Подробная инструкция от Apple
+            </a>
+          </Typography>
+        </Stack>
+      </Alert>
+    )
+  }, [safariGuideUrl, safariIOS])
 
   return (
-    <Stack spacing={1.2}>
+    <Stack spacing={1.5}>
       <Stack direction="row" alignItems="center" spacing={1}>
         <NotificationsActiveIcon fontSize="small" color={notificationsEnabled ? "primary" : "disabled"} />
         <Typography variant="subtitle2" fontWeight={700} component="h3">
           Настройки пушей
         </Typography>
       </Stack>
-      <Typography variant="body2" color="text.secondary">
+      <Typography variant="body2" color="text.primary">
         {statusText}
       </Typography>
+      <FormControlLabel
+        control={
+          <Switch
+            size="medium"
+            color="primary"
+            checked={notificationsEnabled}
+            onChange={handleSwitchChange}
+            disabled={busy || !pushSupported}
+          />
+        }
+        label={
+          <Stack direction="row" alignItems="center" spacing={0.75}>
+            <Typography variant="body2">
+              {notificationsEnabled ? "Уведомления включены" : "Уведомления выключены"}
+            </Typography>
+            {busy && <CircularProgress size={16} />}
+          </Stack>
+        }
+      />
       <Typography variant="caption" color="text.secondary">
-        {hintText}
+        Разрешение браузера: {permissionText}
       </Typography>
-      <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
-        {pushSupported && (
-          <Button
-            size="small"
-            variant={notificationsEnabled ? "outlined" : "contained"}
-            onClick={() => {
-              void handleToggle()
-            }}
-            disabled={busy}
-            startIcon={busy ? <CircularProgress size={16} sx={{ color: "inherit" }} /> : undefined}
-          >
-            {notificationsEnabled ? "Выключить" : "Включить"}
-          </Button>
-        )}
-        <Button
-          size="small"
-          variant="text"
-          onClick={onOpenSettings}
-          startIcon={<SettingsIcon fontSize="small" />}
-        >
-          Подробнее
-        </Button>
-      </Stack>
+      <Typography variant="caption" color="text.secondary">
+        {notificationsEnabled
+          ? selectedTopicsDescription
+          : "Выберите темы и включите уведомления, чтобы получать новости и изменения сразу."}
+      </Typography>
+      <FormGroup sx={{ pl: 0.5 }}>
+        {topicKeys.map(key => (
+          <FormControlLabel
+            key={key}
+            control={
+              <Checkbox
+                size="small"
+                color="primary"
+                checked={Boolean(topicState[key])}
+                onChange={handleTopicToggle(key)}
+                disabled={!notificationsEnabled || busy}
+              />
+            }
+            label={
+              <Typography variant="body2" color="text.primary">
+                {NOTIFICATION_TOPIC_LABELS[key]}
+              </Typography>
+            }
+          />
+        ))}
+      </FormGroup>
+      {safariHint ? (
+        safariHint
+      ) : (
+        <Typography variant="caption" color="text.secondary">
+          {pushSupported
+            ? "Настройки можно изменить здесь или в настройках браузера."
+            : "Попробуйте открыть Экосистему ГУУ в другом браузере или установить приложение."}
+        </Typography>
+      )}
+      <Button
+        size="small"
+        variant="text"
+        onClick={onOpenSettings}
+        startIcon={<SettingsIcon fontSize="small" />}
+      >
+        Полные настройки
+      </Button>
     </Stack>
   )
 }

--- a/root/frontend/src/hooks/usePushPreferences.ts
+++ b/root/frontend/src/hooks/usePushPreferences.ts
@@ -1,17 +1,16 @@
 import { useCallback, useEffect, useMemo, useState } from "react"
 import type { ChangeEvent } from "react"
+import { useQueryClient } from "@tanstack/react-query"
+import { deleteSubscription } from "@/api/notifications"
 import {
+  ensurePushSubscription,
   getExistingPushSubscription,
+  getPersistedTopics,
   isPushSupported,
   setPushConsent,
-  urlBase64ToUint8Array,
 } from "@/push/subscribe"
-import {
-  deleteSubscription,
-  getVapidKey,
-  saveSubscription,
-  updateSubscriptionTopics,
-} from "@/api/notifications"
+import { notificationsQueryKey } from "@/hooks/useNotifications"
+import { currentUserQueryKey } from "@/contexts/AuthContext"
 import { isSafariIOS } from "@/utils/browser"
 
 export type NotificationTopicKey = "news" | "schedule" | "system"
@@ -58,6 +57,23 @@ export function usePushPreferences(options?: UsePushPreferencesOptions) {
   const [pushBusy, setPushBusy] = useState(false)
   const [pushInitializing, setPushInitializing] = useState(true)
   const [safariIOS] = useState(() => isSafariIOS())
+  const queryClient = useQueryClient()
+
+  const invalidatePushQueries = useCallback(() => {
+    queryClient.invalidateQueries({
+      predicate: query => {
+        const key = query.queryKey
+        if (!Array.isArray(key)) return false
+        if (
+          key.length === currentUserQueryKey.length &&
+          key.every((value, index) => value === currentUserQueryKey[index])
+        ) {
+          return true
+        }
+        return key.some(value => value === "notifications" || value === "users")
+      },
+    })
+  }, [queryClient])
 
   const notify = useCallback(
     (toast: NotificationToast) => {
@@ -117,49 +133,27 @@ export function usePushPreferences(options?: UsePushPreferencesOptions) {
     }
     setPushBusy(true)
     try {
-      const permission = await Notification.requestPermission()
-      setNotificationPermission(permission)
-      if (permission !== "granted") {
-        notify({ text: "Разрешите уведомления в настройках браузера", sev: "info" })
-        return
-      }
-
-      if (!("serviceWorker" in navigator)) {
-        notify({ text: "Сервис-воркеры недоступны", sev: "error" })
-        return
-      }
-
       const registration = await navigator.serviceWorker.ready
-      let sub = await registration.pushManager.getSubscription()
-
-      if (!sub) {
-        let vapidKey = ""
-        try {
-          vapidKey = (await getVapidKey())?.trim() || ""
-        } catch (error) {
-          console.error("Failed to load VAPID key", error)
-        }
-        if (!vapidKey) {
-          notify({ text: "Не удалось получить ключ уведомлений", sev: "error" })
-          return
-        }
-        const applicationServerKey = urlBase64ToUint8Array(vapidKey)
-        sub = await registration.pushManager.subscribe({
-          userVisibleOnly: true,
-          applicationServerKey,
+      const sub = await ensurePushSubscription({
+        registration,
+        topics: selectedTopics,
+        requestPermission: true,
+      })
+      const permission = Notification.permission
+      setNotificationPermission(permission)
+      if (permission !== "granted" || !sub) {
+        notify({
+          text: "Разрешите уведомления в настройках браузера, чтобы получать пуши",
+          sev: "info",
         })
-      }
-
-      if (!sub) {
-        notify({ text: "Не удалось активировать подписку", sev: "error" })
+        setPushSubscription(sub)
         return
       }
-
-      type Payload = Parameters<typeof saveSubscription>[0]
-      const saved = await saveSubscription(sub.toJSON() as Payload, selectedTopics)
-      applyServerTopics(saved?.topics ?? selectedTopics)
+      const persistedTopics = getPersistedTopics() ?? selectedTopics
+      applyServerTopics(persistedTopics)
       setPushSubscription(sub)
       setPushConsent(true)
+      invalidatePushQueries()
       notify({ text: "Уведомления включены", sev: "success" })
     } catch (error) {
       console.error("Failed to enable notifications", error)
@@ -168,7 +162,7 @@ export function usePushPreferences(options?: UsePushPreferencesOptions) {
       setPushBusy(false)
       setPushInitializing(false)
     }
-  }, [applyServerTopics, notify, selectedTopics])
+  }, [applyServerTopics, invalidatePushQueries, notify, selectedTopics])
 
   const disableNotifications = useCallback(async () => {
     if (!isPushSupported()) {
@@ -184,6 +178,7 @@ export function usePushPreferences(options?: UsePushPreferencesOptions) {
         setPushSubscription(null)
         setPushConsent(false)
         notify({ text: "Уведомления выключены", sev: "success" })
+        invalidatePushQueries()
         return
       }
       const endpoint = sub.endpoint
@@ -207,6 +202,7 @@ export function usePushPreferences(options?: UsePushPreferencesOptions) {
       } else {
         notify({ text: "Уведомления отключены локально", sev: "info" })
       }
+      invalidatePushQueries()
     } catch (error) {
       console.error("Failed to disable notifications", error)
       notify({ text: "Не удалось выключить уведомления", sev: "error" })
@@ -226,19 +222,24 @@ export function usePushPreferences(options?: UsePushPreferencesOptions) {
         const topicsToSend = topicKeys.filter(topic => nextState[topic])
         try {
           const registration = await navigator.serviceWorker.ready
-          const sub = await registration.pushManager.getSubscription()
+          const sub = await ensurePushSubscription({
+            registration,
+            topics: topicsToSend,
+            requestPermission: false,
+          })
           if (!sub) {
             setPushSubscription(null)
             setPushConsent(false)
+            notify({
+              text: "Подписка недоступна: проверьте разрешения браузера",
+              sev: "warning",
+            })
             return
           }
-          const endpoint = (sub.endpoint || "").trim()
-          type Payload = Parameters<typeof saveSubscription>[0]
-          const saved = endpoint
-            ? await updateSubscriptionTopics(endpoint, topicsToSend)
-            : await saveSubscription(sub.toJSON() as Payload, topicsToSend)
-          applyServerTopics(saved?.topics ?? topicsToSend)
+          const persisted = getPersistedTopics() ?? topicsToSend
+          applyServerTopics(persisted)
           setPushSubscription(sub)
+          invalidatePushQueries()
         } catch (error) {
           console.error("Failed to update topics", error)
           notify({ text: "Не удалось обновить настройки уведомлений", sev: "error" })
@@ -246,7 +247,15 @@ export function usePushPreferences(options?: UsePushPreferencesOptions) {
           setPushBusy(false)
         }
       },
-    [applyServerTopics, notificationsEnabled, pushBusy, topicKeys, topicState, notify],
+    [
+      applyServerTopics,
+      invalidatePushQueries,
+      notificationsEnabled,
+      pushBusy,
+      topicKeys,
+      topicState,
+      notify,
+    ],
   )
 
   useEffect(() => {
@@ -316,18 +325,23 @@ export function usePushPreferences(options?: UsePushPreferencesOptions) {
           return
         }
         setPushInitializing(true)
-        const sub = await getExistingPushSubscription()
+        const storedTopics = getPersistedTopics()
+        let sub: PushSubscription | null = null
+        if (typeof Notification !== "undefined" && Notification.permission === "granted") {
+          sub = await ensurePushSubscription({
+            topics: storedTopics,
+            requestPermission: false,
+          })
+        } else {
+          sub = await getExistingPushSubscription()
+        }
         if (!active) return
         setPushSubscription(sub)
         if (sub) {
           setPushConsent(true)
-          type Payload = Parameters<typeof saveSubscription>[0]
-          try {
-            const saved = await saveSubscription(sub.toJSON() as Payload)
-            if (!active) return
-            applyServerTopics(saved?.topics ?? [])
-          } catch (error) {
-            console.warn("Не удалось получить настройки подписки", error)
+          const persisted = getPersistedTopics() ?? storedTopics ?? []
+          if (persisted) {
+            applyServerTopics(persisted)
           }
         }
       } catch (error) {

--- a/root/frontend/src/main.tsx
+++ b/root/frontend/src/main.tsx
@@ -34,7 +34,7 @@ async function bootstrap() {
       if (!registration) return
       if (!hasPushConsent()) return
       try {
-        await ensurePushSubscription(undefined, registration)
+        await ensurePushSubscription({ registration, requestPermission: false })
       } catch (error) {
         console.error("Failed to ensure push subscription", error)
       }

--- a/root/frontend/src/pages/__tests__/Settings.notifications.test.tsx
+++ b/root/frontend/src/pages/__tests__/Settings.notifications.test.tsx
@@ -1,5 +1,6 @@
 import { act, renderHook, waitFor } from "@testing-library/react"
-import type { ChangeEvent } from "react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import type { ChangeEvent, ReactNode } from "react"
 import {
   afterEach,
   beforeEach,
@@ -11,33 +12,26 @@ import {
 import { usePushPreferences } from "@/hooks/usePushPreferences"
 
 const hoistedMocks = vi.hoisted(() => ({
-  getVapidKeyMock: vi.fn(),
-  saveSubscriptionMock: vi.fn(),
   deleteSubscriptionMock: vi.fn(),
-  updateSubscriptionTopicsMock: vi.fn(),
+  ensurePushSubscriptionMock: vi.fn(),
   setPushConsentMock: vi.fn(),
   getExistingPushSubscriptionMock: vi.fn(),
+  getPersistedTopicsMock: vi.fn(),
   isPushSupportedMock: vi.fn(() => true),
-  requestPermissionMock: vi.fn(),
 })) as {
-  getVapidKeyMock: ReturnType<typeof vi.fn>
-  saveSubscriptionMock: ReturnType<typeof vi.fn>
   deleteSubscriptionMock: ReturnType<typeof vi.fn>
-  updateSubscriptionTopicsMock: ReturnType<typeof vi.fn>
+  ensurePushSubscriptionMock: ReturnType<typeof vi.fn>
   setPushConsentMock: ReturnType<typeof vi.fn>
   getExistingPushSubscriptionMock: ReturnType<typeof vi.fn>
+  getPersistedTopicsMock: ReturnType<typeof vi.fn>
   isPushSupportedMock: ReturnType<typeof vi.fn>
-  requestPermissionMock: ReturnType<typeof vi.fn>
 }
 
 vi.mock("@/api/notifications", async () => {
   const actual = await vi.importActual<typeof import("@/api/notifications")>("@/api/notifications")
   return {
     ...actual,
-    getVapidKey: hoistedMocks.getVapidKeyMock,
-    saveSubscription: hoistedMocks.saveSubscriptionMock,
     deleteSubscription: hoistedMocks.deleteSubscriptionMock,
-    updateSubscriptionTopics: hoistedMocks.updateSubscriptionTopicsMock,
   }
 })
 
@@ -45,27 +39,25 @@ vi.mock("@/push/subscribe", async () => {
   const actual = await vi.importActual<typeof import("@/push/subscribe")>("@/push/subscribe")
   return {
     ...actual,
+    ensurePushSubscription: hoistedMocks.ensurePushSubscriptionMock,
     setPushConsent: hoistedMocks.setPushConsentMock,
     getExistingPushSubscription: hoistedMocks.getExistingPushSubscriptionMock,
+    getPersistedTopics: hoistedMocks.getPersistedTopicsMock,
     isPushSupported: hoistedMocks.isPushSupportedMock,
   }
 })
 
 const {
-  getVapidKeyMock,
-  saveSubscriptionMock,
   deleteSubscriptionMock,
-  updateSubscriptionTopicsMock,
+  ensurePushSubscriptionMock,
   setPushConsentMock,
   getExistingPushSubscriptionMock,
+  getPersistedTopicsMock,
   isPushSupportedMock,
-  requestPermissionMock,
 } = hoistedMocks
 
 class MockNotification {
   static permission: NotificationPermission = "default"
-
-  static requestPermission = requestPermissionMock
 }
 
 type MutableSubscription = PushSubscription & {
@@ -101,6 +93,8 @@ type MockRegistration = ServiceWorkerRegistration & {
 }
 
 let registration: MockRegistration
+let queryClient: QueryClient
+let wrapper: ({ children }: { children: ReactNode }) => JSX.Element
 
 const ensureAtob = () => {
   if (typeof globalThis.atob !== "function") {
@@ -111,7 +105,6 @@ const ensureAtob = () => {
 ensureAtob()
 
 beforeEach(() => {
-  requestPermissionMock.mockReset()
   MockNotification.permission = "default"
   Object.defineProperty(globalThis, "Notification", {
     value: MockNotification,
@@ -151,50 +144,49 @@ beforeEach(() => {
   setPushConsentMock.mockReset()
   isPushSupportedMock.mockReset()
   isPushSupportedMock.mockReturnValue(true)
-  getVapidKeyMock.mockReset()
-  saveSubscriptionMock.mockReset()
+  ensurePushSubscriptionMock.mockReset()
+  ensurePushSubscriptionMock.mockResolvedValue(null)
+  getPersistedTopicsMock.mockReset()
+  getPersistedTopicsMock.mockReturnValue(undefined)
   deleteSubscriptionMock.mockReset()
-  updateSubscriptionTopicsMock.mockReset()
+
+  queryClient = new QueryClient()
+  wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
 })
 
 afterEach(() => {
   vi.clearAllMocks()
   delete (navigator as any).serviceWorker
   delete (window as any).PushManager
+  queryClient.clear()
 })
 
 describe("usePushPreferences notifications flow", () => {
-  it("requests permission and enables notifications", async () => {
+  it("enables notifications when subscription is ensured", async () => {
     const subscription = createMockSubscription()
-    registration.pushManager.getSubscription.mockResolvedValueOnce(null)
-    registration.pushManager.subscribe.mockResolvedValue(subscription)
-
-    requestPermissionMock.mockImplementation(async () => {
-      MockNotification.permission = "granted"
-      return "granted"
-    })
-
-    getVapidKeyMock.mockResolvedValue("BElq1234ABCD5678")
-    saveSubscriptionMock.mockResolvedValue({ topics: ["news", "schedule"] })
+    ensurePushSubscriptionMock.mockResolvedValue(subscription)
+    getPersistedTopicsMock.mockReturnValue(["news", "schedule"])
+    MockNotification.permission = "granted"
 
     const onNotify = vi.fn()
-    const { result } = renderHook(() => usePushPreferences({ onNotify }))
+    const { result } = renderHook(() => usePushPreferences({ onNotify }), { wrapper })
 
     await act(async () => {
       await result.current.enableNotifications()
     })
 
-    expect(requestPermissionMock).toHaveBeenCalled()
     await waitFor(() => expect(result.current.notificationsEnabled).toBe(true))
 
-    expect(registration.pushManager.subscribe).toHaveBeenCalledWith(
-      expect.objectContaining({ userVisibleOnly: true }),
-    )
-    expect(saveSubscriptionMock).toHaveBeenCalledWith(subscription.__payload, [
-      "news",
-      "schedule",
-      "system",
-    ])
+    expect(ensurePushSubscriptionMock).toHaveBeenCalledTimes(2)
+    const initialArgs = ensurePushSubscriptionMock.mock.calls[0][0]
+    expect(initialArgs.requestPermission).toBe(false)
+    const ensureArgs = ensurePushSubscriptionMock.mock.calls[1][0]
+    expect(ensureArgs.registration).toBe(registration)
+    expect(ensureArgs.requestPermission).toBe(true)
+    expect(ensureArgs.topics).toEqual(["news", "schedule", "system"])
+
     expect(setPushConsentMock).toHaveBeenCalledWith(true)
     expect(onNotify).toHaveBeenCalledWith(
       expect.objectContaining({ text: "Уведомления включены", sev: "success" }),
@@ -204,12 +196,13 @@ describe("usePushPreferences notifications flow", () => {
 
   it("disables notifications and removes subscription", async () => {
     const subscription = createMockSubscription()
+    ensurePushSubscriptionMock.mockResolvedValue(subscription)
+    getPersistedTopicsMock.mockReturnValue(["news", "schedule", "system"])
+    MockNotification.permission = "granted"
     registration.pushManager.getSubscription.mockResolvedValue(subscription)
-    getExistingPushSubscriptionMock.mockResolvedValue(subscription)
-    saveSubscriptionMock.mockResolvedValue({ topics: ["news", "schedule", "system"] })
 
     const onNotify = vi.fn()
-    const { result } = renderHook(() => usePushPreferences({ onNotify }))
+    const { result } = renderHook(() => usePushPreferences({ onNotify }), { wrapper })
 
     await waitFor(() => expect(result.current.notificationsEnabled).toBe(true))
 
@@ -228,12 +221,15 @@ describe("usePushPreferences notifications flow", () => {
 
   it("updates topics when toggles change", async () => {
     const subscription = createMockSubscription()
-    registration.pushManager.getSubscription.mockResolvedValue(subscription)
-    getExistingPushSubscriptionMock.mockResolvedValue(subscription)
-    saveSubscriptionMock.mockResolvedValue({ topics: ["news", "schedule", "system"] })
-    updateSubscriptionTopicsMock.mockResolvedValue({ topics: ["news", "schedule"] })
+    ensurePushSubscriptionMock
+      .mockResolvedValueOnce(subscription)
+      .mockResolvedValueOnce(subscription)
+    getPersistedTopicsMock
+      .mockReturnValueOnce(["news", "schedule", "system"])
+      .mockReturnValueOnce(["news", "schedule"])
+    MockNotification.permission = "granted"
 
-    const { result } = renderHook(() => usePushPreferences())
+    const { result } = renderHook(() => usePushPreferences(), { wrapper })
 
     await waitFor(() => expect(result.current.notificationsEnabled).toBe(true))
 
@@ -242,33 +238,29 @@ describe("usePushPreferences notifications flow", () => {
       await handler({} as ChangeEvent<HTMLInputElement>, false)
     })
 
-    expect(updateSubscriptionTopicsMock).toHaveBeenCalledWith(subscription.endpoint, [
-      "news",
-      "schedule",
-    ])
+    expect(ensurePushSubscriptionMock).toHaveBeenCalledTimes(2)
+    const updateArgs = ensurePushSubscriptionMock.mock.calls[1][0]
+    expect(updateArgs.topics).toEqual(["news", "schedule"])
     expect(result.current.topicState.system).toBe(false)
   })
 
   it("notifies user when permission is denied", async () => {
-    registration.pushManager.getSubscription.mockResolvedValue(null)
-
-    requestPermissionMock.mockImplementation(async () => {
-      MockNotification.permission = "denied"
-      return "denied"
-    })
+    ensurePushSubscriptionMock.mockResolvedValue(null)
+    MockNotification.permission = "denied"
 
     const onNotify = vi.fn()
-    const { result } = renderHook(() => usePushPreferences({ onNotify }))
+    const { result } = renderHook(() => usePushPreferences({ onNotify }), { wrapper })
 
     await act(async () => {
       await result.current.enableNotifications()
     })
 
-    expect(requestPermissionMock).toHaveBeenCalled()
-    expect(getVapidKeyMock).not.toHaveBeenCalled()
-    expect(saveSubscriptionMock).not.toHaveBeenCalled()
+    expect(ensurePushSubscriptionMock).toHaveBeenCalled()
     expect(onNotify).toHaveBeenCalledWith(
-      expect.objectContaining({ text: "Разрешите уведомления в настройках браузера", sev: "info" }),
+      expect.objectContaining({
+        text: "Разрешите уведомления в настройках браузера, чтобы получать пуши",
+        sev: "info",
+      }),
     )
     expect(result.current.notificationsEnabled).toBe(false)
     expect(result.current.notificationPermission).toBe("denied")

--- a/root/frontend/src/pages/__tests__/Settings.notifications.test.tsx
+++ b/root/frontend/src/pages/__tests__/Settings.notifications.test.tsx
@@ -1,6 +1,6 @@
 import { act, renderHook, waitFor } from "@testing-library/react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
-import type { ChangeEvent, ReactNode } from "react"
+import type { ChangeEvent, ReactElement, ReactNode } from "react"
 import {
   afterEach,
   beforeEach,
@@ -94,7 +94,7 @@ type MockRegistration = ServiceWorkerRegistration & {
 
 let registration: MockRegistration
 let queryClient: QueryClient
-let wrapper: ({ children }: { children: ReactNode }) => JSX.Element
+let wrapper: ({ children }: { children: ReactNode }) => ReactElement
 
 const ensureAtob = () => {
   if (typeof globalThis.atob !== "function") {

--- a/root/frontend/src/push/subscribe.ts
+++ b/root/frontend/src/push/subscribe.ts
@@ -1,4 +1,4 @@
-import { deleteSubscription, getVapidKey, saveSubscription } from "@/api/notifications"
+import { deleteSubscription, saveSubscription } from "@/api/notifications"
 
 const SUBSCRIPTION_EXPIRY_THRESHOLD_MS = 3 * 24 * 60 * 60 * 1000 // 3 days
 const PERSIST_MAX_ATTEMPTS = 5
@@ -11,7 +11,7 @@ const ensureLocks = new Map<string, Promise<PushSubscription | null>>()
 
 type NormalizedTopics = string[] | undefined
 
-function parseStoredTopics(raw: string | null): NormalizedTopics {
+export function parseStoredTopics(raw: string | null): NormalizedTopics {
   if (!raw) return undefined
   try {
     const parsed = JSON.parse(raw)
@@ -27,6 +27,10 @@ function parseStoredTopics(raw: string | null): NormalizedTopics {
   } catch {
     return undefined
   }
+}
+
+export function getPersistedTopics(): string[] | undefined {
+  return parseStoredTopics(getStoredValue(PUSH_TOPICS_STORAGE_KEY)) ?? undefined
 }
 
 function sleep(ms: number) {
@@ -55,8 +59,8 @@ function removeStoredValue(key: string) {
 
 async function persistSubscriptionWithBackoff(
   payload: Parameters<typeof saveSubscription>[0],
-  topics?: string[]
-) {
+  topics?: string[],
+): Promise<Awaited<ReturnType<typeof saveSubscription>> | null> {
   let attempt = 0
   // Add jitter to reduce the probability of thundering herd
   const jitter = () => Math.random() * PERSIST_BASE_DELAY_MS
@@ -64,11 +68,12 @@ async function persistSubscriptionWithBackoff(
   // eslint-disable-next-line no-constant-condition
   while (true) {
     try {
-      await saveSubscription(payload, topics)
+      const response = await saveSubscription(payload, topics)
+      const normalizedTopics = response?.topics ?? (topics ? [...topics].sort() : [])
       setStoredValue(PUSH_SUB_STORAGE_KEY, JSON.stringify(payload))
       setStoredValue(PUSH_LAST_SYNC_STORAGE_KEY, Date.now().toString())
-      setStoredValue(PUSH_TOPICS_STORAGE_KEY, JSON.stringify(topics ? [...topics].sort() : []))
-      return
+      setStoredValue(PUSH_TOPICS_STORAGE_KEY, JSON.stringify(normalizedTopics))
+      return response
     } catch (error) {
       attempt += 1
       if (attempt >= PERSIST_MAX_ATTEMPTS) {
@@ -102,13 +107,15 @@ export function setPushConsent(consented: boolean): void {
 }
 
 export async function fetchVapidPublicKey(): Promise<string | null> {
-  try {
-    const key = await getVapidKey()
-    const normalized = key?.trim() || ""
-    return normalized || null
-  } catch {
-    return null
+  const rawKey = import.meta.env.VITE_VAPID_PUBLIC_KEY
+  if (typeof rawKey === "string") {
+    const normalized = rawKey.trim()
+    if (normalized) return normalized
   }
+  if (import.meta.env.DEV) {
+    console.warn("VITE_VAPID_PUBLIC_KEY is not configured")
+  }
+  return null
 }
 
 export function urlBase64ToUint8Array(base64String: string) {
@@ -120,11 +127,16 @@ export function urlBase64ToUint8Array(base64String: string) {
   return outputArray
 }
 
-export async function ensurePushSubscription(
-  vapidPublicKey?: string,
-  registration?: ServiceWorkerRegistration,
+type EnsurePushSubscriptionOptions = {
+  registration?: ServiceWorkerRegistration
+  vapidPublicKey?: string
   topics?: string[]
-) {
+  requestPermission?: boolean
+}
+
+export async function ensurePushSubscription(
+  options?: EnsurePushSubscriptionOptions,
+): Promise<PushSubscription | null> {
   if (
     !("serviceWorker" in navigator) ||
     !("PushManager" in window) ||
@@ -132,9 +144,12 @@ export async function ensurePushSubscription(
   ) {
     return null
   }
+
+  const topics = options?.topics
   const lockKey = JSON.stringify({
-    key: vapidPublicKey || null,
+    key: options?.vapidPublicKey || null,
     topics: topics ? [...topics].sort() : [],
+    requestPermission: Boolean(options?.requestPermission),
   })
 
   const existingLock = ensureLocks.get(lockKey)
@@ -143,20 +158,25 @@ export async function ensurePushSubscription(
   }
 
   const task = (async () => {
-    const reg = registration ?? (await navigator.serviceWorker.ready)
+    const reg = options?.registration ?? (await navigator.serviceWorker.ready)
 
     if (Notification.permission === "denied") {
       return null
     }
 
     if (Notification.permission === "default") {
+      if (!options?.requestPermission) {
+        return null
+      }
       const perm = await Notification.requestPermission()
       if (perm !== "granted") {
         return null
       }
     }
 
-    const key = (vapidPublicKey || (await fetchVapidPublicKey()) || "").trim()
+    const key = (
+      options?.vapidPublicKey || (await fetchVapidPublicKey()) || ""
+    ).trim()
     if (!key) {
       return null
     }
@@ -180,7 +200,11 @@ export async function ensurePushSubscription(
       if (!matches || isExpiringSoon) {
         try {
           await sub.unsubscribe()
-        } catch {}
+        } catch (error) {
+          if (import.meta.env.DEV) {
+            console.warn("Failed to unsubscribe push subscription", error)
+          }
+        }
         sub = null
       }
     }
@@ -291,11 +315,12 @@ export async function softSyncPushSubscription(
 
   const storedTopics = options?.topics ?? parseStoredTopics(getStoredValue(PUSH_TOPICS_STORAGE_KEY))
   try {
-    const subscription = await ensurePushSubscription(
-      options?.vapidPublicKey,
-      options?.registration,
-      storedTopics,
-    )
+    const subscription = await ensurePushSubscription({
+      vapidPublicKey: options?.vapidPublicKey,
+      registration: options?.registration,
+      topics: storedTopics,
+      requestPermission: false,
+    })
     return subscription
   } catch (error) {
     console.error("Failed to soft sync push subscription", error)

--- a/root/frontend/src/types/notifications.ts
+++ b/root/frontend/src/types/notifications.ts
@@ -1,7 +1,3 @@
-export type VapidPublicKeyResponse = {
-  publicKey: string
-}
-
 export type PushSubscriptionResponse = {
   id: number
   user_id: number
@@ -11,6 +7,7 @@ export type PushSubscriptionResponse = {
   created_at: string
   user_agent?: string | null
   last_seen_at?: string | null
+  updated_at?: string | null
   topics: string[]
 }
 

--- a/root/tests/test_notifications_push.py
+++ b/root/tests/test_notifications_push.py
@@ -51,9 +51,11 @@ async def _create_user_and_token(
     async_client: AsyncClient,
     user_factory,
     password: str = "StrongP@ssw0rd!",
+    *,
+    role: str = "student",
 ):
     hashed = get_password_hash(password)
-    user = await user_factory(hashed_password=hashed, is_active=True)
+    user = await user_factory(hashed_password=hashed, is_active=True, role=role)
     response = await async_client.post(
         "/auth/login",
         data={"username": user.email, "password": password},
@@ -82,7 +84,7 @@ async def test_subscribe_persists_subscription(
     }
 
     response = await async_client.post(
-        "/webpush/subscribe",
+        "/push/subscribe",
         json=payload,
         headers=headers,
     )
@@ -94,6 +96,7 @@ async def test_subscribe_persists_subscription(
     assert body["topics"] == ["system", "news"]
     assert body["user_agent"] == payload["user_agent"]
     assert body["last_seen_at"] is not None
+    assert body["updated_at"] == body["last_seen_at"]
 
     stored = (
         await db_session.execute(
@@ -115,7 +118,9 @@ async def test_unsubscribe_removes_subscription(
     db_session,
     _configured_webpush_settings,
 ):
-    _user, headers = await _create_user_and_token(async_client, user_factory)
+    _user, headers = await _create_user_and_token(
+        async_client, user_factory, role="admin"
+    )
     endpoint = "https://push.example.test/remove-me"
     payload = {
         "endpoint": endpoint,
@@ -123,19 +128,19 @@ async def test_unsubscribe_removes_subscription(
         "topics": ["system"],
     }
     create_response = await async_client.post(
-        "/webpush/subscribe",
+        "/push/subscribe",
         json=payload,
         headers=headers,
     )
     assert create_response.status_code == 200
 
-    response = await async_client.request(
-        "DELETE",
-        "/webpush/subscribe",
+    response = await async_client.post(
+        "/push/unsubscribe",
         json={"endpoint": endpoint},
         headers=headers,
     )
-    assert response.status_code == 204
+    assert response.status_code == 200
+    assert response.json() == {"ok": True, "removed": True}
 
     remaining = (
         (
@@ -149,13 +154,13 @@ async def test_unsubscribe_removes_subscription(
     assert remaining == []
 
     # Deleting again should still return 204 and keep database clean.
-    second = await async_client.request(
-        "DELETE",
-        "/webpush/subscribe",
+    second = await async_client.post(
+        "/push/unsubscribe",
         json={"endpoint": endpoint},
         headers=headers,
     )
-    assert second.status_code == 204
+    assert second.status_code == 200
+    assert second.json() == {"ok": True, "removed": False}
 
 
 class _WebPushStub:
@@ -207,7 +212,9 @@ async def test_send_test_filters_and_cleans_subscriptions(
     _configured_webpush_settings,
     _sync_session_factory,
 ):
-    _user, headers = await _create_user_and_token(async_client, user_factory)
+    _user, headers = await _create_user_and_token(
+        async_client, user_factory, role="admin"
+    )
 
     stub = _WebPushStub()
     monkeypatch.setattr(webpush_module, "webpush", stub)
@@ -227,7 +234,7 @@ async def test_send_test_filters_and_cleans_subscriptions(
             "topics": topics,
         }
         resp = await async_client.post(
-            "/webpush/subscribe",
+            "/push/subscribe",
             json=payload,
             headers=headers,
         )
@@ -238,7 +245,7 @@ async def test_send_test_filters_and_cleans_subscriptions(
     await _subscribe(gone_404_endpoint, ["system"])
     await _subscribe(news_only_endpoint, ["news"])
 
-    response = await async_client.post("/webpush/send-test", headers=headers)
+    response = await async_client.post("/push/test", headers=headers)
     assert response.status_code == 200
     body = response.json()
     assert body == {


### PR DESCRIPTION
## Summary
- implement a dedicated /push router that validates subscriptions, enforces rate limits, keeps legacy endpoints, and supports admin-only test sends
- refactor frontend push utilities, hook, and bell popover to manage consent, topics, and Safari guidance with React Query invalidations
- align frontend and backend tests with the new flow, including QueryClient-aware Vitest hooks and updated pytest coverage

## Testing
- pnpm --dir root/frontend test -- Settings.notifications.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68e465c0653c8327b5d9acb788259091