### PR TITLE
feat: centralize media URL handling on frontend

### DIFF
--- a/root/frontend/src/components/EventCard.tsx
+++ b/root/frontend/src/components/EventCard.tsx
@@ -50,7 +50,6 @@ type EventCardProps = {
   onChange?: () => void
 }
 
-const BACKEND_ORIGIN = import.meta.env.VITE_BACKEND_ORIGIN || ""
 const normalizeDate = (dt: string) => (dt.length === 16 ? dt + ":00" : dt)
 
 const formatLocalDateTime = (s?: string) => {
@@ -178,7 +177,7 @@ const EventCard: FC<EventCardProps> = ({
   }
 
   const getImageUrl = () =>
-    previewUrl || (editData.image_url ? resolveMediaUrl(editData.image_url, BACKEND_ORIGIN) : undefined)
+    previewUrl || (editData.image_url ? resolveMediaUrl(editData.image_url) : undefined)
 
   const dateError =
     Boolean(editData.starts_at) &&

--- a/root/frontend/src/components/EventDetail.tsx
+++ b/root/frontend/src/components/EventDetail.tsx
@@ -21,8 +21,6 @@ import timezone from 'dayjs/plugin/timezone'
 dayjs.extend(utc)
 dayjs.extend(timezone)
 
-const BACKEND_ORIGIN = import.meta.env.VITE_BACKEND_ORIGIN || ''
-
 const formatLocalDateTime = (s?: string) => {
   if (!s) return '—'
   const norm = s.replace(' ', 'T')
@@ -213,7 +211,7 @@ const EventDetail = () => {
     )
   }
 
-  const imageUrl = resolveMediaUrl(event.image_url, BACKEND_ORIGIN)
+  const imageUrl = resolveMediaUrl(event.image_url)
 
   const BackButton = (
     <Button
@@ -416,7 +414,7 @@ const EventDetail = () => {
                           </Typography>
                         ) : (
                           <a
-                            href={resolveMediaUrl(f.file_url, BACKEND_ORIGIN) || '#'}
+                            href={resolveMediaUrl(f.file_url) || '#'}
                             target="_blank"
                             rel="noopener noreferrer"
                             download
@@ -631,7 +629,7 @@ const EventDetail = () => {
                           </Typography>
                         ) : (
                           <a
-                            href={resolveMediaUrl(f.file_url, BACKEND_ORIGIN) || '#'}
+                            href={resolveMediaUrl(f.file_url) || '#'}
                             target="_blank"
                             rel="noopener noreferrer"
                             download

--- a/root/frontend/src/components/Navbar.tsx
+++ b/root/frontend/src/components/Navbar.tsx
@@ -3,13 +3,11 @@ import { useState, useEffect, useRef, useMemo, useCallback, useLayoutEffect } fr
 import { useAuth } from "../contexts/AuthContext";
 import guuLogo from "../assets/guu_logo.png";
 import defaultAvatar from "../assets/default_avatar.png";
-import { resolveMediaUrl } from "@/utils/media";
+import { appendCacheBust, resolveMediaUrl } from "@/utils/media";
 import NotificationsBell from "@/components/NotificationsBell";
 
 const navTextColor = "var(--nav-text)";
 const navBgColor = "var(--nav-bg)";
-const BACKEND_ORIGIN = import.meta.env.VITE_BACKEND_ORIGIN || "";
-
 function useIsMobile() {
   const getMatch = useCallback(() => {
     if (typeof window === "undefined" || !("matchMedia" in window)) return false;
@@ -124,13 +122,21 @@ const Navbar = () => {
   }, [location.pathname]);
 
   const getAvatarSrc = () => {
-    if (user?.avatar_url) {
-      const url = resolveMediaUrl(user.avatar_url, BACKEND_ORIGIN);
-      const ver = (user as any).avatar_updated_at || Date.now();
-      return `${url}?v=${ver}`;
-    }
-    return defaultAvatar;
+    const resolved = resolveMediaUrl(user?.avatar_url, undefined, { fallback: defaultAvatar });
+    if (!resolved) return defaultAvatar;
+    const version =
+      (user as any)?.avatar_updated_at ??
+      (user as any)?.avatar_version ??
+      (user as any)?.updated_at ??
+      null;
+    return version != null ? appendCacheBust(resolved, version) ?? resolved : resolved;
   };
+
+  const handleAvatarError = useCallback((event: React.SyntheticEvent<HTMLImageElement>) => {
+    const img = event.currentTarget;
+    img.onerror = null;
+    img.src = defaultAvatar;
+  }, []);
 
   const menuLinks = useMemo(() => {
     const base = [
@@ -221,7 +227,7 @@ const Navbar = () => {
                   alt="avatar"
                   style={{ width: avatarSize, height: avatarSize, borderRadius: "50%", objectFit: "cover", border: "1px solid #d7d7d7", background: "#fff", cursor: "pointer" }}
                   onClick={() => go("/profile")}
-                  onError={(e) => { (e.currentTarget as HTMLImageElement).src = defaultAvatar; }}
+                  onError={handleAvatarError}
                 />
               )}
               <button
@@ -273,7 +279,7 @@ const Navbar = () => {
                 alt="avatar"
                 style={{ width: "36px", height: "36px", borderRadius: "50%", objectFit: "cover", border: "1.5px solid #ccc", background: "#fff", cursor: "pointer" }}
                 onClick={() => go("/profile")}
-                onError={(e) => { (e.currentTarget as HTMLImageElement).src = defaultAvatar; }}
+                onError={handleAvatarError}
               />
               <button
                 type="button"

--- a/root/frontend/src/components/NewsCard.tsx
+++ b/root/frontend/src/components/NewsCard.tsx
@@ -29,8 +29,6 @@ type NewsCardProps = {
   onChange?: () => void
 }
 
-const BACKEND_ORIGIN = import.meta.env.VITE_BACKEND_ORIGIN || ""
-
 const getMoscowDate = (dateStr: string) => {
   let parsed = dayjs(dateStr)
   if (!/([Zz]|[+\-]\d\d:?\d\d)$/.test(dateStr)) {
@@ -105,8 +103,8 @@ const NewsCard: FC<NewsCardProps> = ({
     if (imageInputRef.current) imageInputRef.current.value = ""
   }, [previewUrl])
 
-  const getCardImageUrl = () => resolveMediaUrl(image_url, BACKEND_ORIGIN)
-  const getEditImageUrl = () => previewUrl || resolveMediaUrl(editData.image_url, BACKEND_ORIGIN)
+  const getCardImageUrl = () => resolveMediaUrl(image_url)
+  const getEditImageUrl = () => previewUrl || resolveMediaUrl(editData.image_url)
 
   const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]

--- a/root/frontend/src/components/NewsDetail.tsx
+++ b/root/frontend/src/components/NewsDetail.tsx
@@ -22,8 +22,6 @@ import timezone from "dayjs/plugin/timezone"
 dayjs.extend(utc)
 dayjs.extend(timezone)
 
-const BACKEND_ORIGIN = import.meta.env.VITE_BACKEND_ORIGIN || ""
-
 const getMoscowDate = (dateStr: string) => {
   let parsed = dayjs(dateStr)
   if (!/([Zz]|[+\-]\d\d:?\d\d)$/.test(dateStr)) parsed = dayjs.utc(dateStr)
@@ -162,7 +160,7 @@ const NewsDetail = () => {
 
   const currentImagePath = previewUrl || (editOpen ? editData.image_url : news?.image_url)
   const resolvedImageUrl = useMemo(
-    () => resolveMediaUrl(currentImagePath, BACKEND_ORIGIN),
+    () => resolveMediaUrl(currentImagePath),
     [currentImagePath]
   )
 

--- a/root/frontend/src/pages/Events.tsx
+++ b/root/frontend/src/pages/Events.tsx
@@ -15,8 +15,6 @@ import { useAuth } from "../contexts/AuthContext"
 import { resolveMediaUrl } from "@/utils/media"
 import { useSearchParams } from "react-router-dom"
 
-const BACKEND_ORIGIN = import.meta.env.VITE_BACKEND_ORIGIN || ""
-
 type EventTabKey = "active" | "archive" | "my"
 type EventTab = { key: EventTabKey; label: string; is_active?: boolean }
 
@@ -523,7 +521,7 @@ const Events = () => {
               {!createPreview && eventData.image_url && (
                 <Box mt={1}>
                   <img
-                    src={resolveMediaUrl(eventData.image_url, BACKEND_ORIGIN)}
+                    src={resolveMediaUrl(eventData.image_url)}
                     alt="event"
                     style={{ maxHeight: 140, borderRadius: 8, border: "1px solid #eee" }}
                   />

--- a/root/frontend/src/pages/Profile.tsx
+++ b/root/frontend/src/pages/Profile.tsx
@@ -5,6 +5,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import api from "../api/client";
 import profileBg from "../assets/background.jpg";
 import guuLogo from "../assets/guu_logo.png";
+import defaultAvatar from "../assets/default_avatar.png";
 import {
   Avatar,
   Typography,
@@ -42,9 +43,7 @@ import { QRCodeSVG } from "qrcode.react";
 import { motion, useReducedMotion } from "framer-motion";
 import { useNowPlaying } from "@/hooks/useNowPlaying";
 import type { NowPlaying } from "@/types/spotify";
-import { addVersionParam, resolveMediaUrl } from "@/utils/media";
-
-const BACKEND_ORIGIN = import.meta.env.VITE_BACKEND_ORIGIN || "";
+import { appendCacheBust, resolveMediaUrl } from "@/utils/media";
 
 const auraPulse = keyframes`
   0% { box-shadow: 0 0 0 0 rgba(255,255,255,.18); }
@@ -369,8 +368,8 @@ export default function Profile() {
       affiliation: user.institute || user.department || "",
       url: typeof window !== "undefined" ? window.location.href : "",
       image: (() => {
-        const media = resolveMediaUrl(user.avatar_url || "", BACKEND_ORIGIN);
-        const withV = addVersionParam(media, avatarVersion);
+        const media = resolveMediaUrl(user.avatar_url);
+        const withV = media ? appendCacheBust(media, avatarVersion) : "";
         return withV || "";
       })()
     });
@@ -390,15 +389,23 @@ export default function Profile() {
       </Box>
     );
 
-  const getAvatarSrc = () => {
-    const media = resolveMediaUrl(user?.avatar_url || "", BACKEND_ORIGIN);
-    return addVersionParam(media, avatarVersion) || undefined;
-  };
+  const avatarImageUrl = useMemo(() => {
+    const media = resolveMediaUrl(user?.avatar_url);
+    if (!media) return defaultAvatar;
+    return appendCacheBust(media, avatarVersion) || media;
+  }, [user?.avatar_url, avatarVersion]);
 
-  const getCoverSrc = () => {
-    const media = resolveMediaUrl(user?.cover_url || "", BACKEND_ORIGIN);
-    return media || "https://mui.com/static/images/cards/cover1.jpg";
-  };
+  const coverImageUrl = useMemo(() => {
+    const media = resolveMediaUrl(user?.cover_url);
+    if (!media) return profileBg;
+    return appendCacheBust(media, coverVersion) || media;
+  }, [user?.cover_url, coverVersion]);
+
+  const handleAvatarImgError = useCallback((event: React.SyntheticEvent<HTMLImageElement>) => {
+    const img = event.currentTarget;
+    img.onerror = null;
+    img.src = defaultAvatar;
+  }, []);
 
   const ensureConfettiSize = useCallback(() => {
     const canvas = confettiRef.current;
@@ -660,7 +667,7 @@ export default function Profile() {
                       sx={{
                         position: "absolute",
                         inset: 0,
-                        backgroundImage: `url(${addVersionParam(getCoverSrc(), coverVersion)})`,
+                        backgroundImage: coverImageUrl ? `url(${coverImageUrl})` : undefined,
                         backgroundPosition: "center",
                         backgroundSize: "cover",
                         transform: `translateY(${coverParallax}px) scale(${coverScale})`,
@@ -687,8 +694,9 @@ export default function Profile() {
                     >
                       <Box className="avatar-ring" sx={{ width: "100%", height: "100%" }}>
                         <Avatar
-                          src={getAvatarSrc()}
+                          src={avatarImageUrl}
                           alt={user?.full_name}
+                          imgProps={{ onError: handleAvatarImgError }}
                           sx={{
                             width: "100%",
                             height: "100%",

--- a/root/frontend/src/pages/Settings.tsx
+++ b/root/frontend/src/pages/Settings.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, useCallback, ChangeEvent, FocusEvent } from "react";
+import { useEffect, useRef, useState, useCallback, useMemo, ChangeEvent, FocusEvent } from "react";
 import { isAxiosError } from "axios";
 import { useAuth, currentUserQueryKey, fetchCurrentUser } from "@/contexts/AuthContext";
 import { useNavigate } from "react-router-dom";
@@ -52,11 +52,9 @@ import DoNotDisturbOnIcon from "@mui/icons-material/DoNotDisturbOn";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import defaultAvatar from "@/assets/default_avatar.png";
 import spotifyLogo from "@/assets/spotify_icon.png";
-import { addVersionParam, resolveMediaUrl } from "@/utils/media";
+import { appendCacheBust, resolveMediaUrl } from "@/utils/media";
 
 type ThemeMode = "system" | "light" | "dark";
-
-const BACKEND_ORIGIN = import.meta.env.VITE_BACKEND_ORIGIN || "";
 
 const DEFAULT_DND_START = "22:00";
 const DEFAULT_DND_END = "07:00";
@@ -296,21 +294,26 @@ export default function Settings() {
   const [avatarBusy, setAvatarBusy] = useState(false);
   const [coverBusy, setCoverBusy] = useState(false);
 
-  const getAvatarSrc = useCallback(() => {
-    if ((user as any)?.avatar_url) {
-      const url = resolveMediaUrl((user as any).avatar_url, BACKEND_ORIGIN);
-      return addVersionParam(url, avatarVersion) || defaultAvatar;
-    }
-    return defaultAvatar;
-  }, [user, avatarVersion]);
+  const avatarUrl = (user as any)?.avatar_url as string | undefined;
+  const coverUrl = (user as any)?.cover_url as string | undefined;
 
-  const getCoverSrc = useCallback(() => {
-    if ((user as any)?.cover_url) {
-      const url = resolveMediaUrl((user as any).cover_url, BACKEND_ORIGIN);
-      return addVersionParam(url || "", coverVersion) || "";
-    }
-    return "";
-  }, [user, coverVersion]);
+  const avatarSrc = useMemo(() => {
+    const resolved = resolveMediaUrl(avatarUrl);
+    if (!resolved) return defaultAvatar;
+    return appendCacheBust(resolved, avatarVersion) || resolved;
+  }, [avatarUrl, avatarVersion]);
+
+  const coverSrc = useMemo(() => {
+    const resolved = resolveMediaUrl(coverUrl);
+    if (!resolved) return "";
+    return appendCacheBust(resolved, coverVersion) || resolved;
+  }, [coverUrl, coverVersion]);
+
+  const handleAvatarError = useCallback((event: React.SyntheticEvent<HTMLImageElement>) => {
+    const img = event.currentTarget;
+    img.onerror = null;
+    img.src = defaultAvatar;
+  }, []);
 
   const triggerAvatarPick = () => avatarInputRef.current?.click();
   const triggerCoverPick = () => coverInputRef.current?.click();
@@ -700,14 +703,10 @@ export default function Settings() {
               >
                 <ListItemAvatar>
                   <Avatar
-                    src={getAvatarSrc()}
+                    src={avatarSrc}
                     alt={(user as any)?.full_name || "avatar"}
                     sx={{ width: 48, height: 48 }}
-                    imgProps={{
-                      onError: (e) => {
-                        (e.currentTarget as HTMLImageElement).src = defaultAvatar;
-                      }
-                    }}
+                    imgProps={{ onError: handleAvatarError }}
                   />
                 </ListItemAvatar>
                 <ListItemText primary="Фото профиля" secondary="PNG/JPG/WebP/AVIF/GIF, до 12 МБ" />
@@ -739,7 +738,7 @@ export default function Settings() {
                       height: 52,
                       borderRadius: 1.5,
                       border: "1px solid var(--glass-border)",
-                      background: getCoverSrc() ? `url(${getCoverSrc()}) center/cover no-repeat` : "var(--card-bg)"
+                      background: coverSrc ? `url(${coverSrc}) center/cover no-repeat` : "var(--card-bg)"
                     }}
                   />
                 </ListItemAvatar>

--- a/root/frontend/src/utils/media.ts
+++ b/root/frontend/src/utils/media.ts
@@ -17,42 +17,68 @@ const encodePath = (value: string) => {
     .replace(/\/{2,}/g, "/")
 }
 
-export function resolveMediaUrl(input?: string, backendOrigin = ""): string {
-  if (!input) return ""
+const readEnvOrigin = () => {
+  if (typeof import.meta !== "undefined" && import.meta.env?.VITE_BACKEND_ORIGIN) {
+    return import.meta.env.VITE_BACKEND_ORIGIN
+  }
+  return ""
+}
+
+const DEFAULT_BACKEND_ORIGIN = ensureOrigin(readEnvOrigin())
+
+const sanitizePath = (raw: string) => raw.replace(/^\/?static\//i, "/media/")
+
+type ResolveMediaOptions = {
+  fallback?: string
+}
+
+export function resolveMediaUrl(
+  input?: string | null,
+  origin = DEFAULT_BACKEND_ORIGIN,
+  options?: ResolveMediaOptions
+): string {
+  const fallback = options?.fallback ?? ""
+  if (input == null) return fallback
   const raw = String(input).trim()
-  if (!raw) return ""
+  if (!raw) return fallback
   if (ABSOLUTE_PATTERN.test(raw)) return raw
 
-  const origin = ensureOrigin(
-    backendOrigin || (typeof window !== "undefined" ? window.location.origin : "")
+  const normalizedRaw = sanitizePath(raw)
+
+  const resolvedOrigin = ensureOrigin(
+    origin || (typeof window !== "undefined" ? window.location.origin : "")
   )
 
-  if (!origin) {
-    const normalized = raw.startsWith("/") ? raw : `/${raw}`
-    return encodePath(normalized)
+  if (!resolvedOrigin) {
+    const normalized = normalizedRaw.startsWith("/") ? normalizedRaw : `/${normalizedRaw}`
+    return encodePath(normalized) || fallback
   }
 
   try {
-    const resolved = new URL(raw, `${origin}/`)
+    const resolved = new URL(normalizedRaw, `${resolvedOrigin}/`)
     resolved.pathname = encodePath(resolved.pathname)
     return resolved.toString()
   } catch {
-    const normalized = raw.replace(/^\/+/, "")
-    return `${origin}/${encodePath(normalized)}`
+    const normalized = normalizedRaw.replace(/^\/+/, "")
+    return `${resolvedOrigin}/${encodePath(normalized)}` || fallback
   }
 }
 
-export function addVersionParam(
+export function appendCacheBust(
   url: string | undefined,
-  version: number | string
+  version: number | string = Date.now()
 ): string | undefined {
   if (!url) return undefined
+  const value = String(version)
+  if (!value) return url
   try {
     const parsed = new URL(url)
-    parsed.searchParams.set("v", String(version))
+    parsed.searchParams.set("v", value)
     return parsed.toString()
   } catch {
     const sep = url.includes("?") ? "&" : "?"
-    return `${url}${sep}v=${encodeURIComponent(String(version))}`
+    return `${url}${sep}v=${encodeURIComponent(value)}`
   }
 }
+
+export type { ResolveMediaOptions }


### PR DESCRIPTION
## Summary
- update the media utility to normalize backend origins, rewrite /static paths, and expose an appendCacheBust helper
- switch navbar, profile, settings, news, and events views to the unified resolver with safe avatar fallbacks
- refresh avatar and cover updates with cache-busting query params so new uploads show immediately

## Testing
- npm run test -- Settings.media.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e50830dc148327b654b06029608e46