### PR TITLE
Fix Spotify now playing progress sync

### DIFF
--- a/root/frontend/src/components/SpotifyConnect.tsx
+++ b/root/frontend/src/components/SpotifyConnect.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react"
 import { useQueryClient } from "@tanstack/react-query"
 import api from "@/api/client"
-import { useAuth } from "@/contexts/AuthContext"
+import { useAuth, currentUserQueryKey } from "@/contexts/AuthContext"
 import {
   Box,
   Button,
@@ -40,7 +40,10 @@ export default function SpotifyConnect() {
     try {
       await api.post("/spotify/disconnect")
       setUser({ ...user, spotify_connected: false, spotify_display_name: null })
-      queryClient.setQueryData(nowPlayingQueryKey, null)
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: currentUserQueryKey }),
+        queryClient.invalidateQueries({ queryKey: nowPlayingQueryKey }),
+      ])
     } finally {
       setActionLoading(false)
     }

--- a/root/frontend/src/pages/Profile.tsx
+++ b/root/frontend/src/pages/Profile.tsx
@@ -83,20 +83,57 @@ export const NowPlayingCard = memo(function NowPlayingCard({ data }: { data: Now
     [duration]
   );
 
-  const [progress, setProgress] = useState<number>(() => clampProgress(data.progress_ms));
-  const startRef = useRef<number>(Date.now() - clampProgress(data.progress_ms));
+  const initialProgress = clampProgress(data.progress_ms);
+  const [progress, setProgress] = useState<number>(() => initialProgress);
+  const startRef = useRef<number>(Date.now() - initialProgress);
   const rafRef = useRef<number | null>(null);
+  const prevTrackIdRef = useRef<string | null>(data.track_id ?? null);
+  const prevProgressRef = useRef<number>(initialProgress);
+  const prevIsPlayingRef = useRef<boolean>(data.is_playing);
 
   useEffect(() => {
     const next = clampProgress(data.progress_ms);
+    const trackChanged = (data.track_id ?? null) !== prevTrackIdRef.current;
+    const progressChanged = next !== prevProgressRef.current;
+    const resumed = data.is_playing && !prevIsPlayingRef.current;
+
+    if (trackChanged) {
+      prevTrackIdRef.current = data.track_id ?? null;
+    }
+
+    if (progressChanged) {
+      prevProgressRef.current = next;
+    }
+
+    if (trackChanged || progressChanged || resumed) {
+      startRef.current = Date.now() - next;
+      setProgress(next);
+    }
+
+    prevIsPlayingRef.current = data.is_playing;
+  }, [clampProgress, data.is_playing, data.progress_ms, data.track_id]);
+
+  useEffect(() => {
+    if (data.is_playing) return;
+    const next = clampProgress(data.progress_ms);
     startRef.current = Date.now() - next;
-    setProgress(next);
-  }, [clampProgress, data.progress_ms, data.duration_ms, data.track_id, data.is_playing]);
+    setProgress((prev) => (prev === next ? prev : next));
+    if (rafRef.current != null) {
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+    }
+  }, [clampProgress, data.is_playing, data.progress_ms]);
 
   const shouldAnimate = !isTest && data.is_playing && !prefersReduce && !reduced && duration > 0;
 
   useEffect(() => {
-    if (!shouldAnimate) return;
+    if (!shouldAnimate) {
+      if (rafRef.current != null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+      return;
+    }
     const loop = () => {
       const elapsed = Date.now() - startRef.current;
       setProgress(clampProgress(elapsed));
@@ -104,7 +141,10 @@ export const NowPlayingCard = memo(function NowPlayingCard({ data }: { data: Now
     };
     rafRef.current = requestAnimationFrame(loop);
     return () => {
-      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+      if (rafRef.current != null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
     };
   }, [clampProgress, shouldAnimate]);
 

--- a/root/frontend/src/pages/Settings.tsx
+++ b/root/frontend/src/pages/Settings.tsx
@@ -5,6 +5,7 @@ import { useNavigate } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
 import { useNotifications } from "@/hooks/useNotifications";
 import { usePushPreferences, NOTIFICATION_TOPIC_LABELS } from "@/hooks/usePushPreferences";
+import { nowPlayingQueryKey } from "@/hooks/useNowPlaying";
 import api from "../api/client";
 import {
   Box,
@@ -277,6 +278,10 @@ export default function Settings() {
     try {
       const r = await fetch("/spotify/disconnect", { method: "POST", credentials: "include" });
       if (!r.ok) throw new Error();
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: currentUserQueryKey }),
+        queryClient.invalidateQueries({ queryKey: nowPlayingQueryKey }),
+      ]);
       const meResp = await fetch("/api/users/me", { credentials: "include" });
       const me = await meResp.json();
       setUser(me);


### PR DESCRIPTION
## Summary
- synchronize the Spotify "Now Playing" card with track changes, pauses, and resumes without runaway progress
- ensure requestAnimationFrame only runs during playback and keep the card linking to the current track
- invalidate current user and now playing caches whenever Spotify is disconnected

## Testing
- npm run test -- useNowPlaying
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e50dd79d508327b83b18ef58eff182