### PR TITLE
Harden media uploads, logging, and Spotify redirect handling

### DIFF
--- a/root/app/api/routes.py
+++ b/root/app/api/routes.py
@@ -106,7 +106,8 @@ def _send_reset_email(to_email: str, link: str, full_name: str = "") -> None:
         if not host or not port:
             safe_link = _redact_sensitive_query(link)
             logger.warning(
-                "password.reset_email.fallback", extra={"email": to_email, "link": safe_link}
+                "password.reset_email.fallback",
+                extra={"email": to_email, "link": safe_link},
             )
             return
         ctx = ssl.create_default_context()

--- a/root/app/api/routes.py
+++ b/root/app/api/routes.py
@@ -1,6 +1,6 @@
 import base64
 import hashlib
-import mimetypes
+import logging
 import secrets
 import smtplib
 import ssl
@@ -9,7 +9,7 @@ from datetime import datetime, timedelta, timezone
 from email.message import EmailMessage
 from pathlib import Path
 from typing import List, Optional
-from urllib.parse import urlencode
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 import httpx
 from fastapi import (
@@ -38,11 +38,11 @@ from app.core.database import get_db
 from app.deps.cache import etag_matches, format_etag, get_cache
 from app.models import models
 from app.schemas import schemas
+from app.utils.files import save_image
 
 router = APIRouter()
 
-ALLOWED_IMAGE_TYPES = {"image/jpeg", "image/png", "image/webp"}
-MAX_IMAGE_SIZE = 5 * 1024 * 1024
+logger = logging.getLogger(__name__)
 
 
 def _news_item_cache_key(news_id: int) -> str:
@@ -58,6 +58,23 @@ _NEWS_LIST_CACHE_KEY = "news:list"
 
 def _hash_token(token: str) -> str:
     return hashlib.sha256(token.encode()).hexdigest()
+
+
+def _redact_sensitive_query(url: str) -> str:
+    try:
+        parts = urlsplit(url)
+    except ValueError:
+        return "[redacted]"
+    redacted_items = []
+    for key, value in parse_qsl(parts.query, keep_blank_values=True):
+        if key.lower() in {"token", "code"}:
+            redacted_items.append((key, "***redacted***"))
+        else:
+            redacted_items.append((key, value))
+    sanitized_query = urlencode(redacted_items, doseq=True)
+    sanitized = parts._replace(query=sanitized_query)
+    result = urlunsplit(sanitized)
+    return result or "[redacted]"
 
 
 def _send_reset_email(to_email: str, link: str, full_name: str = "") -> None:
@@ -87,7 +104,10 @@ def _send_reset_email(to_email: str, link: str, full_name: str = "") -> None:
     msg.add_alternative(html, subtype="html")
     try:
         if not host or not port:
-            print(f"[EMAIL_FALLBACK] {to_email} <- {link}")
+            safe_link = _redact_sensitive_query(link)
+            logger.warning(
+                "password.reset_email.fallback", extra={"email": to_email, "link": safe_link}
+            )
             return
         ctx = ssl.create_default_context()
         if security == "ssl":
@@ -108,27 +128,17 @@ def _send_reset_email(to_email: str, link: str, full_name: str = "") -> None:
                 if user:
                     s.login(user, password)
                 s.send_message(msg)
-    except Exception as e:
-        print(f"[EMAIL_ERROR] {e}. Link for {to_email}: {link}")
+    except Exception:
+        safe_link = _redact_sensitive_query(link)
+        logger.error(
+            "password.reset_email.error",
+            extra={"email": to_email, "link": safe_link},
+            exc_info=True,
+        )
 
 
 async def save_upload(file: UploadFile, subdir: str, prefix: str) -> str:
-    if file.content_type not in ALLOWED_IMAGE_TYPES:
-        raise HTTPException(status_code=415, detail="unsupported media type")
-    data = await file.read(MAX_IMAGE_SIZE + 1)
-    if len(data) > MAX_IMAGE_SIZE:
-        raise HTTPException(status_code=413, detail="file too large")
-    ext = (
-        mimetypes.guess_extension(file.content_type)
-        or f".{file.filename.split('.')[-1].lower()}"
-    )
-    name = f"{prefix}_{secrets.token_hex(8)}{ext}"
-    base_dir = settings.static_dir_path
-    folder = base_dir / subdir
-    folder.mkdir(parents=True, exist_ok=True)
-    path = folder / name
-    path.write_bytes(data)
-    return f"/static/{subdir}/{name}"
+    return await save_image(file, subdir, prefix)
 
 
 @router.post("/password/forgot")

--- a/root/app/main.py
+++ b/root/app/main.py
@@ -60,12 +60,30 @@ app.add_middleware(
 app.add_middleware(SecurityHeadersMiddleware, settings=settings)
 
 
+def _ensure_vary_header(response, header_name: str) -> None:
+    existing = response.headers.get("Vary")
+    if not existing:
+        response.headers["Vary"] = header_name
+        return
+    values = [value.strip() for value in existing.split(",") if value.strip()]
+    if header_name not in values:
+        values.append(header_name)
+        response.headers["Vary"] = ", ".join(values)
+
+
 @app.middleware("http")
-async def _static_cache_control(request: Request, call_next):
+async def _http_response_hardening(request: Request, call_next):
     response = await call_next(request)
     if request.url.path.startswith("/static/") and response.status_code == 200:
         # Encourage browsers to keep avatars locally without marking them immutable.
         response.headers.setdefault("Cache-Control", "public, max-age=86400")
+    acao = response.headers.get("access-control-allow-origin")
+    if acao and acao != "*":
+        _ensure_vary_header(response, "Origin")
+        if request.method.upper() == "OPTIONS":
+            _ensure_vary_header(response, "Access-Control-Request-Method")
+            if request.headers.get("access-control-request-headers"):
+                _ensure_vary_header(response, "Access-Control-Request-Headers")
     return response
 
 

--- a/root/app/utils/files.py
+++ b/root/app/utils/files.py
@@ -43,11 +43,7 @@ def _detect_image_mime(data: bytes) -> str | None:
         return "image/jpeg"
     if len(data) >= 8 and data[:8] == b"\x89PNG\r\n\x1a\n":
         return "image/png"
-    if (
-        len(data) >= 12
-        and data[:4] == b"RIFF"
-        and data[8:12] == b"WEBP"
-    ):
+    if len(data) >= 12 and data[:4] == b"RIFF" and data[8:12] == b"WEBP":
         return "image/webp"
     return None
 

--- a/root/app/utils/files.py
+++ b/root/app/utils/files.py
@@ -2,15 +2,21 @@ import mimetypes
 import re
 import secrets
 from pathlib import Path
+from typing import Final
 
 from fastapi import HTTPException, UploadFile, status
 
 from app.core.config import settings
 
-ALLOWED_IMAGE_TYPES = {"image/jpeg", "image/png", "image/webp"}
-MAX_IMAGE_SIZE = 5 * 1024 * 1024
+ALLOWED_IMAGE_TYPES: Final[set[str]] = {"image/jpeg", "image/png", "image/webp"}
+MAX_IMAGE_SIZE: Final[int] = 5 * 1024 * 1024
 
 _PREFIX_CLEAN_RE = re.compile(r"[^A-Za-z0-9._-]+")
+_PREFERRED_EXTENSIONS: Final[dict[str, str]] = {
+    "image/jpeg": ".jpg",
+    "image/png": ".png",
+    "image/webp": ".webp",
+}
 
 
 def _ensure_dir(p: Path) -> None:
@@ -32,6 +38,20 @@ def _ext_from_mime(mime: str) -> str:
     return exts[0] if exts else ""
 
 
+def _detect_image_mime(data: bytes) -> str | None:
+    if len(data) >= 3 and data[:3] == b"\xff\xd8\xff":
+        return "image/jpeg"
+    if len(data) >= 8 and data[:8] == b"\x89PNG\r\n\x1a\n":
+        return "image/png"
+    if (
+        len(data) >= 12
+        and data[:4] == b"RIFF"
+        and data[8:12] == b"WEBP"
+    ):
+        return "image/webp"
+    return None
+
+
 def normalize_filename_prefix(prefix: str) -> str:
     """Return a safe, lowercase slug suitable for file names."""
 
@@ -51,17 +71,25 @@ def _gen_name(prefix: str, ext: str) -> str:
 
 
 async def save_image(upload: UploadFile, subdir: str, prefix: str) -> str:
-    if upload.content_type not in ALLOWED_IMAGE_TYPES:
+    declared_type = (upload.content_type or "").lower()
+    if declared_type not in ALLOWED_IMAGE_TYPES:
         raise HTTPException(
             status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
             detail="unsupported media type",
         )
     data = await _read_limited(upload, MAX_IMAGE_SIZE)
-    ext = _ext_from_mime(upload.content_type) or {
-        "image/jpeg": ".jpg",
-        "image/png": ".png",
-        "image/webp": ".webp",
-    }.get(upload.content_type, "")
+    detected_type = _detect_image_mime(data)
+    if detected_type not in ALLOWED_IMAGE_TYPES:
+        raise HTTPException(
+            status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+            detail="unsupported media type",
+        )
+    if detected_type != declared_type:
+        raise HTTPException(
+            status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+            detail="content type mismatch",
+        )
+    ext = _PREFERRED_EXTENSIONS.get(detected_type) or _ext_from_mime(detected_type)
     name = _gen_name(prefix, ext)
     base = settings.static_dir_path
     sanitized_subdir = subdir.strip("/ ")

--- a/root/frontend/src/components/SpotifyConnect.tsx
+++ b/root/frontend/src/components/SpotifyConnect.tsx
@@ -14,6 +14,7 @@ import {
   Typography,
 } from "@mui/material"
 import { nowPlayingQueryKey, useNowPlaying } from "@/hooks/useNowPlaying"
+import { sanitizeSpotifyAuthorizeUrl } from "@/utils/spotify"
 
 export default function SpotifyConnect() {
   const { user, setUser } = useAuth()
@@ -28,8 +29,12 @@ export default function SpotifyConnect() {
   const connect = async () => {
     setActionLoading(true)
     try {
-      const r = await api.get("/spotify/auth-url")
-      window.location.href = r.data.url
+      const r = await api.get<{ url?: string }>("/spotify/auth-url")
+      const safeUrl = sanitizeSpotifyAuthorizeUrl(r.data?.url)
+      if (!safeUrl) {
+        throw new Error("Received unsafe Spotify authorization URL")
+      }
+      window.location.href = safeUrl
     } finally {
       setActionLoading(false)
     }

--- a/root/frontend/src/pages/Settings.tsx
+++ b/root/frontend/src/pages/Settings.tsx
@@ -54,6 +54,7 @@ import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import defaultAvatar from "@/assets/default_avatar.png";
 import spotifyLogo from "@/assets/spotify_icon.png";
 import { appendCacheBust, resolveMediaUrl } from "@/utils/media";
+import { sanitizeSpotifyAuthorizeUrl } from "@/utils/spotify";
 
 type ThemeMode = "system" | "light" | "dark";
 
@@ -267,8 +268,9 @@ export default function Settings() {
       const r = await fetch("/spotify/auth-url", { credentials: "include" });
       if (!r.ok) throw new Error();
       const data = (await r.json()) as { url?: string };
-      if (data?.url) window.location.assign(data.url);
-      else throw new Error();
+      const safeUrl = sanitizeSpotifyAuthorizeUrl(data?.url);
+      if (!safeUrl) throw new Error("Received unsafe Spotify authorization URL");
+      window.location.assign(safeUrl);
     } catch {
       setSnack({ text: "Не удалось открыть авторизацию Spotify", sev: "error" });
     }

--- a/root/frontend/src/utils/spotify.ts
+++ b/root/frontend/src/utils/spotify.ts
@@ -1,0 +1,20 @@
+const ALLOWED_SPOTIFY_HOSTS = new Set(["accounts.spotify.com"])
+const AUTH_PATH_PREFIX = "/authorize"
+
+export const sanitizeSpotifyAuthorizeUrl = (
+  raw: string | null | undefined,
+): string | null => {
+  if (!raw) return null
+  try {
+    const url = new URL(raw)
+    if (url.protocol !== "https:") return null
+    const hostname = url.hostname.toLowerCase()
+    if (!ALLOWED_SPOTIFY_HOSTS.has(hostname)) return null
+    if (url.username || url.password) return null
+    if (url.port && url.port !== "443") return null
+    if (!url.pathname.startsWith(AUTH_PATH_PREFIX)) return null
+    return url.toString()
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
## Summary
- redact sensitive reset links from password reset logging and reuse the hardened image saver with MIME signature checks
- ensure responses emit the correct Vary headers when CORS is enabled to keep the policy strict
- validate Spotify authorization URLs on the client before redirecting the browser

## Testing
- npm --prefix root/frontend run typecheck
- ruff check root/app *(fails: repository has pre-existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e519c249d08327b74788992b2a4207