### PR TITLE
Improve media URL resolver robustness

### DIFF
--- a/root/frontend/src/components/Navbar.tsx
+++ b/root/frontend/src/components/Navbar.tsx
@@ -4,7 +4,7 @@ import Skeleton from "@mui/material/Skeleton";
 import { useAuth } from "../contexts/AuthContext";
 import guuLogo from "../assets/guu_logo.png";
 import defaultAvatar from "../assets/default_avatar.png";
-import { appendCacheBust, resolveMediaUrl } from "@/utils/media";
+import { addCacheBuster, resolveMediaUrl } from "@/utils/media";
 import NotificationsBell from "@/components/NotificationsBell";
 
 const navTextColor = "var(--nav-text)";
@@ -242,7 +242,7 @@ const Navbar = () => {
       (user as any)?.avatar_version ??
       (user as any)?.updated_at ??
       null;
-    return version != null ? appendCacheBust(resolved, version) ?? resolved : resolved;
+    return version != null ? addCacheBuster(resolved, version) ?? resolved : resolved;
   };
 
   const handleAvatarError = useCallback((event: React.SyntheticEvent<HTMLImageElement>) => {

--- a/root/frontend/src/pages/Profile.tsx
+++ b/root/frontend/src/pages/Profile.tsx
@@ -43,7 +43,7 @@ import { QRCodeSVG } from "qrcode.react";
 import { motion, useReducedMotion } from "framer-motion";
 import { useNowPlaying } from "@/hooks/useNowPlaying";
 import type { NowPlaying } from "@/types/spotify";
-import { appendCacheBust, resolveMediaUrl } from "@/utils/media";
+import { addCacheBuster, resolveMediaUrl } from "@/utils/media";
 
 const auraPulse = keyframes`
   0% { box-shadow: 0 0 0 0 rgba(255,255,255,.18); }
@@ -409,7 +409,7 @@ export default function Profile() {
       url: typeof window !== "undefined" ? window.location.href : "",
       image: (() => {
         const media = resolveMediaUrl(user.avatar_url);
-        const withV = media ? appendCacheBust(media, avatarVersion) : "";
+        const withV = media ? addCacheBuster(media, avatarVersion) : "";
         return withV || "";
       })()
     });
@@ -432,13 +432,13 @@ export default function Profile() {
   const avatarImageUrl = useMemo(() => {
     const media = resolveMediaUrl(user?.avatar_url);
     if (!media) return defaultAvatar;
-    return appendCacheBust(media, avatarVersion) || media;
+    return addCacheBuster(media, avatarVersion) || media;
   }, [user?.avatar_url, avatarVersion]);
 
   const coverImageUrl = useMemo(() => {
     const media = resolveMediaUrl(user?.cover_url);
     if (!media) return profileBg;
-    return appendCacheBust(media, coverVersion) || media;
+    return addCacheBuster(media, coverVersion) || media;
   }, [user?.cover_url, coverVersion]);
 
   const handleAvatarImgError = useCallback((event: React.SyntheticEvent<HTMLImageElement>) => {

--- a/root/frontend/src/pages/Settings.tsx
+++ b/root/frontend/src/pages/Settings.tsx
@@ -53,7 +53,7 @@ import DoNotDisturbOnIcon from "@mui/icons-material/DoNotDisturbOn";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import defaultAvatar from "@/assets/default_avatar.png";
 import spotifyLogo from "@/assets/spotify_icon.png";
-import { appendCacheBust, resolveMediaUrl } from "@/utils/media";
+import { addCacheBuster, resolveMediaUrl } from "@/utils/media";
 import { sanitizeSpotifyAuthorizeUrl } from "@/utils/spotify";
 
 type ThemeMode = "system" | "light" | "dark";
@@ -307,13 +307,13 @@ export default function Settings() {
   const avatarSrc = useMemo(() => {
     const resolved = resolveMediaUrl(avatarUrl);
     if (!resolved) return defaultAvatar;
-    return appendCacheBust(resolved, avatarVersion) || resolved;
+    return addCacheBuster(resolved, avatarVersion) || resolved;
   }, [avatarUrl, avatarVersion]);
 
   const coverSrc = useMemo(() => {
     const resolved = resolveMediaUrl(coverUrl);
     if (!resolved) return "";
-    return appendCacheBust(resolved, coverVersion) || resolved;
+    return addCacheBuster(resolved, coverVersion) || resolved;
   }, [coverUrl, coverVersion]);
 
   const handleAvatarError = useCallback((event: React.SyntheticEvent<HTMLImageElement>) => {

--- a/root/frontend/src/utils/__tests__/media.test.ts
+++ b/root/frontend/src/utils/__tests__/media.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { addCacheBuster, resolveMediaUrl } from "@/utils/media";
+
+const ORIGIN = "https://backend.example";
+
+describe("resolveMediaUrl", () => {
+  it("returns undefined for empty input", () => {
+    expect(resolveMediaUrl(undefined, ORIGIN)).toBeUndefined();
+    expect(resolveMediaUrl("   ", ORIGIN)).toBeUndefined();
+  });
+
+  it("keeps absolute URLs untouched", () => {
+    const absolute = "https://cdn.example/images/photo.png";
+    expect(resolveMediaUrl(absolute, ORIGIN)).toBe(absolute);
+  });
+
+  it("normalizes static prefix and encodes unicode segments", () => {
+    const url = resolveMediaUrl(" /static/аватары/фото 1.png", ORIGIN);
+    expect(url).toBe(
+      "https://backend.example/media/%D0%B0%D0%B2%D0%B0%D1%82%D0%B0%D1%80%D1%8B/%D1%84%D0%BE%D1%82%D0%BE%201.png",
+    );
+  });
+
+  it("collapses duplicate slashes and preserves query and hash", () => {
+    const url = resolveMediaUrl("media//gallery//item.jpg?foo=bar&foo=bar#секция", ORIGIN);
+    expect(url).toBe(
+      "https://backend.example/media/gallery/item.jpg?foo=bar&foo=bar#%D1%81%D0%B5%D0%BA%D1%86%D0%B8%D1%8F",
+    );
+  });
+
+  it("falls back to window origin when explicit origin is missing", () => {
+    const original = window.location;
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { origin: "https://app.local" } as Location,
+    });
+    try {
+      expect(resolveMediaUrl("avatars/photo.png")).toBe("https://app.local/avatars/photo.png");
+    } finally {
+      Object.defineProperty(window, "location", { configurable: true, value: original });
+    }
+  });
+});
+
+describe("addCacheBuster", () => {
+  it("adds the version query parameter", () => {
+    expect(addCacheBuster("https://example.com/image.png", 123)).toBe(
+      "https://example.com/image.png?v=123",
+    );
+  });
+
+  it("updates an existing version parameter", () => {
+    expect(addCacheBuster("https://example.com/image.png?v=1", "456")).toBe(
+      "https://example.com/image.png?v=456",
+    );
+  });
+
+  it("handles relative URLs gracefully", () => {
+    expect(addCacheBuster("/media/photo.png", 7)).toBe("/media/photo.png?v=7");
+  });
+});

--- a/root/frontend/src/utils/media.ts
+++ b/root/frontend/src/utils/media.ts
@@ -1,21 +1,6 @@
-const ABSOLUTE_PATTERN = /^(data:|blob:|https?:\/\/)/i
+const ABSOLUTE_URL_PATTERN = /^(?:[a-z][a-z\d+\-.]*:|\/\/)/i
 
 const ensureOrigin = (origin?: string) => origin?.replace(/\/+$/, "") ?? ""
-
-const encodePath = (value: string) => {
-  return value
-    .split("/")
-    .map((segment) => {
-      if (!segment) return segment
-      try {
-        return encodeURIComponent(decodeURIComponent(segment))
-      } catch {
-        return encodeURIComponent(segment)
-      }
-    })
-    .join("/")
-    .replace(/\/{2,}/g, "/")
-}
 
 const readEnvOrigin = () => {
   if (typeof import.meta !== "undefined" && import.meta.env?.VITE_BACKEND_ORIGIN) {
@@ -26,7 +11,59 @@ const readEnvOrigin = () => {
 
 const DEFAULT_BACKEND_ORIGIN = ensureOrigin(readEnvOrigin())
 
-const sanitizePath = (raw: string) => raw.replace(/^\/?static\//i, "/media/")
+const sanitizeStaticPrefix = (value: string) => value.replace(/^\/?static\//i, "/media/")
+
+const encodeSegment = (segment: string) => {
+  if (!segment) return segment
+  if (segment === "." || segment === "..") return segment
+  try {
+    return encodeURIComponent(decodeURIComponent(segment))
+  } catch {
+    return encodeURIComponent(segment)
+  }
+}
+
+const encodePathname = (pathname: string) => {
+  const normalized = pathname.replace(/\\+/g, "/")
+  const hasLeadingSlash = normalized.startsWith("/")
+  const hasTrailingSlash = normalized.endsWith("/")
+  const rawSegments = normalized.split("/")
+  const filtered = rawSegments.filter((segment, index) => {
+    if (segment) return true
+    if (index === 0 && hasLeadingSlash) return false
+    if (index === rawSegments.length - 1 && hasTrailingSlash) return false
+    return false
+  })
+  const encodedSegments = filtered.map(encodeSegment).filter((segment) => segment !== undefined && segment !== "")
+  let result = encodedSegments.join("/")
+  if (hasLeadingSlash) result = `/${result}`
+  if (!result && hasLeadingSlash) result = "/"
+  if (hasTrailingSlash && result !== "/") result = `${result}/`
+  return result
+}
+
+const normalizeRelativePath = (rawPath: string) => {
+  const trimmed = sanitizeStaticPrefix(rawPath.trim())
+  if (!trimmed) return ""
+  const replacedBackslashes = trimmed.replace(/\\/g, "/")
+  const [pathAndQuery, hash = ""] = replacedBackslashes.split("#", 2)
+  const [pathPart, query = ""] = pathAndQuery.split("?", 2)
+
+  const encodedPath = encodePathname(pathPart || "/") || "/"
+
+  const normalizedQuery = query
+    ? (() => {
+        const params = new URLSearchParams(query)
+        return params.toString()
+      })()
+    : ""
+
+  const normalizedHash = hash ? `#${encodeURIComponent(hash)}` : ""
+
+  const queryPart = normalizedQuery ? `?${normalizedQuery}` : ""
+
+  return `${encodedPath}${queryPart}${normalizedHash}`
+}
 
 type ResolveMediaOptions = {
   fallback?: string
@@ -34,40 +71,34 @@ type ResolveMediaOptions = {
 
 export function resolveMediaUrl(
   input?: string | null,
-  origin = DEFAULT_BACKEND_ORIGIN,
+  backendOrigin = DEFAULT_BACKEND_ORIGIN || (typeof window !== "undefined" ? window.location.origin : ""),
   options?: ResolveMediaOptions
-): string {
-  const fallback = options?.fallback ?? ""
+): string | undefined {
+  const fallback = options?.fallback
   if (input == null) return fallback
   const raw = String(input).trim()
   if (!raw) return fallback
-  if (ABSOLUTE_PATTERN.test(raw)) return raw
+  if (ABSOLUTE_URL_PATTERN.test(raw)) return raw
 
-  const normalizedRaw = sanitizePath(raw)
+  const origin = ensureOrigin(backendOrigin)
+  const normalizedRelative = normalizeRelativePath(raw)
 
-  const resolvedOrigin = ensureOrigin(
-    origin || (typeof window !== "undefined" ? window.location.origin : "")
-  )
-
-  if (!resolvedOrigin) {
-    const normalized = normalizedRaw.startsWith("/") ? normalizedRaw : `/${normalizedRaw}`
-    return encodePath(normalized) || fallback
+  if (!origin) {
+    return normalizedRelative || fallback
   }
 
   try {
-    const resolved = new URL(normalizedRaw, `${resolvedOrigin}/`)
-    resolved.pathname = encodePath(resolved.pathname)
-    return resolved.toString()
+    const url = new URL(normalizedRelative || "/", `${origin}/`)
+    url.pathname = encodePathname(url.pathname)
+    return url.toString()
   } catch {
-    const normalized = normalizedRaw.replace(/^\/+/, "")
-    return `${resolvedOrigin}/${encodePath(normalized)}` || fallback
+    const basePath = normalizedRelative.replace(/^\/+/, "")
+    const finalPath = basePath ? `/${basePath}` : ""
+    return `${origin}${finalPath}` || fallback
   }
 }
 
-export function appendCacheBust(
-  url: string | undefined,
-  version: number | string = Date.now()
-): string | undefined {
+export function addCacheBuster(url: string | undefined, version: number | string): string | undefined {
   if (!url) return undefined
   const value = String(version)
   if (!value) return url
@@ -76,8 +107,8 @@ export function appendCacheBust(
     parsed.searchParams.set("v", value)
     return parsed.toString()
   } catch {
-    const sep = url.includes("?") ? "&" : "?"
-    return `${url}${sep}v=${encodeURIComponent(value)}`
+    const separator = url.includes("?") ? "&" : "?"
+    return `${url}${separator}v=${encodeURIComponent(value)}`
   }
 }
 


### PR DESCRIPTION
## Summary
- harden media URL resolution by normalizing segments, encoding unicode safely, and supporting cache-busting updates
- update navbar, profile, and settings avatars/covers to use the new cache-busting helper consistently
- add vitest coverage for resolveMediaUrl and addCacheBuster edge cases

## Testing
- npm run test -- src/utils/__tests__/media.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e62c75f5a88327a64456a03a1c4b08