### PR TITLE
Avoid blocking login on push subscription sync

### DIFF
--- a/root/frontend/src/contexts/AuthContext.tsx
+++ b/root/frontend/src/contexts/AuthContext.tsx
@@ -278,11 +278,13 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 
         if (typeof window !== "undefined" && typeof Notification !== "undefined") {
           if (Notification.permission === "granted") {
-            try {
-              await softSyncPushSubscription()
-            } catch (error) {
-              console.warn("Failed to sync push subscription", error)
-            }
+            void (async () => {
+              try {
+                await softSyncPushSubscription()
+              } catch (error) {
+                console.warn("Failed to sync push subscription", error)
+              }
+            })()
           }
         }
       } catch (error) {


### PR DESCRIPTION
## Summary
- stop awaiting the background push subscription sync so the login flow can finish even if the service worker is not ready

## Testing
- npm test -- Login

------
https://chatgpt.com/codex/tasks/task_e_68e6f66902408327abcd399abde11b48