### PR TITLE
Add backend logout endpoint

### DIFF
--- a/root/app/auth/auth.py
+++ b/root/app/auth/auth.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Response, status
 from fastapi.security import OAuth2PasswordRequestForm
 from pydantic import BaseModel, EmailStr
 from sqlalchemy import select
@@ -119,3 +119,13 @@ async def register(user: UserCreate, db: AsyncSession = Depends(get_db)):
     await db.commit()
     await db.refresh(new_user)
     return {"status": "ok", "id": new_user.id}
+
+
+@router.post("/logout", status_code=status.HTTP_200_OK)
+async def logout(response: Response):
+    """Terminate the client session."""
+
+    response.delete_cookie("Authorization")
+    response.delete_cookie("token")
+    response.delete_cookie("access_token")
+    return {"status": "ok"}


### PR DESCRIPTION
## Summary
- add a POST /auth/logout endpoint that returns a success payload
- clear potential auth cookies during logout to avoid stale credentials

## Testing
- pytest tests/test_smoke.py

------
https://chatgpt.com/codex/tasks/task_e_68e7115af5988327abfc064f443c0b6b