### PR TITLE
Invalidate JWTs on logout

### DIFF
--- a/root/alembic/versions/8f6e0bcb76bc_add_user_token_version.py
+++ b/root/alembic/versions/8f6e0bcb76bc_add_user_token_version.py
@@ -1,0 +1,56 @@
+"""add token_version to users
+
+Revision ID: 8f6e0bcb76bc
+Revises: ffe470bc9ca2
+Create Date: 2024-05-13 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+from alembic import op
+
+
+revision: str = "8f6e0bcb76bc"
+down_revision: Union[str, Sequence[str], None] = "ffe470bc9ca2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    tables = {table for table in inspector.get_table_names()}
+    if "users" not in tables:
+        return
+
+    columns = {column["name"] for column in inspector.get_columns("users")}
+    if "token_version" in columns:
+        return
+
+    op.add_column(
+        "users",
+        sa.Column(
+            "token_version",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+    )
+    op.execute(sa.text("UPDATE users SET token_version = 0 WHERE token_version IS NULL"))
+    if bind.dialect.name != "sqlite":
+        op.alter_column("users", "token_version", server_default=None)
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    tables = {table for table in inspector.get_table_names()}
+    if "users" not in tables:
+        return
+
+    columns = {column["name"] for column in inspector.get_columns("users")}
+    if "token_version" in columns:
+        op.drop_column("users", "token_version")

--- a/root/alembic/versions/8f6e0bcb76bc_add_user_token_version.py
+++ b/root/alembic/versions/8f6e0bcb76bc_add_user_token_version.py
@@ -12,7 +12,6 @@ from sqlalchemy import inspect
 
 from alembic import op
 
-
 revision: str = "8f6e0bcb76bc"
 down_revision: Union[str, Sequence[str], None] = "ffe470bc9ca2"
 branch_labels: Union[str, Sequence[str], None] = None
@@ -39,7 +38,9 @@ def upgrade() -> None:
             server_default=sa.text("0"),
         ),
     )
-    op.execute(sa.text("UPDATE users SET token_version = 0 WHERE token_version IS NULL"))
+    op.execute(
+        sa.text("UPDATE users SET token_version = 0 WHERE token_version IS NULL")
+    )
     if bind.dialect.name != "sqlite":
         op.alter_column("users", "token_version", server_default=None)
 

--- a/root/app/api/deps.py
+++ b/root/app/api/deps.py
@@ -31,4 +31,12 @@ async def get_current_user(
     user = await db.get(User, user_id)
     if not user or not user.is_active:
         raise credentials_exception
+    raw_version = payload.get("ver", 0)
+    try:
+        token_version = int(raw_version)
+    except (TypeError, ValueError):
+        token_version = 0
+    current_version = user.token_version or 0
+    if token_version != current_version:
+        raise credentials_exception
     return user

--- a/root/app/auth/auth.py
+++ b/root/app/auth/auth.py
@@ -1,9 +1,10 @@
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Response, status
 from fastapi.security import OAuth2PasswordRequestForm
 from pydantic import BaseModel, EmailStr
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.api.deps import get_current_user
 from app.auth.security import (
     create_access_token,
     get_password_hash,
@@ -56,7 +57,7 @@ async def login(
         user.hashed_password = new_hash
         await db.commit()
         await db.refresh(user)
-    token = create_access_token(str(user_id))
+    token = create_access_token(str(user_id), extra={"ver": user.token_version or 0})
     return {"access_token": token, "token_type": "bearer"}
 
 
@@ -92,7 +93,7 @@ async def login_json(payload: LoginIn, db: AsyncSession = Depends(get_db)):
         user.hashed_password = new_hash
         await db.commit()
         await db.refresh(user)
-    token = create_access_token(str(user_id))
+    token = create_access_token(str(user_id), extra={"ver": user.token_version or 0})
     return {"access_token": token, "token_type": "bearer"}
 
 
@@ -119,3 +120,22 @@ async def register(user: UserCreate, db: AsyncSession = Depends(get_db)):
     await db.commit()
     await db.refresh(new_user)
     return {"status": "ok", "id": new_user.id}
+
+
+@router.post("/logout", status_code=status.HTTP_200_OK)
+async def logout(
+    response: Response,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Terminate the client session and revoke issued tokens."""
+
+    response.delete_cookie("Authorization")
+    response.delete_cookie("token")
+    response.delete_cookie("access_token")
+
+    current_version = user.token_version or 0
+    user.token_version = current_version + 1
+    await db.commit()
+
+    return {"status": "ok"}

--- a/root/app/models/models.py
+++ b/root/app/models/models.py
@@ -67,6 +67,8 @@ class User(Base):
     spotify_last_track_url = Column(String)
     spotify_last_album_image_url = Column(String)
 
+    token_version = Column(Integer, nullable=False, default=0, server_default="0")
+
     group = relationship("Group", back_populates="students", passive_deletes=True)
     notifications = relationship(
         "Notification",

--- a/root/tests/test_auth_logout.py
+++ b/root/tests/test_auth_logout.py
@@ -5,7 +5,9 @@ from app.auth.security import get_password_hash
 
 
 @pytest.mark.anyio
-async def test_logout_invalidates_token(async_client: AsyncClient, user_factory) -> None:
+async def test_logout_invalidates_token(
+    async_client: AsyncClient, user_factory
+) -> None:
     password = "StrongP@ssw0rd!"
     hashed_password = get_password_hash(password)
     user = await user_factory(hashed_password=hashed_password, is_active=True)

--- a/root/tests/test_auth_logout.py
+++ b/root/tests/test_auth_logout.py
@@ -1,0 +1,41 @@
+import pytest
+from httpx import AsyncClient
+
+from app.auth.security import get_password_hash
+
+
+@pytest.mark.anyio
+async def test_logout_invalidates_token(async_client: AsyncClient, user_factory) -> None:
+    password = "StrongP@ssw0rd!"
+    hashed_password = get_password_hash(password)
+    user = await user_factory(hashed_password=hashed_password, is_active=True)
+
+    login_response = await async_client.post(
+        "/auth/login",
+        data={"username": user.email, "password": password},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert login_response.status_code == 200
+    token = login_response.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    logout_response = await async_client.post("/auth/logout", headers=headers)
+    assert logout_response.status_code == 200
+    assert logout_response.json() == {"status": "ok"}
+
+    me_response = await async_client.get("/users/me", headers=headers)
+    assert me_response.status_code == 401
+
+    relogin_response = await async_client.post(
+        "/auth/login",
+        data={"username": user.email, "password": password},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert relogin_response.status_code == 200
+    new_token = relogin_response.json()["access_token"]
+    assert new_token != token
+
+    refreshed_headers = {"Authorization": f"Bearer {new_token}"}
+    me_after_relogin = await async_client.get("/users/me", headers=refreshed_headers)
+    assert me_after_relogin.status_code == 200
+    assert me_after_relogin.json()["id"] == user.id


### PR DESCRIPTION
## Summary
- add a `token_version` column to users and migrate the database
- include the token version in issued JWTs and bump it during logout to revoke prior tokens
- add a regression test that ensures the old token becomes unauthorized after logout

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e7115af5988327abfc064f443c0b6b