### PR TITLE
Handle missing service worker during logout unsubscribe

### DIFF
--- a/root/frontend/src/push/__tests__/unsubscribePush.test.ts
+++ b/root/frontend/src/push/__tests__/unsubscribePush.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { unsubscribePush } from "@/push/subscribe"
+
+const CONSENT_KEY = "push:consent"
+const LAST_SYNC_KEY = "push:last_sync"
+const SUB_KEY = "push:last_payload"
+const TOPICS_KEY = "push:last_topics"
+
+describe("unsubscribePush", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    try {
+      delete (navigator as any).serviceWorker
+    } catch {
+      /* ignore */
+    }
+  })
+
+  it("resolves when the service worker never becomes ready", async () => {
+    localStorage.setItem(CONSENT_KEY, "granted")
+    localStorage.setItem(LAST_SYNC_KEY, "123")
+    localStorage.setItem(SUB_KEY, "{}")
+    localStorage.setItem(TOPICS_KEY, "[]")
+
+    const neverReady = new Promise<ServiceWorkerRegistration>(() => {})
+    const getRegistration = vi.fn().mockResolvedValue(undefined)
+
+    Object.defineProperty(navigator, "serviceWorker", {
+      configurable: true,
+      value: {
+        ready: neverReady,
+        getRegistration,
+      },
+    })
+
+    const resultPromise = unsubscribePush()
+
+    await vi.advanceTimersByTimeAsync(2100)
+
+    const result = await resultPromise
+    expect(result).toBe(false)
+
+    expect(localStorage.getItem(CONSENT_KEY)).toBeNull()
+    expect(localStorage.getItem(LAST_SYNC_KEY)).toBeNull()
+    expect(localStorage.getItem(SUB_KEY)).toBeNull()
+    expect(localStorage.getItem(TOPICS_KEY)).toBeNull()
+  })
+})

--- a/root/frontend/src/push/subscribe.ts
+++ b/root/frontend/src/push/subscribe.ts
@@ -251,12 +251,70 @@ type UnsubscribePushOptions = {
   preserveConsent?: boolean
 }
 
+function clearPushLocals(preserveConsent?: boolean) {
+  if (!preserveConsent) {
+    try {
+      localStorage.removeItem(PUSH_CONSENT_STORAGE_KEY)
+    } catch {}
+  }
+  removeStoredValue(PUSH_LAST_SYNC_STORAGE_KEY)
+  removeStoredValue(PUSH_SUB_STORAGE_KEY)
+  removeStoredValue(PUSH_TOPICS_STORAGE_KEY)
+}
+
+async function resolveServiceWorkerRegistration(
+  provided?: ServiceWorkerRegistration,
+): Promise<ServiceWorkerRegistration | null> {
+  if (provided) return provided
+
+  try {
+    const existing = await navigator.serviceWorker.getRegistration()
+    if (existing) return existing
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.warn("Failed to get existing service worker registration", error)
+    }
+  }
+
+  try {
+    const withTimeout = Promise.race<
+      ServiceWorkerRegistration | null | undefined
+    >([
+      navigator.serviceWorker.ready,
+      new Promise<null>((resolve) => setTimeout(() => resolve(null), 2000)),
+    ])
+    const registration = await withTimeout
+    return registration ?? null
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.warn("Failed to await service worker readiness", error)
+    }
+    return null
+  }
+}
+
 export async function unsubscribePush(options?: UnsubscribePushOptions) {
-  if (!("serviceWorker" in navigator)) return false
-  const reg = options?.registration ?? (await navigator.serviceWorker.ready)
-  const sub = await reg.pushManager.getSubscription()
-  if (!sub) return true
-  const endpoint = sub.endpoint
+  if (!("serviceWorker" in navigator)) {
+    clearPushLocals(options?.preserveConsent)
+    return false
+  }
+
+  const registration = await resolveServiceWorkerRegistration(
+    options?.registration,
+  )
+
+  if (!registration) {
+    clearPushLocals(options?.preserveConsent)
+    return false
+  }
+
+  const subscription = await registration.pushManager.getSubscription()
+  if (!subscription) {
+    clearPushLocals(options?.preserveConsent)
+    return true
+  }
+
+  const endpoint = subscription.endpoint
   let deleted = false
   if (endpoint) {
     try {
@@ -266,15 +324,11 @@ export async function unsubscribePush(options?: UnsubscribePushOptions) {
       console.warn("Failed to delete push subscription on server", error)
     }
   }
-  const ok = await sub.unsubscribe()
-  if (!options?.preserveConsent) {
-    try {
-      localStorage.removeItem(PUSH_CONSENT_STORAGE_KEY)
-    } catch {}
-  }
-  removeStoredValue(PUSH_LAST_SYNC_STORAGE_KEY)
-  removeStoredValue(PUSH_SUB_STORAGE_KEY)
-  removeStoredValue(PUSH_TOPICS_STORAGE_KEY)
+
+  const ok = await subscription.unsubscribe()
+
+  clearPushLocals(options?.preserveConsent)
+
   return ok && (deleted || !endpoint)
 }
 


### PR DESCRIPTION
## Summary
- ensure push unsubscription does not hang when no service worker registration becomes ready
- clear stored push state even when no subscription is available during logout
- add a regression test covering logout with an unresolved service worker

## Testing
- npm test -- unsubscribePush

------
https://chatgpt.com/codex/tasks/task_e_68e71c783f688327a49f23ddab9fdd43