### PR TITLE
Fix Spotify settings actions and clean up media cache

### DIFF
--- a/root/frontend/src/pages/Schedule.tsx
+++ b/root/frontend/src/pages/Schedule.tsx
@@ -31,10 +31,10 @@ import {
 import DeleteIcon from "@mui/icons-material/Delete"
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined"
 import AddIcon from "@mui/icons-material/Add"
-import CalendarMonthIcon from "@mui/icons-material/CalendarMonth"
 import AccessTimeIcon from "@mui/icons-material/AccessTime"
 import SchoolIcon from "@mui/icons-material/School"
 import RoomIcon from "@mui/icons-material/Room"
+import CalendarMonthIcon from "@mui/icons-material/CalendarMonth"
 import useMediaQuery from "@mui/material/useMediaQuery"
 import dayjs from "dayjs"
 import isoWeek from "dayjs/plugin/isoWeek"
@@ -83,12 +83,6 @@ const writeToStorage = (key: string, value: unknown) => {
     /* noop */
   }
 }
-
-const API_BASE = (() => {
-  const raw = (api.defaults.baseURL as string | undefined) || (import.meta.env.VITE_BACKEND_ORIGIN || "/api")
-  if (!raw) return "/api"
-  return raw.endsWith("/") ? raw.slice(0, -1) : raw
-})()
 
 type LessonParity = "odd" | "even" | "both"
 type LessonWeekday = (typeof days)[number] | string
@@ -228,14 +222,6 @@ export default function Schedule() {
     return () => clearInterval(id)
   }, [])
   const minutesNow = useMemo(() => nowTick.hour() * 60 + nowTick.minute(), [nowTick])
-
-  const exportHref = useMemo(() => {
-    const groupValue = selectedGroup ?? user?.group_id
-    if (!groupValue && groupValue !== 0) return null
-    const value = typeof groupValue === "number" ? groupValue.toString() : String(groupValue)
-    if (!value) return null
-    return `${API_BASE}/schedule/ics?group=${encodeURIComponent(value)}`
-  }, [selectedGroup, user])
 
   const groupsQuery = useQuery<ScheduleGroup[], Error, ScheduleGroup[], ScheduleGroupsQueryKey>({
     queryKey: scheduleGroupsQueryKey,
@@ -484,24 +470,6 @@ export default function Schedule() {
       >
         Чётная
       </Button>
-      <Tooltip
-        title={exportHref ? "" : "Выберите группу"}
-        disableHoverListener={!!exportHref}
-        placement="top"
-      >
-        <span>
-          <Button
-            component="a"
-            href={exportHref ?? undefined}
-            variant="outlined"
-            startIcon={<CalendarMonthIcon />}
-            disabled={!exportHref}
-            download={exportHref ? "" : undefined}
-          >
-            Экспорт в календарь
-          </Button>
-        </span>
-      </Tooltip>
     </Stack>
   )
 

--- a/root/frontend/src/pages/Settings.tsx
+++ b/root/frontend/src/pages/Settings.tsx
@@ -288,7 +288,7 @@ export default function Settings() {
         setUser(profile ?? null);
       } catch (error) {
         console.warn("Failed to refresh user after Spotify disconnect", error);
-        setUser((prev) =>
+        setUser((prev: ReturnType<typeof useAuth>["user"]) =>
           prev
             ? {
                 ...prev,

--- a/root/frontend/src/pages/Settings.tsx
+++ b/root/frontend/src/pages/Settings.tsx
@@ -265,30 +265,44 @@ export default function Settings() {
 
   const connectSpotify = async () => {
     try {
-      const r = await fetch("/spotify/auth-url", { credentials: "include" });
-      if (!r.ok) throw new Error();
-      const data = (await r.json()) as { url?: string };
+      const { data } = await api.get<{ url?: string }>("/spotify/auth-url");
       const safeUrl = sanitizeSpotifyAuthorizeUrl(data?.url);
       if (!safeUrl) throw new Error("Received unsafe Spotify authorization URL");
       window.location.assign(safeUrl);
-    } catch {
+    } catch (error) {
+      console.error("Failed to initiate Spotify auth", error);
       setSnack({ text: "Не удалось открыть авторизацию Spotify", sev: "error" });
     }
   };
 
   const disconnectSpotify = async () => {
     try {
-      const r = await fetch("/spotify/disconnect", { method: "POST", credentials: "include" });
-      if (!r.ok) throw new Error();
+      await api.post("/spotify/disconnect");
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: currentUserQueryKey }),
         queryClient.invalidateQueries({ queryKey: nowPlayingQueryKey }),
       ]);
-      const meResp = await fetch("/api/users/me", { credentials: "include" });
-      const me = await meResp.json();
-      setUser(me);
+
+      try {
+        const profile = await fetchCurrentUser();
+        setUser(profile ?? null);
+      } catch (error) {
+        console.warn("Failed to refresh user after Spotify disconnect", error);
+        setUser((prev) =>
+          prev
+            ? {
+                ...prev,
+                spotify_connected: false,
+                spotify_is_connected: false,
+                spotify_display_name: null,
+              }
+            : prev,
+        );
+      }
+
       setSnack({ text: "Spotify отключён", sev: "success" });
-    } catch {
+    } catch (error) {
+      console.error("Failed to disconnect Spotify", error);
       setSnack({ text: "Не удалось отключить Spotify", sev: "error" });
     }
   };

--- a/root/frontend/src/utils/__tests__/media.test.ts
+++ b/root/frontend/src/utils/__tests__/media.test.ts
@@ -90,4 +90,11 @@ describe("addVersionParam", () => {
     const { addVersionParam } = await import("@/utils/media")
     expect(addVersionParam("/media/photo.png", 7)).toBe("/media/photo.png?v=7")
   })
+
+  it("returns original URL when version is not provided", async () => {
+    const { addVersionParam } = await import("@/utils/media")
+    expect(addVersionParam("https://example.com/image.png")).toBe(
+      "https://example.com/image.png",
+    )
+  })
 })

--- a/root/frontend/src/utils/media.ts
+++ b/root/frontend/src/utils/media.ts
@@ -63,13 +63,13 @@ export function resolveMediaUrl(
 
 export function addVersionParam(url: string, version?: number): string {
   if (!url) return ""
-  const v = version ?? Date.now()
+  if (version == null) return url
   try {
     const parsed = new URL(url)
-    parsed.searchParams.set("v", String(v))
+    parsed.searchParams.set("v", String(version))
     return parsed.toString()
   } catch {
     const separator = url.includes("?") ? "&" : "?"
-    return `${url}${separator}v=${encodeURIComponent(String(v))}`
+    return `${url}${separator}v=${encodeURIComponent(String(version))}`
   }
 }


### PR DESCRIPTION
## Summary
- call the backend Spotify endpoints through the shared API client and refresh the cached profile state more safely
- prevent SmartImage renders from cache-busting media URLs unless an explicit version is provided and add a regression test
- remove the "Export to calendar" action from the schedule header as requested

## Testing
- npm run test -- src/utils/__tests__/media.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e72254dd708327a57a281473497a46