### PR TITLE
Add Spotify fallback data when playback is unavailable

### DIFF
--- a/root/app/api/routes.py
+++ b/root/app/api/routes.py
@@ -482,7 +482,9 @@ def _spotify_fallback_now_playing(user: models.User) -> schemas.SpotifyNowPlayin
     )
 
     if not has_payload:
-        return schemas.SpotifyNowPlayingOut(is_playing=False, fetched_at=datetime.now(timezone.utc))
+        return schemas.SpotifyNowPlayingOut(
+            is_playing=False, fetched_at=datetime.now(timezone.utc)
+        )
 
     return schemas.SpotifyNowPlayingOut(
         is_playing=False,

--- a/root/app/api/routes.py
+++ b/root/app/api/routes.py
@@ -467,6 +467,38 @@ async def _spotify_refresh_if_needed(db: AsyncSession, user: models.User) -> Non
         await db.refresh(user)
 
 
+def _spotify_fallback_now_playing(user: models.User) -> schemas.SpotifyNowPlayingOut:
+    artists: list[str] = []
+    last_artists = getattr(user, "spotify_last_artist_name", None)
+    if last_artists:
+        artists = [name.strip() for name in last_artists.split(",") if name.strip()]
+
+    has_payload = any(
+        (
+            getattr(user, "spotify_last_track_id", None),
+            getattr(user, "spotify_last_track_name", None),
+            artists,
+        )
+    )
+
+    if not has_payload:
+        return schemas.SpotifyNowPlayingOut(is_playing=False, fetched_at=datetime.now(timezone.utc))
+
+    return schemas.SpotifyNowPlayingOut(
+        is_playing=False,
+        progress_ms=None,
+        duration_ms=None,
+        track_id=getattr(user, "spotify_last_track_id", None),
+        track_name=getattr(user, "spotify_last_track_name", None),
+        artists=artists,
+        album_name=getattr(user, "spotify_last_album_name", None),
+        album_image_url=getattr(user, "spotify_last_album_image_url", None),
+        track_url=getattr(user, "spotify_last_track_url", None),
+        preview_url=None,
+        fetched_at=datetime.now(timezone.utc),
+    )
+
+
 @router.get("/spotify/auth-url", response_model=schemas.SpotifyAuthURL)
 async def spotify_auth_url(req: Request, user: models.User = Depends(get_current_user)):
     if not settings.spotify_client_id or not settings.spotify_redirect_uri:
@@ -562,7 +594,7 @@ async def spotify_now_playing(
             user.spotify_is_playing = False
             user.spotify_last_checked_at = now
             await db.commit()
-        return schemas.SpotifyNowPlayingOut(is_playing=False, fetched_at=now)
+        return _spotify_fallback_now_playing(user)
     if r.status_code == 200:
         data = r.json() or {}
         item = data.get("item") or {}
@@ -599,7 +631,7 @@ async def spotify_now_playing(
         return out
     if r.status_code == 401:
         raise HTTPException(status_code=401, detail="Требуется переподключить Spotify")
-    raise HTTPException(status_code=400, detail="Не удалось получить трек")
+    return _spotify_fallback_now_playing(user)
 
 
 @router.post("/events", response_model=schemas.EventOut)

--- a/root/app/api/spotify.py
+++ b/root/app/api/spotify.py
@@ -32,6 +32,41 @@ def _b64(s: str) -> str:
     return base64.b64encode(s.encode()).decode()
 
 
+def _fallback_now_playing(user: User) -> SpotifyNowPlayingOut:
+    artists: list[str] = []
+    if user.spotify_last_artist_name:
+        artists = [
+            name.strip()
+            for name in user.spotify_last_artist_name.split(",")
+            if name.strip()
+        ]
+
+    has_payload = any(
+        (
+            user.spotify_last_track_id,
+            user.spotify_last_track_name,
+            artists,
+        )
+    )
+
+    if not has_payload:
+        return SpotifyNowPlayingOut(is_playing=False, fetched_at=_now_utc())
+
+    return SpotifyNowPlayingOut(
+        is_playing=False,
+        progress_ms=None,
+        duration_ms=None,
+        track_id=user.spotify_last_track_id,
+        track_name=user.spotify_last_track_name,
+        artists=artists,
+        album_name=user.spotify_last_album_name,
+        album_image_url=user.spotify_last_album_image_url,
+        track_url=user.spotify_last_track_url,
+        preview_url=None,
+        fetched_at=_now_utc(),
+    )
+
+
 async def _save_tokens(
     db: AsyncSession,
     user: User,
@@ -151,7 +186,7 @@ async def now_playing(
 ):
     token = await _ensure_access_token(db, user)
     if not token:
-        return SpotifyNowPlayingOut(is_playing=False, fetched_at=_now_utc())
+        return _fallback_now_playing(user)
     async with httpx.AsyncClient(timeout=15) as client:
         r = await client.get(
             "https://api.spotify.com/v1/me/player/currently-playing",
@@ -161,9 +196,9 @@ async def now_playing(
         user.spotify_is_playing = False
         user.spotify_last_checked_at = _now_utc()
         await db.commit()
-        return SpotifyNowPlayingOut(is_playing=False, fetched_at=_now_utc())
+        return _fallback_now_playing(user)
     if r.status_code != 200:
-        return SpotifyNowPlayingOut(is_playing=False, fetched_at=_now_utc())
+        return _fallback_now_playing(user)
     j = r.json()
     item = j.get("item") or {}
     artists = [a.get("name") for a in item.get("artists", []) if a.get("name")]

--- a/root/tests/test_spotify_fallback.py
+++ b/root/tests/test_spotify_fallback.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 
-from app.api.spotify import _fallback_now_playing
 from app.api.routes import _spotify_fallback_now_playing
+from app.api.spotify import _fallback_now_playing
 from app.models.models import User
 
 
@@ -44,7 +44,9 @@ def test_fallback_now_playing_returns_last_track_details():
     assert out.track_url == "https://open.spotify.com/track/track-123"
     assert isinstance(out.fetched_at, datetime)
     assert out.fetched_at.tzinfo is not None
-    assert out.fetched_at.tzinfo.utcoffset(out.fetched_at) == timezone.utc.utcoffset(None)
+    assert out.fetched_at.tzinfo.utcoffset(out.fetched_at) == timezone.utc.utcoffset(
+        None
+    )
 
 
 def test_fallback_now_playing_handles_missing_data():

--- a/root/tests/test_spotify_fallback.py
+++ b/root/tests/test_spotify_fallback.py
@@ -1,0 +1,79 @@
+from datetime import datetime, timezone
+
+from app.api.spotify import _fallback_now_playing
+from app.api.routes import _spotify_fallback_now_playing
+from app.models.models import User
+
+
+def _make_user(
+    track_id: str | None = None,
+    track_name: str | None = None,
+    artists: str | None = None,
+    album: str | None = None,
+    album_image: str | None = None,
+    track_url: str | None = None,
+):
+    user = User()
+    user.spotify_last_track_id = track_id
+    user.spotify_last_track_name = track_name
+    user.spotify_last_artist_name = artists
+    user.spotify_last_album_name = album
+    user.spotify_last_album_image_url = album_image
+    user.spotify_last_track_url = track_url
+    return user
+
+
+def test_fallback_now_playing_returns_last_track_details():
+    user = _make_user(
+        track_id="track-123",
+        track_name="Test Song",
+        artists="Artist One, Artist Two",
+        album="Album",
+        album_image="https://img",
+        track_url="https://open.spotify.com/track/track-123",
+    )
+
+    out = _fallback_now_playing(user)
+
+    assert out.is_playing is False
+    assert out.track_id == "track-123"
+    assert out.track_name == "Test Song"
+    assert out.artists == ["Artist One", "Artist Two"]
+    assert out.album_name == "Album"
+    assert out.album_image_url == "https://img"
+    assert out.track_url == "https://open.spotify.com/track/track-123"
+    assert isinstance(out.fetched_at, datetime)
+    assert out.fetched_at.tzinfo is not None
+    assert out.fetched_at.tzinfo.utcoffset(out.fetched_at) == timezone.utc.utcoffset(None)
+
+
+def test_fallback_now_playing_handles_missing_data():
+    user = _make_user()
+
+    out = _fallback_now_playing(user)
+
+    assert out.is_playing is False
+    assert out.track_id is None
+    assert out.track_name is None
+    assert out.artists == []
+
+
+def test_legacy_fallback_matches_new_behavior():
+    user = _make_user(
+        track_id="track-42",
+        track_name="Legacy Song",
+        artists="Solo Artist",
+        album="Legacy Album",
+        album_image="https://legacy",
+        track_url="https://open.spotify.com/track/track-42",
+    )
+
+    modern = _fallback_now_playing(user)
+    legacy = _spotify_fallback_now_playing(user)
+
+    assert legacy.track_id == modern.track_id
+    assert legacy.track_name == modern.track_name
+    assert legacy.artists == modern.artists
+    assert legacy.album_name == modern.album_name
+    assert legacy.album_image_url == modern.album_image_url
+    assert legacy.track_url == modern.track_url


### PR DESCRIPTION
## Summary
- return the last known Spotify track metadata when the now playing API has no active playback
- reuse the fallback for both the new and legacy Spotify endpoints
- add unit tests for the fallback helpers

## Testing
- pytest tests/test_spotify_fallback.py

------
https://chatgpt.com/codex/tasks/task_e_68e7270f289883278d1bcbe4aa57a4e4