### PR TITLE
Speed up Spotify status refresh

### DIFF
--- a/root/frontend/src/hooks/useNowPlaying.ts
+++ b/root/frontend/src/hooks/useNowPlaying.ts
@@ -88,13 +88,15 @@ export const fetchNowPlaying = async () => {
 }
 
 const computeInterval = (data: NowPlaying | null) => {
-  if (!data || !data.is_playing) return 75_000
+  if (!data) return 10_000
+  if (!data.is_playing) return 6_000
   if (data.duration_ms != null && data.progress_ms != null) {
     const remaining = Math.max(0, data.duration_ms - data.progress_ms)
-    const padded = remaining + 5_000
-    return Math.min(Math.max(padded, 15_000), 20_000)
+    if (remaining <= 5_000) return 1_000
+    if (remaining <= 15_000) return 1_500
+    return Math.max(2_000, Math.min(4_000, Math.floor(remaining / 3)))
   }
-  return 18_000
+  return 1_500
 }
 
 export const useNowPlaying = (enabled: boolean) => {


### PR DESCRIPTION
## Summary
- reduce the Spotify now playing polling intervals to refresh the widget in near real time

## Testing
- npm run test -- src/hooks/__tests__/useNowPlaying.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e79af9a0a88327ac434e481f19bf11