### PR TITLE
Enhance page transitions and stabilize media loading

### DIFF
--- a/root/frontend/src/components/EventCard.tsx
+++ b/root/frontend/src/components/EventCard.tsx
@@ -182,6 +182,13 @@ const EventCardComponent: FC<EventCardProps> = ({
     () => (previewUrl ? previewUrl : editData.image_url ? resolveMediaUrl(editData.image_url) : undefined),
     [editData.image_url, previewUrl],
   )
+  const [cardImageReady, setCardImageReady] = useState(() => !cardImageUrl)
+
+  useEffect(() => {
+    setCardImageReady(!cardImageUrl)
+  }, [cardImageUrl])
+
+  const handleCardImageReady = useCallback(() => setCardImageReady(true), [])
 
   const dateError =
     Boolean(editData.starts_at) &&
@@ -410,8 +417,19 @@ const EventCardComponent: FC<EventCardProps> = ({
               borderRadius: 2,
               border: "1px solid #e0e0e0",
               overflow: "hidden",
+              position: "relative",
+              background: "linear-gradient(135deg, rgba(30,136,229,0.18), rgba(21,101,192,0.1))",
               transition: "transform 0.25s ease",
               "&:hover": { transform: isMobile ? "none" : "scale(1.01)" },
+              "&::after": {
+                content: '""',
+                position: "absolute",
+                inset: 0,
+                background: "linear-gradient(120deg, rgba(255,255,255,0.28), rgba(255,255,255,0.05))",
+                opacity: cardImageReady ? 0 : 1,
+                transition: "opacity 280ms ease",
+                pointerEvents: "none",
+              },
             }}
           >
             <SmartImage
@@ -424,6 +442,8 @@ const EventCardComponent: FC<EventCardProps> = ({
                 e.stopPropagation()
                 navigateToDetails()
               }}
+              onLoad={handleCardImageReady}
+              onError={handleCardImageReady}
             />
           </Box>
         </Box>

--- a/root/frontend/src/components/NewsCard.tsx
+++ b/root/frontend/src/components/NewsCard.tsx
@@ -60,6 +60,7 @@ const NewsCardComponent: FC<NewsCardProps> = ({
   const [previewUrl, setPreviewUrl] = useState<string | null>(null)
   const [imageLoading, setImageLoading] = useState(false)
   const imageInputRef = useRef<HTMLInputElement>(null)
+  const [cardImageReady, setCardImageReady] = useState(!image_url)
 
   const isMobile = useMediaQuery("(max-width:600px)")
   const menuId = `news-card-menu-${id}`
@@ -68,6 +69,12 @@ const NewsCardComponent: FC<NewsCardProps> = ({
   const createdAtIso = useMemo(() => (created_at ? dayjs(created_at).toISOString() : ""), [created_at])
   const createdAtLabel = useMemo(() => (created_at ? getMoscowDate(created_at) : ""), [created_at])
   const cardImageUrl = useMemo(() => resolveMediaUrl(image_url), [image_url])
+
+  useEffect(() => {
+    setCardImageReady(!cardImageUrl)
+  }, [cardImageUrl])
+
+  const handleCardImageReady = useCallback(() => setCardImageReady(true), [])
 
   // preview URL lifecycle
   useEffect(() => {
@@ -276,8 +283,18 @@ const NewsCardComponent: FC<NewsCardProps> = ({
             borderTopLeftRadius: { xs: "1.1rem", sm: "1.2rem" },
             borderTopRightRadius: { xs: "1.1rem", sm: "1.2rem" },
             borderBottom: "1px solid #eee",
-            background: "#f3f3f3",
+            background: "linear-gradient(135deg, rgba(13,71,161,0.18), rgba(63,81,181,0.08))",
+            position: "relative",
             overflow: "hidden",
+            "&::after": {
+              content: '""',
+              position: "absolute",
+              inset: 0,
+              background: "linear-gradient(120deg, rgba(255,255,255,0.2), rgba(255,255,255,0.05))",
+              opacity: cardImageReady ? 0 : 1,
+              transition: "opacity 260ms ease",
+              pointerEvents: "none",
+            },
           }}
         >
           <SmartImage
@@ -285,6 +302,8 @@ const NewsCardComponent: FC<NewsCardProps> = ({
             alt={title ? `Изображение новости ${title}` : "Обложка новости"}
             sizes="(min-width: 1200px) 640px, (min-width: 900px) 520px, 100vw"
             style={{ width: "100%", height: "100%", objectFit: "cover", display: "block" }}
+            onLoad={handleCardImageReady}
+            onError={handleCardImageReady}
           />
         </Box>
       )}

--- a/root/frontend/src/components/PageFadeIn.tsx
+++ b/root/frontend/src/components/PageFadeIn.tsx
@@ -1,0 +1,53 @@
+import { Box } from "@mui/material"
+import { type ReactNode, useEffect, useState } from "react"
+
+type PageFadeInProps = {
+  children: ReactNode
+  delay?: number
+}
+
+const transitionEase = "cubic-bezier(0.33, 1, 0.68, 1)"
+
+export default function PageFadeIn({ children, delay = 80 }: PageFadeInProps) {
+  const [ready, setReady] = useState(false)
+
+  useEffect(() => {
+    const frame = requestAnimationFrame(() => setReady(true))
+    return () => cancelAnimationFrame(frame)
+  }, [])
+
+  return (
+    <Box
+      data-ready={ready ? "true" : "false"}
+      sx={{
+        position: "relative",
+        minHeight: "100%",
+        opacity: ready ? 1 : 0,
+        transform: ready ? "none" : "translateY(18px)",
+        transition: `opacity 560ms ${transitionEase} ${delay}ms, transform 560ms ${transitionEase} ${delay}ms`,
+        willChange: "opacity, transform",
+        "& [data-fade]": {
+          opacity: ready ? 1 : 0,
+          transform: ready ? "none" : "translateY(22px)",
+          transitionProperty: "opacity, transform",
+          transitionDuration: "560ms",
+          transitionTimingFunction: transitionEase,
+          transitionDelay: `calc(var(--fade-delay, 120ms) + ${delay}ms)`,
+          willChange: "opacity, transform",
+        },
+        "@media (prefers-reduced-motion: reduce)": {
+          opacity: 1,
+          transform: "none",
+          transition: "none",
+          "& [data-fade]": {
+            opacity: 1,
+            transform: "none",
+            transition: "none",
+          },
+        },
+      }}
+    >
+      {children}
+    </Box>
+  )
+}

--- a/root/frontend/src/components/SmartImage.tsx
+++ b/root/frontend/src/components/SmartImage.tsx
@@ -1,4 +1,4 @@
-import { useState, memo } from "react"
+import { memo, useEffect, useMemo, useState, type CSSProperties, type ReactEventHandler } from "react"
 import { addVersionParam, resolveMediaUrl } from "@/utils/media"
 
 type Props = React.ImgHTMLAttributes<HTMLImageElement> & {
@@ -7,27 +7,86 @@ type Props = React.ImgHTMLAttributes<HTMLImageElement> & {
   fallback?: string
 }
 
-export default memo(function SmartImage({ srcRaw, cacheV, fallback, ...rest }: Props) {
+export default memo(function SmartImage({
+  srcRaw,
+  cacheV,
+  fallback,
+  style,
+  onLoad,
+  onError,
+  loading,
+  alt,
+  ...rest
+}: Props) {
   const [err, setErr] = useState(false)
+  const [loaded, setLoaded] = useState(false)
+
   const raw = srcRaw ?? ""
   const isSpecial = /^blob:/i.test(raw) || /^data:/i.test(raw)
   const resolved = isSpecial ? raw : resolveMediaUrl(raw)
   const base = resolved || fallback || ""
-  const src = err
-    ? fallback || ""
-    : resolved
-    ? isSpecial
-      ? resolved
-      : addVersionParam(resolved, cacheV)
-    : base
+
+  useEffect(() => {
+    setErr(false)
+    setLoaded(false)
+  }, [raw, cacheV, fallback])
+
+  const src = useMemo(() => {
+    if (err) return fallback || ""
+    if (resolved) {
+      if (isSpecial) return resolved
+      return addVersionParam(resolved, cacheV)
+    }
+    return base
+  }, [base, cacheV, err, fallback, isSpecial, resolved])
+
+  useEffect(() => {
+    if (!src) setLoaded(true)
+  }, [src])
+
+  const handleLoad: ReactEventHandler<HTMLImageElement> = (event) => {
+    setLoaded(true)
+    onLoad?.(event)
+  }
+
+  const handleError: ReactEventHandler<HTMLImageElement> = (event) => {
+    setErr(true)
+    setLoaded(true)
+    onError?.(event)
+  }
+
+  const transition =
+    typeof style?.transition === "string"
+      ? `${style.transition}, opacity 320ms ease`
+      : "opacity 320ms ease"
+
+  const willChange =
+    typeof style?.willChange === "string"
+      ? style.willChange.includes("opacity")
+        ? style.willChange
+        : `${style.willChange}, opacity`
+      : "opacity"
+
+  const mergedStyle: CSSProperties = {
+    ...style,
+    transition,
+    willChange,
+    opacity: loaded ? 1 : 0,
+  }
+
   return (
     <img
-      loading="lazy"
+      {...rest}
+      loading={loading ?? "lazy"}
       decoding="async"
       referrerPolicy="no-referrer"
-      onError={() => setErr(true)}
-      {...rest}
+      onLoad={handleLoad}
+      onError={handleError}
+      style={mergedStyle}
       src={src}
+      alt={alt ?? ""}
+      data-loaded={loaded ? "true" : "false"}
+      data-has-error={err ? "true" : undefined}
     />
   )
 })

--- a/root/frontend/src/pages/Dashboard.tsx
+++ b/root/frontend/src/pages/Dashboard.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useMemo, useState, useCallback, type KeyboardEvent } from "react"
+import { useEffect, useMemo, useState, useCallback, type KeyboardEvent, type CSSProperties } from "react"
 import Layout from "../components/Layout"
+import PageFadeIn from "../components/PageFadeIn"
 import { useAuth } from "../contexts/AuthContext"
 import axios from "../api/client"
 import {
@@ -58,8 +59,8 @@ function DateBullet({ date }: { date?: string }) {
     <Tooltip title={full} enterDelay={150}>
       <Box
         aria-label={`Дата публикации: ${full}`}
-        sx={{
-          width: 44,
+          sx={{
+            width: 44,
           height: 44,
           minWidth: 44,
           minHeight: 44,
@@ -338,8 +339,9 @@ export default function Dashboard() {
       >
         Перейти к содержимому
       </a>
-      <Box
-        id="main"
+      <PageFadeIn>
+        <Box
+          id="main"
         sx={{
           width: "100%",
           maxWidth: "min(1800px, 100%)",
@@ -348,9 +350,11 @@ export default function Dashboard() {
           mx: "auto"
         }}
       >
-        <Box
-          sx={{
-            background: headerGradient,
+          <Box
+            data-fade
+          style={{ '--fade-delay': '40ms' } as CSSProperties }
+            sx={{
+              background: headerGradient,
             borderRadius: "2rem",
             p: { xs: 2.2, md: 3 },
             boxShadow: "0 12px 36px #1d5fff16, 0 4px 14px #0000000a",
@@ -397,7 +401,7 @@ export default function Dashboard() {
             gap: { xs: 2, md: 3 }
           }}
         >
-          <Box sx={{ ...homeCardSx, gridColumn: { xs: "1 / -1", lg: "1 / span 4" }, ...newsLikeHover }} aria-busy={loadingSched}>
+          <Box data-fade style={{ '--fade-delay': '140ms' } as CSSProperties } sx={{ ...homeCardSx, gridColumn: { xs: "1 / -1", lg: "1 / span 4" }, ...newsLikeHover }} aria-busy={loadingSched}>
             <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 1 }}>
               <Typography sx={{ fontWeight: 800, fontSize: "clamp(1.05rem, 2vw, 1.4rem)" }}>
                 Сегодня в расписании
@@ -480,7 +484,7 @@ export default function Dashboard() {
             )}
           </Box>
 
-          <Box sx={{ ...homeCardSx, gridColumn: { xs: "1 / -1", lg: "5 / span 4" }, ...newsLikeHover }} aria-busy={loadingNews}>
+          <Box data-fade style={{ '--fade-delay': '200ms' } as CSSProperties } sx={{ ...homeCardSx, gridColumn: { xs: "1 / -1", lg: "5 / span 4" }, ...newsLikeHover }} aria-busy={loadingNews}>
             <Stack direction="row" alignItems="center" justifyContent="space-between">
               <Typography sx={{ fontWeight: 800, fontSize: "clamp(1.05rem, 2vw, 1.4rem)" }}>Новости</Typography>
               <Button
@@ -551,7 +555,7 @@ export default function Dashboard() {
             )}
           </Box>
 
-          <Box sx={{ ...homeCardSx, gridColumn: { xs: "1 / -1", lg: "9 / span 4" }, ...newsLikeHover }} aria-busy={loadingEvents}>
+          <Box data-fade style={{ '--fade-delay': '260ms' } as CSSProperties } sx={{ ...homeCardSx, gridColumn: { xs: "1 / -1", lg: "9 / span 4" }, ...newsLikeHover }} aria-busy={loadingEvents}>
             <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 1 }}>
               <Typography sx={{ fontWeight: 800, fontSize: "clamp(1.05rem, 2vw, 1.4rem)" }}>События</Typography>
               <Button
@@ -638,6 +642,7 @@ export default function Dashboard() {
           </Box>
         </Box>
       </Box>
+      </PageFadeIn>
     </Layout>
   )
 }

--- a/root/frontend/src/pages/Events.tsx
+++ b/root/frontend/src/pages/Events.tsx
@@ -1,6 +1,7 @@
 import Layout from "../components/Layout"
+import PageFadeIn from "../components/PageFadeIn"
 import EventCard from "../components/EventCard"
-import { useEffect, useState, useCallback, useMemo, type SyntheticEvent } from "react"
+import { useEffect, useState, useCallback, useMemo, type SyntheticEvent, type CSSProperties } from "react"
 import axios from "../api/client"
 import {
   Box, Tabs, Tab, TextField, Typography, Button,
@@ -187,7 +188,7 @@ const Events = () => {
 
   const mobileContent = useMemo(
     () => (
-      <Stack spacing={2} mt={1}>
+      <Stack data-fade style={{ '--fade-delay': '260ms' } as CSSProperties } spacing={2} mt={1}>
         {loading &&
           Array.from({ length: 3 }).map((_, i) => (
             <Box key={`event-skel-mobile-${i}`} sx={{ p: 0 }}>
@@ -213,6 +214,8 @@ const Events = () => {
   const desktopContent = useMemo(
     () => (
       <Box
+        data-fade
+        style={{ '--fade-delay': '260ms' } as CSSProperties }
         sx={{
           display: "grid",
           gridTemplateColumns: "repeat(auto-fit, minmax(320px, 1fr))",
@@ -251,7 +254,8 @@ const Events = () => {
 
   return (
     <Layout>
-      <Box
+      <PageFadeIn>
+        <Box
         sx={{
           width: "100vw",
           minHeight: "100vh",
@@ -263,6 +267,8 @@ const Events = () => {
         }}
       >
         <Box
+          data-fade
+          style={{ '--fade-delay': '80ms' } as CSSProperties }
           display="flex"
           alignItems="center"
           gap={2}
@@ -281,7 +287,9 @@ const Events = () => {
         </Box>
 
         {(user?.role === "admin" || user?.role === "teacher") && (
-          <Box sx={{ display: "flex", justifyContent: "flex-start", mb: isMobile ? 1.3 : 2 }}>
+          <Box
+            data-fade
+            style={{ '--fade-delay': '140ms' } as CSSProperties } sx={{ display: "flex", justifyContent: "flex-start", mb: isMobile ? 1.3 : 2 }}>
             <Button
               variant="contained"
               sx={{ fontWeight: 600, fontSize: 16, px: 2.5, borderRadius: 2 }}
@@ -294,6 +302,8 @@ const Events = () => {
         )}
 
         <Tabs
+          data-fade
+          style={{ '--fade-delay': '200ms' } as CSSProperties }
           value={tab}
           onChange={handleTabChange}
           variant={isMobile ? "scrollable" : "standard"}
@@ -330,6 +340,8 @@ const Events = () => {
         </Tabs>
 
         <Stack
+          data-fade
+          style={{ '--fade-delay': '240ms' } as CSSProperties }
           direction="row"
           spacing={1.5}
           alignItems="center"
@@ -579,6 +591,7 @@ const Events = () => {
           </DialogContent>
         </Dialog>
       </Box>
+      </PageFadeIn>
     </Layout>
   )
 }

--- a/root/frontend/src/pages/News.tsx
+++ b/root/frontend/src/pages/News.tsx
@@ -1,4 +1,5 @@
 import Layout from "../components/Layout"
+import PageFadeIn from "../components/PageFadeIn"
 import NewsCard from "../components/NewsCard"
 import {
   useEffect,
@@ -8,6 +9,7 @@ import {
   useDeferredValue,
   startTransition,
   useMemo,
+  type CSSProperties,
 } from "react"
 import axios from "../api/client"
 import {
@@ -204,19 +206,22 @@ const News = () => {
 
   return (
     <Layout>
-      <Box
-        sx={{
-          width: "100vw",
-          minHeight: "100vh",
+      <PageFadeIn>
+        <Box
+          sx={{
+            width: "100vw",
+            minHeight: "100vh",
           pl: { xs: 2, sm: 4, md: 5, lg: 8 },
           pr: { xs: 4, sm: 6, md: 7, lg: 10 },
           py: { xs: 0, sm: 0, md: 0, lg: 0 },
           boxSizing: "border-box",
           overflowX: "hidden",
         }}
-      >
-        <Stack
-          direction="row"
+        >
+          <Stack
+            data-fade
+            style={{ '--fade-delay': '80ms' } as CSSProperties }
+            direction="row"
           alignItems="center"
           gap={2}
           mb={isMobile ? 1.5 : 3}
@@ -234,7 +239,10 @@ const News = () => {
         </Stack>
 
         {user?.role === "admin" && (
-          <Box sx={{ display: "flex", justifyContent: "flex-start", mb: 2 }}>
+          <Box
+            data-fade
+            style={{ '--fade-delay': '140ms' } as CSSProperties }
+            sx={{ display: "flex", justifyContent: "flex-start", mb: 2 }}>
             <Button
               variant="contained"
               sx={{
@@ -253,7 +261,9 @@ const News = () => {
           </Box>
         )}
 
-        <Box
+          <Box
+            data-fade
+          style={{ '--fade-delay': '200ms' } as CSSProperties }
           sx={{
             display: "grid",
             gridTemplateColumns: "repeat(auto-fit, minmax(320px, 1fr))",
@@ -395,6 +405,7 @@ const News = () => {
           </DialogContent>
         </Dialog>
       </Box>
+      </PageFadeIn>
     </Layout>
   )
 }

--- a/root/frontend/src/pages/Schedule.tsx
+++ b/root/frontend/src/pages/Schedule.tsx
@@ -1,6 +1,7 @@
 import Layout from "../components/Layout"
+import PageFadeIn from "../components/PageFadeIn"
 import { useAuth } from "../contexts/AuthContext"
-import { useState, useEffect, useMemo, useRef, useDeferredValue, startTransition } from "react"
+import { useState, useEffect, useMemo, useRef, useDeferredValue, startTransition, type CSSProperties } from "react"
 import api from "../api/client"
 import {
   Box,
@@ -831,7 +832,8 @@ export default function Schedule() {
 
   return (
     <Layout>
-      <style>{`
+      <PageFadeIn>
+        <style>{`
         @media print {
           body { background: #fff !important; }
           .no-print { display: none !important; }
@@ -843,7 +845,7 @@ export default function Schedule() {
       `}</style>
       <Box sx={{ width: "100vw", minHeight: "100vh", bgcolor: "var(--page-bg)", color: "var(--page-text)", py: { xs: 3.5, sm: 3.5, md: 3.5, lg: 3.5 } }}>
         <Box sx={{ ...mainAlignSx, ml: { xs: 2, sm: 4, md: 5, lg: 8 }, mr: { xs: 2, sm: 4, md: 5, lg: 8 }, maxWidth: 980, mb: 2, mt: 0 }}>
-          <Stack direction="row" alignItems="center" flexWrap="wrap" gap={1.3} mb={2.2} mt={0.5}>
+          <Stack data-fade style={{ '--fade-delay': '80ms' } as CSSProperties } direction="row" alignItems="center" flexWrap="wrap" gap={1.3} mb={2.2} mt={0.5}>
             <CalendarMonthIcon color="primary" sx={{ fontSize: 34 }} />
             <Typography variant="h4" fontWeight={700} color="primary.main" sx={{ fontSize: "clamp(0.8rem, 5vw, 2.7rem)" }}>
               {user?.role === "student" ? "Расписание моей группы" : "Расписание групп"}
@@ -852,11 +854,11 @@ export default function Schedule() {
             {activeGroupName && <Box sx={{ ...badgeGhost, transform: "translateY(8px)" }}>Группа: {activeGroupName}</Box>}
           </Stack>
 
-          <Stack direction="row" alignItems="center" flexWrap="wrap" gap={1} mb={2}>
+          <Stack data-fade style={{ '--fade-delay': '140ms' } as CSSProperties } direction="row" alignItems="center" flexWrap="wrap" gap={1} mb={2}>
             {headerActions}
           </Stack>
 
-          <Box className="no-print" sx={{ ...headerCardSx, mb: 2 }}>
+          <Box data-fade style={{ '--fade-delay': '200ms' } as CSSProperties } className="no-print" sx={{ ...headerCardSx, mb: 2 }}>
             {currentLesson ? (
               <Box>
                 <Stack direction="row" alignItems="center" gap={1} flexWrap="wrap">
@@ -899,7 +901,7 @@ export default function Schedule() {
           </Box>
 
           {(user?.role === "teacher" || user?.role === "admin") && (
-            <FormControl fullWidth sx={{ mb: 2, maxWidth: 340 }}>
+            <FormControl data-fade style={{ '--fade-delay': '240ms' } as CSSProperties } fullWidth sx={{ mb: 2, maxWidth: 340 }}>
               <InputLabel>Группа</InputLabel>
               <Select
                 value={selectedGroup ?? ""}
@@ -914,7 +916,7 @@ export default function Schedule() {
           )}
         </Box>
 
-        <Box sx={{ ...mainAlignSx, maxWidth: 1920, px: { xs: 1, md: 2 } }}>
+        <Box data-fade style={{ '--fade-delay': '280ms' } as CSSProperties } sx={{ ...mainAlignSx, maxWidth: 1920, px: { xs: 1, md: 2 } }}>
           {isMobile ? renderMobileCards() : renderTable()}
         </Box>
 
@@ -1071,6 +1073,7 @@ export default function Schedule() {
           anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
         />
       </Box>
+      </PageFadeIn>
     </Layout>
   )
 


### PR DESCRIPTION
## Summary
- add a reusable PageFadeIn wrapper that animates page content with delayed child fades
- update Dashboard, News, Events, and Schedule pages to use the new animation container for smoother entry transitions
- improve SmartImage usage on News and Event cards to preload gracefully and fade in without flicker

## Testing
- npm run lint:all *(fails: existing lint issues in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68e79fae58f4832782bc98042defed94