### PR TITLE
Handle Spotify rate limits gracefully

### DIFF
--- a/root/app/api/spotify.py
+++ b/root/app/api/spotify.py
@@ -197,6 +197,19 @@ async def now_playing(
         user.spotify_last_checked_at = _now_utc()
         await db.commit()
         return _fallback_now_playing(user)
+    if r.status_code == 429:
+        retry_after_header = r.headers.get("Retry-After")
+        try:
+            retry_after = max(1, int(float(retry_after_header))) if retry_after_header else 5
+        except (TypeError, ValueError):
+            retry_after = 5
+        user.spotify_last_checked_at = _now_utc()
+        await db.commit()
+        raise HTTPException(
+            status_code=429,
+            detail="Rate limited by Spotify",
+            headers={"Retry-After": str(retry_after)},
+        )
     if r.status_code != 200:
         return _fallback_now_playing(user)
     j = r.json()

--- a/root/app/api/spotify.py
+++ b/root/app/api/spotify.py
@@ -200,7 +200,9 @@ async def now_playing(
     if r.status_code == 429:
         retry_after_header = r.headers.get("Retry-After")
         try:
-            retry_after = max(1, int(float(retry_after_header))) if retry_after_header else 5
+            retry_after = (
+                max(1, int(float(retry_after_header))) if retry_after_header else 5
+            )
         except (TypeError, ValueError):
             retry_after = 5
         user.spotify_last_checked_at = _now_utc()

--- a/root/frontend/src/hooks/__tests__/useNowPlaying.test.tsx
+++ b/root/frontend/src/hooks/__tests__/useNowPlaying.test.tsx
@@ -11,7 +11,7 @@ import {
 import type { ReactNode } from "react";
 import { createQueryClient } from "@/app/queryClient";
 import api from "@/api/client";
-import { fetchNowPlaying, useNowPlaying } from "@/hooks/useNowPlaying";
+import { fetchNowPlaying, useNowPlaying, __testing as nowPlayingTesting } from "@/hooks/useNowPlaying";
 import type { NowPlaying } from "@/types/spotify";
 
 const STORAGE_KEY = "spotify:now-playing:last";
@@ -19,6 +19,8 @@ const STORAGE_KEY = "spotify:now-playing:last";
 afterEach(() => {
   localStorage.clear();
   vi.restoreAllMocks();
+  vi.useRealTimers();
+  nowPlayingTesting.clearRateLimit();
 });
 
 beforeEach(() => {
@@ -73,6 +75,26 @@ describe("fetchNowPlaying", () => {
     vi.spyOn(api, "get").mockResolvedValue({ status: 204, data: null } as any);
     const result = await fetchNowPlaying();
     expect(result).toBeNull();
+  });
+
+  it("records rate limit window on 429 errors", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-01T00:00:00Z"));
+
+    const error = Object.assign(new Error("Too Many Requests"), {
+      isAxiosError: true,
+      response: {
+        status: 429,
+        headers: { "retry-after": "3" },
+      },
+    });
+
+    vi.spyOn(api, "get").mockRejectedValue(error);
+
+    await expect(fetchNowPlaying()).rejects.toThrow("Too Many Requests");
+    const limit = nowPlayingTesting.getRateLimitedUntil();
+    expect(limit).toBeGreaterThan(Date.now());
+    expect(limit).toBe(Date.now() + 3_250);
   });
 });
 

--- a/root/frontend/src/hooks/useNowPlaying.ts
+++ b/root/frontend/src/hooks/useNowPlaying.ts
@@ -1,5 +1,6 @@
 import { useEffect, useMemo } from "react"
 import { useQuery } from "@tanstack/react-query"
+import { isAxiosError } from "axios"
 import api from "@/api/client"
 import type { NowPlaying } from "@/types/spotify"
 
@@ -8,6 +9,24 @@ export const nowPlayingQueryKey = ["spotify", "now-playing"] as const
 const isTestEnv = typeof import.meta !== "undefined" && import.meta.env.MODE === "test"
 
 const STORAGE_KEY = "spotify:now-playing:last"
+
+const RATE_LIMIT_FALLBACK_MS = 5_000
+const RATE_LIMIT_BUFFER_MS = 250
+
+let rateLimitedUntil = 0
+
+const clearRateLimit = () => {
+  rateLimitedUntil = 0
+}
+
+const scheduleRateLimit = (ms: number) => {
+  const wait = Math.max(0, ms)
+  rateLimitedUntil = Date.now() + wait
+}
+
+const rateLimitDelay = () => {
+  return Math.max(0, rateLimitedUntil - Date.now())
+}
 
 type RawNowPlaying = Partial<NowPlaying> | null | undefined
 
@@ -79,12 +98,25 @@ const persistNowPlaying = (value: NowPlaying | null) => {
 }
 
 export const fetchNowPlaying = async () => {
-  const res = await api.get<RawNowPlaying>("/spotify/now-playing", {
-    validateStatus: (status) => status === 204 || (status >= 200 && status < 300),
-  })
+  try {
+    const res = await api.get<RawNowPlaying>("/spotify/now-playing", {
+      validateStatus: (status) => status === 204 || (status >= 200 && status < 300),
+    })
 
-  if (res.status === 204) return null
-  return normalizeNowPlaying(res.data)
+    clearRateLimit()
+
+    if (res.status === 204) return null
+    return normalizeNowPlaying(res.data)
+  } catch (error) {
+    if (isAxiosError(error) && error.response?.status === 429) {
+      const header = error.response.headers?.["retry-after"]
+      const raw = Array.isArray(header) ? header[0] : header
+      const parsed = raw != null ? Number.parseFloat(String(raw)) : NaN
+      const waitMs = Number.isFinite(parsed) && parsed > 0 ? parsed * 1000 : RATE_LIMIT_FALLBACK_MS
+      scheduleRateLimit(waitMs + RATE_LIMIT_BUFFER_MS)
+    }
+    throw error
+  }
 }
 
 const computeInterval = (data: NowPlaying | null) => {
@@ -114,12 +146,22 @@ export const useNowPlaying = (enabled: boolean) => {
     staleTime: 60_000,
     gcTime: 5 * 60_000,
     networkMode: "online",
-    retry: 1,
+    retry: (failureCount, error) => {
+      if (isAxiosError(error) && error.response?.status === 429) {
+        return false
+      }
+      return failureCount < 1
+    },
     refetchOnWindowFocus: false,
     refetchInterval: ({ state }) => {
       if (!enabled || isTestEnv) return false
       if (typeof document !== "undefined" && document.visibilityState === "hidden") return false
-      return computeInterval(state.data ?? null)
+      const interval = computeInterval(state.data ?? null)
+      const rateLimitWait = rateLimitDelay()
+      if (rateLimitWait > 0) {
+        return Math.max(interval, rateLimitWait)
+      }
+      return interval
     },
     refetchIntervalInBackground: true,
   })
@@ -143,4 +185,9 @@ export const useNowPlaying = (enabled: boolean) => {
   }, [enabled, refetch])
 
   return query
+}
+
+export const __testing = {
+  clearRateLimit,
+  getRateLimitedUntil: () => rateLimitedUntil,
 }


### PR DESCRIPTION
## Summary
- return a 429 error with Retry-After when Spotify rate limits the now playing endpoint so clients keep the last known state
- teach the now playing hook to respect rate limit windows, avoid redundant retries, and expose helpers for tests
- extend the now playing hook test suite with coverage for rate limiting behaviour

## Testing
- pnpm test
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e7b4f5b1608327b414f5c47b86c137