### PR TITLE
Fix media URL resolution for signed assets

### DIFF
--- a/root/frontend/src/utils/__tests__/media.test.ts
+++ b/root/frontend/src/utils/__tests__/media.test.ts
@@ -60,6 +60,18 @@ describe("resolveMediaUrl", () => {
     )
   })
 
+  it("preserves query strings on relative URLs", async () => {
+    const { resolveMediaUrl } = await import("@/utils/media")
+    expect(resolveMediaUrl("media/picture.png?token=abc&expires=1"))
+      .toBe("https://backend.example/media/picture.png?token=abc&expires=1")
+  })
+
+  it("keeps query and hash when encoding path segments", async () => {
+    const { resolveMediaUrl } = await import("@/utils/media")
+    expect(resolveMediaUrl("/media/фото 2.png?x=1#anchor"))
+      .toBe("https://backend.example/media/%D1%84%D0%BE%D1%82%D0%BE%202.png?x=1#anchor")
+  })
+
   it("supports overriding origin", async () => {
     const { resolveMediaUrl } = await import("@/utils/media")
     expect(resolveMediaUrl("avatar.png", "https://custom.example"))

--- a/root/frontend/src/utils/media.ts
+++ b/root/frontend/src/utils/media.ts
@@ -47,17 +47,26 @@ export function resolveMediaUrl(
   const base = normaliseOrigin(origin)
   if (!base) return cleaned
 
-  const normalised = cleaned.replace(/^\/+/, "").replace(/\/{2,}/g, "/")
-  const encodedPath = normalised
+  const stripped = cleaned.replace(/^\/+/, "")
+  const match = /^([^?#]*)(\?[^#]*)?(#.*)?$/.exec(stripped)
+  const pathPart = match?.[1] ?? ""
+  const queryPart = match?.[2] ?? ""
+  const hashPart = match?.[3] ?? ""
+
+  const normalisedPath = pathPart.replace(/\/{2,}/g, "/")
+  const encodedPath = normalisedPath
     .split("/")
     .map((segment) => safeEncode(segment))
     .join("/")
 
+  const relative = `${encodedPath}${queryPart}${hashPart}`
+
   try {
-    const resolved = new URL(encodedPath, base + "/")
+    const resolved = new URL(relative, base + "/")
     return resolved.toString()
   } catch {
-    return `${base}/${encodedPath}`.replace(/(?<!:)\/{2,}/g, "/")
+    const fallback = `${base}/${relative}`
+    return fallback.replace(/(?<!:)\/{2,}/g, "/")
   }
 }
 


### PR DESCRIPTION
## Summary
- update media URL resolver to preserve query and hash fragments when building relative URLs
- extend media utility tests to cover signed asset URLs and hashed resources

## Testing
- `cd root/frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68e7bc8cc4c083278b702e2d76d93bad