### PR TITLE
Fix media images failing to load

### DIFF
--- a/root/frontend/src/components/SmartImage.tsx
+++ b/root/frontend/src/components/SmartImage.tsx
@@ -79,7 +79,6 @@ export default memo(function SmartImage({
       {...rest}
       loading={loading ?? "lazy"}
       decoding="async"
-      referrerPolicy="no-referrer"
       onLoad={handleLoad}
       onError={handleError}
       style={mergedStyle}

--- a/root/frontend/src/pages/NewsDetail.tsx
+++ b/root/frontend/src/pages/NewsDetail.tsx
@@ -30,6 +30,7 @@ import timezone from "dayjs/plugin/timezone"
 import api from "@/api/client"
 import Layout from "@/components/Layout"
 import SmartImage from "@/components/SmartImage"
+import { resolveMediaUrl } from "@/utils/media"
 import { useAuth } from "@/contexts/AuthContext"
 
 dayjs.extend(utc)
@@ -169,11 +170,15 @@ export default function NewsDetail() {
     else navigate("/news")
   }
 
+  const rawImageUrl = useMemo(
+    () => (editOpen ? editData.image_url : query.data?.image_url) || "",
+    [editData.image_url, editOpen, query.data?.image_url],
+  )
+
   const imageUrl = useMemo(() => {
     if (previewUrl) return previewUrl
-    const base = editOpen ? editData.image_url : query.data?.image_url
-    return base || ""
-  }, [previewUrl, editOpen, editData.image_url, query.data?.image_url])
+    return resolveMediaUrl(rawImageUrl)
+  }, [previewUrl, rawImageUrl])
 
   const content = query.data?.content ?? ""
   const createdAt = query.data?.created_at


### PR DESCRIPTION
## Summary
- restore the browser default referrer policy in SmartImage so hosted media files are requested with the expected headers
- resolve stored news image paths in the detail page before rendering so both the card and detail views share the same loader

## Testing
- npm --prefix root/frontend run test

------
https://chatgpt.com/codex/tasks/task_e_68e7c0758a648327a6c440c64782df15