### PR TITLE
Prefer assets base when resolving media URLs

### DIFF
--- a/root/frontend/src/utils/__tests__/media.test.ts
+++ b/root/frontend/src/utils/__tests__/media.test.ts
@@ -18,15 +18,26 @@ const setEnvOrigin = (origin?: string) => {
   }
 }
 
+const setEnvAssets = (origin?: string) => {
+  const env = import.meta.env as any
+  if (origin === undefined) {
+    delete env.VITE_ASSETS_BASE
+  } else {
+    env.VITE_ASSETS_BASE = origin
+  }
+}
+
 afterAll(() => {
   Object.defineProperty(window, "location", { configurable: true, value: originalLocation })
   setEnvOrigin(undefined)
+  setEnvAssets(undefined)
 })
 
 describe("resolveMediaUrl", () => {
   beforeEach(() => {
     vi.resetModules()
     setEnvOrigin(undefined)
+    setEnvAssets(undefined)
     setWindowOrigin("https://backend.example")
   })
 
@@ -57,6 +68,13 @@ describe("resolveMediaUrl", () => {
     setEnvOrigin("https://env.example")
     const { resolveMediaUrl } = await import("@/utils/media")
     expect(resolveMediaUrl("media/file.png")).toBe("https://env.example/media/file.png")
+  })
+
+  it("prefers assets base over backend origin", async () => {
+    setEnvOrigin("https://env.example")
+    setEnvAssets("https://cdn.example")
+    const { resolveMediaUrl } = await import("@/utils/media")
+    expect(resolveMediaUrl("media/photo.png")).toBe("https://cdn.example/media/photo.png")
   })
 
   it("encodes unicode path segments and collapses slashes", async () => {

--- a/root/frontend/src/utils/media.ts
+++ b/root/frontend/src/utils/media.ts
@@ -46,7 +46,7 @@ const normaliseOrigin = (origin?: string) => {
 
 export function resolveMediaUrl(
   raw?: string,
-  origin = import.meta.env.VITE_BACKEND_ORIGIN,
+  origin = import.meta.env.VITE_ASSETS_BASE || import.meta.env.VITE_BACKEND_ORIGIN,
 ): string {
   if (!raw) return ""
   const cleaned = String(raw).trim()


### PR DESCRIPTION
## Summary
- prefer the dedicated assets origin when resolving media URLs so images can load from a CDN
- extend the media utility tests to cover the assets base precedence

## Testing
- npm run test -- src/utils/__tests__/media.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e7c9cacb088327a6fb85a64a688d46