### PR TITLE
Return 204 when Spotify playback is inactive

### DIFF
--- a/root/app/api/spotify.py
+++ b/root/app/api/spotify.py
@@ -4,7 +4,7 @@ from typing import Optional
 from urllib.parse import urlencode
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from fastapi.responses import RedirectResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -184,9 +184,14 @@ async def spotify_callback(
 async def now_playing(
     db: AsyncSession = Depends(get_db), user: User = Depends(get_current_user)
 ):
+    def _as_response(data: SpotifyNowPlayingOut):
+        if data.track_id or data.track_name or data.artists:
+            return data
+        return Response(status_code=204)
+
     token = await _ensure_access_token(db, user)
     if not token:
-        return _fallback_now_playing(user)
+        return _as_response(_fallback_now_playing(user))
     async with httpx.AsyncClient(timeout=15) as client:
         r = await client.get(
             "https://api.spotify.com/v1/me/player/currently-playing",
@@ -196,7 +201,7 @@ async def now_playing(
         user.spotify_is_playing = False
         user.spotify_last_checked_at = _now_utc()
         await db.commit()
-        return _fallback_now_playing(user)
+        return Response(status_code=204)
     if r.status_code == 429:
         retry_after_header = r.headers.get("Retry-After")
         try:
@@ -213,7 +218,7 @@ async def now_playing(
             headers={"Retry-After": str(retry_after)},
         )
     if r.status_code != 200:
-        return _fallback_now_playing(user)
+        return _as_response(_fallback_now_playing(user))
     j = r.json()
     item = j.get("item") or {}
     artists = [a.get("name") for a in item.get("artists", []) if a.get("name")]

--- a/root/tests/test_spotify_fallback.py
+++ b/root/tests/test_spotify_fallback.py
@@ -1,8 +1,14 @@
 from datetime import datetime, timezone
 
+import pytest
+from httpx import AsyncClient
+
 from app.api.routes import _spotify_fallback_now_playing
 from app.api.spotify import _fallback_now_playing
-from app.models.models import User
+from app.auth.security import get_password_hash
+from app.models.models import User as ModelUser
+
+pytestmark = pytest.mark.anyio("asyncio")
 
 
 def _make_user(
@@ -13,7 +19,7 @@ def _make_user(
     album_image: str | None = None,
     track_url: str | None = None,
 ):
-    user = User()
+    user = ModelUser()
     user.spotify_last_track_id = track_id
     user.spotify_last_track_name = track_name
     user.spotify_last_artist_name = artists
@@ -79,3 +85,54 @@ def test_legacy_fallback_matches_new_behavior():
     assert legacy.album_name == modern.album_name
     assert legacy.album_image_url == modern.album_image_url
     assert legacy.track_url == modern.track_url
+
+
+async def _login(async_client: AsyncClient, user: ModelUser, password: str) -> dict[str, str]:
+    response = await async_client.post(
+        "/auth/login",
+        data={"username": user.email, "password": password},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert response.status_code == 200
+    token = response.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def test_now_playing_returns_204_when_user_has_no_track(
+    async_client: AsyncClient, user_factory
+) -> None:
+    password = "SpotifyP@ss1"
+    hashed = get_password_hash(password)
+    user = await user_factory(hashed_password=hashed, is_active=True)
+
+    headers = await _login(async_client, user, password)
+
+    response = await async_client.get("/spotify/now-playing", headers=headers)
+
+    assert response.status_code == 204
+
+
+async def test_now_playing_uses_last_known_track_from_fallback(
+    async_client: AsyncClient, user_factory, db_session
+) -> None:
+    password = "SpotifyP@ss2"
+    hashed = get_password_hash(password)
+    user = await user_factory(hashed_password=hashed, is_active=True)
+
+    user.spotify_last_track_id = "track-xyz"
+    user.spotify_last_track_name = "Fallback Song"
+    user.spotify_last_artist_name = "Fallback Artist"
+    user.spotify_last_track_url = "https://open.spotify.com/track/track-xyz"
+    await db_session.commit()
+    await db_session.refresh(user)
+
+    headers = await _login(async_client, user, password)
+
+    response = await async_client.get("/spotify/now-playing", headers=headers)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["is_playing"] is False
+    assert body["track_id"] == "track-xyz"
+    assert body["track_name"] == "Fallback Song"
+    assert body["artists"] == ["Fallback Artist"]

--- a/root/tests/test_spotify_fallback.py
+++ b/root/tests/test_spotify_fallback.py
@@ -87,7 +87,9 @@ def test_legacy_fallback_matches_new_behavior():
     assert legacy.track_url == modern.track_url
 
 
-async def _login(async_client: AsyncClient, user: ModelUser, password: str) -> dict[str, str]:
+async def _login(
+    async_client: AsyncClient, user: ModelUser, password: str
+) -> dict[str, str]:
     response = await async_client.post(
         "/auth/login",
         data={"username": user.email, "password": password},


### PR DESCRIPTION
## Summary
- return 204 from `/spotify/now-playing` when no track metadata is available instead of replaying the cached payload
- keep fallback data for the last known track when metadata exists so paused playback still shows details
- add API tests covering both empty and populated fallback responses

## Testing
- pytest root/tests/test_spotify_fallback.py

------
https://chatgpt.com/codex/tasks/task_e_68e849f4a5e0832786d32be39c8f7d08