### PR TITLE
Handle Spotify token refresh failures

### DIFF
--- a/root/app/api/spotify.py
+++ b/root/app/api/spotify.py
@@ -32,6 +32,21 @@ def _b64(s: str) -> str:
     return base64.b64encode(s.encode()).decode()
 
 
+def _disconnect_user(
+    user: User, *, clear_refresh: bool = False, clear_profile: bool = False
+) -> None:
+    user.spotify_access_token = None
+    if clear_refresh:
+        user.spotify_refresh_token = None
+        user.spotify_scope = None
+    user.spotify_token_expires_at = None
+    user.spotify_is_connected = False
+    user.spotify_is_playing = False
+    if clear_profile:
+        user.spotify_display_name = None
+        user.spotify_user_id = None
+
+
 def _fallback_now_playing(user: User) -> SpotifyNowPlayingOut:
     artists: list[str] = []
     if user.spotify_last_artist_name:
@@ -86,11 +101,15 @@ async def _save_tokens(
 
 
 async def _ensure_access_token(db: AsyncSession, user: User) -> Optional[str]:
-    if not user.spotify_access_token or not user.spotify_refresh_token:
+    if not user.spotify_access_token:
         return None
     exp = _ensure_utc(user.spotify_token_expires_at)
     if exp and exp > _now_utc():
         return user.spotify_access_token
+    if not user.spotify_refresh_token:
+        _disconnect_user(user, clear_refresh=True)
+        await db.commit()
+        raise HTTPException(status_code=401, detail="Требуется переподключить Spotify")
     async with httpx.AsyncClient(timeout=15) as client:
         r = await client.post(
             "https://accounts.spotify.com/api/token",
@@ -104,7 +123,9 @@ async def _ensure_access_token(db: AsyncSession, user: User) -> Optional[str]:
             },
         )
     if r.status_code != 200:
-        return None
+        _disconnect_user(user, clear_refresh=True)
+        await db.commit()
+        raise HTTPException(status_code=401, detail="Требуется переподключить Spotify")
     data = r.json()
     await _save_tokens(
         db,
@@ -255,13 +276,6 @@ async def now_playing(
 async def disconnect(
     db: AsyncSession = Depends(get_db), user: User = Depends(get_current_user)
 ):
-    user.spotify_access_token = None
-    user.spotify_refresh_token = None
-    user.spotify_token_expires_at = None
-    user.spotify_scope = None
-    user.spotify_display_name = None
-    user.spotify_user_id = None
-    user.spotify_is_connected = False
-    user.spotify_is_playing = False
+    _disconnect_user(user, clear_refresh=True, clear_profile=True)
     await db.commit()
     return {"ok": True}

--- a/root/frontend/src/api/client.ts
+++ b/root/frontend/src/api/client.ts
@@ -1,6 +1,7 @@
 import axios from "axios";
 
 export const API_UNAUTHORIZED_EVENT = "auth:unauthorized";
+export const SKIP_UNAUTHORIZED_HEADER = "X-Client-Skip-Unauthorized";
 
 const devBase = "/api";
 const prodBase = import.meta.env.VITE_BACKEND_ORIGIN || "/api";
@@ -44,6 +45,11 @@ api.interceptors.response.use(
   (r) => r,
   (err) => {
     if (err?.response?.status === 401) {
+      const headers = (err.config?.headers ?? {}) as Record<string, unknown>;
+      if (headers[SKIP_UNAUTHORIZED_HEADER]) {
+        delete headers[SKIP_UNAUTHORIZED_HEADER];
+        return Promise.reject(err);
+      }
       setAuthToken(undefined);
       if (typeof window !== "undefined") {
         window.dispatchEvent(new CustomEvent(API_UNAUTHORIZED_EVENT));

--- a/root/frontend/src/components/SpotifyConnect.tsx
+++ b/root/frontend/src/components/SpotifyConnect.tsx
@@ -44,7 +44,12 @@ export default function SpotifyConnect() {
     setActionLoading(true)
     try {
       await api.post("/spotify/disconnect")
-      setUser({ ...user, spotify_connected: false, spotify_display_name: null })
+      setUser({
+        ...user,
+        spotify_connected: false,
+        spotify_is_connected: false,
+        spotify_display_name: null,
+      })
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: currentUserQueryKey }),
         queryClient.invalidateQueries({ queryKey: nowPlayingQueryKey }),

--- a/root/frontend/src/contexts/AuthContext.tsx
+++ b/root/frontend/src/contexts/AuthContext.tsx
@@ -12,6 +12,7 @@ import { useQueryClient } from "@tanstack/react-query"
 import { isAxiosError } from "axios"
 import { softSyncPushSubscription, unsubscribePush } from "@/push/subscribe"
 import api, { API_UNAUTHORIZED_EVENT, setAuthToken } from "../api/client"
+import { SPOTIFY_REAUTH_EVENT } from "@/hooks/useNowPlaying"
 
 type UserState = any | null
 
@@ -245,6 +246,26 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     return () =>
       window.removeEventListener(API_UNAUTHORIZED_EVENT, onUnauthorized as EventListener)
   }, [handleUnauthorized])
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+    const onSpotifyReauth = () => {
+      setUser((prev) => {
+        if (!prev) return prev
+        if (!prev.spotify_connected && !prev.spotify_is_connected) return prev
+        return {
+          ...prev,
+          spotify_connected: false,
+          spotify_is_connected: false,
+          spotify_display_name: null,
+        }
+      })
+      void queryClient.invalidateQueries({ queryKey: currentUserQueryKey })
+    }
+    window.addEventListener(SPOTIFY_REAUTH_EVENT, onSpotifyReauth as EventListener)
+    return () =>
+      window.removeEventListener(SPOTIFY_REAUTH_EVENT, onSpotifyReauth as EventListener)
+  }, [queryClient, setUser])
 
   const login = useCallback(
     async (email: string, password: string) => {

--- a/root/frontend/src/hooks/useNowPlaying.ts
+++ b/root/frontend/src/hooks/useNowPlaying.ts
@@ -1,10 +1,11 @@
 import { useEffect, useMemo } from "react"
 import { useQuery } from "@tanstack/react-query"
 import { isAxiosError } from "axios"
-import api from "@/api/client"
+import api, { SKIP_UNAUTHORIZED_HEADER } from "@/api/client"
 import type { NowPlaying } from "@/types/spotify"
 
 export const nowPlayingQueryKey = ["spotify", "now-playing"] as const
+export const SPOTIFY_REAUTH_EVENT = "spotify:reauth-required"
 
 const isTestEnv = typeof import.meta !== "undefined" && import.meta.env.MODE === "test"
 
@@ -101,6 +102,7 @@ export const fetchNowPlaying = async () => {
   try {
     const res = await api.get<RawNowPlaying>("/spotify/now-playing", {
       validateStatus: (status) => status === 204 || (status >= 200 && status < 300),
+      headers: { [SKIP_UNAUTHORIZED_HEADER]: "1" },
     })
 
     clearRateLimit()
@@ -108,12 +110,21 @@ export const fetchNowPlaying = async () => {
     if (res.status === 204) return null
     return normalizeNowPlaying(res.data)
   } catch (error) {
-    if (isAxiosError(error) && error.response?.status === 429) {
-      const header = error.response.headers?.["retry-after"]
-      const raw = Array.isArray(header) ? header[0] : header
-      const parsed = raw != null ? Number.parseFloat(String(raw)) : NaN
-      const waitMs = Number.isFinite(parsed) && parsed > 0 ? parsed * 1000 : RATE_LIMIT_FALLBACK_MS
-      scheduleRateLimit(waitMs + RATE_LIMIT_BUFFER_MS)
+    if (isAxiosError(error)) {
+      if (error.response?.status === 401) {
+        clearRateLimit()
+        if (typeof window !== "undefined") {
+          window.dispatchEvent(new CustomEvent(SPOTIFY_REAUTH_EVENT))
+        }
+        return null
+      }
+      if (error.response?.status === 429) {
+        const header = error.response.headers?.["retry-after"]
+        const raw = Array.isArray(header) ? header[0] : header
+        const parsed = raw != null ? Number.parseFloat(String(raw)) : NaN
+        const waitMs = Number.isFinite(parsed) && parsed > 0 ? parsed * 1000 : RATE_LIMIT_FALLBACK_MS
+        scheduleRateLimit(waitMs + RATE_LIMIT_BUFFER_MS)
+      }
     }
     throw error
   }

--- a/root/tests/test_spotify_fallback.py
+++ b/root/tests/test_spotify_fallback.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta, timezone
 
-import pytest
 import httpx
+import pytest
 from httpx import AsyncClient
 
 from app.api.routes import _spotify_fallback_now_playing

--- a/root/tests/test_spotify_fallback.py
+++ b/root/tests/test_spotify_fallback.py
@@ -1,6 +1,7 @@
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import pytest
+import httpx
 from httpx import AsyncClient
 
 from app.api.routes import _spotify_fallback_now_playing
@@ -138,3 +139,45 @@ async def test_now_playing_uses_last_known_track_from_fallback(
     assert body["track_id"] == "track-xyz"
     assert body["track_name"] == "Fallback Song"
     assert body["artists"] == ["Fallback Artist"]
+
+
+async def test_now_playing_returns_401_when_refresh_fails(
+    async_client: AsyncClient, user_factory, db_session, monkeypatch
+) -> None:
+    password = "SpotifyP@ss3"
+    hashed = get_password_hash(password)
+    user = await user_factory(hashed_password=hashed, is_active=True)
+
+    user.spotify_access_token = "expired"
+    user.spotify_refresh_token = "refresh"
+    user.spotify_token_expires_at = datetime.now(timezone.utc) - timedelta(seconds=5)
+    user.spotify_is_connected = True
+    await db_session.commit()
+    await db_session.refresh(user)
+
+    class DummyResponse:
+        status_code = 400
+        headers: dict[str, str] = {}
+
+        def json(self) -> dict[str, str]:
+            return {}
+
+    original_post = httpx.AsyncClient.post
+
+    async def fake_post(self, url, *args, **kwargs):
+        if str(url).endswith("/api/token"):
+            return DummyResponse()
+        return await original_post(self, url, *args, **kwargs)
+
+    monkeypatch.setattr("httpx.AsyncClient.post", fake_post)
+
+    headers = await _login(async_client, user, password)
+
+    response = await async_client.get("/spotify/now-playing", headers=headers)
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Требуется переподключить Spotify"
+
+    await db_session.refresh(user)
+    assert user.spotify_is_connected is False
+    assert user.spotify_access_token is None


### PR DESCRIPTION
## Summary
- clear Spotify credentials and return 401 when token refresh fails so clients know to reconnect
- skip global logout for Spotify 401 responses and broadcast a reconnect event to update client state
- cover the refresh failure scenario with a regression test for the now playing endpoint

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e84e1568048327b83fd177561238b7