### PR TITLE
Fix Spotify connection status gating on frontend

### DIFF
--- a/root/frontend/src/components/SpotifyConnect.tsx
+++ b/root/frontend/src/components/SpotifyConnect.tsx
@@ -79,7 +79,7 @@ export default function SpotifyConnect() {
     <Card sx={{ mt: 2 }}>
       <CardHeader title="Spotify" />
       <CardContent>
-        {!user.spotify_connected ? (
+        {!spotifyEnabled ? (
           <Button onClick={connect} variant="contained" disabled={actionLoading}>
             {loadingIndicator}
           </Button>


### PR DESCRIPTION
## Summary
- ensure the Spotify connect card toggles between connect and status states based on either connection flag

## Testing
- npm --prefix root/frontend test

------
https://chatgpt.com/codex/tasks/task_e_68e85955be9c8327b9ed00d90cc5978a