### PR TITLE
Fix event registration errors and surface QR codes

### DIFF
--- a/root/app/api/routes.py
+++ b/root/app/api/routes.py
@@ -24,7 +24,7 @@ from fastapi import (
     status,
 )
 from fastapi.encoders import jsonable_encoder
-from sqlalchemy import func, select, update
+from sqlalchemy import and_, func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.responses import RedirectResponse
 
@@ -605,6 +605,20 @@ async def get_event(
     q = await db.get(models.Event, id)
     if not q:
         raise HTTPException(status_code=404, detail="Событие не найдено")
+    attendance = (
+        await db.execute(
+            select(models.EventAttendance).where(
+                and_(
+                    models.EventAttendance.event_id == q.id,
+                    models.EventAttendance.user_id == user.id,
+                )
+            )
+        )
+    ).scalar_one_or_none()
+    if attendance and not attendance.qr_code:
+        attendance.qr_code = str(uuid.uuid4())
+        await db.commit()
+        await db.refresh(attendance)
     files = (
         (
             await db.execute(
@@ -624,6 +638,8 @@ async def get_event(
     out = schemas.EventOut.from_orm(q)
     out.files = [schemas.EventFileOut.from_orm(f) for f in files]
     out.participant_count = participant_count
+    out.is_registered = attendance is not None
+    out.my_qr_code = attendance.qr_code if attendance else None
     return out
 
 

--- a/root/app/crud/__init__.py
+++ b/root/app/crud/__init__.py
@@ -170,12 +170,16 @@ async def get_all_events(
     qr_map: Dict[int, Optional[str]] = {}
     if user_id:
         attendance_rows = (
-            await db.execute(
-                select(models.EventAttendance).where(
-                    models.EventAttendance.user_id == user_id
+            (
+                await db.execute(
+                    select(models.EventAttendance).where(
+                        models.EventAttendance.user_id == user_id
+                    )
                 )
             )
-        ).scalars().all()
+            .scalars()
+            .all()
+        )
         missing_qr = [row for row in attendance_rows if not row.qr_code]
         if missing_qr:
             for row in missing_qr:
@@ -293,12 +297,16 @@ async def unregister_attendance(
 
 async def get_my_events(db: AsyncSession, user_id: int):
     attendance_rows = (
-        await db.execute(
-            select(models.EventAttendance).where(
-                models.EventAttendance.user_id == user_id
+        (
+            await db.execute(
+                select(models.EventAttendance).where(
+                    models.EventAttendance.user_id == user_id
+                )
             )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     if not attendance_rows:
         return []
     missing_qr = [row for row in attendance_rows if not row.qr_code]

--- a/root/app/crud/__init__.py
+++ b/root/app/crud/__init__.py
@@ -166,14 +166,25 @@ async def get_all_events(
     counts = await _attendance_counts(db, ids)
     files_map = await _files_by_event(db, ids)
 
-    registered_ids = set()
+    registered_ids: set[int] = set()
+    qr_map: Dict[int, Optional[str]] = {}
     if user_id:
-        reg_q = await db.execute(
-            select(models.EventAttendance.event_id).where(
-                models.EventAttendance.user_id == user_id
+        attendance_rows = (
+            await db.execute(
+                select(models.EventAttendance).where(
+                    models.EventAttendance.user_id == user_id
+                )
             )
-        )
-        registered_ids = set(reg_q.scalars().all())
+        ).scalars().all()
+        missing_qr = [row for row in attendance_rows if not row.qr_code]
+        if missing_qr:
+            for row in missing_qr:
+                row.qr_code = str(uuid.uuid4())
+            await db.commit()
+            for row in missing_qr:
+                await db.refresh(row)
+        registered_ids = {row.event_id for row in attendance_rows}
+        qr_map = {row.event_id: row.qr_code for row in attendance_rows}
 
     result = []
     for event in events:
@@ -196,6 +207,7 @@ async def get_all_events(
                 ],
                 "is_active": getattr(event, "is_active", True),
                 "is_registered": event.id in registered_ids,
+                "my_qr_code": qr_map.get(event.id),
                 "speaker": getattr(event, "speaker", None),
                 "image_url": getattr(event, "image_url", None),
             }
@@ -235,6 +247,10 @@ async def register_attendance(
     )
     exist = (await db.execute(stmt)).scalar_one_or_none()
     if exist:
+        if not exist.qr_code:
+            exist.qr_code = str(uuid.uuid4())
+            await db.commit()
+            await db.refresh(exist)
         return exist
 
     qr_code = str(uuid.uuid4())
@@ -242,7 +258,18 @@ async def register_attendance(
         user_id=user_id, event_id=data.event_id, qr_code=qr_code
     )
     db.add(record)
-    await db.commit()
+    try:
+        await db.commit()
+    except IntegrityError:
+        await db.rollback()
+        exist = (await db.execute(stmt)).scalar_one_or_none()
+        if not exist:
+            raise
+        if not exist.qr_code:
+            exist.qr_code = str(uuid.uuid4())
+            await db.commit()
+            await db.refresh(exist)
+        return exist
     await db.refresh(record)
     return record
 
@@ -265,19 +292,24 @@ async def unregister_attendance(
 
 
 async def get_my_events(db: AsyncSession, user_id: int):
-    ids = (
-        (
-            await db.execute(
-                select(models.EventAttendance.event_id).where(
-                    models.EventAttendance.user_id == user_id
-                )
+    attendance_rows = (
+        await db.execute(
+            select(models.EventAttendance).where(
+                models.EventAttendance.user_id == user_id
             )
         )
-        .scalars()
-        .all()
-    )
-    if not ids:
+    ).scalars().all()
+    if not attendance_rows:
         return []
+    missing_qr = [row for row in attendance_rows if not row.qr_code]
+    if missing_qr:
+        for row in missing_qr:
+            row.qr_code = str(uuid.uuid4())
+        await db.commit()
+        for row in missing_qr:
+            await db.refresh(row)
+    ids = [row.event_id for row in attendance_rows]
+    qr_map = {row.event_id: row.qr_code for row in attendance_rows}
     q = select(models.Event).where(models.Event.id.in_(ids))
     events = (await db.execute(q)).scalars().all()
     counts = await _attendance_counts(db, ids)
@@ -304,6 +336,7 @@ async def get_my_events(db: AsyncSession, user_id: int):
                 ],
                 "is_active": getattr(event, "is_active", True),
                 "is_registered": True,
+                "my_qr_code": qr_map.get(event.id),
                 "speaker": getattr(event, "speaker", None),
                 "image_url": getattr(event, "image_url", None),
             }

--- a/root/app/schemas/schemas.py
+++ b/root/app/schemas/schemas.py
@@ -204,6 +204,7 @@ class EventOut(OrmModel):
     files: List[EventFileOut] = Field(default_factory=list)
     participant_count: int = 0
     is_registered: Optional[bool] = None
+    my_qr_code: Optional[str] = None
 
 
 class EventAttendanceCreate(BaseModel):

--- a/root/frontend/src/components/EventCard.tsx
+++ b/root/frontend/src/components/EventCard.tsx
@@ -46,6 +46,7 @@ type EventCardProps = {
   files: any[]
   is_active: boolean
   is_registered?: boolean
+  my_qr_code?: string
   speaker?: string
   image_url?: string
   onChange?: () => void
@@ -75,6 +76,7 @@ const EventCardComponent: FC<EventCardProps> = ({
   participant_count,
   is_active,
   is_registered = false,
+  my_qr_code,
   speaker,
   image_url,
   onChange
@@ -117,12 +119,28 @@ const EventCardComponent: FC<EventCardProps> = ({
   useEffect(() => setCount(participant_count), [participant_count])
 
   useEffect(() => {
-    if (!registered || qr) return
+    if (!registered) {
+      setQr(undefined)
+      try {
+        localStorage.removeItem(qrKey(id, user))
+      } catch {}
+      return
+    }
+    if (my_qr_code) {
+      setQr(my_qr_code)
+      try {
+        localStorage.setItem(qrKey(id, user), my_qr_code)
+      } catch {}
+    }
+  }, [registered, my_qr_code, id, user])
+
+  useEffect(() => {
+    if (!registered || qr || my_qr_code) return
     try {
       const stored = localStorage.getItem(qrKey(id, user))
       if (stored) setQr(stored)
     } catch {}
-  }, [registered, qr, id, user])
+  }, [registered, qr, my_qr_code, id, user])
 
   useLayoutEffect(() => {
     try {
@@ -753,6 +771,7 @@ const areEventCardPropsEqual = (prev: EventCardProps, next: EventCardProps) =>
   prev.participant_count === next.participant_count &&
   prev.is_active === next.is_active &&
   prev.is_registered === next.is_registered &&
+  prev.my_qr_code === next.my_qr_code &&
   prev.speaker === next.speaker &&
   prev.image_url === next.image_url &&
   prev.onChange === next.onChange &&


### PR DESCRIPTION
## Summary
- ensure event attendance registration gracefully handles duplicates and always issues a QR code
- include the attendee QR code in event list/detail responses through the updated schema
- update the event card to hydrate and persist the QR code so it is shown immediately after registration

## Testing
- pytest tests/test_smoke.py -q
- npm --prefix frontend run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e8ffeae5b08327a698f43e54b110af