### PR TITLE
Fix push notification enablement when service worker is delayed

### DIFF
--- a/root/frontend/src/push/subscribe.ts
+++ b/root/frontend/src/push/subscribe.ts
@@ -141,6 +141,14 @@ export async function resolveServiceWorkerRegistration(
   }
 
   try {
+    const { registerServiceWorker } = await import("./register-sw")
+    const registered = await registerServiceWorker()
+    if (registered) return registered
+  } catch (error) {
+    console.warn("Failed to auto-register service worker", error)
+  }
+
+  try {
     return (await navigator.serviceWorker.getRegistration()) ?? null
   } catch (error) {
     console.warn("Failed to get service worker registration after timeout", error)


### PR DESCRIPTION
## Summary
- auto-register the service worker when enabling push notifications if no ready registration exists

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e92c1c403c83279964a9c6be21ba94