### PR TITLE
Improve push notification permission feedback

### DIFF
--- a/root/frontend/src/hooks/usePushPreferences.ts
+++ b/root/frontend/src/hooks/usePushPreferences.ts
@@ -151,7 +151,18 @@ export function usePushPreferences(options?: UsePushPreferencesOptions) {
       })
       const permission = Notification.permission
       setNotificationPermission(permission)
-      if (permission !== "granted" || !sub) {
+      if (!sub) {
+        const text =
+          permission === "denied"
+            ? "Разрешите уведомления в настройках браузера, чтобы получать пуши"
+            : permission === "default"
+              ? "Подтвердите запрос на отправку уведомлений, чтобы получать пуши"
+              : "Не удалось оформить подписку на push-уведомления"
+        notify({ text, sev: permission === "granted" ? "error" : "info" })
+        setPushSubscription(sub)
+        return
+      }
+      if (permission !== "granted") {
         notify({
           text: "Разрешите уведомления в настройках браузера, чтобы получать пуши",
           sev: "info",

--- a/root/frontend/src/pages/__tests__/Settings.notifications.test.tsx
+++ b/root/frontend/src/pages/__tests__/Settings.notifications.test.tsx
@@ -270,4 +270,46 @@ describe("usePushPreferences notifications flow", () => {
     expect(result.current.notificationsEnabled).toBe(false)
     expect(result.current.notificationPermission).toBe("denied")
   })
+
+  it("asks user to confirm permission prompt when subscription is unavailable", async () => {
+    ensurePushSubscriptionMock.mockResolvedValue(null)
+    MockNotification.permission = "default"
+
+    const onNotify = vi.fn()
+    const { result } = renderHook(() => usePushPreferences({ onNotify }), { wrapper })
+
+    await act(async () => {
+      await result.current.enableNotifications()
+    })
+
+    expect(onNotify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "Подтвердите запрос на отправку уведомлений, чтобы получать пуши",
+        sev: "info",
+      }),
+    )
+    expect(result.current.notificationsEnabled).toBe(false)
+    expect(result.current.notificationPermission).toBe("default")
+  })
+
+  it("informs user when subscription cannot be created despite granted permission", async () => {
+    ensurePushSubscriptionMock.mockResolvedValue(null)
+    MockNotification.permission = "granted"
+
+    const onNotify = vi.fn()
+    const { result } = renderHook(() => usePushPreferences({ onNotify }), { wrapper })
+
+    await act(async () => {
+      await result.current.enableNotifications()
+    })
+
+    expect(onNotify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "Не удалось оформить подписку на push-уведомления",
+        sev: "error",
+      }),
+    )
+    expect(result.current.notificationsEnabled).toBe(false)
+    expect(result.current.notificationPermission).toBe("granted")
+  })
 })


### PR DESCRIPTION
## Summary
- adjust push preference hook to show context-specific messages when subscription creation fails
- cover new notification flows with vitest cases for denied, pending, and granted permissions

## Testing
- npm test -- Settings.notifications

------
https://chatgpt.com/codex/tasks/task_e_68e930590f3c8327ae484c34521af7ca