### PR TITLE
Fetch VAPID key from API when enabling push notifications

### DIFF
--- a/root/frontend/src/api/notifications.ts
+++ b/root/frontend/src/api/notifications.ts
@@ -34,3 +34,14 @@ export async function sendTest(): Promise<SendTestNotificationResponse> {
   const { data } = await api.post<SendTestNotificationResponse>("/push/test")
   return data
 }
+
+type VapidPublicKeyResponse = {
+  publicKey?: string | null
+}
+
+export async function getVapidPublicKey(): Promise<string | null> {
+  const { data } = await api.get<VapidPublicKeyResponse>("/push/vapid-public-key")
+  const raw = typeof data?.publicKey === "string" ? data.publicKey : null
+  const normalized = raw?.trim()
+  return normalized ? normalized : null
+}

--- a/root/frontend/src/push/subscribe.ts
+++ b/root/frontend/src/push/subscribe.ts
@@ -1,4 +1,4 @@
-import { deleteSubscription, saveSubscription } from "@/api/notifications"
+import { deleteSubscription, getVapidPublicKey, saveSubscription } from "@/api/notifications"
 
 const SUBSCRIPTION_EXPIRY_THRESHOLD_MS = 3 * 24 * 60 * 60 * 1000 // 3 days
 const PERSIST_MAX_ATTEMPTS = 5
@@ -9,6 +9,7 @@ const PUSH_TOPICS_STORAGE_KEY = "push:last_topics"
 
 const ensureLocks = new Map<string, Promise<PushSubscription | null>>()
 const SERVICE_WORKER_READY_TIMEOUT_MS = 2000
+let cachedVapidPublicKey: string | null | undefined
 
 type NormalizedTopics = string[] | undefined
 
@@ -156,16 +157,32 @@ export async function resolveServiceWorkerRegistration(
   }
 }
 
-export async function fetchVapidPublicKey(): Promise<string | null> {
+export async function resolveVapidPublicKey(): Promise<string | null> {
+  if (cachedVapidPublicKey !== undefined) {
+    return cachedVapidPublicKey
+  }
+
   const rawKey = import.meta.env.VITE_VAPID_PUBLIC_KEY
   if (typeof rawKey === "string") {
     const normalized = rawKey.trim()
-    if (normalized) return normalized
+    if (normalized) {
+      cachedVapidPublicKey = normalized
+      return cachedVapidPublicKey
+    }
   }
-  if (import.meta.env.DEV) {
-    console.warn("VITE_VAPID_PUBLIC_KEY is not configured")
+
+  try {
+    const serverKey = await getVapidPublicKey()
+    cachedVapidPublicKey = serverKey ?? null
+    if (!cachedVapidPublicKey && import.meta.env.DEV) {
+      console.warn("VAPID public key is not configured on the server")
+    }
+    return cachedVapidPublicKey
+  } catch (error) {
+    console.warn("Failed to fetch VAPID public key", error)
+    cachedVapidPublicKey = null
+    return null
   }
-  return null
 }
 
 export function urlBase64ToUint8Array(base64String: string) {
@@ -229,9 +246,8 @@ export async function ensurePushSubscription(
       }
     }
 
-    const key = (
-      options?.vapidPublicKey || (await fetchVapidPublicKey()) || ""
-    ).trim()
+    const resolvedKey = options?.vapidPublicKey ?? (await resolveVapidPublicKey())
+    const key = (resolvedKey ?? "").trim()
     if (!key) {
       return null
     }


### PR DESCRIPTION
## Summary
- add an API helper that retrieves the VAPID public key from `/push/vapid-public-key`
- cache the resolved VAPID key and fall back to requesting it from the backend when the Vite env var is missing before creating a push subscription

## Testing
- `npm --prefix root/frontend run lint:all` *(fails: repository currently has pre-existing lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e93436664c8327938efd4babf9255d