### PR TITLE
Fix push subscription serialization for legacy records

### DIFF
--- a/root/app/routers/notifications.py
+++ b/root/app/routers/notifications.py
@@ -96,13 +96,16 @@ class PushSubscriptionOut(BaseModel):
 
 def _serialize_subscription(subscription: PushSubscription) -> PushSubscriptionOut:
     topics = normalize_topics(subscription.topics or [])
+    created_at = subscription.created_at
+    if created_at is None:
+        created_at = subscription.last_seen_at or datetime.now(UTC)
     data = {
         "id": subscription.id,
         "user_id": subscription.user_id,
         "endpoint": subscription.endpoint,
         "p256dh": subscription.p256dh,
         "auth": subscription.auth,
-        "created_at": subscription.created_at,
+        "created_at": created_at,
         "user_agent": subscription.user_agent,
         "last_seen_at": subscription.last_seen_at,
         "updated_at": subscription.last_seen_at,
@@ -266,6 +269,8 @@ async def subscribe(
             existing.user_id = user.id
             existing.user_agent = user_agent or None
             existing.last_seen_at = now
+            if existing.created_at is None:
+                existing.created_at = now
             existing.topics = _resolve_topics()
             await db.commit()
             await db.refresh(existing)
@@ -280,6 +285,8 @@ async def subscribe(
                 last_seen_at=now,
                 topics=_resolve_topics(),
             )
+            if subscription.created_at is None:
+                subscription.created_at = now
             db.add(subscription)
             await db.commit()
             await db.refresh(subscription)

--- a/root/tests/test_notifications_push.py
+++ b/root/tests/test_notifications_push.py
@@ -16,8 +16,8 @@ from sqlalchemy.orm import sessionmaker
 from app.auth.security import get_password_hash
 from app.core.config import settings
 from app.models.models import PushSubscription
-from app.services import webpush as webpush_module
 from app.routers.notifications import _serialize_subscription
+from app.services import webpush as webpush_module
 
 
 @pytest.fixture

--- a/root/tests/test_notifications_push.py
+++ b/root/tests/test_notifications_push.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Iterator
+from types import SimpleNamespace
 
 import pytest
 from httpx import AsyncClient
@@ -16,6 +17,7 @@ from app.auth.security import get_password_hash
 from app.core.config import settings
 from app.models.models import PushSubscription
 from app.services import webpush as webpush_module
+from app.routers.notifications import _serialize_subscription
 
 
 @pytest.fixture
@@ -109,6 +111,25 @@ async def test_subscribe_persists_subscription(
     assert stored.p256dh == payload["keys"]["p256dh"]
     assert stored.auth == payload["keys"]["auth"]
     assert stored.topics == ["system", "news"]
+
+
+def test_serialize_subscription_handles_missing_created_at():
+    legacy = SimpleNamespace(
+        id=1,
+        user_id=2,
+        endpoint="https://example.test/legacy",
+        p256dh="p256",
+        auth="auth",
+        created_at=None,
+        user_agent="UA/1.0",
+        last_seen_at=None,
+        topics=["system"],
+    )
+
+    result = _serialize_subscription(legacy)
+
+    assert result.created_at is not None
+    assert result.user_agent == "UA/1.0"
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- ensure push subscription serialization falls back to a safe timestamp when created_at is missing
- normalize stored subscriptions by restoring a created_at timestamp when updating or inserting records
- add regression test covering serialization of legacy subscriptions without created_at

## Testing
- pytest root/tests/test_notifications_push.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e9372074d083279e85f033f918bc63