### PR TITLE
Ensure push subscription schema is created on demand

### DIFF
--- a/root/app/api/push.py
+++ b/root/app/api/push.py
@@ -16,6 +16,7 @@ from app.core.config import settings
 from app.core.database import get_db
 from app.models.models import PushSubscription, User
 from app.services.notifications import prepare_push_payload_for_user
+from app.services.push_schema import ensure_push_subscription_schema
 from app.services.push_topics import normalize_topic, subscription_supports_topic
 from app.services.webpush import WebPushResult, send_web_push
 
@@ -85,6 +86,7 @@ async def subscribe(
     session: AsyncSession = Depends(get_db),
     user: User = Depends(get_current_user),
 ):
+    await ensure_push_subscription_schema(session)
     endpoint = payload.endpoint.strip()
     p256dh = payload.keys.p256dh.strip()
     auth = payload.keys.auth.strip()
@@ -129,6 +131,7 @@ async def unsubscribe(
     session: AsyncSession = Depends(get_db),
     user: User = Depends(get_current_user),
 ):
+    await ensure_push_subscription_schema(session)
     endpoint = payload.endpoint.strip()
     if not endpoint:
         raise HTTPException(status_code=400, detail="invalid subscription")
@@ -177,6 +180,7 @@ async def disable_user_push(
     session: AsyncSession = Depends(get_db),
     user: User = Depends(get_current_user),
 ):
+    await ensure_push_subscription_schema(session)
     if user.role != "admin":
         raise HTTPException(status_code=403, detail="forbidden")
     target = await session.get(User, payload.user_id)
@@ -214,6 +218,7 @@ async def send_test(
     session: AsyncSession = Depends(get_db),
     user: User = Depends(get_current_user),
 ) -> PushSendResponse:
+    await ensure_push_subscription_schema(session)
     res = await session.execute(
         select(PushSubscription)
         .options(selectinload(PushSubscription.user))
@@ -261,6 +266,7 @@ async def broadcast(
     session: AsyncSession = Depends(get_db),
     user: User = Depends(get_current_user),
 ) -> PushSendResponse:
+    await ensure_push_subscription_schema(session)
     if user.role != "admin":
         raise HTTPException(status_code=403, detail="forbidden")
     res = await session.execute(

--- a/root/app/management/weekly_cleanup.py
+++ b/root/app/management/weekly_cleanup.py
@@ -13,6 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.config import settings
 from app.core.database import async_session, engine
 from app.models.models import PushSubscription, User
+from app.services.push_schema import ensure_push_subscription_schema
 
 logger = logging.getLogger(__name__)
 
@@ -84,6 +85,7 @@ async def run_weekly_cleanup() -> dict[str, int | None]:
     removed_orphaned = 0
     removed_stale = 0
     async with async_session() as session:
+        await ensure_push_subscription_schema(session)
         removed_orphaned = await _delete_orphaned_subscriptions(session)
         removed_stale = await _delete_stale_subscriptions(session)
     await _reindex_database()

--- a/root/app/routers/notifications.py
+++ b/root/app/routers/notifications.py
@@ -27,6 +27,7 @@ from app.services.push_topics import (
     resolve_topics,
     subscription_supports_topic,
 )
+from app.services.push_schema import ensure_push_subscription_schema
 from app.services.webpush import WebPushResult, send_web_push
 
 logger = logging.getLogger(__name__)
@@ -208,6 +209,7 @@ async def subscribe(
     db: Annotated[AsyncSession, Depends(get_db)],
     user: Annotated[User, Depends(get_current_user)],
 ) -> PushSubscriptionOut:
+    await ensure_push_subscription_schema(db)
     endpoint, p256dh, auth = await _validate_subscription_payload(payload)
 
     client_host = request.client.host if request.client else None
@@ -309,6 +311,7 @@ async def update_subscription_topics(
     db: Annotated[AsyncSession, Depends(get_db)],
     user: Annotated[User, Depends(get_current_user)],
 ) -> PushSubscriptionOut:
+    await ensure_push_subscription_schema(db)
     endpoint = payload.endpoint.strip()
     if not endpoint:
         raise HTTPException(
@@ -350,6 +353,7 @@ async def unsubscribe(
     db: Annotated[AsyncSession, Depends(get_db)],
     user: Annotated[User, Depends(get_current_user)],
 ) -> dict[str, bool]:
+    await ensure_push_subscription_schema(db)
     endpoint = payload.endpoint.strip()
     if not endpoint:
         raise HTTPException(
@@ -411,6 +415,7 @@ async def send_test(
     user: Annotated[User, Depends(get_current_user)],
     payload: PushTestRequest | None = None,
 ) -> SendTestResponse:
+    await ensure_push_subscription_schema(db)
     if user.role != "admin":
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,

--- a/root/app/routers/notifications.py
+++ b/root/app/routers/notifications.py
@@ -21,13 +21,13 @@ from app.core.database import get_db
 from app.core.rate_limit import RateLimitExceeded, RateLimitInfo, enforce_rate_limit
 from app.models.models import PushSubscription, User
 from app.services.notifications import prepare_push_payload_for_user
+from app.services.push_schema import ensure_push_subscription_schema
 from app.services.push_topics import (
     normalize_topic,
     normalize_topics,
     resolve_topics,
     subscription_supports_topic,
 )
-from app.services.push_schema import ensure_push_subscription_schema
 from app.services.webpush import WebPushResult, send_web_push
 
 logger = logging.getLogger(__name__)

--- a/root/app/services/notifications.py
+++ b/root/app/services/notifications.py
@@ -22,6 +22,7 @@ from app.models.models import (
     User,
 )
 from app.services.notification_templates import render_notification_template
+from app.services.push_schema import ensure_push_subscription_schema
 from app.services.push_topics import normalize_topic, subscription_supports_topic
 from app.services.webpush import send_web_push
 
@@ -225,6 +226,7 @@ async def create_notifications_for_users(
     await db.execute(insert(Notification).values(rows))
     await db.commit()
     if settings.VAPID_PRIVATE_KEY and settings.VAPID_PUBLIC_KEY:
+        await ensure_push_subscription_schema(db)
         subs = (
             (
                 await db.execute(

--- a/root/app/services/push_schema.py
+++ b/root/app/services/push_schema.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import asyncio
+from threading import Lock
+from typing import Optional
+
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.models import PushSubscription
+
+_async_ready = False
+_async_lock = asyncio.Lock()
+_sync_ready = False
+_sync_lock = Lock()
+
+
+def _create_schema(bind) -> None:
+    PushSubscription.__table__.create(bind=bind, checkfirst=True)
+
+
+async def ensure_push_subscription_schema(db: AsyncSession) -> None:
+    global _async_ready, _sync_ready
+    if _async_ready:
+        return
+    async with _async_lock:
+        if _async_ready:
+            return
+
+        def _sync_create(sync_session) -> None:
+            connection = sync_session.connection()
+            _create_schema(connection)
+
+        await db.run_sync(_sync_create)
+        _async_ready = True
+        _sync_ready = True
+
+
+def ensure_push_subscription_schema_sync(engine: Optional[Engine]) -> None:
+    global _sync_ready, _async_ready
+    if engine is None or _sync_ready:
+        return
+    with _sync_lock:
+        if _sync_ready:
+            return
+        _create_schema(engine)
+        _sync_ready = True
+        _async_ready = True

--- a/root/app/services/webpush.py
+++ b/root/app/services/webpush.py
@@ -21,6 +21,7 @@ from app.core.database import async_session
 from app.core.rate_limit import RateLimitExceeded, RateLimitInfo, enforce_rate_limit
 from app.models.models import PushSubscription
 from app.services.notification_templates import render_notification_template
+from app.services.push_schema import ensure_push_subscription_schema_sync
 from app.services.push_topics import normalize_topic, subscription_supports_topic
 
 logger = logging.getLogger(__name__)
@@ -29,7 +30,10 @@ logger.setLevel(logging.NOTSET)
 url = make_url(settings.database_url)
 if url.drivername.endswith("+asyncpg"):
     url = url.set(drivername="postgresql+psycopg")
+elif url.drivername.endswith("+aiosqlite"):
+    url = url.set(drivername="sqlite")
 _sync_engine = create_engine(str(url), pool_pre_ping=True, future=True)
+ensure_push_subscription_schema_sync(_sync_engine)
 _Session = sessionmaker(bind=_sync_engine, autocommit=False, autoflush=False)
 
 _OPTION_KEYS: set[str] = {


### PR DESCRIPTION
## Summary
- add a push schema helper that lazily ensures the `push_subscriptions` table exists
- invoke the helper across push endpoints, services, and cleanup jobs before touching push data
- update the synchronous webpush engine to use a sync driver and create the schema eagerly

## Testing
- pytest root/tests/test_notifications_push.py
- pytest root/tests/test_push_api.py
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e93ec317048327a09150da2a43c73c