### PR TITLE
Handle unavailable database when preparing push schema

### DIFF
--- a/root/app/services/push_schema.py
+++ b/root/app/services/push_schema.py
@@ -6,7 +6,7 @@ from threading import Lock
 from typing import Optional
 
 from sqlalchemy.engine import Engine
-from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.exc import OperationalError, SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.models import PushSubscription
@@ -56,7 +56,15 @@ def ensure_push_subscription_schema_sync(engine: Optional[Engine]) -> None:
         if _sync_ready:
             return
         try:
-            _create_schema(engine)
+            with engine.connect() as connection:
+                _create_schema(connection)
+        except OperationalError as exc:
+            logger.warning(
+                "Push subscription schema creation skipped; database is unavailable: %s",
+                exc,
+                exc_info=False,
+            )
+            return
         except SQLAlchemyError:
             logger.exception(
                 "Failed to ensure push subscription schema using sync engine"


### PR DESCRIPTION
## Summary
- avoid stack traces when the synchronous push schema setup runs without an available database
- open a transient connection during setup so connection errors can be reported as a warning and skipped gracefully

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e960bc67e883278835b120fa4113de