### PR TITLE
Fix push subscription schema upgrades

### DIFF
--- a/root/app/services/push_schema.py
+++ b/root/app/services/push_schema.py
@@ -5,7 +5,7 @@ import logging
 from threading import Lock
 from typing import Optional
 
-from sqlalchemy import Column, DateTime, JSON, String, inspect
+from sqlalchemy import JSON, Column, DateTime, String, inspect
 from sqlalchemy.engine import Engine
 from sqlalchemy.exc import OperationalError, SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -35,7 +35,9 @@ def _ensure_columns(bind) -> None:
     columns = {col["name"] for col in inspector.get_columns(table_name)}
     preparer = bind.dialect.identifier_preparer
 
-    def _add_column(column: Column, *, default_sql: str | None = None, not_null: bool = False) -> None:
+    def _add_column(
+        column: Column, *, default_sql: str | None = None, not_null: bool = False
+    ) -> None:
         column_name = preparer.quote(column.name)
         type_sql = column.type.compile(bind.dialect)
         parts = [column_name, type_sql]
@@ -43,7 +45,9 @@ def _ensure_columns(bind) -> None:
             parts.append(f"DEFAULT {default_sql}")
         if not_null:
             parts.append("NOT NULL")
-        statement = f"ALTER TABLE {preparer.quote(table_name)} ADD COLUMN {' '.join(parts)}"
+        statement = (
+            f"ALTER TABLE {preparer.quote(table_name)} ADD COLUMN {' '.join(parts)}"
+        )
         bind.exec_driver_sql(statement)
 
     if "user_agent" not in columns:
@@ -67,7 +71,6 @@ def _ensure_columns(bind) -> None:
             default_sql=default_expr,
             not_null=True,
         )
-
 
 
 async def ensure_push_subscription_schema(db: AsyncSession) -> None:

--- a/root/app/services/push_schema.py
+++ b/root/app/services/push_schema.py
@@ -5,6 +5,7 @@ import logging
 from threading import Lock
 from typing import Optional
 
+from sqlalchemy import Column, DateTime, JSON, String, inspect
 from sqlalchemy.engine import Engine
 from sqlalchemy.exc import OperationalError, SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -23,6 +24,52 @@ def _create_schema(bind) -> None:
     PushSubscription.__table__.create(bind=bind, checkfirst=True)
 
 
+def _ensure_columns(bind) -> None:
+    table_name = PushSubscription.__tablename__
+    inspector = inspect(bind)
+    tables = {name for name in inspector.get_table_names()}
+    if table_name not in tables:
+        _create_schema(bind)
+        inspector = inspect(bind)
+
+    columns = {col["name"] for col in inspector.get_columns(table_name)}
+    preparer = bind.dialect.identifier_preparer
+
+    def _add_column(column: Column, *, default_sql: str | None = None, not_null: bool = False) -> None:
+        column_name = preparer.quote(column.name)
+        type_sql = column.type.compile(bind.dialect)
+        parts = [column_name, type_sql]
+        if default_sql:
+            parts.append(f"DEFAULT {default_sql}")
+        if not_null:
+            parts.append("NOT NULL")
+        statement = f"ALTER TABLE {preparer.quote(table_name)} ADD COLUMN {' '.join(parts)}"
+        bind.exec_driver_sql(statement)
+
+    if "user_agent" not in columns:
+        _add_column(PushSubscription.__table__.c.user_agent)
+    if "last_seen_at" not in columns:
+        _add_column(PushSubscription.__table__.c.last_seen_at)
+    if "created_at" not in columns:
+        created_at_col = PushSubscription.__table__.c.created_at
+        default_clause = created_at_col.server_default
+        default_sql = None
+        if default_clause is not None:
+            default_sql = str(default_clause.arg.compile(dialect=bind.dialect))
+        _add_column(created_at_col, default_sql=default_sql, not_null=True)
+    if "topics" not in columns:
+        if bind.dialect.name.startswith("postgresql"):
+            default_expr = "'[]'::jsonb"
+        else:
+            default_expr = "'[]'"
+        _add_column(
+            PushSubscription.__table__.c.topics,
+            default_sql=default_expr,
+            not_null=True,
+        )
+
+
+
 async def ensure_push_subscription_schema(db: AsyncSession) -> None:
     global _async_ready, _sync_ready
     if _async_ready:
@@ -35,7 +82,7 @@ async def ensure_push_subscription_schema(db: AsyncSession) -> None:
 
             def _sync_create(sync_session) -> None:
                 connection = sync_session.connection()
-                _create_schema(connection)
+                _ensure_columns(connection)
 
             await db.run_sync(_sync_create)
         except SQLAlchemyError:
@@ -57,7 +104,7 @@ def ensure_push_subscription_schema_sync(engine: Optional[Engine]) -> None:
             return
         try:
             with engine.connect() as connection:
-                _create_schema(connection)
+                _ensure_columns(connection)
         except OperationalError as exc:
             logger.warning(
                 "Push subscription schema creation skipped; database is unavailable: %s",

--- a/root/tests/test_push_schema.py
+++ b/root/tests/test_push_schema.py
@@ -49,21 +49,32 @@ async def test_ensure_push_subscription_schema_upgrades_existing_table(
             columns = {
                 column["name"] for column in inspector.get_columns("push_subscriptions")
             }
-            assert {"endpoint", "user_agent", "last_seen_at", "created_at", "topics"}.issubset(
-                columns
-            )
+            assert {
+                "endpoint",
+                "user_agent",
+                "last_seen_at",
+                "created_at",
+                "topics",
+            }.issubset(columns)
             created_at = next(
-                (col for col in inspector.get_columns("push_subscriptions") if col["name"] == "created_at"),
+                (
+                    col
+                    for col in inspector.get_columns("push_subscriptions")
+                    if col["name"] == "created_at"
+                ),
                 None,
             )
             assert created_at is not None
             assert created_at.get("default") is not None
             topics = next(
-                (col for col in inspector.get_columns("push_subscriptions") if col["name"] == "topics"),
+                (
+                    col
+                    for col in inspector.get_columns("push_subscriptions")
+                    if col["name"] == "topics"
+                ),
                 None,
             )
             assert topics is not None
             assert topics.get("default") is not None
 
         await conn.run_sync(_assert_schema)
-

--- a/root/tests/test_push_schema.py
+++ b/root/tests/test_push_schema.py
@@ -1,0 +1,69 @@
+"""Runtime checks for push subscription schema helpers."""
+
+from __future__ import annotations
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy import text
+
+from app.core.database import Base, async_session, engine
+from app.services import push_schema as push_schema_module
+from app.services.push_schema import ensure_push_subscription_schema
+
+
+def _reset_flags(monkeypatch):
+    monkeypatch.setattr(push_schema_module, "_async_ready", False)
+    monkeypatch.setattr(push_schema_module, "_sync_ready", False)
+
+
+@pytest.mark.asyncio
+async def test_ensure_push_subscription_schema_upgrades_existing_table(
+    monkeypatch,
+) -> None:
+    _reset_flags(monkeypatch)
+
+    async with engine.begin() as conn:
+        await conn.execute(text("DROP TABLE IF EXISTS push_subscriptions"))
+        await conn.execute(
+            text(
+                """
+                CREATE TABLE push_subscriptions (
+                    id INTEGER PRIMARY KEY,
+                    user_id INTEGER NOT NULL,
+                    endpoint TEXT,
+                    p256dh VARCHAR(200) NOT NULL,
+                    auth VARCHAR(200) NOT NULL
+                )
+                """
+            )
+        )
+
+    async with async_session() as session:
+        await ensure_push_subscription_schema(session)
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+        def _assert_schema(sync_conn):
+            inspector = sa.inspect(sync_conn)
+            columns = {
+                column["name"] for column in inspector.get_columns("push_subscriptions")
+            }
+            assert {"endpoint", "user_agent", "last_seen_at", "created_at", "topics"}.issubset(
+                columns
+            )
+            created_at = next(
+                (col for col in inspector.get_columns("push_subscriptions") if col["name"] == "created_at"),
+                None,
+            )
+            assert created_at is not None
+            assert created_at.get("default") is not None
+            topics = next(
+                (col for col in inspector.get_columns("push_subscriptions") if col["name"] == "topics"),
+                None,
+            )
+            assert topics is not None
+            assert topics.get("default") is not None
+
+        await conn.run_sync(_assert_schema)
+


### PR DESCRIPTION
## Summary
- ensure the push subscription schema helper backfills missing columns before inserting subscriptions
- add a regression test that exercises schema upgrades against an existing table

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e9637fde548327a2513d329f48cd47