### PR TITLE
Respect push consent when restoring notification settings

### DIFF
--- a/root/frontend/src/hooks/usePushPreferences.ts
+++ b/root/frontend/src/hooks/usePushPreferences.ts
@@ -6,6 +6,7 @@ import {
   ensurePushSubscription,
   getExistingPushSubscription,
   getPersistedTopics,
+  hasPushConsent,
   isPushSupported,
   resolveServiceWorkerRegistration,
   setPushConsent,
@@ -369,8 +370,16 @@ export function usePushPreferences(options?: UsePushPreferencesOptions) {
         }
         setPushInitializing(true)
         const storedTopics = getPersistedTopics()
+        if (storedTopics !== undefined) {
+          applyServerTopics(storedTopics)
+        }
+        const consented = hasPushConsent()
         let sub: PushSubscription | null = null
-        if (typeof Notification !== "undefined" && Notification.permission === "granted") {
+        if (
+          consented &&
+          typeof Notification !== "undefined" &&
+          Notification.permission === "granted"
+        ) {
           sub = await ensurePushSubscription({
             topics: storedTopics,
             requestPermission: false,
@@ -381,9 +390,11 @@ export function usePushPreferences(options?: UsePushPreferencesOptions) {
         if (!active) return
         setPushSubscription(sub)
         if (sub) {
-          setPushConsent(true)
-          const persisted = getPersistedTopics() ?? storedTopics ?? []
-          if (persisted) {
+          if (consented) {
+            setPushConsent(true)
+          }
+          const persisted = getPersistedTopics()
+          if (persisted !== undefined) {
             applyServerTopics(persisted)
           }
         }

--- a/root/frontend/src/hooks/usePushPreferences.ts
+++ b/root/frontend/src/hooks/usePushPreferences.ts
@@ -9,6 +9,7 @@ import {
   hasPushConsent,
   isPushSupported,
   resolveServiceWorkerRegistration,
+  setPersistedTopics,
   setPushConsent,
 } from "@/push/subscribe"
 import { currentUserQueryKey } from "@/contexts/AuthContext"
@@ -52,9 +53,23 @@ export function usePushPreferences(options?: UsePushPreferencesOptions) {
   const { onNotify } = options ?? {}
 
   const topicKeys = useMemo(() => NOTIFICATION_TOPIC_KEYS, [])
-  const [topicState, setTopicState] = useState<Record<NotificationTopicKey, boolean>>(
-    () => ({ ...DEFAULT_NOTIFICATION_TOPICS }),
-  )
+  const [topicState, setTopicState] = useState<Record<NotificationTopicKey, boolean>>(() => {
+    const stored = getPersistedTopics()
+    if (stored === undefined) {
+      return { ...DEFAULT_NOTIFICATION_TOPICS }
+    }
+    const initial: Record<NotificationTopicKey, boolean> = {} as Record<NotificationTopicKey, boolean>
+    for (const key of NOTIFICATION_TOPIC_KEYS) {
+      initial[key] = false
+    }
+    for (const raw of stored) {
+      const normalized = raw.toString().trim().toLowerCase()
+      if ((NOTIFICATION_TOPIC_KEYS as string[]).includes(normalized)) {
+        initial[normalized as NotificationTopicKey] = true
+      }
+    }
+    return initial
+  })
   const [pushSupported, setPushSupported] = useState(() => isPushSupported())
   const [notificationPermission, setNotificationPermission] = useState<NotificationPermission>(() => {
     if (typeof window === "undefined" || typeof Notification === "undefined") return "default"
@@ -243,6 +258,7 @@ export function usePushPreferences(options?: UsePushPreferencesOptions) {
         const previousState = topicState
         const nextState = { ...topicState, [key]: checked }
         setTopicState(nextState)
+        setPersistedTopics(topicKeys.filter(topic => nextState[topic]))
         if (!notificationsEnabled || pushBusy) return
         if (!isPushSupported()) {
           setTopicState(previousState)

--- a/root/frontend/src/pages/__tests__/Settings.notifications.test.tsx
+++ b/root/frontend/src/pages/__tests__/Settings.notifications.test.tsx
@@ -17,6 +17,7 @@ const hoistedMocks = vi.hoisted(() => ({
   setPushConsentMock: vi.fn(),
   getExistingPushSubscriptionMock: vi.fn(),
   getPersistedTopicsMock: vi.fn(),
+  setPersistedTopicsMock: vi.fn(),
   hasPushConsentMock: vi.fn(() => false),
   isPushSupportedMock: vi.fn(() => true),
 })) as {
@@ -25,6 +26,7 @@ const hoistedMocks = vi.hoisted(() => ({
   setPushConsentMock: ReturnType<typeof vi.fn>
   getExistingPushSubscriptionMock: ReturnType<typeof vi.fn>
   getPersistedTopicsMock: ReturnType<typeof vi.fn>
+  setPersistedTopicsMock: ReturnType<typeof vi.fn>
   hasPushConsentMock: ReturnType<typeof vi.fn>
   isPushSupportedMock: ReturnType<typeof vi.fn>
 }
@@ -45,6 +47,7 @@ vi.mock("@/push/subscribe", async () => {
     setPushConsent: hoistedMocks.setPushConsentMock,
     getExistingPushSubscription: hoistedMocks.getExistingPushSubscriptionMock,
     getPersistedTopics: hoistedMocks.getPersistedTopicsMock,
+    setPersistedTopics: hoistedMocks.setPersistedTopicsMock,
     hasPushConsent: hoistedMocks.hasPushConsentMock,
     isPushSupported: hoistedMocks.isPushSupportedMock,
   }
@@ -56,6 +59,7 @@ const {
   setPushConsentMock,
   getExistingPushSubscriptionMock,
   getPersistedTopicsMock,
+  setPersistedTopicsMock,
   hasPushConsentMock,
   isPushSupportedMock,
 } = hoistedMocks
@@ -154,6 +158,7 @@ beforeEach(() => {
   ensurePushSubscriptionMock.mockResolvedValue(null)
   getPersistedTopicsMock.mockReset()
   getPersistedTopicsMock.mockReturnValue(undefined)
+  setPersistedTopicsMock.mockReset()
   deleteSubscriptionMock.mockReset()
 
   queryClient = new QueryClient()
@@ -255,7 +260,24 @@ describe("usePushPreferences notifications flow", () => {
     expect(ensurePushSubscriptionMock).toHaveBeenCalledTimes(2)
     const updateArgs = ensurePushSubscriptionMock.mock.calls[1][0]
     expect(updateArgs.topics).toEqual(["schedule", "news"])
+    expect(setPersistedTopicsMock).toHaveBeenCalledWith(["schedule", "news"])
     expect(result.current.topicState.system).toBe(false)
+  })
+
+  it("persists topic selection locally when notifications are disabled", async () => {
+    ensurePushSubscriptionMock.mockResolvedValue(null)
+
+    const { result } = renderHook(() => usePushPreferences(), { wrapper })
+
+    expect(result.current.notificationsEnabled).toBe(false)
+
+    const handler = result.current.handleTopicToggle("news")
+    await act(async () => {
+      await handler({} as ChangeEvent<HTMLInputElement>, false)
+    })
+
+    expect(setPersistedTopicsMock).toHaveBeenCalledWith(["schedule", "events", "system"])
+    expect(result.current.topicState.news).toBe(false)
   })
 
   it("notifies user when permission is denied", async () => {

--- a/root/frontend/src/pages/__tests__/Settings.notifications.test.tsx
+++ b/root/frontend/src/pages/__tests__/Settings.notifications.test.tsx
@@ -17,6 +17,7 @@ const hoistedMocks = vi.hoisted(() => ({
   setPushConsentMock: vi.fn(),
   getExistingPushSubscriptionMock: vi.fn(),
   getPersistedTopicsMock: vi.fn(),
+  hasPushConsentMock: vi.fn(() => false),
   isPushSupportedMock: vi.fn(() => true),
 })) as {
   deleteSubscriptionMock: ReturnType<typeof vi.fn>
@@ -24,6 +25,7 @@ const hoistedMocks = vi.hoisted(() => ({
   setPushConsentMock: ReturnType<typeof vi.fn>
   getExistingPushSubscriptionMock: ReturnType<typeof vi.fn>
   getPersistedTopicsMock: ReturnType<typeof vi.fn>
+  hasPushConsentMock: ReturnType<typeof vi.fn>
   isPushSupportedMock: ReturnType<typeof vi.fn>
 }
 
@@ -43,6 +45,7 @@ vi.mock("@/push/subscribe", async () => {
     setPushConsent: hoistedMocks.setPushConsentMock,
     getExistingPushSubscription: hoistedMocks.getExistingPushSubscriptionMock,
     getPersistedTopics: hoistedMocks.getPersistedTopicsMock,
+    hasPushConsent: hoistedMocks.hasPushConsentMock,
     isPushSupported: hoistedMocks.isPushSupportedMock,
   }
 })
@@ -53,6 +56,7 @@ const {
   setPushConsentMock,
   getExistingPushSubscriptionMock,
   getPersistedTopicsMock,
+  hasPushConsentMock,
   isPushSupportedMock,
 } = hoistedMocks
 
@@ -142,6 +146,8 @@ beforeEach(() => {
   getExistingPushSubscriptionMock.mockReset()
   getExistingPushSubscriptionMock.mockResolvedValue(null)
   setPushConsentMock.mockReset()
+  hasPushConsentMock.mockReset()
+  hasPushConsentMock.mockReturnValue(false)
   isPushSupportedMock.mockReset()
   isPushSupportedMock.mockReturnValue(true)
   ensurePushSubscriptionMock.mockReset()
@@ -169,6 +175,7 @@ describe("usePushPreferences notifications flow", () => {
     ensurePushSubscriptionMock.mockResolvedValue(subscription)
     getPersistedTopicsMock.mockReturnValue(["news", "schedule"])
     MockNotification.permission = "granted"
+    hasPushConsentMock.mockReturnValue(true)
 
     const onNotify = vi.fn()
     const { result } = renderHook(() => usePushPreferences({ onNotify }), { wrapper })
@@ -185,7 +192,7 @@ describe("usePushPreferences notifications flow", () => {
     const ensureArgs = ensurePushSubscriptionMock.mock.calls[1][0]
     expect(ensureArgs.registration).toBe(registration)
     expect(ensureArgs.requestPermission).toBe(true)
-    expect(ensureArgs.topics).toEqual(["schedule", "news", "events", "system"])
+    expect(ensureArgs.topics).toEqual(["schedule", "news"])
 
     expect(setPushConsentMock).toHaveBeenCalledWith(true)
     expect(onNotify).toHaveBeenCalledWith(
@@ -204,6 +211,7 @@ describe("usePushPreferences notifications flow", () => {
     ensurePushSubscriptionMock.mockResolvedValue(subscription)
     getPersistedTopicsMock.mockReturnValue(["news", "schedule", "system"])
     MockNotification.permission = "granted"
+    hasPushConsentMock.mockReturnValue(true)
     registration.pushManager.getSubscription.mockResolvedValue(subscription)
 
     const onNotify = vi.fn()
@@ -233,6 +241,7 @@ describe("usePushPreferences notifications flow", () => {
       .mockReturnValueOnce(["news", "schedule", "system"])
       .mockReturnValueOnce(["news", "schedule"])
     MockNotification.permission = "granted"
+    hasPushConsentMock.mockReturnValue(true)
 
     const { result } = renderHook(() => usePushPreferences(), { wrapper })
 

--- a/root/frontend/src/push/subscribe.ts
+++ b/root/frontend/src/push/subscribe.ts
@@ -35,6 +35,26 @@ export function getPersistedTopics(): string[] | undefined {
   return parseStoredTopics(getStoredValue(PUSH_TOPICS_STORAGE_KEY)) ?? undefined
 }
 
+export function setPersistedTopics(topics: string[] | null | undefined): void {
+  if (topics == null) {
+    removeStoredValue(PUSH_TOPICS_STORAGE_KEY)
+    return
+  }
+
+  const normalized: string[] = []
+  const seen = new Set<string>()
+  for (const topic of topics) {
+    if (!topic) continue
+    const trimmed = topic.toString().trim()
+    if (!trimmed || seen.has(trimmed)) continue
+    seen.add(trimmed)
+    normalized.push(trimmed)
+  }
+
+  normalized.sort()
+  setStoredValue(PUSH_TOPICS_STORAGE_KEY, JSON.stringify(normalized))
+}
+
 function sleep(ms: number) {
   return new Promise<void>(resolve => setTimeout(resolve, ms))
 }
@@ -74,7 +94,7 @@ async function persistSubscriptionWithBackoff(
       const normalizedTopics = response?.topics ?? (topics ? [...topics].sort() : [])
       setStoredValue(PUSH_SUB_STORAGE_KEY, JSON.stringify(payload))
       setStoredValue(PUSH_LAST_SYNC_STORAGE_KEY, Date.now().toString())
-      setStoredValue(PUSH_TOPICS_STORAGE_KEY, JSON.stringify(normalizedTopics))
+      setPersistedTopics(normalizedTopics)
       return response
     } catch (error) {
       attempt += 1


### PR DESCRIPTION
## Summary
- avoid re-subscribing to push notifications unless the user previously granted consent and preload saved topics on mount
- update the notification settings tests to cover consent-aware subscription restoration and topic persistence

## Testing
- npm test -- Settings.notifications

------
https://chatgpt.com/codex/tasks/task_e_68e973996d50832782fbc003efc025b1