### PR TITLE
Preserve notification topic preferences after logout

### DIFF
--- a/root/frontend/src/contexts/AuthContext.tsx
+++ b/root/frontend/src/contexts/AuthContext.tsx
@@ -351,7 +351,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       }
     } finally {
       try {
-        await unsubscribePush({ preserveConsent: true })
+        await unsubscribePush({ preserveConsent: true, preserveTopics: true })
       } catch (error) {
         console.error("Failed to unsubscribe push subscription on logout", error)
       } finally {

--- a/root/frontend/src/push/__tests__/unsubscribePush.test.ts
+++ b/root/frontend/src/push/__tests__/unsubscribePush.test.ts
@@ -51,4 +51,34 @@ describe("unsubscribePush", () => {
     expect(localStorage.getItem(SUB_KEY)).toBeNull()
     expect(localStorage.getItem(TOPICS_KEY)).toBeNull()
   })
+
+  it("keeps stored topics when preserveTopics is requested", async () => {
+    localStorage.setItem(CONSENT_KEY, "granted")
+    localStorage.setItem(LAST_SYNC_KEY, "123")
+    localStorage.setItem(SUB_KEY, "{}")
+    localStorage.setItem(TOPICS_KEY, "[\"news\"]")
+
+    const neverReady = new Promise<ServiceWorkerRegistration>(() => {})
+    const getRegistration = vi.fn().mockResolvedValue(undefined)
+
+    Object.defineProperty(navigator, "serviceWorker", {
+      configurable: true,
+      value: {
+        ready: neverReady,
+        getRegistration,
+      },
+    })
+
+    const resultPromise = unsubscribePush({ preserveTopics: true })
+
+    await vi.advanceTimersByTimeAsync(2100)
+
+    const result = await resultPromise
+    expect(result).toBe(false)
+
+    expect(localStorage.getItem(CONSENT_KEY)).toBeNull()
+    expect(localStorage.getItem(LAST_SYNC_KEY)).toBeNull()
+    expect(localStorage.getItem(SUB_KEY)).toBeNull()
+    expect(localStorage.getItem(TOPICS_KEY)).toBe('["news"]')
+  })
 })

--- a/root/frontend/src/push/subscribe.ts
+++ b/root/frontend/src/push/subscribe.ts
@@ -340,22 +340,25 @@ export async function ensurePushSubscription(
 type UnsubscribePushOptions = {
   registration?: ServiceWorkerRegistration
   preserveConsent?: boolean
+  preserveTopics?: boolean
 }
 
-function clearPushLocals(preserveConsent?: boolean) {
-  if (!preserveConsent) {
+function clearPushLocals(options?: Pick<UnsubscribePushOptions, "preserveConsent" | "preserveTopics">) {
+  if (!options?.preserveConsent) {
     try {
       localStorage.removeItem(PUSH_CONSENT_STORAGE_KEY)
     } catch {}
   }
   removeStoredValue(PUSH_LAST_SYNC_STORAGE_KEY)
   removeStoredValue(PUSH_SUB_STORAGE_KEY)
-  removeStoredValue(PUSH_TOPICS_STORAGE_KEY)
+  if (!options?.preserveTopics) {
+    removeStoredValue(PUSH_TOPICS_STORAGE_KEY)
+  }
 }
 
 export async function unsubscribePush(options?: UnsubscribePushOptions) {
   if (!("serviceWorker" in navigator)) {
-    clearPushLocals(options?.preserveConsent)
+    clearPushLocals(options)
     return false
   }
 
@@ -364,13 +367,13 @@ export async function unsubscribePush(options?: UnsubscribePushOptions) {
   )
 
   if (!registration) {
-    clearPushLocals(options?.preserveConsent)
+    clearPushLocals(options)
     return false
   }
 
   const subscription = await registration.pushManager.getSubscription()
   if (!subscription) {
-    clearPushLocals(options?.preserveConsent)
+    clearPushLocals(options)
     return true
   }
 
@@ -387,7 +390,7 @@ export async function unsubscribePush(options?: UnsubscribePushOptions) {
 
   const ok = await subscription.unsubscribe()
 
-  clearPushLocals(options?.preserveConsent)
+  clearPushLocals(options)
 
   return ok && (deleted || !endpoint)
 }


### PR DESCRIPTION
## Summary
- keep push topic selections in local storage when logout cleanup preserves consent
- propagate the new preserveTopics flag from the logout flow
- cover unsubscribePush with a test that ensures topics remain stored when requested

## Testing
- npm test -- src/push/__tests__/unsubscribePush.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e97db3c8488327bbf26b6847bc15de