### PR TITLE
Fix push notification topic persistence across sessions

### DIFF
--- a/root/frontend/src/hooks/usePushPreferences.ts
+++ b/root/frontend/src/hooks/usePushPreferences.ts
@@ -12,7 +12,7 @@ import {
   setPersistedTopics,
   setPushConsent,
 } from "@/push/subscribe"
-import { currentUserQueryKey } from "@/contexts/AuthContext"
+import { currentUserQueryKey, useAuth } from "@/contexts/AuthContext"
 import { isSafariIOS } from "@/utils/browser"
 
 export type NotificationTopicKey = "news" | "schedule" | "events" | "system"
@@ -53,8 +53,10 @@ export function usePushPreferences(options?: UsePushPreferencesOptions) {
   const { onNotify } = options ?? {}
 
   const topicKeys = useMemo(() => NOTIFICATION_TOPIC_KEYS, [])
+  const { user } = useAuth()
+  const activeUserId = user?.id ?? null
   const [topicState, setTopicState] = useState<Record<NotificationTopicKey, boolean>>(() => {
-    const stored = getPersistedTopics()
+    const stored = getPersistedTopics({ userId: activeUserId })
     if (stored === undefined) {
       return { ...DEFAULT_NOTIFICATION_TOPICS }
     }
@@ -186,7 +188,7 @@ export function usePushPreferences(options?: UsePushPreferencesOptions) {
         setPushSubscription(sub)
         return
       }
-      const persistedTopics = getPersistedTopics() ?? selectedTopics
+      const persistedTopics = getPersistedTopics({ userId: activeUserId }) ?? selectedTopics
       applyServerTopics(persistedTopics)
       setPushSubscription(sub)
       setPushConsent(true)
@@ -199,7 +201,7 @@ export function usePushPreferences(options?: UsePushPreferencesOptions) {
       setPushBusy(false)
       setPushInitializing(false)
     }
-  }, [applyServerTopics, invalidatePushQueries, notify, selectedTopics])
+  }, [activeUserId, applyServerTopics, invalidatePushQueries, notify, selectedTopics])
 
   const disableNotifications = useCallback(async () => {
     if (!isPushSupported()) {
@@ -258,7 +260,7 @@ export function usePushPreferences(options?: UsePushPreferencesOptions) {
         const previousState = topicState
         const nextState = { ...topicState, [key]: checked }
         setTopicState(nextState)
-        setPersistedTopics(topicKeys.filter(topic => nextState[topic]))
+        setPersistedTopics(topicKeys.filter(topic => nextState[topic]), { userId: activeUserId })
         if (!notificationsEnabled || pushBusy) return
         if (!isPushSupported()) {
           setTopicState(previousState)
@@ -288,7 +290,7 @@ export function usePushPreferences(options?: UsePushPreferencesOptions) {
             setTopicState(previousState)
             return
           }
-          const persisted = getPersistedTopics() ?? topicsToSend
+          const persisted = getPersistedTopics({ userId: activeUserId }) ?? topicsToSend
           applyServerTopics(persisted)
           setPushSubscription(sub)
           invalidatePushQueries()
@@ -308,6 +310,7 @@ export function usePushPreferences(options?: UsePushPreferencesOptions) {
         }
       },
     [
+      activeUserId,
       applyServerTopics,
       invalidatePushQueries,
       notificationsEnabled,
@@ -385,7 +388,7 @@ export function usePushPreferences(options?: UsePushPreferencesOptions) {
           return
         }
         setPushInitializing(true)
-        const storedTopics = getPersistedTopics()
+        const storedTopics = getPersistedTopics({ userId: activeUserId })
         if (storedTopics !== undefined) {
           applyServerTopics(storedTopics)
         }
@@ -409,7 +412,7 @@ export function usePushPreferences(options?: UsePushPreferencesOptions) {
           if (consented) {
             setPushConsent(true)
           }
-          const persisted = getPersistedTopics()
+          const persisted = getPersistedTopics({ userId: activeUserId })
           if (persisted !== undefined) {
             applyServerTopics(persisted)
           }
@@ -426,7 +429,7 @@ export function usePushPreferences(options?: UsePushPreferencesOptions) {
     return () => {
       active = false
     }
-  }, [applyServerTopics])
+  }, [activeUserId, applyServerTopics])
 
   return {
     topicKeys,

--- a/root/frontend/src/pages/__tests__/Settings.notifications.test.tsx
+++ b/root/frontend/src/pages/__tests__/Settings.notifications.test.tsx
@@ -11,6 +11,8 @@ import {
 } from "vitest"
 import { usePushPreferences } from "@/hooks/usePushPreferences"
 
+const AUTH_USER_ID = 123
+
 const hoistedMocks = vi.hoisted(() => ({
   deleteSubscriptionMock: vi.fn(),
   ensurePushSubscriptionMock: vi.fn(),
@@ -31,6 +33,8 @@ const hoistedMocks = vi.hoisted(() => ({
   isPushSupportedMock: ReturnType<typeof vi.fn>
 }
 
+const authState: { user: any } = { user: { id: AUTH_USER_ID } }
+
 vi.mock("@/api/notifications", async () => {
   const actual = await vi.importActual<typeof import("@/api/notifications")>("@/api/notifications")
   return {
@@ -50,6 +54,16 @@ vi.mock("@/push/subscribe", async () => {
     setPersistedTopics: hoistedMocks.setPersistedTopicsMock,
     hasPushConsent: hoistedMocks.hasPushConsentMock,
     isPushSupported: hoistedMocks.isPushSupportedMock,
+  }
+})
+
+vi.mock("@/contexts/AuthContext", async () => {
+  const actual = await vi.importActual<typeof import("@/contexts/AuthContext")>(
+    "@/contexts/AuthContext",
+  )
+  return {
+    ...actual,
+    useAuth: () => authState,
   }
 })
 
@@ -119,6 +133,8 @@ beforeEach(() => {
     configurable: true,
     writable: true,
   })
+
+  authState.user = { id: AUTH_USER_ID }
 
   const pushManager = {
     getSubscription: vi.fn(),
@@ -260,7 +276,10 @@ describe("usePushPreferences notifications flow", () => {
     expect(ensurePushSubscriptionMock).toHaveBeenCalledTimes(2)
     const updateArgs = ensurePushSubscriptionMock.mock.calls[1][0]
     expect(updateArgs.topics).toEqual(["schedule", "news"])
-    expect(setPersistedTopicsMock).toHaveBeenCalledWith(["schedule", "news"])
+    expect(setPersistedTopicsMock).toHaveBeenCalledWith(
+      ["schedule", "news"],
+      expect.objectContaining({ userId: AUTH_USER_ID }),
+    )
     expect(result.current.topicState.system).toBe(false)
   })
 
@@ -276,7 +295,10 @@ describe("usePushPreferences notifications flow", () => {
       await handler({} as ChangeEvent<HTMLInputElement>, false)
     })
 
-    expect(setPersistedTopicsMock).toHaveBeenCalledWith(["schedule", "events", "system"])
+    expect(setPersistedTopicsMock).toHaveBeenCalledWith(
+      ["schedule", "events", "system"],
+      expect.objectContaining({ userId: AUTH_USER_ID }),
+    )
     expect(result.current.topicState.news).toBe(false)
   })
 

--- a/root/frontend/src/push/__tests__/topicsPersistence.test.ts
+++ b/root/frontend/src/push/__tests__/topicsPersistence.test.ts
@@ -85,6 +85,15 @@ describe("push topic persistence", () => {
     expect(Object.keys(raw?.perUser ?? {})).toEqual(["2"])
   })
 
+  it("reads stored topics for a specific user even when none is active", () => {
+    setActiveUser(5)
+    setPersistedTopics(["system"])
+
+    setActiveUser(null)
+
+    expect(getPersistedTopics({ userId: 5 })).toEqual(["system"])
+  })
+
   it("stores shared topics when user is unknown", () => {
     setActiveUser(null)
     setPersistedTopics(["system"])

--- a/root/frontend/src/push/subscribe.ts
+++ b/root/frontend/src/push/subscribe.ts
@@ -15,6 +15,17 @@ let cachedVapidPublicKey: string | null | undefined
 
 type NormalizedTopics = string[] | undefined
 
+type MaybeUserId = string | number | null | undefined
+
+function normalizeUserId(input: MaybeUserId): string | null {
+  if (input == null) return null
+  if (typeof input === "string" || typeof input === "number") {
+    const normalized = String(input).trim()
+    return normalized ? normalized : null
+  }
+  return null
+}
+
 function normalizeTopics(input: unknown): string[] | undefined {
   if (!Array.isArray(input)) return undefined
   const normalized: string[] = []
@@ -39,13 +50,8 @@ function readActiveUserId(): string | null {
     const data =
       parsed && typeof parsed === "object" && "data" in parsed ? (parsed as { data?: unknown }).data : parsed
     if (!data || typeof data !== "object") return null
-    const id = (data as Record<string, unknown>).id
-    if (id == null) return null
-    if (typeof id === "string" || typeof id === "number") {
-      const normalized = String(id).trim()
-      return normalized ? normalized : null
-    }
-    return null
+    const id = (data as Record<string, unknown>).id as MaybeUserId
+    return normalizeUserId(id)
   } catch {
     return null
   }
@@ -53,10 +59,10 @@ function readActiveUserId(): string | null {
 
 function parseTopicsPayload(
   raw: string | null,
-  options?: { userId?: string | null },
+  options?: { userId?: MaybeUserId },
 ): string[] | undefined {
   if (!raw) return undefined
-  const userId = options?.userId ?? readActiveUserId()
+  const userId = normalizeUserId(options?.userId) ?? readActiveUserId()
   try {
     const parsed = JSON.parse(raw)
     if (Array.isArray(parsed)) {
@@ -94,12 +100,12 @@ function parseTopicsPayload(
   }
 }
 
-export function parseStoredTopics(raw: string | null): NormalizedTopics {
-  return parseTopicsPayload(raw)
+export function parseStoredTopics(raw: string | null, options?: { userId?: MaybeUserId }): NormalizedTopics {
+  return parseTopicsPayload(raw, options)
 }
 
-export function getPersistedTopics(): string[] | undefined {
-  return parseTopicsPayload(getStoredValue(PUSH_TOPICS_STORAGE_KEY)) ?? undefined
+export function getPersistedTopics(options?: { userId?: MaybeUserId }): string[] | undefined {
+  return parseTopicsPayload(getStoredValue(PUSH_TOPICS_STORAGE_KEY), options) ?? undefined
 }
 
 function buildTopicsPayload(
@@ -285,8 +291,12 @@ function buildTopicsPayload(
   return JSON.stringify(payload)
 }
 
-export function setPersistedTopics(topics: string[] | null | undefined): void {
-  const userId = readActiveUserId()
+export function setPersistedTopics(
+  topics: string[] | null | undefined,
+  options?: { userId?: MaybeUserId },
+): void {
+  const normalizedUserId = normalizeUserId(options?.userId)
+  const userId = normalizedUserId ?? readActiveUserId()
   const currentRaw = getStoredValue(PUSH_TOPICS_STORAGE_KEY)
   const payload = buildTopicsPayload(topics, currentRaw, userId)
   if (payload === null) {


### PR DESCRIPTION
## Summary
- add explicit user-aware helpers so stored push topics remain tied to individual accounts
- update push preferences hook to pass the active user id when reading or writing topic settings
- adjust notification tests and topic persistence spec to cover the new behavior

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e9adcc8e948327b18a366cd1ea5032