### PR TITLE
Respect push consent when auto-syncing push subscriptions

### DIFF
--- a/root/frontend/src/contexts/AuthContext.tsx
+++ b/root/frontend/src/contexts/AuthContext.tsx
@@ -10,7 +10,11 @@ import {
 } from "react"
 import { useQueryClient } from "@tanstack/react-query"
 import { isAxiosError } from "axios"
-import { softSyncPushSubscription, unsubscribePush } from "@/push/subscribe"
+import {
+  hasPushConsent,
+  softSyncPushSubscription,
+  unsubscribePush,
+} from "@/push/subscribe"
 import api, { API_UNAUTHORIZED_EVENT, setAuthToken } from "../api/client"
 import { SPOTIFY_REAUTH_EVENT } from "@/hooks/useNowPlaying"
 
@@ -298,7 +302,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         setUser(profile ?? null)
 
         if (typeof window !== "undefined" && typeof Notification !== "undefined") {
-          if (Notification.permission === "granted") {
+          if (Notification.permission === "granted" && hasPushConsent()) {
             void (async () => {
               try {
                 await softSyncPushSubscription()


### PR DESCRIPTION
## Summary
- avoid restoring push subscriptions on login for users who disabled notifications by checking stored consent

## Testing
- npm run test -- AuthContext

------
https://chatgpt.com/codex/tasks/task_e_68e9b2c8428483279c129bd9d9a9e1a3