### PR TITLE
Handle Spotify unauthorized responses

### DIFF
--- a/root/app/api/spotify.py
+++ b/root/app/api/spotify.py
@@ -254,6 +254,10 @@ async def now_playing(
         user.spotify_last_checked_at = _now_utc()
         await db.commit()
         return Response(status_code=204)
+    if r.status_code == 401:
+        _disconnect_user(user, clear_refresh=True)
+        await db.commit()
+        raise HTTPException(status_code=401, detail="Требуется переподключить Spotify")
     if r.status_code == 429:
         retry_after_header = r.headers.get("Retry-After")
         try:

--- a/root/tests/test_spotify_fallback.py
+++ b/root/tests/test_spotify_fallback.py
@@ -241,3 +241,46 @@ async def test_now_playing_refreshes_when_access_token_missing(
     await db_session.refresh(user)
     assert user.spotify_access_token == "fresh"
     assert user.spotify_is_connected is True
+
+
+async def test_now_playing_disconnects_on_unauthorized_response(
+    async_client: AsyncClient, user_factory, db_session, monkeypatch
+) -> None:
+    password = "SpotifyP@ss5"
+    hashed = get_password_hash(password)
+    user = await user_factory(hashed_password=hashed, is_active=True)
+
+    user.spotify_access_token = "valid"
+    user.spotify_refresh_token = "refresh"
+    user.spotify_token_expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
+    user.spotify_is_connected = True
+    await db_session.commit()
+    await db_session.refresh(user)
+
+    class UnauthorizedResponse:
+        status_code = 401
+        headers: dict[str, str] = {}
+
+        def json(self) -> dict[str, str]:
+            return {"error": {"status": 401, "message": "The access token expired"}}
+
+    original_get = httpx.AsyncClient.get
+
+    async def fake_get(self, url, *args, **kwargs):
+        if str(url) == "https://api.spotify.com/v1/me/player/currently-playing":
+            return UnauthorizedResponse()
+        return await original_get(self, url, *args, **kwargs)
+
+    monkeypatch.setattr("httpx.AsyncClient.get", fake_get)
+
+    headers = await _login(async_client, user, password)
+
+    response = await async_client.get("/spotify/now-playing", headers=headers)
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Требуется переподключить Spotify"
+
+    await db_session.refresh(user)
+    assert user.spotify_is_connected is False
+    assert user.spotify_access_token is None
+    assert user.spotify_refresh_token is None


### PR DESCRIPTION
## Summary
- clear stored Spotify tokens when the currently-playing endpoint returns 401 and surface a re-auth requirement to the client
- add a regression test ensuring the unauthorized response disconnects the integration

## Testing
- pytest tests/test_spotify_fallback.py

------
https://chatgpt.com/codex/tasks/task_e_68ea77f68e3083279468b8b0eee7b240