### PR TITLE
Refine desktop navbar settings control

### DIFF
--- a/root/frontend/src/assets/themes.css
+++ b/root/frontend/src/assets/themes.css
@@ -598,14 +598,53 @@ body.dark .navbar-root {
 
 .mobile-drawer { z-index: 2500; overflow-x: hidden }
 body,html { overflow-x: hidden }
-.menu-btn-settings,
-.menu-link.settings { transition: transform 0.27s cubic-bezier(.42,0,.58,1); display: inline-flex; align-items: center; justify-content: center }
+.menu-btn-settings {
+  width: 38px;
+  height: 38px;
+  padding: 0;
+  border-radius: 12px;
+  border: 1px solid rgba(255,255,255,.18);
+  background: linear-gradient(180deg, rgba(255,255,255,.12), rgba(255,255,255,.04));
+  color: rgba(255,255,255,.92);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0;
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.24);
+  backdrop-filter: saturate(160%) blur(12px);
+  transition: background var(--anim-fast), color var(--anim-fast), border-color var(--anim-fast), box-shadow var(--anim-fast), transform var(--anim-fast);
+}
+.menu-btn-settings svg {
+  width: 18px;
+  height: 18px;
+}
 .menu-btn-settings:hover,
+.menu-btn-settings:focus-visible {
+  background: rgba(255,255,255,.2);
+  border-color: rgba(255,255,255,.32);
+  color: #fff;
+  transform: translateY(-1px);
+  box-shadow: 0 12px 28px rgba(6,18,43,.32), inset 0 1px 0 rgba(255,255,255,.3);
+}
+body:not(.dark) .menu-btn-settings {
+  background: rgba(255,255,255,.92);
+  border-color: rgba(16,42,79,.12);
+  color: #153654;
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.85), 0 10px 24px rgba(22,43,76,.16);
+  backdrop-filter: blur(16px);
+}
+body:not(.dark) .menu-btn-settings:hover,
+body:not(.dark) .menu-btn-settings:focus-visible {
+  background: #fff;
+  border-color: rgba(16,42,79,.24);
+  color: #102a43;
+  transform: translateY(-2px);
+  box-shadow: 0 14px 30px rgba(22,43,76,.2), inset 0 1px 0 rgba(255,255,255,.9);
+}
+.menu-link.settings { transition: transform 0.27s cubic-bezier(.42,0,.58,1); display: inline-flex; align-items: center; justify-content: center }
 .menu-link.settings:hover { transform: rotate(140deg) scale(1.15) }
 @media (max-width: 1350px) {
-  .menu-btn-settings,
   .menu-link.settings { transition: transform 0.19s cubic-bezier(.42,0,.58,1) }
-  .menu-btn-settings:hover,
   .menu-link.settings:hover { transform: scale(1.11) !important; color: var(--menu-hover-text) !important; background: var(--menu-hover-bg); box-shadow: 0 2px 12px #0001; z-index: 2 }
   body.blurred #root > *:not(.mobile-drawer):not(.navbar-root):not(.settings-modal) { filter: blur(7px) brightness(0.95); transition: filter 0.25s cubic-bezier(.42,0,.58,1); pointer-events: none; user-select: none }
 }

--- a/root/frontend/src/components/Navbar.tsx
+++ b/root/frontend/src/components/Navbar.tsx
@@ -476,12 +476,28 @@ const Navbar = () => {
               <button
                 type="button"
                 className="menu-btn-settings"
-                style={{ background: "none", border: "none", padding: 0, width: 32, height: 32, cursor: "pointer", display: "flex", alignItems: "center", justifyContent: "center", color: "#fff", fontSize: 22 }}
                 onClick={() => go("/settings")}
                 aria-label="Настройки"
                 title="Настройки"
               >
-                <span role="img" aria-label="Настройки">⚙️</span>
+                <svg
+                  width="20"
+                  height="20"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                  aria-hidden="true"
+                  focusable="false"
+                >
+                  <g stroke="currentColor" strokeWidth="1.7" strokeLinecap="round">
+                    <path d="M5 7h14" />
+                    <path d="M5 12h14" />
+                    <path d="M5 17h14" />
+                  </g>
+                  <circle cx="9" cy="7" r="2" fill="currentColor" />
+                  <circle cx="15" cy="12" r="2" fill="currentColor" />
+                  <circle cx="11" cy="17" r="2" fill="currentColor" />
+                </svg>
               </button>
             </div>
           ))}


### PR DESCRIPTION
## Summary
- replace the desktop navbar settings control with a minimalist SVG icon instead of the emoji button
- refresh the `.menu-btn-settings` styles to match the glassmorphism aesthetic used across the navbar

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68ea7e99af088327813c06d4f4dd038b