### PR TITLE
Improve theme handling for navigation and controls

### DIFF
--- a/root/frontend/src/assets/themes.css
+++ b/root/frontend/src/assets/themes.css
@@ -1,6 +1,19 @@
 :root {
   --nav-bg: #F5F6F7;
   --nav-text: #10151b;
+  --nav-heading: #10151b;
+  --nav-surface: #ffffff;
+  --nav-surface-border: rgba(16,42,79,.12);
+  --nav-surface-shadow: 0 0 8px rgba(0,0,0,0.13);
+  --nav-control-bg: rgba(255,255,255,.92);
+  --nav-control-border: rgba(16,42,79,.12);
+  --nav-control-color: #153654;
+  --nav-control-shadow: inset 0 1px 0 rgba(255,255,255,.85), 0 10px 24px rgba(22,43,76,.16);
+  --nav-control-hover-bg: #fff;
+  --nav-control-hover-border: rgba(16,42,79,.24);
+  --nav-control-hover-color: #102a43;
+  --nav-control-hover-shadow: 0 14px 30px rgba(22,43,76,.2), inset 0 1px 0 rgba(255,255,255,.9);
+  --nav-contrast: #ffffff;
   --nav-link: #005EA2;
   --nav-link-hover: #1A4480;
   --btn-bg: #F7F9FB;
@@ -18,9 +31,20 @@
   --link-color: #005EA2;
   --menu-hover-bg: #E8F0FA;
   --menu-hover-text: #0F2A47;
+  --danger-bg: #fff4f4;
+  --danger-border: #fae1e1;
+  --danger-hover-bg: #ffe8ec;
+  --danger-hover-text: #232323;
+  --danger-active-bg: #e53935;
+  --danger-contrast: #ffffff;
+  --danger-shadow: 0 10px 22px #e5393540;
   --option-bg: #fff;
   --option-hover-bg: #F2F7FC;
   --option-shadow: 0 2px 14px #C7D1DE70;
+  --switch-track: #485063;
+  --switch-track-active: #363d49;
+  --switch-knob: #232635;
+  --switch-knob-active: #181a1e;
   --font-ui: "Oxygen","Manrope","Inter","Segoe UI",Arial,"Helvetica Neue",Helvetica,sans-serif;
   --font-display: "Varela","Manrope","Inter","Segoe UI",Arial,"Helvetica Neue",Helvetica,sans-serif;
   --fs-h1: clamp(1.9rem, 1.2rem + 2.2vw, 3rem);
@@ -89,6 +113,19 @@
 body.dark {
   --nav-bg: #0E1116;
   --nav-text: #E6EBF2;
+  --nav-heading: #E6EBF2;
+  --nav-surface: rgba(17,22,30,.94);
+  --nav-surface-border: rgba(105,169,220,.24);
+  --nav-surface-shadow: 0 0 14px rgba(8,12,18,.65);
+  --nav-control-bg: linear-gradient(180deg, rgba(255,255,255,.12), rgba(255,255,255,.04));
+  --nav-control-border: rgba(255,255,255,.18);
+  --nav-control-color: rgba(230,235,242,.92);
+  --nav-control-shadow: inset 0 1px 0 rgba(255,255,255,.24);
+  --nav-control-hover-bg: rgba(255,255,255,.2);
+  --nav-control-hover-border: rgba(255,255,255,.32);
+  --nav-control-hover-color: #ffffff;
+  --nav-control-hover-shadow: 0 12px 28px rgba(6,18,43,.32), inset 0 1px 0 rgba(255,255,255,.3);
+  --nav-contrast: #0B0F15;
   --nav-link: #69A9DC;
   --nav-link-hover: #B5D4EA;
   --btn-bg: #11161E;
@@ -96,6 +133,13 @@ body.dark {
   --page-bg: #0B0F15;
   --page-text: #E6EBF2;
   --card-bg: #11161E;
+  --danger-bg: rgba(229,57,53,.12);
+  --danger-border: rgba(229,57,53,.35);
+  --danger-hover-bg: rgba(229,57,53,.24);
+  --danger-hover-text: #ffecec;
+  --danger-active-bg: #e53935;
+  --danger-contrast: #0B0F15;
+  --danger-shadow: 0 12px 26px rgba(229,57,53,.35);
   --badge-lec: #7FB6E6;
   --badge-prac: #4ADE80;
   --badge-lab: #FBBF24;
@@ -123,6 +167,10 @@ body.dark {
   --glass-alpha: .05;
   --hint-fg: rgba(255,255,255,.72);
   --placeholder-fg: rgba(255,255,255,.64);
+  --switch-track: #202734;
+  --switch-track-active: #2d3646;
+  --switch-knob: #bcd9ff;
+  --switch-knob-active: #ffffff;
   --ue-focus-ring: 0 0 0 1px rgba(11,15,21,.92), 0 0 0 4px rgba(105,169,220,.5)
 }
 ::selection { background: var(--selection-bg); color: var(--selection-text) }
@@ -233,23 +281,23 @@ h3 { font-size: var(--fs-h3) }
 .menu-link.settings:hover,
 .menu-link.settings:focus { background: var(--menu-hover-bg); color: var(--menu-hover-text) !important; box-shadow: 0 2px 10px #0001 }
 .menu-link.logout {
-  color: #e53935 !important;
-  background: #fff4f4;
-  border: 1.5px solid #fae1e1;
+  color: var(--danger-text, #e53935) !important;
+  background: var(--danger-bg);
+  border: 1.5px solid var(--danger-border);
   font-weight: 800;
   transition: background var(--anim-fast), color var(--anim-fast), box-shadow var(--anim-fast), border-color var(--anim-fast)
 }
 .menu-link.logout:hover,.menu-link.logout:focus {
-  background: #ffe8ec;
-  color: #232323 !important;
-  border-color: #e53935;
-  box-shadow: 0 10px 22px #e5393540;
+  background: var(--danger-hover-bg);
+  color: var(--danger-hover-text) !important;
+  border-color: var(--danger-text, #e53935);
+  box-shadow: var(--danger-shadow);
   transform: scale(1.08)
 }
 .menu-link.logout:active {
-  background: #e53935;
-  color: #fff !important;
-  border-color: #c62828;
+  background: var(--danger-active-bg);
+  color: var(--danger-contrast) !important;
+  border-color: color-mix(in srgb, var(--danger-active-bg) 80%, transparent);
   box-shadow: 0 2px 8px #e5393550
 }
 .menu-btn-logout {
@@ -274,7 +322,7 @@ h3 { font-size: var(--fs-h3) }
   position: absolute;
   cursor: pointer;
   top: 0; left: 0; right: 0; bottom: 0;
-  background: #485063;
+  background: var(--switch-track);
   border-radius: 999px;
   transition: background var(--anim-med);
   width: 64px; height: 32px;
@@ -284,14 +332,14 @@ h3 { font-size: var(--fs-h3) }
   position: absolute;
   top: 5.5px; left: 7px;
   width: 21px; height: 21px;
-  background: #232635;
+  background: var(--switch-knob);
   border-radius: 50%;
   transition: left .33s cubic-bezier(.6,.03,.29,1.46), background var(--anim-med);
   z-index: 1;
   box-shadow: 0 4px 18px 0 #0002, 0 1.5px 8px 0 #0001
 }
-.theme-switch input:checked + .theme-slider .theme-knob { left: 37px; background: #181a1e }
-.theme-switch input:checked + .theme-slider { background: #363d49 }
+.theme-switch input:checked + .theme-slider .theme-knob { left: 37px; background: var(--switch-knob-active) }
+.theme-switch input:checked + .theme-slider { background: var(--switch-track-active) }
 .theme-emoji { position: absolute; z-index: 2; font-size: 21px; pointer-events: none; transition: opacity var(--anim-med), transform var(--anim-med); line-height: 1; top: 50%; transform: translateY(-50%) }
 .theme-sun { left: 7px; top: 14px }
 .theme-moon { right: 8px }
@@ -603,43 +651,28 @@ body,html { overflow-x: hidden }
   height: 38px;
   padding: 0;
   border-radius: 12px;
-  border: 1px solid rgba(255,255,255,.18);
-  background: linear-gradient(180deg, rgba(255,255,255,.12), rgba(255,255,255,.04));
-  color: rgba(255,255,255,.92);
+  border: 1px solid var(--nav-control-border);
+  background: var(--nav-control-bg);
+  color: var(--nav-control-color);
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: 0;
-  box-shadow: inset 0 1px 0 rgba(255,255,255,.24);
+  box-shadow: var(--nav-control-shadow);
   backdrop-filter: saturate(160%) blur(12px);
   transition: background var(--anim-fast), color var(--anim-fast), border-color var(--anim-fast), box-shadow var(--anim-fast), transform var(--anim-fast);
 }
 .menu-btn-settings svg {
-  width: 18px;
-  height: 18px;
+  width: calc(100% - 12px);
+  height: calc(100% - 12px);
 }
 .menu-btn-settings:hover,
 .menu-btn-settings:focus-visible {
-  background: rgba(255,255,255,.2);
-  border-color: rgba(255,255,255,.32);
-  color: #fff;
+  background: var(--nav-control-hover-bg);
+  border-color: var(--nav-control-hover-border);
+  color: var(--nav-control-hover-color);
   transform: translateY(-1px);
-  box-shadow: 0 12px 28px rgba(6,18,43,.32), inset 0 1px 0 rgba(255,255,255,.3);
-}
-body:not(.dark) .menu-btn-settings {
-  background: rgba(255,255,255,.92);
-  border-color: rgba(16,42,79,.12);
-  color: #153654;
-  box-shadow: inset 0 1px 0 rgba(255,255,255,.85), 0 10px 24px rgba(22,43,76,.16);
-  backdrop-filter: blur(16px);
-}
-body:not(.dark) .menu-btn-settings:hover,
-body:not(.dark) .menu-btn-settings:focus-visible {
-  background: #fff;
-  border-color: rgba(16,42,79,.24);
-  color: #102a43;
-  transform: translateY(-2px);
-  box-shadow: 0 14px 30px rgba(22,43,76,.2), inset 0 1px 0 rgba(255,255,255,.9);
+  box-shadow: var(--nav-control-hover-shadow);
 }
 .menu-link.settings { transition: transform 0.27s cubic-bezier(.42,0,.58,1); display: inline-flex; align-items: center; justify-content: center }
 .menu-link.settings:hover { transform: rotate(140deg) scale(1.15) }

--- a/root/frontend/src/components/EventCard.tsx
+++ b/root/frontend/src/components/EventCard.tsx
@@ -17,6 +17,7 @@ import {
   Dialog, DialogTitle, DialogContent, DialogActions,
   IconButton, Menu, MenuItem, useMediaQuery, Tooltip, Snackbar
 } from "@mui/material"
+import { alpha } from "@mui/material/styles"
 import type { DialogProps } from "@mui/material/Dialog"
 import PeopleAltIcon from "@mui/icons-material/PeopleAlt"
 import PlaceIcon from "@mui/icons-material/Place"
@@ -445,14 +446,15 @@ const EventCardComponent: FC<EventCardProps> = ({
             aria-controls={menuAnchor ? menuId : undefined}
             aria-haspopup="true"
             aria-expanded={Boolean(menuAnchor) ? "true" : undefined}
-            sx={{
+            sx={(theme) => ({
               position: "absolute",
               top: 10,
               right: 10,
               zIndex: 2,
-              bgcolor: "rgba(255,255,255,0.82)",
-              "&:hover": { bgcolor: "#fff" }
-            }}
+              bgcolor: alpha(theme.palette.background.paper, 0.88),
+              '&:hover': { bgcolor: theme.palette.background.paper },
+              boxShadow: '0 6px 16px rgba(0,0,0,0.1)',
+            })}
             onClick={(e) => {
               e.stopPropagation()
               setMenuAnchor(e.currentTarget)
@@ -634,7 +636,7 @@ const EventCardComponent: FC<EventCardProps> = ({
                     width: "clamp(52px, 8vw, 76px)",
                     height: "clamp(52px, 8vw, 76px)",
                     borderRadius: 8,
-                    background: "#fff",
+                    background: "var(--card-bg)",
                     cursor: "pointer",
                     display: "block",
                   }}
@@ -678,14 +680,14 @@ const EventCardComponent: FC<EventCardProps> = ({
               >
                 <Box display="flex" flexDirection="column" alignItems="center">
                   <Box
-                    sx={{
+                    sx={(theme) => ({
                       p: { xs: 1.5, sm: 2.5 },
                       borderRadius: 2,
-                      bgcolor: "#fff",
+                      bgcolor: theme.palette.background.paper,
                       boxShadow: 1,
                       width: "100%",
                       maxWidth: "min(76vw, 76vh, 520px)",
-                    }}
+                    })}
                   >
                     <Box
                       component="img"

--- a/root/frontend/src/components/EventDetail.tsx
+++ b/root/frontend/src/components/EventDetail.tsx
@@ -234,32 +234,32 @@ const EventDetail = () => {
     <Button
       onClick={handleBack}
       startIcon={<ArrowBackIcon />}
-      sx={{
+      sx={(theme) => ({
         mb: 3,
         alignSelf: 'flex-start',
         fontWeight: 700,
         borderRadius: 2.5,
-        background: 'linear-gradient(100deg, #1d5fff 20%, #65b2ff 100%)',
-        color: '#fff',
+        background: `linear-gradient(100deg, ${theme.palette.primary.main} 20%, ${theme.palette.primary.light} 100%)`,
+        color: theme.palette.primary.contrastText,
         fontSize: 'clamp(0.98rem, 2.1vw, 1.17rem)',
         letterSpacing: '0.02em',
         px: { xs: 1.6, sm: 2.3, md: 2.9, lg: 3.5 },
         py: { xs: 0.9, sm: 1.12, md: 1.2, lg: 1.28 },
         width: { xs: '100%', sm: 'auto' },
         minWidth: { xs: 0, sm: 0 },
-        boxShadow: '0 2px 18px #1976d238, 0 1.5px 8px #0001',
+        boxShadow: '0 2px 18px rgba(25,118,210,0.22), 0 1.5px 8px rgba(0,0,0,0.08)',
         transition: 'transform 0.16s, box-shadow 0.16s, background 0.19s, color 0.16s',
         '&:hover': {
-          background: 'linear-gradient(100deg, #1976d2 20%, #449aff 100%)',
-          color: '#eaf6ff',
+          background: `linear-gradient(100deg, ${theme.palette.primary.dark} 20%, ${theme.palette.primary.main} 100%)`,
+          color: theme.palette.primary.contrastText,
           transform: 'scale(1.06)',
-          boxShadow: '0 6px 28px #1d5fff40, 0 2.5px 10px #0002'
+          boxShadow: '0 6px 28px rgba(29,95,255,0.25), 0 2.5px 10px rgba(0,0,0,0.16)'
         },
         '&:active': { transform: 'scale(0.98)' },
         position: { xs: 'static', md: 'sticky' },
         top: { md: 12 },
         zIndex: 99
-      }}
+      })}
     >
       Назад
     </Button>

--- a/root/frontend/src/components/Navbar.tsx
+++ b/root/frontend/src/components/Navbar.tsx
@@ -10,7 +10,11 @@ import { AVATAR_PLACEHOLDER_URL } from "@/constants/placeholders";
 const AVATAR_FALLBACK = AVATAR_PLACEHOLDER_URL;
 
 const navTextColor = "var(--nav-text)";
+const navHeadingColor = "var(--nav-heading, var(--nav-text))";
 const navBgColor = "var(--nav-bg)";
+const navSurfaceColor = "var(--nav-surface, var(--card-bg))";
+const navSurfaceShadow = "var(--nav-surface-shadow, 0 0 8px rgba(0,0,0,0.13))";
+const navSurfaceBorder = "var(--nav-surface-border, rgba(0,0,0,0.12))";
 
 const focusableSelectors =
   'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"]), input:not([disabled]), select:not([disabled]), textarea:not([disabled])';
@@ -335,7 +339,19 @@ const Navbar = () => {
             }}
             style={{ display: "inline-flex", alignItems: "center", gap: isMobile ? "8px" : "10px", minWidth: 0, padding: "6px 6px", borderRadius: 12, textDecoration: "none" }}
           >
-            <div style={{ width: `${logoWrapSize}px`, height: `${logoWrapSize}px`, display: "flex", alignItems: "center", justifyContent: "center", borderRadius: "50%", background: "#fff", boxShadow: "0 0 8px rgba(0,0,0,0.13)" }}>
+            <div
+              style={{
+                width: `${logoWrapSize}px`,
+                height: `${logoWrapSize}px`,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                borderRadius: "50%",
+                background: navSurfaceColor,
+                boxShadow: navSurfaceShadow,
+                border: `1px solid ${navSurfaceBorder}`,
+              }}
+            >
               <img
                 src={guuLogo}
                 alt="ГУУ"
@@ -346,7 +362,16 @@ const Navbar = () => {
                 decoding="async"
               />
             </div>
-            <span style={{ color: "#fff", fontWeight: 800, fontSize: titleFont, whiteSpace: "nowrap", letterSpacing: ".2px" }}>
+            <span
+              style={{
+                color: navHeadingColor,
+                fontWeight: 800,
+                fontSize: titleFont,
+                whiteSpace: "nowrap",
+                letterSpacing: ".2px",
+                textShadow: "0 1px 2px rgba(0,0,0,0.12)",
+              }}
+            >
               Экосистема ГУУ
             </span>
           </Link>
@@ -366,8 +391,8 @@ const Navbar = () => {
                     height: avatarSize,
                     borderRadius: "50%",
                     objectFit: "cover",
-                    border: "1px solid #d7d7d7",
-                    background: "#fff",
+                  border: "1px solid var(--btn-border)",
+                  background: navSurfaceColor,
                     cursor: "pointer",
                     display: "block",
                   }}
@@ -385,7 +410,19 @@ const Navbar = () => {
               <button
                 type="button"
                 className="burger-btn"
-                style={{ background: "none", border: "none", padding: 0, width: burgerBtnSize, height: burgerBtnSize, display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: "#fff", borderRadius: 10 }}
+                style={{
+                  background: "none",
+                  border: "none",
+                  padding: 0,
+                  width: burgerBtnSize,
+                  height: burgerBtnSize,
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  cursor: "pointer",
+                  color: navHeadingColor,
+                  borderRadius: 10,
+                }}
                 onClick={() => setMobileMenu(v => !v)}
                 aria-label={mobileMenu ? "Закрыть меню" : "Открыть меню"}
                 aria-expanded={mobileMenu}
@@ -426,9 +463,24 @@ const Navbar = () => {
 
           {!isMobile && loading ? (
             <div style={{ display: "flex", alignItems: "center", gap: "10px", marginLeft: "8px" }} aria-hidden="true">
-              <Skeleton variant="circular" width={36} height={36} sx={{ bgcolor: "rgba(255,255,255,0.25)" }} />
-              <Skeleton variant="rectangular" width={96} height={18} sx={{ borderRadius: 1, bgcolor: "rgba(255,255,255,0.25)" }} />
-              <Skeleton variant="circular" width={32} height={32} sx={{ bgcolor: "rgba(255,255,255,0.25)" }} />
+              <Skeleton
+                variant="circular"
+                width={36}
+                height={36}
+                sx={{ bgcolor: "color-mix(in srgb, var(--nav-contrast, #ffffff) 18%, transparent)" }}
+              />
+              <Skeleton
+                variant="rectangular"
+                width={96}
+                height={18}
+                sx={{ borderRadius: 1, bgcolor: "color-mix(in srgb, var(--nav-contrast, #ffffff) 18%, transparent)" }}
+              />
+              <Skeleton
+                variant="circular"
+                width={32}
+                height={32}
+                sx={{ bgcolor: "color-mix(in srgb, var(--nav-contrast, #ffffff) 18%, transparent)" }}
+              />
             </div>
           ) : (!isMobile && isAuth && user && (
             <div style={{ display: "flex", alignItems: "center", gap: "10px", marginLeft: "8px", minWidth: 0, whiteSpace: "nowrap" }}>
@@ -444,8 +496,8 @@ const Navbar = () => {
                   height: "36px",
                   borderRadius: "50%",
                   objectFit: "cover",
-                  border: "1.5px solid #ccc",
-                  background: "#fff",
+                  border: "1.5px solid var(--btn-border)",
+                  background: navSurfaceColor,
                   cursor: "pointer",
                   display: "block",
                 }}
@@ -461,7 +513,7 @@ const Navbar = () => {
                   border: "none",
                   padding: 0,
                   margin: 0,
-                  color: "#fff",
+                  color: navHeadingColor,
                   fontWeight: 600,
                   whiteSpace: "nowrap",
                   cursor: "pointer",
@@ -519,8 +571,29 @@ const Navbar = () => {
             style={{ width: 270, maxWidth: "88vw", background: navBgColor, height: "100vh", boxShadow: "2px 0 22px #0003", padding: 0, display: "flex", flexDirection: "column", alignItems: "flex-start", transition: prefersReducedMotion ? "none" : "transform 0.35s cubic-bezier(.52,1.29,.47,.97)", transform: mobileMenu ? "translateX(0)" : "translateX(-120%)", justifyContent: "flex-start", position: "relative" }}
             onClick={e => e.stopPropagation()}
           >
-            <div style={{ width: "100%", padding: "18px 0 10px 22px", display: "flex", alignItems: "center", gap: 8, borderBottom: "1px solid #ede2d2" }}>
-              <div style={{ width: 32, height: 32, borderRadius: "50%", display: "flex", alignItems: "center", justifyContent: "center", background: "#fff", boxShadow: "0 0 6px rgba(0,0,0,0.10)" }}>
+            <div
+              style={{
+                width: "100%",
+                padding: "18px 0 10px 22px",
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
+                borderBottom: `1px solid color-mix(in srgb, ${navTextColor} 12%, transparent)`,
+              }}
+            >
+              <div
+                style={{
+                  width: 32,
+                  height: 32,
+                  borderRadius: "50%",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  background: navSurfaceColor,
+                  boxShadow: navSurfaceShadow,
+                  border: `1px solid ${navSurfaceBorder}`,
+                }}
+              >
                 <img
                   src={guuLogo}
                   alt="ГУУ"

--- a/root/frontend/src/components/NewsCard.tsx
+++ b/root/frontend/src/components/NewsCard.tsx
@@ -4,6 +4,7 @@ import {
   Dialog, DialogTitle, DialogContent, DialogActions,
   TextField, Stack, Button, useMediaQuery
 } from "@mui/material"
+import { alpha } from "@mui/material/styles"
 import MoreVertIcon from "@mui/icons-material/MoreVert"
 import EditIcon from "@mui/icons-material/Edit"
 import DeleteIcon from "@mui/icons-material/Delete"
@@ -236,14 +237,15 @@ const NewsCardComponent: FC<NewsCardProps> = ({
             aria-controls={menuAnchor ? menuId : undefined}
             aria-haspopup="true"
             aria-expanded={Boolean(menuAnchor) ? "true" : undefined}
-            sx={{
+            sx={(theme) => ({
               position: "absolute",
               top: 10,
               right: 10,
               zIndex: 2,
-              bgcolor: "rgba(255,255,255,0.82)",
-              "&:hover": { bgcolor: "#fff" }
-            }}
+              bgcolor: alpha(theme.palette.background.paper, 0.88),
+              '&:hover': { bgcolor: theme.palette.background.paper },
+              boxShadow: '0 6px 16px rgba(0,0,0,0.1)',
+            })}
             onClick={e => {
               e.stopPropagation()
               setMenuAnchor(e.currentTarget)

--- a/root/frontend/src/pages/Dashboard.tsx
+++ b/root/frontend/src/pages/Dashboard.tsx
@@ -19,6 +19,8 @@ import {
   LinearProgress
 } from "@mui/material"
 import { Link, useNavigate } from "react-router-dom"
+import { alpha } from "@mui/material/styles"
+import type { Theme } from "@mui/material/styles"
 
 type NewsItem = { id: number; title: string; content: string; created_at?: string; pinned?: boolean }
 type EventItem = { id: number; title: string; description?: string; starts_at?: string; location?: string }
@@ -59,23 +61,24 @@ function DateBullet({ date }: { date?: string }) {
     <Tooltip title={full} enterDelay={150}>
       <Box
         aria-label={`Дата публикации: ${full}`}
-          sx={{
-            width: 44,
+        sx={(theme) => ({
+          width: 44,
           height: 44,
           minWidth: 44,
           minHeight: 44,
           flex: "0 0 44px",
           borderRadius: "50%",
-          background: "linear-gradient(120deg,#1d5fff,#65b2ff)",
-          color: "#fff",
+          background: `linear-gradient(120deg, ${theme.palette.primary.main}, ${theme.palette.primary.light})`,
+          color: theme.palette.primary.contrastText,
           display: "flex",
           flexDirection: "column",
           alignItems: "center",
           justifyContent: "center",
           fontWeight: 800,
           lineHeight: 1,
-          userSelect: "none"
-        }}
+          userSelect: "none",
+          boxShadow: "0 8px 22px rgba(0,0,0,0.12)",
+        })}
       >
         <Box sx={{ fontSize: 14 }}>{dd}</Box>
         <Box sx={{ fontSize: 10, opacity: 0.9 }}>{mm}</Box>
@@ -280,8 +283,32 @@ export default function Dashboard() {
   useEffect(() => { fetchSchedule() }, [fetchSchedule])
 
   const headerGradient = isNarrow ? "linear-gradient(100deg,var(--hero-grad-start) 50%,var(--hero-grad-end) 100%)" : "linear-gradient(100deg,var(--hero-grad-start) 40%,var(--hero-grad-end) 100%)"
-  const focusRing = "0 0 0 3px #2563eb33, 0 0 0 6px #2563eb1f"
-  const btnSx = { borderRadius: 2, fontWeight: 700, px: 1.8, py: 0.5, whiteSpace: "nowrap", transition: "background .16s,color .16s,border-color .16s,box-shadow .16s, transform .16s", "&:hover": { background: "linear-gradient(100deg,#1976d2 20%,#449aff 100%)", color: "#fff", borderColor: "transparent", transform: "translateY(-1px)" }, "&:active": { transform: "translateY(0)" }, "&:focus-visible": { boxShadow: focusRing, outline: "none" } }
+  const getButtonSx = useCallback(
+    (theme: Theme) => ({
+      borderRadius: 2,
+      fontWeight: 700,
+      px: 1.8,
+      py: 0.5,
+      whiteSpace: "nowrap",
+      transition: "background .16s,color .16s,border-color .16s,box-shadow .16s, transform .16s",
+      color: theme.palette.text.primary,
+      borderColor: alpha(theme.palette.primary.main, theme.palette.mode === "dark" ? 0.4 : 0.24),
+      '&:hover': {
+        background: `linear-gradient(100deg, ${theme.palette.primary.main} 20%, ${theme.palette.primary.light} 100%)`,
+        color: theme.palette.primary.contrastText,
+        borderColor: "transparent",
+        transform: "translateY(-1px)",
+      },
+      '&:active': {
+        transform: "translateY(0)",
+      },
+      '&:focus-visible': {
+        boxShadow: `0 0 0 3px ${alpha(theme.palette.primary.main, 0.24)}, 0 0 0 6px ${alpha(theme.palette.primary.main, 0.12)}`,
+        outline: "none",
+      },
+    }),
+    []
+  )
 
   const warmNewsPage = () => import("../pages/News").catch(() => {})
   const warmEventsPage = () => import("../pages/Events").catch(() => {})
@@ -327,12 +354,13 @@ export default function Dashboard() {
           left: 8,
           top: 8,
           padding: "8px 12px",
-          background: "#1d5fff",
-          color: "#fff",
+          background: "var(--nav-link)",
+          color: "var(--nav-contrast)",
           borderRadius: 8,
           transform: "translateY(-200%)",
           transition: "transform .2s",
-          zIndex: 5000
+          zIndex: 5000,
+          boxShadow: "0 6px 18px rgba(0,0,0,0.18)",
         }}
         onFocus={(e) => { ;(e.currentTarget as HTMLAnchorElement).style.transform = "translateY(0)" }}
         onBlur={(e) => { ;(e.currentTarget as HTMLAnchorElement).style.transform = "translateY(-200%)" }}
@@ -387,7 +415,12 @@ export default function Dashboard() {
             </Stack>
           </Box>
           <Box sx={{ display: { xs: "none", md: "flex" }, gap: 1 }}>
-            <Button variant="outlined" onClick={() => navigate("/profile")} sx={{ ...btnSx, px: 2.2, py: 0.9 }} aria-label="Открыть профиль">
+            <Button
+              variant="outlined"
+              onClick={() => navigate("/profile")}
+              sx={(theme) => ({ ...getButtonSx(theme), px: 2.2, py: 0.9 })}
+              aria-label="Открыть профиль"
+            >
               Профиль
             </Button>
           </Box>
@@ -412,7 +445,7 @@ export default function Dashboard() {
                   to="/schedule"
                   size="small"
                   variant="outlined"
-                  sx={{ ...btnSx, px: 3, py: 0.9 }}
+                  sx={(theme) => ({ ...getButtonSx(theme), px: 3, py: 0.9 })}
                   aria-label="Перейти к полному расписанию"
                   onPointerDown={warmSchedulePage}
                   onKeyDown={(event) => prepareOnKey(event, warmSchedulePage)}
@@ -492,7 +525,7 @@ export default function Dashboard() {
                 to="/news"
                 size="small"
                 variant="outlined"
-                sx={btnSx}
+                sx={(theme) => getButtonSx(theme)}
                 aria-label="Смотреть все новости"
                 onPointerDown={() => { warmNewsPage(); prefetchData("news") }}
                 onKeyDown={(event) => {
@@ -563,7 +596,7 @@ export default function Dashboard() {
                 to="/events"
                 size="small"
                 variant="outlined"
-                sx={btnSx}
+                sx={(theme) => getButtonSx(theme)}
                 aria-label="Смотреть все события"
                 onPointerDown={() => { warmEventsPage(); prefetchData("events") }}
                 onKeyDown={(event) => {
@@ -581,7 +614,7 @@ export default function Dashboard() {
                 size="small"
                 variant={eventsScope === "today" ? "contained" : "outlined"}
                 onClick={() => setEventsScope("today")}
-                sx={btnSx}
+                sx={(theme) => getButtonSx(theme)}
                 aria-pressed={eventsScope === "today"}
               >
                 Сегодня
@@ -590,7 +623,7 @@ export default function Dashboard() {
                 size="small"
                 variant={eventsScope === "week" ? "contained" : "outlined"}
                 onClick={() => setEventsScope("week")}
-                sx={btnSx}
+                sx={(theme) => getButtonSx(theme)}
                 aria-pressed={eventsScope === "week"}
               >
                 Неделя

--- a/root/frontend/src/pages/Login.tsx
+++ b/root/frontend/src/pages/Login.tsx
@@ -186,7 +186,24 @@ const Login = () => {
             <Box sx={{ minHeight: 20, textAlign: "left" }}>{caps && <Typography color="warning.main" fontSize={13}>Включён Caps Lock</Typography>}</Box>
             <Box sx={{ minHeight: 22, display: "flex", alignItems: "center", justifyContent: "center" }} aria-live="assertive">{submitError && <Typography color="error" fontSize={15}>{submitError}</Typography>}</Box>
             <FormControlLabel control={<Checkbox checked={remember} onChange={(e) => setRemember(e.target.checked)} disabled={submitting} />} label="Запомнить email" sx={{ mt: -0.5 }} />
-            <Button type="submit" variant="contained" size="large" fullWidth disabled={submitting} sx={{ mt: 1, fontWeight: 600, borderRadius: 2, fontSize: 17, py: 1.2, bgcolor: "var(--nav-link)", color: "#fff", touchAction: "manipulation", "&:hover": { bgcolor: "var(--nav-link-hover)" } }}>
+            <Button
+              type="submit"
+              variant="contained"
+              size="large"
+              fullWidth
+              disabled={submitting}
+              sx={(theme) => ({
+                mt: 1,
+                fontWeight: 600,
+                borderRadius: 2,
+                fontSize: 17,
+                py: 1.2,
+                bgcolor: theme.palette.primary.main,
+                color: theme.palette.primary.contrastText,
+                touchAction: "manipulation",
+                '&:hover': { bgcolor: theme.palette.primary.dark },
+              })}
+            >
               {submitting ? <CircularProgress size={26} color="inherit" /> : "Войти"}
             </Button>
           </Stack>

--- a/root/frontend/src/pages/Map.tsx
+++ b/root/frontend/src/pages/Map.tsx
@@ -15,14 +15,15 @@ function MapSkeleton() {
 
   return (
     <Paper
-      sx={{
+      sx={(theme) => ({
         width: "100%",
         borderRadius: 0,
         boxShadow: 5,
-        bgcolor: "var(--card-bg,#fff)",
-        color: "var(--page-text,#222)",
+        bgcolor: theme.palette.background.paper,
+        color: theme.palette.text.primary,
         p: 0,
-      }}
+        transition: "background-color 0.2s ease, color 0.2s ease",
+      })}
     >
       <Box
         className="map-page"

--- a/root/frontend/src/pages/MapContent.tsx
+++ b/root/frontend/src/pages/MapContent.tsx
@@ -127,14 +127,15 @@ export default function MapContent() {
   return (
     <>
       <Paper
-        sx={{
+        sx={(theme) => ({
           width: "100%",
           borderRadius: 0,
           boxShadow: 5,
-          bgcolor: "var(--card-bg,#fff)",
-          color: "var(--page-text,#222)",
+          bgcolor: theme.palette.background.paper,
+          color: theme.palette.text.primary,
           p: 0,
-        }}
+          transition: "background-color 0.2s ease, color 0.2s ease",
+        })}
       >
         <Box ref={containerRef} className="map-page" sx={{ background: theme.palette.mode === "dark" ? "#0b0d12" : "#f6f7fb" }}>
           <Box className="glass glass--panel glass--sheen map-head">

--- a/root/frontend/src/pages/NewsDetail.tsx
+++ b/root/frontend/src/pages/NewsDetail.tsx
@@ -246,29 +246,29 @@ export default function NewsDetail() {
         <Button
           onClick={handleBack}
           startIcon={<ArrowBackIcon />}
-          sx={{
+          sx={(theme) => ({
             mb: 3,
             alignSelf: "flex-start",
             fontWeight: 700,
             borderRadius: 2.5,
-            background: "linear-gradient(100deg, #1d5fff 20%, #65b2ff 100%)",
-            color: "#fff",
+            background: `linear-gradient(100deg, ${theme.palette.primary.main} 20%, ${theme.palette.primary.light} 100%)`,
+            color: theme.palette.primary.contrastText,
             fontSize: "clamp(0.98rem, 2.1vw, 1.17rem)",
             letterSpacing: "0.02em",
             px: { xs: 1.6, sm: 2.3, md: 2.9, lg: 3.5 },
             py: { xs: 0.9, sm: 1.12, md: 1.2, lg: 1.28 },
             width: { xs: "100%", sm: "auto" },
             minWidth: { xs: 0, sm: 0 },
-            boxShadow: "0 2px 18px #1976d238, 0 1.5px 8px #0001",
+            boxShadow: "0 2px 18px rgba(25,118,210,0.22), 0 1.5px 8px rgba(0,0,0,0.08)",
             transition: "transform 0.16s, box-shadow 0.16s, background 0.19s, color 0.16s",
-            "&:hover": {
-              background: "linear-gradient(100deg, #1976d2 20%, #449aff 100%)",
-              color: "#eaf6ff",
+            '&:hover': {
+              background: `linear-gradient(100deg, ${theme.palette.primary.dark} 20%, ${theme.palette.primary.main} 100%)`,
+              color: theme.palette.primary.contrastText,
               transform: "scale(1.06)",
-              boxShadow: "0 6px 28px #1d5fff40, 0 2.5px 10px #0002",
+              boxShadow: "0 6px 28px rgba(29,95,255,0.25), 0 2.5px 10px rgba(0,0,0,0.16)",
             },
-            "&:active": { transform: "scale(0.98)" },
-          }}
+            '&:active': { transform: "scale(0.98)" },
+          })}
         >
           Назад
         </Button>

--- a/root/frontend/src/pages/Profile.tsx
+++ b/root/frontend/src/pages/Profile.tsx
@@ -1120,13 +1120,13 @@ export default function Profile() {
         <DialogTitle sx={{ textAlign: "center", fontWeight: 900, letterSpacing: 0.4 }}>QR-код</DialogTitle>
         <DialogContent sx={{ display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", gap: 1.2, minHeight: 320 }}>
           <Box
-            sx={{
-              background: "#fff",
+            sx={(theme) => ({
+              background: alpha(theme.palette.background.paper, theme.palette.mode === "dark" ? 0.9 : 1),
               p: 2,
               borderRadius: 3,
-              border: `1px solid ${alpha(theme.palette.primary.main, 0.15)}`,
-              boxShadow: `0 18px 40px -28px ${alpha(theme.palette.common.black, 0.4)}`
-            }}
+              border: `1px solid ${alpha(theme.palette.primary.main, 0.18)}`,
+              boxShadow: `0 18px 40px -28px ${alpha(theme.palette.common.black, theme.palette.mode === "dark" ? 0.65 : 0.4)}`,
+            })}
           >
             <QRCodeSVG
               value={buildVCard()}

--- a/root/frontend/src/pages/Schedule.tsx
+++ b/root/frontend/src/pages/Schedule.tsx
@@ -537,7 +537,12 @@ export default function Schedule() {
           <Chip
             size="small"
             label={lesson.lesson_type ?? ""}
-            sx={{ height: 22, fontWeight: 700, color: "#fff", background: getLessonTypeColor(lesson.lesson_type) }}
+            sx={(theme) => ({
+              height: 22,
+              fontWeight: 700,
+              color: theme.palette.getContrastText(getLessonTypeColor(lesson.lesson_type)),
+              background: getLessonTypeColor(lesson.lesson_type),
+            })}
           />
           <Chip
             size="small"
@@ -799,7 +804,17 @@ export default function Schedule() {
                       >
                         <Box sx={{ position: "absolute", left: 0, top: 0, bottom: 0, width: 6, borderTopLeftRadius: 8, borderBottomLeftRadius: 8, background: getLessonTypeColor(lesson.lesson_type) }} />
                         <Stack direction="row" gap={1} alignItems="center" flexWrap="wrap" sx={{ pl: 1 }}>
-                          <Chip size="small" label={lesson.lesson_type ?? ""} className="chip-type" sx={{ background: getLessonTypeColor(lesson.lesson_type), color: "#fff", height: 24, fontWeight: 700 }} />
+                          <Chip
+                            size="small"
+                            label={lesson.lesson_type ?? ""}
+                            className="chip-type"
+                            sx={(theme) => ({
+                              background: getLessonTypeColor(lesson.lesson_type),
+                              color: theme.palette.getContrastText(getLessonTypeColor(lesson.lesson_type)),
+                              height: 24,
+                              fontWeight: 700,
+                            })}
+                          />
                           <Chip size="small" className="chip-time" icon={<AccessTimeIcon sx={{ fontSize: 16 }} />} label={`${getTimeStr(lesson)}–${getEndTimeStr(lesson)}`} />
                         </Stack>
                         <Typography fontWeight={700} fontSize="1.02rem" sx={{ color: "var(--page-text)", pl: 1, mt: 0.5, display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden" }}>
@@ -835,7 +850,7 @@ export default function Schedule() {
       <PageFadeIn>
         <style>{`
         @media print {
-          body { background: #fff !important; }
+          body { background: var(--card-bg,#fff) !important; color: var(--page-text,#000) !important; }
           .no-print { display: none !important; }
           table { box-shadow: none !important; }
           .MuiTableCell-root { border: 1px solid #999 !important; }
@@ -927,9 +942,19 @@ export default function Schedule() {
               <Box>
                 <Box mb={1}>
                   <b>Тип:</b>{" "}
-                  <span style={{ color: "#fff", background: getLessonTypeColor(dialogLesson.lesson_type), borderRadius: 5, padding: "2px 8px" }}>
+                  <Box
+                    component="span"
+                    sx={(theme) => ({
+                      color: theme.palette.getContrastText(getLessonTypeColor(dialogLesson.lesson_type)),
+                      background: getLessonTypeColor(dialogLesson.lesson_type),
+                      borderRadius: 5,
+                      px: 1,
+                      py: "2px",
+                      fontWeight: 700,
+                    })}
+                  >
                     {dialogLesson.lesson_type ?? ""}
-                  </span>
+                  </Box>
                 </Box>
                 <Box><b>Время:</b> {getTimeStr(dialogLesson)}–{getEndTimeStr(dialogLesson)}</Box>
                 <Box><b>Преподаватель:</b> {dialogLesson.teacher}</Box>

--- a/root/frontend/src/theme.ts
+++ b/root/frontend/src/theme.ts
@@ -1,4 +1,4 @@
-import { extendTheme, responsiveFontSizes } from "@mui/material/styles";
+import { alpha, extendTheme, responsiveFontSizes } from "@mui/material/styles";
 
 const spacingScale = {
   "2xs": "0.25rem",
@@ -289,6 +289,14 @@ const baseTheme = extendTheme({
             paddingInline: `max(${spacingVars.sm}, ${theme.spacing(2)})`,
             paddingBlock: `max(${spacingVars["2xs"]}, ${theme.spacing(1)})`,
             minHeight: "44px",
+            fontWeight: 700,
+            color: theme.palette.text.primary,
+            '&.MuiButton-contained': {
+              color: theme.palette.primary.contrastText,
+            },
+            '&.MuiButton-contained:hover': {
+              boxShadow: 'none',
+            },
           }
         },
       },
@@ -323,11 +331,32 @@ const baseTheme = extendTheme({
             minHeight: "44px",
             borderRadius: radiusVars.md,
             paddingInline: spacingVars.sm,
+            color: theme.palette.text.secondary,
             "&:focus-visible": {
               boxShadow: `var(--ue-focus-ring, ${focusVars.light})`,
             },
+            "&.Mui-selected": {
+              color: theme.palette.text.primary,
+              backgroundColor: alpha(theme.palette.primary.main, theme.palette.mode === "dark" ? 0.24 : 0.16),
+            },
+            "&.Mui-selected:hover": {
+              backgroundColor: alpha(theme.palette.primary.main, theme.palette.mode === "dark" ? 0.28 : 0.22),
+            },
           }
         },
+      },
+    },
+    MuiToggleButtonGroup: {
+      styleOverrides: {
+        root: ({ theme }) => ({
+          borderRadius: theme.vars?.radiusScale?.pill ?? radiusScale.pill,
+          padding: theme.spacing(0.5),
+          gap: theme.spacing(0.5),
+          backgroundColor: alpha(
+            theme.palette.text.primary,
+            theme.palette.mode === "dark" ? 0.14 : 0.08
+          ),
+        }),
       },
     },
     MuiListItemButton: {
@@ -368,6 +397,73 @@ const baseTheme = extendTheme({
         root: {
           borderRadius: "var(--ue-radius-lg)",
         },
+      },
+    },
+    MuiOutlinedInput: {
+      styleOverrides: {
+        root: ({ theme }) => ({
+          backgroundColor: alpha(
+            theme.palette.background.paper,
+            theme.palette.mode === "dark" ? 0.72 : 0.96,
+          ),
+          transition: "background-color 0.2s ease, box-shadow 0.2s ease",
+          '&:hover .MuiOutlinedInput-notchedOutline': {
+            borderColor: alpha(theme.palette.primary.main, 0.45),
+          },
+          '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+            borderColor: alpha(theme.palette.primary.main, 0.65),
+          },
+          '&.Mui-disabled': {
+            backgroundColor: alpha(theme.palette.action.disabledBackground, 0.45),
+          },
+        }),
+        input: ({ theme }) => ({
+          paddingBlock: `calc(${theme.spacing(1)} - 1px)`,
+        }),
+        notchedOutline: ({ theme }) => ({
+          borderColor: alpha(theme.palette.text.primary, 0.18),
+        }),
+      },
+    },
+    MuiSwitch: {
+      styleOverrides: {
+        root: ({ theme }) => ({
+          padding: theme.spacing(1),
+          width: 56,
+          '& .MuiSwitch-switchBase': {
+            padding: 2,
+            '&.Mui-checked': {
+              transform: 'translateX(20px)',
+              color: theme.palette.mode === 'dark' ? theme.palette.common.black : theme.palette.common.white,
+              '& + .MuiSwitch-track': {
+                backgroundColor: alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.6 : 0.45),
+                opacity: 1,
+              },
+            },
+            '&.Mui-disabled + .MuiSwitch-track': {
+              opacity: 0.4,
+            },
+            '&.Mui-disabled .MuiSwitch-thumb': {
+              color: alpha(theme.palette.text.primary, 0.3),
+            },
+          },
+          '& .MuiSwitch-thumb': {
+            width: 22,
+            height: 22,
+            boxShadow: '0 2px 6px rgba(0,0,0,0.22)',
+            backgroundColor:
+              theme.palette.mode === 'dark'
+                ? alpha(theme.palette.primary.light, 0.9)
+                : theme.palette.common.white,
+          },
+          '& .MuiSwitch-track': {
+            borderRadius: 999,
+            opacity: 1,
+            backgroundColor: theme.palette.mode === 'dark'
+              ? alpha(theme.palette.text.primary, 0.28)
+              : alpha(theme.palette.text.primary, 0.16),
+          },
+        }),
       },
     },
     MuiDialog: {


### PR DESCRIPTION
## Summary
- expand the global theme tokens to cover navigation controls, danger states, and switch styling so light and dark modes stay coherent
- rework the desktop navbar to size the settings icon to the full button and rely on the updated CSS variables for avatar, skeleton, and text colors
- update frequently used pages and cards to use theme-aware button, chip, and surface colors for consistent light/dark presentation

## Testing
- `CI=1 npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68eb1e6dd0148327be93122c0f598a82