### PR TITLE
Expand settings button icon on desktop

### DIFF
--- a/root/frontend/src/assets/themes.css
+++ b/root/frontend/src/assets/themes.css
@@ -615,8 +615,14 @@ body,html { overflow-x: hidden }
   transition: background var(--anim-fast), color var(--anim-fast), border-color var(--anim-fast), box-shadow var(--anim-fast), transform var(--anim-fast);
 }
 .menu-btn-settings svg {
-  width: 18px;
-  height: 18px;
+  width: 100%;
+  height: 100%;
+}
+@media (max-width: 1350px) {
+  .menu-btn-settings svg {
+    width: 20px;
+    height: 20px;
+  }
 }
 .menu-btn-settings:hover,
 .menu-btn-settings:focus-visible {


### PR DESCRIPTION
## Summary
- enlarge the navbar settings icon to match the full button size on desktop displays while retaining a smaller mobile footprint

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68eb24d9637083278c341658ead900b5