### PR TITLE
Ensure Activity toggle labels stay white

### DIFF
--- a/root/frontend/src/pages/Activity.tsx
+++ b/root/frontend/src/pages/Activity.tsx
@@ -172,7 +172,6 @@ export default function Activity() {
   const darkToggleHover = alpha(theme.palette.common.white, 0.96)
   const darkToggleBorder = alpha(theme.palette.common.white, 0.24)
   const darkToggleSelected = lighten(theme.palette.primary.main, 0.6)
-  const darkToggleText = theme.palette.grey[900]
 
   const [period, setPeriod] = useState<"30d" | "90d" | "180d">("90d")
   const [attendance, setAttendance] = useState<AttendanceStats | null>(null)

--- a/root/frontend/src/pages/Activity.tsx
+++ b/root/frontend/src/pages/Activity.tsx
@@ -535,7 +535,7 @@ export default function Activity() {
                     borderRadius: 999,
                     border: 0,
                     fontWeight: 700,
-                    color: isDark ? darkToggleText : alpha(theme.palette.text.primary, 0.8),
+                    color: theme.palette.common.white,
                     backgroundColor: isDark ? darkToggleBase : "transparent",
                     transition: theme.transitions.create(
                       ["background-color", "color", "box-shadow"],
@@ -561,7 +561,7 @@ export default function Activity() {
                     background: isDark
                       ? darkToggleSelected
                       : lighten(theme.palette.primary.main, 0.35),
-                    color: isDark ? theme.palette.primary.dark : theme.palette.primary.contrastText,
+                    color: theme.palette.common.white,
                     boxShadow: isDark
                       ? `0 8px 24px ${alpha(theme.palette.primary.main, 0.45)}`
                       : `0 2px 8px ${alpha(theme.palette.primary.main, 0.2)}`,


### PR DESCRIPTION
## Summary
- force the Activity period toggle buttons to render white text in all states for better visibility

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ebcd102ba48327b3c4d2138d32c87b