### PR TITLE
Adjust events grid spacing

### DIFF
--- a/root/frontend/src/pages/Events.tsx
+++ b/root/frontend/src/pages/Events.tsx
@@ -194,8 +194,10 @@ const Events = () => {
           style={{ '--fade-delay': '260ms' } as CSSProperties }
           sx={{
             display: "grid",
-            gridTemplateColumns: "repeat(auto-fit, minmax(320px, 1fr))",
+            gridTemplateColumns: "repeat(auto-fill, minmax(320px, 380px))",
             gap: { xs: 2, sm: 3 },
+            justifyContent: "center",
+            justifyItems: "center",
             minHeight: "180px",
           }}
         >


### PR DESCRIPTION
## Summary
- center the events grid layout to prevent excessive spacing between cards
- restrict grid column widths for more consistent card spacing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ebea5c74f88327ba81c14bb539b801