### PR TITLE
Adjust two-card layout spacing on events page

### DIFF
--- a/root/frontend/src/pages/Events.tsx
+++ b/root/frontend/src/pages/Events.tsx
@@ -188,14 +188,17 @@ const Events = () => {
   const eventsContent = useMemo(
     () => {
       const skeletonCount = isMobile ? 3 : 6
+      const isTwoCardLayout = !isMobile && normalizedEvents.length === 2
       return (
         <Box
           data-fade
           style={{ '--fade-delay': '260ms' } as CSSProperties }
           sx={{
             display: "grid",
-            gridTemplateColumns: "repeat(auto-fit, minmax(320px, 1fr))",
-            gap: { xs: 2, sm: 3 },
+            gridTemplateColumns: isTwoCardLayout
+              ? "repeat(auto-fit, minmax(420px, 1fr))"
+              : "repeat(auto-fit, minmax(320px, 1fr))",
+            gap: isTwoCardLayout ? { xs: 2, sm: 2.5 } : { xs: 2, sm: 3 },
             minHeight: "180px",
           }}
         >


### PR DESCRIPTION
## Summary
- widen the grid columns and reduce spacing when only two event cards are visible to shrink the gap between them

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ebee1160b883279c258715a14016d7