### PR TITLE
Unify card hover animation across pages

### DIFF
--- a/root/frontend/src/components/EventCard.tsx
+++ b/root/frontend/src/components/EventCard.tsx
@@ -27,6 +27,7 @@ import EditIcon from "@mui/icons-material/Edit"
 import CloseIcon from "@mui/icons-material/Close"
 import { useAuth } from "../contexts/AuthContext"
 import SmartImage from "@/components/SmartImage"
+import { cardHoverSx } from "@/constants/cardHover"
 
 import dayjs from "dayjs"
 import utc from "dayjs/plugin/utc"
@@ -407,28 +408,20 @@ const EventCardComponent: FC<EventCardProps> = ({
         position: "relative",
         cursor: editOpen ? "default" : "pointer",
         boxShadow: 5,
-        transition: "transform 0.25s ease, box-shadow 0.25s ease, max-width 0.25s ease",
-        willChange: "transform",
         p: { xs: 2, sm: 3 },
         overflow: "hidden",
-        "&:hover": !editOpen
-          ? {
-              transform: isMobile ? "none" : "scale(1.03)",
-              boxShadow: "0 12px 28px rgba(0,0,0,0.18)"
-            }
-          : undefined,
-        "&:active": {
-          transform: editOpen ? "none" : "scale(0.997)"
-        },
+        ...cardHoverSx({
+          disabled: editOpen,
+          hoverTransform: isMobile ? "none" : "scale(1.03)",
+          activeTransform: editOpen ? "none" : "scale(0.997)"
+        }),
+        transition: "transform 0.25s ease, box-shadow 0.25s ease, max-width 0.25s ease",
         "&:focus-visible": {
           outline: "2px solid var(--nav-link)",
           outlineOffset: "2px"
         },
         pointerEvents: qrOpen ? "none" : "auto",
-        filter: qrOpen ? "grayscale(0.12) opacity(0.92)" : "none",
-        "@media (prefers-reduced-motion: reduce)": {
-          transition: "box-shadow 0.25s ease"
-        }
+        filter: qrOpen ? "grayscale(0.12) opacity(0.92)" : "none"
       }}
       role="button"
       tabIndex={0}

--- a/root/frontend/src/components/NewsCard.tsx
+++ b/root/frontend/src/components/NewsCard.tsx
@@ -15,6 +15,7 @@ import dayjs from "dayjs"
 import utc from "dayjs/plugin/utc"
 import timezone from "dayjs/plugin/timezone"
 import SmartImage from "@/components/SmartImage"
+import { cardHoverSx } from "@/constants/cardHover"
 import { sanitizeNewsText } from "@/utils/sanitize"
 
 dayjs.extend(utc)
@@ -200,21 +201,10 @@ const NewsCardComponent: FC<NewsCardProps> = ({
         display: "flex",
         flexDirection: "column",
         minHeight: 340,
-        transition: "transform 0.25s ease, box-shadow 0.25s ease",
-        willChange: "transform",
-        "&:hover": {
-          transform: hoveringDisabled ? "none" : "scale(1.03)",
-          boxShadow: hoveringDisabled ? 5 : "0 12px 28px rgba(0,0,0,0.18)"
-        },
-        "&:active": {
-          transform: hoveringDisabled ? "none" : "scale(0.997)"
-        },
+        ...cardHoverSx({ disabled: hoveringDisabled }),
         "&:focus-visible": {
           outline: "2px solid var(--nav-link)",
           outlineOffset: "2px"
-        },
-        "@media (prefers-reduced-motion: reduce)": {
-          transition: "box-shadow 0.25s ease"
         }
       }}
       role="button"

--- a/root/frontend/src/constants/cardHover.ts
+++ b/root/frontend/src/constants/cardHover.ts
@@ -1,0 +1,49 @@
+import type { SxProps } from "@mui/system"
+import type { Theme } from "@mui/material/styles"
+
+type CardHoverOptions = {
+  disabled?: boolean
+  hoverTransform?: string | null
+  hoverBoxShadow?: string | null
+  activeTransform?: string | null
+}
+
+export const cardHoverSx = ({
+  disabled = false,
+  hoverTransform = "scale(1.03)",
+  hoverBoxShadow = "0 12px 28px rgba(0,0,0,0.18)",
+  activeTransform = "scale(0.997)"
+}: CardHoverOptions = {}): SxProps<Theme> => {
+  const base: SxProps<Theme> = {
+    transition: "transform 0.25s ease, box-shadow 0.25s ease",
+    willChange: "transform",
+    "@media (prefers-reduced-motion: reduce)": {
+      transition: "box-shadow 0.25s ease"
+    }
+  }
+
+  if (disabled) {
+    return base
+  }
+
+  const hoverStyles: Record<string, unknown> = {}
+
+  if (hoverTransform !== null && hoverTransform !== undefined) {
+    hoverStyles.transform = hoverTransform
+  }
+
+  if (hoverBoxShadow !== null && hoverBoxShadow !== undefined) {
+    hoverStyles.boxShadow = hoverBoxShadow
+  }
+
+  const activeStyles =
+    activeTransform !== null && activeTransform !== undefined
+      ? { transform: activeTransform }
+      : undefined
+
+  return {
+    ...base,
+    ...(Object.keys(hoverStyles).length > 0 ? { "&:hover": hoverStyles } : {}),
+    ...(activeStyles ? { "&:active": activeStyles } : {})
+  }
+}

--- a/root/frontend/src/pages/Dashboard.tsx
+++ b/root/frontend/src/pages/Dashboard.tsx
@@ -19,6 +19,7 @@ import {
   LinearProgress
 } from "@mui/material"
 import { Link, useNavigate } from "react-router-dom"
+import { cardHoverSx } from "@/constants/cardHover"
 
 type NewsItem = { id: number; title: string; content: string; created_at?: string; pinned?: boolean }
 type EventItem = { id: number; title: string; description?: string; starts_at?: string; location?: string }
@@ -297,18 +298,6 @@ export default function Dashboard() {
     }
   }
 
-  const newsLikeHover = {
-    transition: "transform 0.25s ease, box-shadow 0.25s ease",
-    willChange: "transform",
-    "&:hover": {
-      transform: "scale(1.03)",
-      boxShadow: "0 12px 28px rgba(0,0,0,0.18)"
-    },
-    "&:active": {
-      transform: "scale(0.997)"
-    }
-  } as const
-
   const homeCardSx = {
     p: 2.2,
     borderRadius: "2rem",
@@ -362,7 +351,7 @@ export default function Dashboard() {
             alignItems: "center",
             justifyContent: "space-between",
             gap: 2,
-            ...newsLikeHover,
+            ...cardHoverSx(),
             border: { xs: "1px solid color-mix(in srgb, var(--page-text) 10%, transparent)" }
           }}
         >
@@ -401,7 +390,7 @@ export default function Dashboard() {
             gap: { xs: 2, md: 3 }
           }}
         >
-          <Box data-fade style={{ '--fade-delay': '140ms' } as CSSProperties } sx={{ ...homeCardSx, gridColumn: { xs: "1 / -1", lg: "1 / span 4" }, ...newsLikeHover }} aria-busy={loadingSched}>
+          <Box data-fade style={{ '--fade-delay': '140ms' } as CSSProperties } sx={{ ...homeCardSx, gridColumn: { xs: "1 / -1", lg: "1 / span 4" }, ...cardHoverSx() }} aria-busy={loadingSched}>
             <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 1 }}>
               <Typography sx={{ fontWeight: 800, fontSize: "clamp(1.05rem, 2vw, 1.4rem)" }}>
                 Сегодня в расписании
@@ -484,7 +473,7 @@ export default function Dashboard() {
             )}
           </Box>
 
-          <Box data-fade style={{ '--fade-delay': '200ms' } as CSSProperties } sx={{ ...homeCardSx, gridColumn: { xs: "1 / -1", lg: "5 / span 4" }, ...newsLikeHover }} aria-busy={loadingNews}>
+          <Box data-fade style={{ '--fade-delay': '200ms' } as CSSProperties } sx={{ ...homeCardSx, gridColumn: { xs: "1 / -1", lg: "5 / span 4" }, ...cardHoverSx() }} aria-busy={loadingNews}>
             <Stack direction="row" alignItems="center" justifyContent="space-between">
               <Typography sx={{ fontWeight: 800, fontSize: "clamp(1.05rem, 2vw, 1.4rem)" }}>Новости</Typography>
               <Button
@@ -555,7 +544,7 @@ export default function Dashboard() {
             )}
           </Box>
 
-          <Box data-fade style={{ '--fade-delay': '260ms' } as CSSProperties } sx={{ ...homeCardSx, gridColumn: { xs: "1 / -1", lg: "9 / span 4" }, ...newsLikeHover }} aria-busy={loadingEvents}>
+          <Box data-fade style={{ '--fade-delay': '260ms' } as CSSProperties } sx={{ ...homeCardSx, gridColumn: { xs: "1 / -1", lg: "9 / span 4" }, ...cardHoverSx() }} aria-busy={loadingEvents}>
             <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 1 }}>
               <Typography sx={{ fontWeight: 800, fontSize: "clamp(1.05rem, 2vw, 1.4rem)" }}>События</Typography>
               <Button


### PR DESCRIPTION
## Summary
- create a reusable `cardHoverSx` helper that encapsulates the news card hover animation
- apply the shared hover animation to news, event, and dashboard cards for consistent behavior

## Testing
- npm --prefix root/frontend run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68ec1075db688327925be1d877b63d4d