### PR TITLE
Align card hover animation on dashboard and events

### DIFF
--- a/root/frontend/src/components/EventCard.tsx
+++ b/root/frontend/src/components/EventCard.tsx
@@ -411,11 +411,9 @@ const EventCardComponent: FC<EventCardProps> = ({
         p: { xs: 2, sm: 3 },
         overflow: "hidden",
         ...cardHoverSx({
-          disabled: editOpen,
-          hoverTransform: isMobile ? "none" : "scale(1.03)",
-          activeTransform: editOpen ? "none" : "scale(0.997)"
+          disabled: editOpen || qrOpen,
+          extraTransitions: ["max-width 0.25s ease"],
         }),
-        transition: "transform 0.25s ease, box-shadow 0.25s ease, max-width 0.25s ease",
         "&:focus-visible": {
           outline: "2px solid var(--nav-link)",
           outlineOffset: "2px"

--- a/root/frontend/src/constants/cardHover.ts
+++ b/root/frontend/src/constants/cardHover.ts
@@ -6,19 +6,30 @@ type CardHoverOptions = {
   hoverTransform?: string | null
   hoverBoxShadow?: string | null
   activeTransform?: string | null
+  extraTransitions?: string[]
 }
 
 export const cardHoverSx = ({
   disabled = false,
   hoverTransform = "scale(1.03)",
   hoverBoxShadow = "0 12px 28px rgba(0,0,0,0.18)",
-  activeTransform = "scale(0.997)"
+  activeTransform = "scale(0.997)",
+  extraTransitions = [],
 }: CardHoverOptions = {}): SxProps<Theme> => {
+  const transitions = [
+    "transform 0.25s ease",
+    "box-shadow 0.25s ease",
+    ...extraTransitions,
+  ].filter((transition): transition is string => Boolean(transition?.trim?.() ?? transition))
+  const reducedTransitions = transitions.filter(
+    transition => !transition.toLowerCase().startsWith("transform"),
+  )
+
   const base: SxProps<Theme> = {
-    transition: "transform 0.25s ease, box-shadow 0.25s ease",
+    transition: transitions.join(", ") || undefined,
     willChange: "transform",
     "@media (prefers-reduced-motion: reduce)": {
-      transition: "box-shadow 0.25s ease"
+      transition: reducedTransitions.join(", ") || "box-shadow 0.25s ease",
     }
   }
 

--- a/root/frontend/src/pages/Dashboard.tsx
+++ b/root/frontend/src/pages/Dashboard.tsx
@@ -298,7 +298,9 @@ export default function Dashboard() {
     }
   }
 
+  const cardHoverBase = cardHoverSx()
   const homeCardSx = {
+    ...cardHoverBase,
     p: 2.2,
     borderRadius: "2rem",
     background: "var(--card-bg)",
@@ -351,7 +353,7 @@ export default function Dashboard() {
             alignItems: "center",
             justifyContent: "space-between",
             gap: 2,
-            ...cardHoverSx(),
+            ...cardHoverBase,
             border: { xs: "1px solid color-mix(in srgb, var(--page-text) 10%, transparent)" }
           }}
         >
@@ -390,7 +392,7 @@ export default function Dashboard() {
             gap: { xs: 2, md: 3 }
           }}
         >
-          <Box data-fade style={{ '--fade-delay': '140ms' } as CSSProperties } sx={{ ...homeCardSx, gridColumn: { xs: "1 / -1", lg: "1 / span 4" }, ...cardHoverSx() }} aria-busy={loadingSched}>
+          <Box data-fade style={{ '--fade-delay': '140ms' } as CSSProperties } sx={{ ...homeCardSx, gridColumn: { xs: "1 / -1", lg: "1 / span 4" } }} aria-busy={loadingSched}>
             <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 1 }}>
               <Typography sx={{ fontWeight: 800, fontSize: "clamp(1.05rem, 2vw, 1.4rem)" }}>
                 Сегодня в расписании
@@ -473,7 +475,7 @@ export default function Dashboard() {
             )}
           </Box>
 
-          <Box data-fade style={{ '--fade-delay': '200ms' } as CSSProperties } sx={{ ...homeCardSx, gridColumn: { xs: "1 / -1", lg: "5 / span 4" }, ...cardHoverSx() }} aria-busy={loadingNews}>
+          <Box data-fade style={{ '--fade-delay': '200ms' } as CSSProperties } sx={{ ...homeCardSx, gridColumn: { xs: "1 / -1", lg: "5 / span 4" } }} aria-busy={loadingNews}>
             <Stack direction="row" alignItems="center" justifyContent="space-between">
               <Typography sx={{ fontWeight: 800, fontSize: "clamp(1.05rem, 2vw, 1.4rem)" }}>Новости</Typography>
               <Button
@@ -544,7 +546,7 @@ export default function Dashboard() {
             )}
           </Box>
 
-          <Box data-fade style={{ '--fade-delay': '260ms' } as CSSProperties } sx={{ ...homeCardSx, gridColumn: { xs: "1 / -1", lg: "9 / span 4" }, ...cardHoverSx() }} aria-busy={loadingEvents}>
+          <Box data-fade style={{ '--fade-delay': '260ms' } as CSSProperties } sx={{ ...homeCardSx, gridColumn: { xs: "1 / -1", lg: "9 / span 4" } }} aria-busy={loadingEvents}>
             <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 1 }}>
               <Typography sx={{ fontWeight: 800, fontSize: "clamp(1.05rem, 2vw, 1.4rem)" }}>События</Typography>
               <Button


### PR DESCRIPTION
## Summary
- extend the shared `cardHoverSx` helper with optional transitions so cards can animate consistently
- reuse the helper on dashboard overview cards and event cards to mirror the news card hover effect

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68ec15792d908327a943a051b33f7f6f