### PR TITLE
Offload blocking file operations to worker threads

### DIFF
--- a/root/app/api/routes.py
+++ b/root/app/api/routes.py
@@ -1,3 +1,4 @@
+import asyncio
 import hashlib
 import logging
 import secrets
@@ -513,10 +514,10 @@ async def upload_event_file(
     filename = f"event_{id}_{uuid.uuid4()}.{ext}"
     base_dir = settings.static_dir_path
     folder = base_dir / "event_files"
-    folder.mkdir(parents=True, exist_ok=True)
+    await asyncio.to_thread(folder.mkdir, parents=True, exist_ok=True)
     file_path = folder / filename
     data = await file.read()
-    file_path.write_bytes(data)
+    await asyncio.to_thread(file_path.write_bytes, data)
     ef = models.EventFile(event_id=id, file_url=f"/static/event_files/{filename}")
     db.add(ef)
     await db.commit()

--- a/root/app/utils/files.py
+++ b/root/app/utils/files.py
@@ -1,3 +1,4 @@
+import asyncio
 import mimetypes
 import re
 import secrets
@@ -90,9 +91,8 @@ async def save_image(upload: UploadFile, subdir: str, prefix: str) -> str:
     base = settings.static_dir_path
     sanitized_subdir = subdir.strip("/ ")
     target_dir = base / sanitized_subdir
-    _ensure_dir(target_dir)
+    await asyncio.to_thread(_ensure_dir, target_dir)
     path = target_dir / name
-    with open(path, "wb") as f:
-        f.write(data)
+    await asyncio.to_thread(path.write_bytes, data)
     # Return canonical public URL without accidental duplicate slashes.
     return f"/static/{sanitized_subdir}/{name}"

--- a/root/tests/test_event_file_upload.py
+++ b/root/tests/test_event_file_upload.py
@@ -1,0 +1,52 @@
+import asyncio
+import io
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi import UploadFile
+
+from app.api import routes
+from app.core.config import settings
+from app.models import models
+
+
+@pytest.mark.asyncio
+async def test_upload_event_file_offloads_io(
+    tmp_path, monkeypatch, db_session, user_factory
+):
+    admin = await user_factory(role="admin")
+    event = models.Event(
+        title="Test Event",
+        description="desc",
+        location="",
+        event_type="workshop",
+        starts_at=datetime.now(timezone.utc),
+        ends_at=datetime.now(timezone.utc) + timedelta(hours=1),
+        created_by=admin.id,
+    )
+    db_session.add(event)
+    await db_session.commit()
+    await db_session.refresh(event)
+
+    payload = b"example data"
+    upload = UploadFile(filename="notes.txt", file=io.BytesIO(payload))
+
+    calls: list[tuple[object, tuple[object, ...], dict[str, object]]] = []
+
+    async def fake_to_thread(func, /, *args, **kwargs):  # type: ignore[override]
+        calls.append((func, args, kwargs))
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(routes, "asyncio", asyncio)
+    monkeypatch.setattr(routes.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(settings, "static_dir_path", tmp_path)
+
+    result = await routes.upload_event_file(event.id, upload, db=db_session, user=admin)
+
+    assert result.event_id == event.id
+    assert result.file_url.startswith("/static/event_files/")
+    stored_path = tmp_path / "event_files" / result.file_url.rsplit("/", 1)[-1]
+    assert stored_path.exists()
+    assert stored_path.read_bytes() == payload
+    assert any(func.__name__ == "mkdir" for func, _, _ in calls)
+    assert any(func.__name__ == "write_bytes" for func, _, _ in calls)

--- a/root/tests/test_file_utils.py
+++ b/root/tests/test_file_utils.py
@@ -1,6 +1,13 @@
+import asyncio
+import io
 import re
 
+import pytest
+from fastapi import UploadFile
+from starlette.datastructures import Headers
+
 from app.utils import files
+from app.core.config import settings
 
 
 def test_normalize_filename_prefix_basic():
@@ -11,3 +18,33 @@ def test_normalize_filename_prefix_compacts_symbols():
     value = files.normalize_filename_prefix("***Weird__Prefix   ---+++!!!")
     assert value == "weird__prefix"
     assert not re.search(r"\s", value)
+
+
+@pytest.mark.asyncio
+async def test_save_image_offloads_io(tmp_path, monkeypatch):
+    png_header = b"\x89PNG\r\n\x1a\n"
+    body = png_header + b"\x00" * 10
+    upload = UploadFile(
+        filename="avatar.png",
+        file=io.BytesIO(body),
+        headers=Headers({"content-type": "image/png"}),
+    )
+
+    calls: list[tuple[object, tuple[object, ...], dict[str, object]]] = []
+
+    async def fake_to_thread(func, /, *args, **kwargs):  # type: ignore[override]
+        calls.append((func, args, kwargs))
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(files, "asyncio", asyncio)
+    monkeypatch.setattr(files.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(settings, "static_dir_path", tmp_path)
+
+    url = await files.save_image(upload, "avatars", "Profile Pic")
+
+    assert url.startswith("/static/avatars/")
+    stored = tmp_path / "avatars"
+    assert stored.exists()
+    assert any(stored.iterdir())
+    assert any(func is files._ensure_dir for func, _, _ in calls)
+    assert any(func.__name__ == "write_bytes" for func, _, _ in calls)

--- a/root/tests/test_file_utils.py
+++ b/root/tests/test_file_utils.py
@@ -6,8 +6,8 @@ import pytest
 from fastapi import UploadFile
 from starlette.datastructures import Headers
 
-from app.utils import files
 from app.core.config import settings
+from app.utils import files
 
 
 def test_normalize_filename_prefix_basic():


### PR DESCRIPTION
## Summary
- offload image saving to background threads to keep FastAPI handlers responsive
- ensure event file uploads create directories and write files without blocking the event loop
- add async tests covering both helpers and verifying thread delegation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ec210df25c8327aa95bf68885956e5