### PR TITLE
Improve auth user typing

### DIFF
--- a/root/frontend/src/app/__tests__/a11y.test.tsx
+++ b/root/frontend/src/app/__tests__/a11y.test.tsx
@@ -12,6 +12,7 @@ import { routerFutureFlags } from "@/App";
 import { checkA11y } from "@/tests/axeTest";
 import { createQueryClient } from "@/app/queryClient";
 import api from "@/api/client";
+import type { User } from "@/types/User";
 
 vi.mock("@/components/NotificationsBell", () => ({
   default: ({ iconColor }: { iconColor?: string }) => (
@@ -54,26 +55,33 @@ vi.mock("@/hooks/useNowPlaying", async () => {
   };
 });
 
-const baseUser = {
-  id: "user-1",
-  full_name: "Тестовый Пользователь",
+const baseUser: User = {
+  id: 1,
   email: "user@example.com",
+  full_name: "Тестовый Пользователь",
   role: "student",
-  group_id: "group-1",
-  telegram: "@testuser",
-  about: "Студент ГУУ",
-  achievements: "Победитель олимпиады|ГУУ|2023",
-  institute: "Институт цифровых технологий",
-  course: "3",
-  record_book_number: "123456",
-  status: "Студент",
-  program: "Информатика",
-  track: "Разработка",
-  department: "Кафедра ИТ",
-  position: "",
+  group_id: 1,
   avatar_url: "",
   cover_url: "",
+  about: "Студент ГУУ",
+  record_book_number: "123456",
+  status: "Студент",
+  institute: "Институт цифровых технологий",
+  course: "3",
+  education_level: null,
+  track: "Разработка",
+  program: "Информатика",
+  telegram: "@testuser",
+  achievements: "Победитель олимпиады|ГУУ|2023",
+  department: "Кафедра ИТ",
+  position: "",
   spotify_connected: false,
+  spotify_display_name: null,
+  spotify_is_connected: false,
+  dnd_enabled: false,
+  dnd_start: null,
+  dnd_end: null,
+  is_active: true,
 };
 
 const activeClients: QueryClient[] = [];

--- a/root/frontend/src/components/SpotifyConnect.tsx
+++ b/root/frontend/src/components/SpotifyConnect.tsx
@@ -44,12 +44,16 @@ export default function SpotifyConnect() {
     setActionLoading(true)
     try {
       await api.post("/spotify/disconnect")
-      setUser({
-        ...user,
-        spotify_connected: false,
-        spotify_is_connected: false,
-        spotify_display_name: null,
-      })
+      setUser((prev) =>
+        prev
+          ? {
+              ...prev,
+              spotify_connected: false,
+              spotify_is_connected: false,
+              spotify_display_name: null,
+            }
+          : prev
+      )
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: currentUserQueryKey }),
         queryClient.invalidateQueries({ queryKey: nowPlayingQueryKey }),

--- a/root/frontend/src/contexts/AuthContext.tsx
+++ b/root/frontend/src/contexts/AuthContext.tsx
@@ -1,5 +1,6 @@
 import {
   createContext,
+  type Dispatch,
   useCallback,
   useContext,
   useEffect,
@@ -7,6 +8,7 @@ import {
   useRef,
   useState,
   type ReactNode,
+  type SetStateAction,
 } from "react"
 import { useQueryClient } from "@tanstack/react-query"
 import { isAxiosError } from "axios"
@@ -17,10 +19,11 @@ import {
 } from "@/push/subscribe"
 import api, { API_UNAUTHORIZED_EVENT, setAuthToken } from "../api/client"
 import { SPOTIFY_REAUTH_EVENT } from "@/hooks/useNowPlaying"
+import type { User } from "@/types/User"
 
-type UserState = any | null
+type UserState = User | null
 
-type SetUserArg = UserState | ((prev: UserState) => UserState)
+type SetUserArg = SetStateAction<UserState>
 
 type AuthContextType = {
   isAuth: boolean
@@ -28,8 +31,14 @@ type AuthContextType = {
   logout: () => Promise<void>
   user: UserState
   loading: boolean
-  setUser: (user: SetUserArg) => void
+  setUser: Dispatch<SetUserArg>
   refresh: () => Promise<void>
+}
+
+const noopSetUser: Dispatch<SetUserArg> = (_value) => {
+  if (import.meta.env.DEV) {
+    console.warn("AuthContext setUser called outside provider")
+  }
 }
 
 export const AuthContext = createContext<AuthContextType>({
@@ -38,7 +47,7 @@ export const AuthContext = createContext<AuthContextType>({
   logout: async () => {},
   user: null,
   loading: false,
-  setUser: () => {},
+  setUser: noopSetUser,
   refresh: async () => {},
 })
 
@@ -48,21 +57,28 @@ export const currentUserQueryKey = ["users", "me"] as const
 
 const PROFILE_CACHE_KEY = "ecosystem.profile.cache.v1"
 
-const readCachedUser = (): any | undefined => {
+const isUser = (value: unknown): value is User => {
+  if (!value || typeof value !== "object") return false
+  const candidate = value as Partial<User>
+  return typeof candidate.id === "number" && typeof candidate.email === "string"
+}
+
+const readCachedUser = (): User | undefined => {
   try {
     const raw = localStorage.getItem(PROFILE_CACHE_KEY)
     if (!raw) return undefined
-    const parsed = JSON.parse(raw)
+    const parsed = JSON.parse(raw) as unknown
     if (parsed && typeof parsed === "object" && "data" in parsed) {
-      return (parsed as { data: unknown }).data
+      const data = (parsed as { data: unknown }).data
+      return isUser(data) ? data : undefined
     }
-    return parsed
+    return isUser(parsed) ? parsed : undefined
   } catch {
     return undefined
   }
 }
 
-const persistUserToCache = (value: any | null) => {
+const persistUserToCache = (value: User | null) => {
   try {
     if (value != null) {
       localStorage.setItem(
@@ -90,7 +106,7 @@ type FetchCurrentUserOptions = {
 }
 
 export const fetchCurrentUser = async ({ signal }: FetchCurrentUserOptions = {}) => {
-  const response = await api.get("/users/me", { signal })
+  const response = await api.get<User>("/users/me", { signal })
   return response.data
 }
 
@@ -118,14 +134,13 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const setUser = useCallback(
     (value: SetUserArg) => {
       setUserState((prev: UserState) => {
-        const previous = prev ?? null
         const next =
           typeof value === "function"
-            ? (value as (prev: UserState) => UserState)(previous)
+            ? (value as (prev: UserState) => UserState)(prev)
             : value
         const normalized: UserState = next ?? null
         persistUserToCache(normalized)
-        queryClient.setQueryData(currentUserQueryKey, normalized)
+        queryClient.setQueryData<UserState>(currentUserQueryKey, normalized)
         return normalized
       })
     },
@@ -134,7 +149,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 
   useEffect(() => {
     if (cachedUserRef.current !== null) {
-      queryClient.setQueryData(currentUserQueryKey, cachedUserRef.current)
+      queryClient.setQueryData<UserState>(currentUserQueryKey, cachedUserRef.current)
       cachedUserRef.current = null
     }
   }, [queryClient])
@@ -172,7 +187,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     ;(async () => {
       try {
         const profile = await fetchCurrentUser({ signal: controller.signal })
-        setUser(profile ?? null)
+        setUser(profile)
       } catch (error) {
         if (controller.signal.aborted) return
         if (isAxiosError(error) && error.response?.status === 401) {
@@ -209,7 +224,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     try {
       setInitializing(true)
       const profile = await fetchCurrentUser({ signal: controller.signal })
-      setUser(profile ?? null)
+      setUser(profile)
     } catch (error) {
       if (controller.signal.aborted) return
       if (isAxiosError(error) && error.response?.status === 401) {
@@ -299,7 +314,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         applyToken(nextToken)
 
         const profile = await fetchCurrentUser({ signal: controller.signal })
-        setUser(profile ?? null)
+        setUser(profile)
 
         if (typeof window !== "undefined" && typeof Notification !== "undefined") {
           if (Notification.permission === "granted" && hasPushConsent()) {
@@ -365,7 +380,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     }
   }, [handleUnauthorized])
 
-  const user = userState ?? null
+  const user = userState
   const isAuth = Boolean(token && user)
   const loading = initializing || authOperation
 

--- a/root/frontend/src/pages/Profile.tsx
+++ b/root/frontend/src/pages/Profile.tsx
@@ -422,7 +422,7 @@ export default function Profile() {
       affiliation: user.institute || user.department || "",
       url: typeof window !== "undefined" ? window.location.href : "",
       image: (() => {
-        const media = resolveMediaUrl(user.avatar_url);
+        const media = resolveMediaUrl(user.avatar_url ?? undefined);
         return media ? addVersionParam(media, avatarVersion) : "";
       })()
     });
@@ -443,12 +443,12 @@ export default function Profile() {
     );
 
   const avatarImageUrl = useMemo(() => {
-    const media = resolveMediaUrl(user?.avatar_url);
+    const media = resolveMediaUrl(user?.avatar_url ?? undefined);
     return media ? addVersionParam(media, avatarVersion) : DEFAULT_AVATAR;
   }, [user?.avatar_url, avatarVersion]);
 
   const coverImageUrl = useMemo(() => {
-    const media = resolveMediaUrl(user?.cover_url);
+    const media = resolveMediaUrl(user?.cover_url ?? undefined);
     return media ? addVersionParam(media, coverVersion) : profileBg;
   }, [user?.cover_url, coverVersion]);
 
@@ -747,7 +747,7 @@ export default function Profile() {
                       <Box className="avatar-ring" sx={{ width: "100%", height: "100%" }}>
                         <Avatar
                           src={avatarImageUrl}
-                          alt={user?.full_name}
+                          alt={user?.full_name ?? undefined}
                           imgProps={{
                             onError: handleAvatarImgError,
                             loading: "lazy",

--- a/root/frontend/src/pages/Settings.tsx
+++ b/root/frontend/src/pages/Settings.tsx
@@ -14,6 +14,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { usePushPreferences } from "@/hooks/usePushPreferences";
 import { nowPlayingQueryKey } from "@/hooks/useNowPlaying";
 import api from "../api/client";
+import type { User } from "@/types/User";
 import {
   Box,
   Paper,
@@ -279,7 +280,7 @@ export default function Settings() {
   const [avatarVersion, setAvatarVersion] = useState(Date.now());
   const [coverVersion, setCoverVersion] = useState(Date.now());
 
-  const syncDndFromUser = useCallback((value: any) => {
+  const syncDndFromUser = useCallback((value: User | null) => {
     const enabled = Boolean(value?.dnd_enabled);
     const start = toInputTime(value?.dnd_start);
     const end = toInputTime(value?.dnd_end);
@@ -293,9 +294,9 @@ export default function Settings() {
       if (dndSaving) return;
       const normalizedStart = nextStart ? nextStart.trim() : null;
       const normalizedEnd = nextEnd ? nextEnd.trim() : null;
-      const prevEnabled = Boolean((user as any)?.dnd_enabled);
-      const prevStart = toInputTime((user as any)?.dnd_start);
-      const prevEnd = toInputTime((user as any)?.dnd_end);
+      const prevEnabled = Boolean(user?.dnd_enabled);
+      const prevStart = toInputTime(user?.dnd_start);
+      const prevEnd = toInputTime(user?.dnd_end);
       if (
         nextEnabled === prevEnabled &&
         (!nextEnabled ||
@@ -310,7 +311,7 @@ export default function Settings() {
       }
       setDndSaving(true);
       try {
-        const payload: Record<string, any> = { dnd_enabled: nextEnabled };
+        const payload: Record<string, unknown> = { dnd_enabled: nextEnabled };
         if (nextEnabled) {
           payload.dnd_start = toServerTime(normalizedStart);
           payload.dnd_end = toServerTime(normalizedEnd);
@@ -318,7 +319,7 @@ export default function Settings() {
           payload.dnd_start = null;
           payload.dnd_end = null;
         }
-        const res = await api.put("/users/me", payload);
+        const res = await api.put<User>("/users/me", payload);
         setUser(res.data);
         syncDndFromUser(res.data);
         const wasEnabled = prevEnabled;
@@ -327,16 +328,22 @@ export default function Settings() {
         else if (!nextEnabled && wasEnabled) message = 'Режим "Не беспокоить" выключен';
         else message = 'Настройки режима "Не беспокоить" обновлены';
         setSnack({ text: message, sev: "success" });
-      } catch (error: any) {
+      } catch (error: unknown) {
         let message = 'Не удалось обновить настройки режима "Не беспокоить"';
-        const detail = error?.response?.data?.detail;
-        if (typeof detail === "string") message = detail;
-        else if (Array.isArray(detail)) {
-          const collected = detail
-            .map((item: any) => (item?.msg ? String(item.msg) : ""))
-            .filter(Boolean)
-            .join("; ");
-          if (collected) message = collected;
+        if (isAxiosError(error)) {
+          const detail = (error.response?.data as { detail?: unknown } | undefined)?.detail;
+          if (typeof detail === "string") message = detail;
+          else if (Array.isArray(detail)) {
+            const collected = detail
+              .map((item: unknown) =>
+                item && typeof item === "object" && "msg" in item
+                  ? String((item as { msg?: unknown }).msg)
+                  : ""
+              )
+              .filter(Boolean)
+              .join("; ");
+            if (collected) message = collected;
+          }
         }
         setSnack({ text: message, sev: "error" });
         syncDndFromUser(user);
@@ -422,8 +429,8 @@ export default function Settings() {
     [disableNotifications, enableNotifications, pushBusy, pushInitializing]
   );
 
-  const spotifyConnected = Boolean((user as any)?.spotify_connected || (user as any)?.spotify_is_connected);
-  const spotifyName = (user as any)?.spotify_display_name || "";
+  const spotifyConnected = Boolean(user?.spotify_connected || user?.spotify_is_connected);
+  const spotifyName = user?.spotify_display_name ?? "";
 
   const connectSpotify = async () => {
     try {
@@ -445,9 +452,9 @@ export default function Settings() {
       ]);
       try {
         const profile = await fetchCurrentUser();
-        setUser(profile ?? null);
+        setUser(profile);
       } catch {
-        setUser((prev: ReturnType<typeof useAuth>["user"]) =>
+        setUser((prev) =>
           prev
             ? {
                 ...prev,
@@ -472,8 +479,8 @@ export default function Settings() {
   const [avatarBusy, setAvatarBusy] = useState(false);
   const [coverBusy, setCoverBusy] = useState(false);
 
-  const avatarUrl = (user as any)?.avatar_url as string | undefined;
-  const coverUrl = (user as any)?.cover_url as string | undefined;
+  const avatarUrl = user?.avatar_url ?? undefined;
+  const coverUrl = user?.cover_url ?? undefined;
 
   const avatarSrc = useMemo(() => {
     const resolved = resolveMediaUrl(avatarUrl);
@@ -495,7 +502,7 @@ export default function Settings() {
   const triggerCoverPick = () => coverInputRef.current?.click();
 
   const refreshMe = useCallback(async () => {
-    const fresh = await queryClient.fetchQuery({
+    const fresh = await queryClient.fetchQuery<User>({
       queryKey: currentUserQueryKey,
       queryFn: fetchCurrentUser,
       staleTime: 0,
@@ -506,11 +513,13 @@ export default function Settings() {
 
   const resolveDetailMessage = useCallback((error: unknown, fallback: string) => {
     if (isAxiosError(error)) {
-      const detail = (error.response?.data as any)?.detail;
+      const detail = (error.response?.data as { detail?: unknown } | undefined)?.detail;
       if (typeof detail === "string") return detail;
       if (Array.isArray(detail)) {
         const combined = detail
-          .map((item) => (item && typeof item === "object" && "msg" in item ? String(item.msg) : ""))
+          .map((item) =>
+            item && typeof item === "object" && "msg" in item ? String((item as { msg?: unknown }).msg) : ""
+          )
           .filter(Boolean)
           .join("; ");
         if (combined) return combined;
@@ -785,7 +794,7 @@ export default function Settings() {
                 <ListItemAvatar>
                   <Avatar
                     src={avatarSrc}
-                    alt={(user as any)?.full_name || "avatar"}
+                    alt={user?.full_name || "avatar"}
                     sx={{ width: 48, height: 48 }}
                     imgProps={{ onError: handleAvatarError, loading: "lazy", decoding: "async", referrerPolicy: "no-referrer" }}
                   />

--- a/root/frontend/src/pages/__tests__/Settings.media.test.tsx
+++ b/root/frontend/src/pages/__tests__/Settings.media.test.tsx
@@ -7,6 +7,7 @@ import api from "@/api/client";
 import { createQueryClient } from "@/app/queryClient";
 import { AuthContext } from "@/contexts/AuthContext";
 import Settings from "@/pages/Settings";
+import type { User } from "@/types/User";
 
 vi.mock("@/hooks/useNotifications", () => ({
   useNotifications: () => ({ unreadCount: 0 }),
@@ -32,15 +33,33 @@ vi.mock("@/hooks/usePushPreferences", () => ({
   NOTIFICATION_TOPIC_LABELS: {},
 }));
 
-const baseUser = {
+const baseUser: User = {
   id: 1,
-  full_name: "Test User",
   email: "test@example.com",
+  full_name: "Test User",
   role: "student",
+  group_id: null,
   avatar_url: "/media/avatars/original.png",
   cover_url: "/media/covers/original.jpg",
+  about: null,
+  record_book_number: null,
+  status: null,
+  institute: null,
+  course: null,
+  education_level: null,
+  track: null,
+  program: null,
+  telegram: null,
+  achievements: null,
+  department: null,
+  position: null,
   spotify_connected: false,
+  spotify_display_name: null,
   spotify_is_connected: false,
+  dnd_enabled: false,
+  dnd_start: null,
+  dnd_end: null,
+  is_active: true,
 };
 
 const renderSettings = () => {
@@ -95,7 +114,7 @@ describe("Settings media actions", () => {
     await waitFor(() => expect(document.querySelectorAll("input[type='file']").length).toBeGreaterThan(1));
     const fileInputs = document.querySelectorAll<HTMLInputElement>("input[type='file']");
 
-    const avatar = await screen.findByAltText(baseUser.full_name);
+    const avatar = await screen.findByAltText(baseUser.full_name ?? "");
     const initialSrc = avatar.getAttribute("src");
 
     const file = new File(["avatar"], "avatar.png", { type: "image/png" });

--- a/root/frontend/src/tests/mocks/handlers.ts
+++ b/root/frontend/src/tests/mocks/handlers.ts
@@ -1,4 +1,5 @@
 import { HttpResponse, http } from 'msw';
+import type { User } from '@/types/User';
 
 type NewUserPayload = {
   email?: string;
@@ -10,11 +11,33 @@ type ResetPasswordPayload = {
   [key: string]: unknown;
 };
 
-export const testUser = {
-  id: 'user-1',
-  full_name: 'Тестовый Пользователь',
+export const testUser: User = {
+  id: 1,
   email: 'user@example.com',
+  full_name: 'Тестовый Пользователь',
   role: 'student',
+  group_id: null,
+  avatar_url: null,
+  cover_url: null,
+  about: null,
+  record_book_number: null,
+  status: null,
+  institute: null,
+  course: null,
+  education_level: null,
+  track: null,
+  program: null,
+  telegram: null,
+  achievements: null,
+  department: null,
+  position: null,
+  spotify_connected: false,
+  spotify_display_name: null,
+  spotify_is_connected: false,
+  dnd_enabled: false,
+  dnd_start: null,
+  dnd_end: null,
+  is_active: true,
 };
 
 export const handlers = [
@@ -24,7 +47,7 @@ export const handlers = [
     if (body.email === 'taken@example.com') {
       return HttpResponse.json({ detail: 'Email already used' }, { status: 400 });
     }
-    return HttpResponse.json({ id: 'user-2', ...body }, { status: 201 });
+    return HttpResponse.json({ id: 2, ...body }, { status: 201 });
   }),
   http.post('*/auth/login', async ({ request }) => {
     const raw = await request.text();

--- a/root/frontend/src/types/User.ts
+++ b/root/frontend/src/types/User.ts
@@ -1,0 +1,28 @@
+export interface User {
+  id: number
+  email: string
+  full_name: string | null
+  role: string | null
+  group_id: number | null
+  avatar_url: string | null
+  cover_url: string | null
+  about: string | null
+  record_book_number: string | null
+  status: string | null
+  institute: string | null
+  course: string | null
+  education_level: string | null
+  track: string | null
+  program: string | null
+  telegram: string | null
+  achievements: string | null
+  department: string | null
+  position: string | null
+  spotify_connected: boolean
+  spotify_display_name: string | null
+  spotify_is_connected?: boolean | null
+  dnd_enabled: boolean
+  dnd_start: string | null
+  dnd_end: string | null
+  is_active: boolean
+}


### PR DESCRIPTION
## Summary
- add a typed `User` interface mirroring the backend schema and wire it into the auth context and cache helpers
- update settings, Spotify, and profile flows plus supporting tests to rely on the typed user object and safer parsing

## Testing
- npm run typecheck
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68ec2860ab5c8327bfeb4331bd3a42e4