### PR TITLE
Add configurable event attachment helper

### DIFF
--- a/root/app/api/events.py
+++ b/root/app/api/events.py
@@ -1,6 +1,4 @@
-import asyncio
 import logging
-import uuid
 from typing import List
 
 from fastapi import (
@@ -18,11 +16,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app import crud
 from app.api.deps import get_current_user
 from app.api.utils import save_upload
-from app.core.config import settings
 from app.core.database import get_db
 from app.models import models
 from app.schemas import schemas
 from app.services.notifications import notify_about_event
+from app.utils.files import save_attachment
 
 logger = logging.getLogger(__name__)
 
@@ -109,15 +107,8 @@ async def upload_event_file(
         raise HTTPException(status_code=404, detail="Событие не найдено")
     if user.role not in ("admin", "teacher") and event.created_by != user.id:
         raise HTTPException(status_code=403, detail="forbidden")
-    ext = file.filename.split(".")[-1].lower()
-    filename = f"event_{id}_{uuid.uuid4()}.{ext}"
-    base_dir = settings.static_dir_path
-    folder = base_dir / "event_files"
-    await asyncio.to_thread(folder.mkdir, parents=True, exist_ok=True)
-    file_path = folder / filename
-    data = await file.read()
-    await asyncio.to_thread(file_path.write_bytes, data)
-    ef = models.EventFile(event_id=id, file_url=f"/static/event_files/{filename}")
+    url = await save_attachment(file, "event_files", f"event_{id}")
+    ef = models.EventFile(event_id=id, file_url=url)
     db.add(ef)
     await db.commit()
     await db.refresh(ef)

--- a/root/app/core/config.py
+++ b/root/app/core/config.py
@@ -134,6 +134,18 @@ class Settings(BaseSettings):
     cache_enabled: bool = False
     cache_redis_url: str = "redis://127.0.0.1:6379/0"
     cache_default_ttl_seconds: int = 300
+    event_file_allowed_mime_types: str | list[str] = (
+        "application/pdf,"
+        "text/plain,"
+        "application/msword,"
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document,"
+        "application/vnd.ms-excel,"
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    )
+    event_file_allowed_extensions: str | list[str] = (
+        ".pdf,.txt,.doc,.docx,.xls,.xlsx"
+    )
+    event_file_max_size_bytes: int = 10 * 1024 * 1024
 
     @field_validator("coep_value")
     @classmethod
@@ -257,6 +269,26 @@ class Settings(BaseSettings):
         if not raw_path.is_absolute():
             raw_path = (_PROJECT_ROOT / raw_path).resolve()
         return raw_path
+
+    @property
+    def event_file_allowed_mime_types_set(self) -> set[str]:
+        values = {
+            value.lower()
+            for value in _coerce_str_list(self.event_file_allowed_mime_types)
+            if value
+        }
+        return values
+
+    @property
+    def event_file_allowed_extensions_set(self) -> set[str]:
+        values: set[str] = set()
+        for value in _coerce_str_list(self.event_file_allowed_extensions):
+            normalized = value.strip().lower()
+            if normalized.startswith("."):
+                normalized = normalized[1:]
+            if normalized:
+                values.add(normalized)
+        return values
 
     @cached_property
     def app_base_url_clean(self) -> str:

--- a/root/app/core/config.py
+++ b/root/app/core/config.py
@@ -142,9 +142,7 @@ class Settings(BaseSettings):
         "application/vnd.ms-excel,"
         "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
     )
-    event_file_allowed_extensions: str | list[str] = (
-        ".pdf,.txt,.doc,.docx,.xls,.xlsx"
-    )
+    event_file_allowed_extensions: str | list[str] = ".pdf,.txt,.doc,.docx,.xls,.xlsx"
     event_file_max_size_bytes: int = 10 * 1024 * 1024
 
     @field_validator("coep_value")

--- a/root/app/utils/files.py
+++ b/root/app/utils/files.py
@@ -28,7 +28,7 @@ async def _read_limited(upload: UploadFile, limit: int) -> bytes:
     data = await upload.read(limit + 1)
     if len(data) > limit:
         raise HTTPException(
-            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            status_code=status.HTTP_413_CONTENT_TOO_LARGE,
             detail="file too large",
         )
     return data
@@ -95,4 +95,47 @@ async def save_image(upload: UploadFile, subdir: str, prefix: str) -> str:
     path = target_dir / name
     await asyncio.to_thread(path.write_bytes, data)
     # Return canonical public URL without accidental duplicate slashes.
+    return f"/static/{sanitized_subdir}/{name}"
+
+
+async def save_attachment(upload: UploadFile, subdir: str, prefix: str) -> str:
+    declared_raw = (upload.content_type or "").strip()
+    declared_type = declared_raw.split(";", 1)[0].strip().lower()
+    allowed_types = settings.event_file_allowed_mime_types_set
+    if not declared_type or (allowed_types and declared_type not in allowed_types):
+        raise HTTPException(
+            status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+            detail="unsupported media type",
+        )
+
+    original_name = upload.filename or ""
+    ext = Path(original_name).suffix.lower()
+    ext_without_dot = ext[1:] if ext.startswith(".") else ext
+    if not ext_without_dot and declared_type:
+        guessed = _ext_from_mime(declared_type).lower()
+        ext = guessed
+        ext_without_dot = guessed[1:] if guessed.startswith(".") else guessed
+
+    allowed_exts = settings.event_file_allowed_extensions_set
+    if not ext_without_dot or (allowed_exts and ext_without_dot not in allowed_exts):
+        raise HTTPException(
+            status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+            detail="unsupported file extension",
+        )
+
+    try:
+        limit = int(settings.event_file_max_size_bytes)
+    except (TypeError, ValueError):
+        limit = 0
+    if limit <= 0:
+        limit = 1
+    data = await _read_limited(upload, limit)
+
+    name = _gen_name(prefix, ext)
+    base = settings.static_dir_path
+    sanitized_subdir = subdir.strip("/ ")
+    target_dir = base / sanitized_subdir
+    await asyncio.to_thread(_ensure_dir, target_dir)
+    path = target_dir / name
+    await asyncio.to_thread(path.write_bytes, data)
     return f"/static/{sanitized_subdir}/{name}"

--- a/root/tests/test_event_file_upload.py
+++ b/root/tests/test_event_file_upload.py
@@ -3,18 +3,16 @@ import io
 from datetime import datetime, timedelta, timezone
 
 import pytest
-from fastapi import UploadFile
+from fastapi import HTTPException, UploadFile, status
+from starlette.datastructures import Headers
 
 from app.api import events
 from app.core.config import settings
 from app.models import models
+from app.utils import files
 
 
-@pytest.mark.anyio("asyncio")
-async def test_upload_event_file_offloads_io(
-    tmp_path, monkeypatch, db_session, user_factory
-):
-    admin = await user_factory(role="admin")
+async def _create_event(db_session, user: models.User) -> models.Event:
     event = models.Event(
         title="Test Event",
         description="desc",
@@ -22,14 +20,27 @@ async def test_upload_event_file_offloads_io(
         event_type="workshop",
         starts_at=datetime.now(timezone.utc),
         ends_at=datetime.now(timezone.utc) + timedelta(hours=1),
-        created_by=admin.id,
+        created_by=user.id,
     )
     db_session.add(event)
     await db_session.commit()
     await db_session.refresh(event)
+    return event
+
+
+@pytest.mark.anyio("asyncio")
+async def test_upload_event_file_offloads_io(
+    tmp_path, monkeypatch, db_session, user_factory
+):
+    admin = await user_factory(role="admin")
+    event = await _create_event(db_session, admin)
 
     payload = b"example data"
-    upload = UploadFile(filename="notes.txt", file=io.BytesIO(payload))
+    upload = UploadFile(
+        filename="notes.txt",
+        file=io.BytesIO(payload),
+        headers=Headers({"content-type": "text/plain"}),
+    )
 
     calls: list[tuple[object, tuple[object, ...], dict[str, object]]] = []
 
@@ -37,9 +48,12 @@ async def test_upload_event_file_offloads_io(
         calls.append((func, args, kwargs))
         return func(*args, **kwargs)
 
-    monkeypatch.setattr(events, "asyncio", asyncio)
-    monkeypatch.setattr(events.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(files, "asyncio", asyncio)
+    monkeypatch.setattr(files.asyncio, "to_thread", fake_to_thread)
     monkeypatch.setattr(settings, "static_dir_path", tmp_path)
+    monkeypatch.setattr(settings, "event_file_allowed_mime_types", ["text/plain"])
+    monkeypatch.setattr(settings, "event_file_allowed_extensions", [".txt"])
+    monkeypatch.setattr(settings, "event_file_max_size_bytes", 1024)
 
     result = await events.upload_event_file(event.id, upload, db=db_session, user=admin)
 
@@ -48,5 +62,58 @@ async def test_upload_event_file_offloads_io(
     stored_path = tmp_path / "event_files" / result.file_url.rsplit("/", 1)[-1]
     assert stored_path.exists()
     assert stored_path.read_bytes() == payload
-    assert any(func.__name__ == "mkdir" for func, _, _ in calls)
+    assert any(func is files._ensure_dir for func, _, _ in calls)
     assert any(func.__name__ == "write_bytes" for func, _, _ in calls)
+
+
+@pytest.mark.anyio("asyncio")
+async def test_upload_event_file_rejects_large_payload(
+    tmp_path, monkeypatch, db_session, user_factory
+):
+    admin = await user_factory(role="admin")
+    event = await _create_event(db_session, admin)
+
+    payload = b"x" * 9
+    upload = UploadFile(
+        filename="notes.txt",
+        file=io.BytesIO(payload),
+        headers=Headers({"content-type": "text/plain"}),
+    )
+
+    monkeypatch.setattr(settings, "static_dir_path", tmp_path)
+    monkeypatch.setattr(settings, "event_file_allowed_mime_types", ["text/plain"])
+    monkeypatch.setattr(settings, "event_file_allowed_extensions", [".txt"])
+    monkeypatch.setattr(settings, "event_file_max_size_bytes", 8)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await events.upload_event_file(event.id, upload, db=db_session, user=admin)
+
+    assert excinfo.value.status_code == status.HTTP_413_CONTENT_TOO_LARGE
+    folder = tmp_path / "event_files"
+    assert not folder.exists()
+
+
+@pytest.mark.anyio("asyncio")
+async def test_upload_event_file_rejects_forbidden_type(
+    tmp_path, monkeypatch, db_session, user_factory
+):
+    admin = await user_factory(role="admin")
+    event = await _create_event(db_session, admin)
+
+    upload = UploadFile(
+        filename="malware.exe",
+        file=io.BytesIO(b"binary"),
+        headers=Headers({"content-type": "application/x-msdownload"}),
+    )
+
+    monkeypatch.setattr(settings, "static_dir_path", tmp_path)
+    monkeypatch.setattr(settings, "event_file_allowed_mime_types", ["text/plain"])
+    monkeypatch.setattr(settings, "event_file_allowed_extensions", [".txt"])
+    monkeypatch.setattr(settings, "event_file_max_size_bytes", 1024)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await events.upload_event_file(event.id, upload, db=db_session, user=admin)
+
+    assert excinfo.value.status_code == status.HTTP_415_UNSUPPORTED_MEDIA_TYPE
+    folder = tmp_path / "event_files"
+    assert not folder.exists()


### PR DESCRIPTION
## Summary
- add a reusable helper for saving non-image attachments with filename normalization, type validation, and size limits
- make event attachment limits configurable through settings and reuse the helper in the event upload endpoint
- expand event upload tests to cover success, oversized payloads, and forbidden media types

## Testing
- pytest root/tests/test_event_file_upload.py

------
https://chatgpt.com/codex/tasks/task_e_68ec34177fc883279036ae24281bbf66