### PR TITLE
Safely delete event attachments from filesystem

### DIFF
--- a/root/app/api/events.py
+++ b/root/app/api/events.py
@@ -10,7 +10,7 @@ from fastapi import (
     UploadFile,
     status,
 )
-from sqlalchemy import and_, func, select
+from sqlalchemy import and_, delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import crud
@@ -20,7 +20,7 @@ from app.core.database import get_db
 from app.models import models
 from app.schemas import schemas
 from app.services.notifications import notify_about_event
-from app.utils.files import save_attachment
+from app.utils.files import delete_static_file, save_attachment
 
 logger = logging.getLogger(__name__)
 
@@ -190,8 +190,24 @@ async def delete_event(
         raise HTTPException(status_code=404, detail="Событие не найдено")
     if user.role not in ("admin", "teacher") and q.created_by != user.id:
         raise HTTPException(status_code=403, detail="forbidden")
+    file_urls = [
+        row[0]
+        for row in (
+            await db.execute(
+                select(models.EventFile.file_url).where(
+                    models.EventFile.event_id == event_id
+                )
+            )
+        ).all()
+        if row[0]
+    ]
+    await db.execute(
+        delete(models.EventFile).where(models.EventFile.event_id == event_id)
+    )
     await db.delete(q)
     await db.commit()
+    for url in file_urls:
+        await delete_static_file(url)
     return {"ok": True}
 
 
@@ -254,8 +270,10 @@ async def delete_event_file(
     event = await db.get(models.Event, ef.event_id)
     if user.role not in ("admin", "teacher") and event.created_by != user.id:
         raise HTTPException(status_code=403, detail="forbidden")
+    file_url = ef.file_url
     await db.delete(ef)
     await db.commit()
+    await delete_static_file(file_url)
     return {"ok": True}
 
 

--- a/root/app/utils/files.py
+++ b/root/app/utils/files.py
@@ -1,13 +1,17 @@
 import asyncio
+import logging
 import mimetypes
 import re
 import secrets
 from pathlib import Path
 from typing import Final
+from urllib.parse import unquote, urlparse
 
 from fastapi import HTTPException, UploadFile, status
 
 from app.core.config import settings
+
+logger = logging.getLogger(__name__)
 
 ALLOWED_IMAGE_TYPES: Final[set[str]] = {"image/jpeg", "image/png", "image/webp"}
 MAX_IMAGE_SIZE: Final[int] = 5 * 1024 * 1024
@@ -139,3 +143,50 @@ async def save_attachment(upload: UploadFile, subdir: str, prefix: str) -> str:
     path = target_dir / name
     await asyncio.to_thread(path.write_bytes, data)
     return f"/static/{sanitized_subdir}/{name}"
+
+
+def _resolve_static_file_path(file_url: str) -> Path | None:
+    if not file_url:
+        return None
+
+    parsed = urlparse(file_url)
+    raw_path = unquote(parsed.path or "")
+    if not raw_path:
+        return None
+
+    trimmed = raw_path.lstrip("/")
+    if not trimmed:
+        return None
+
+    parts = Path(trimmed).parts
+    if not parts or parts[0] != "static":
+        return None
+
+    relative = Path(*parts[1:])
+    if not relative.parts:
+        return None
+
+    base = settings.static_dir_path
+    base_resolved = base.resolve()
+    target = (base_resolved / relative).resolve()
+    try:
+        target.relative_to(base_resolved)
+    except ValueError:
+        return None
+    return target
+
+
+def _unlink_ignore_missing(path: Path) -> None:
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        return
+    except OSError:
+        logger.warning("Failed to remove file at %s", path, exc_info=True)
+
+
+async def delete_static_file(file_url: str) -> None:
+    path = _resolve_static_file_path(file_url)
+    if path is None:
+        return
+    await asyncio.to_thread(_unlink_ignore_missing, path)

--- a/root/tests/test_event_file_upload.py
+++ b/root/tests/test_event_file_upload.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta, timezone
 import pytest
 from fastapi import HTTPException, UploadFile, status
 from starlette.datastructures import Headers
+from sqlalchemy import select
 
 from app.api import events
 from app.core.config import settings
@@ -117,3 +118,77 @@ async def test_upload_event_file_rejects_forbidden_type(
     assert excinfo.value.status_code == status.HTTP_415_UNSUPPORTED_MEDIA_TYPE
     folder = tmp_path / "event_files"
     assert not folder.exists()
+
+
+@pytest.mark.anyio("asyncio")
+async def test_delete_event_file_removes_payload(
+    tmp_path, monkeypatch, db_session, user_factory
+):
+    admin = await user_factory(role="admin")
+    event = await _create_event(db_session, admin)
+
+    payload = b"example data"
+    upload = UploadFile(
+        filename="notes.txt",
+        file=io.BytesIO(payload),
+        headers=Headers({"content-type": "text/plain"}),
+    )
+
+    monkeypatch.setattr(settings, "static_dir_path", tmp_path)
+    monkeypatch.setattr(settings, "event_file_allowed_mime_types", ["text/plain"])
+    monkeypatch.setattr(settings, "event_file_allowed_extensions", [".txt"])
+    monkeypatch.setattr(settings, "event_file_max_size_bytes", 1024)
+
+    event_file = await events.upload_event_file(
+        event.id, upload, db=db_session, user=admin
+    )
+
+    stored_path = tmp_path / "event_files" / event_file.file_url.rsplit("/", 1)[-1]
+    assert stored_path.exists()
+
+    result = await events.delete_event_file(event_file.id, db=db_session, user=admin)
+
+    assert result == {"ok": True}
+    assert not stored_path.exists()
+
+
+@pytest.mark.anyio("asyncio")
+async def test_delete_event_removes_all_files(
+    tmp_path, monkeypatch, db_session, user_factory
+):
+    admin = await user_factory(role="admin")
+    event = await _create_event(db_session, admin)
+
+    monkeypatch.setattr(settings, "static_dir_path", tmp_path)
+    monkeypatch.setattr(settings, "event_file_allowed_mime_types", ["text/plain"])
+    monkeypatch.setattr(settings, "event_file_allowed_extensions", [".txt"])
+    monkeypatch.setattr(settings, "event_file_max_size_bytes", 1024)
+
+    stored_paths = []
+    for idx in range(2):
+        upload = UploadFile(
+            filename=f"notes-{idx}.txt",
+            file=io.BytesIO(f"payload-{idx}".encode()),
+            headers=Headers({"content-type": "text/plain"}),
+        )
+        event_file = await events.upload_event_file(
+            event.id, upload, db=db_session, user=admin
+        )
+        stored_paths.append(
+            tmp_path / "event_files" / event_file.file_url.rsplit("/", 1)[-1]
+        )
+
+    for path in stored_paths:
+        assert path.exists()
+
+    result = await events.delete_event(event.id, db=db_session, user=admin)
+
+    assert result == {"ok": True}
+    for path in stored_paths:
+        assert not path.exists()
+    remaining_files = (
+        await db_session.execute(
+            select(models.EventFile).where(models.EventFile.event_id == event.id)
+        )
+    ).scalars()
+    assert list(remaining_files) == []

--- a/root/tests/test_event_file_upload.py
+++ b/root/tests/test_event_file_upload.py
@@ -4,8 +4,8 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 from fastapi import HTTPException, UploadFile, status
-from starlette.datastructures import Headers
 from sqlalchemy import select
+from starlette.datastructures import Headers
 
 from app.api import events
 from app.core.config import settings


### PR DESCRIPTION
## Summary
- add a reusable helper to resolve static file paths and unlink them safely
- ensure event and event file deletions remove both database records and on-disk files
- cover the new behaviour with regression tests for deleting event files and events

## Testing
- pytest root/tests/test_event_file_upload.py

------
https://chatgpt.com/codex/tasks/task_e_68ec3ae75ce483279bc34ca5486f5360