### PR TITLE
Add validation and integrity checks for event times

### DIFF
--- a/root/app/api/events.py
+++ b/root/app/api/events.py
@@ -153,10 +153,10 @@ async def update_event(
         raise HTTPException(status_code=404, detail="Событие не найдено")
     if user.role not in ("admin", "teacher") and q.created_by != user.id:
         raise HTTPException(status_code=403, detail="forbidden")
-    for field, value in data.model_dump(exclude_unset=True).items():
-        setattr(q, field, value)
-    await db.commit()
-    await db.refresh(q)
+    try:
+        q = await crud.update_event(db, q, data)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     files = (
         (
             await db.execute(

--- a/root/app/crud/__init__.py
+++ b/root/app/crud/__init__.py
@@ -22,6 +22,10 @@ def _ensure_utc(value: datetime) -> datetime:
     return value.astimezone(UTC) if value.tzinfo else value.replace(tzinfo=UTC)
 
 
+_EVENT_TIME_ORDER_ERROR = "Время окончания должно быть позже времени начала мероприятия"
+_EVENT_TIME_PAIR_ERROR = "Укажите время начала и окончания мероприятия одновременно"
+
+
 async def create_user(db: AsyncSession, user_in: schemas.UserCreate):
     code = None
     if hasattr(user_in, "invite_code") and getattr(user_in, "role", "student") in (
@@ -222,6 +226,8 @@ async def get_all_events(
 async def create_event(db: AsyncSession, event: schemas.EventCreate, user_id: int):
     starts_at = _ensure_utc(event.starts_at)
     ends_at = _ensure_utc(event.ends_at)
+    if ends_at <= starts_at:
+        raise ValueError(_EVENT_TIME_ORDER_ERROR)
     record = models.Event(
         title=event.title,
         description=event.description,
@@ -235,7 +241,48 @@ async def create_event(db: AsyncSession, event: schemas.EventCreate, user_id: in
         image_url=getattr(event, "image_url", None),
     )
     db.add(record)
-    await db.commit()
+    try:
+        await db.commit()
+    except IntegrityError as exc:
+        await db.rollback()
+        if "ck_event_time_order" in str(exc.orig):
+            raise ValueError(_EVENT_TIME_ORDER_ERROR) from None
+        raise
+    await db.refresh(record)
+    return record
+
+
+async def update_event(
+    db: AsyncSession, record: models.Event, data: schemas.EventUpdate
+) -> models.Event:
+    updates = data.model_dump(exclude_unset=True)
+    if not updates:
+        return record
+    if "starts_at" in updates:
+        updates["starts_at"] = _ensure_utc(updates["starts_at"])
+    if "ends_at" in updates:
+        updates["ends_at"] = _ensure_utc(updates["ends_at"])
+    starts_set = "starts_at" in updates
+    ends_set = "ends_at" in updates
+    if starts_set ^ ends_set:
+        raise ValueError(_EVENT_TIME_PAIR_ERROR)
+    if starts_set or ends_set:
+        starts_at = updates.get("starts_at", record.starts_at)
+        ends_at = updates.get("ends_at", record.ends_at)
+        if starts_at is None or ends_at is None:
+            raise ValueError(_EVENT_TIME_PAIR_ERROR)
+        if ends_at <= starts_at:
+            raise ValueError(_EVENT_TIME_ORDER_ERROR)
+    for field, value in updates.items():
+        setattr(record, field, value)
+    db.add(record)
+    try:
+        await db.commit()
+    except IntegrityError as exc:
+        await db.rollback()
+        if "ck_event_time_order" in str(exc.orig):
+            raise ValueError(_EVENT_TIME_ORDER_ERROR) from None
+        raise
     await db.refresh(record)
     return record
 

--- a/root/app/models/models.py
+++ b/root/app/models/models.py
@@ -137,6 +137,10 @@ class Event(Base):
     image_url = Column(String)
     about = Column(Text)
 
+    __table_args__ = (
+        CheckConstraint("ends_at > starts_at", name="ck_event_time_order"),
+    )
+
 
 class EventAttendance(Base):
     __tablename__ = "event_attendance"

--- a/root/app/schemas/schemas.py
+++ b/root/app/schemas/schemas.py
@@ -173,6 +173,12 @@ class EventCreate(BaseModel):
     image_url: Optional[str] = None
     about: Optional[str] = None
 
+    @model_validator(mode="after")
+    def _validate_time_order(self):  # type: ignore[override]
+        if self.ends_at <= self.starts_at:
+            raise ValueError("Время окончания должно быть позже времени начала мероприятия")
+        return self
+
 
 class EventUpdate(BaseModel):
     title: Optional[str] = None
@@ -185,6 +191,26 @@ class EventUpdate(BaseModel):
     speaker: Optional[str] = None
     image_url: Optional[str] = None
     about: Optional[str] = None
+
+    @model_validator(mode="after")
+    def _validate_time_updates(self):  # type: ignore[override]
+        provided = self.model_fields_set
+        starts_set = "starts_at" in provided
+        ends_set = "ends_at" in provided
+        if starts_set ^ ends_set:
+            raise ValueError(
+                "Укажите время начала и окончания мероприятия одновременно"
+            )
+        if starts_set or ends_set:
+            if self.starts_at is None or self.ends_at is None:
+                raise ValueError(
+                    "Укажите время начала и окончания мероприятия одновременно"
+                )
+            if self.ends_at <= self.starts_at:
+                raise ValueError(
+                    "Время окончания должно быть позже времени начала мероприятия"
+                )
+        return self
 
 
 class EventOut(OrmModel):

--- a/root/app/schemas/schemas.py
+++ b/root/app/schemas/schemas.py
@@ -176,7 +176,9 @@ class EventCreate(BaseModel):
     @model_validator(mode="after")
     def _validate_time_order(self):  # type: ignore[override]
         if self.ends_at <= self.starts_at:
-            raise ValueError("Время окончания должно быть позже времени начала мероприятия")
+            raise ValueError(
+                "Время окончания должно быть позже времени начала мероприятия"
+            )
         return self
 
 

--- a/root/tests/test_event_time_constraints.py
+++ b/root/tests/test_event_time_constraints.py
@@ -1,0 +1,62 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from app import crud
+from app.models import models
+from app.schemas import schemas
+
+pytestmark = pytest.mark.anyio("asyncio")
+
+
+async def test_create_event_guard(db_session, user_factory):
+    user = await user_factory()
+    starts = datetime.now(timezone.utc)
+    payload = schemas.EventCreate.model_construct(
+        title="Invalid",
+        description=None,
+        location=None,
+        event_type=None,
+        starts_at=starts,
+        ends_at=starts,
+        speaker=None,
+        image_url=None,
+        about=None,
+    )
+    with pytest.raises(ValueError, match="Время окончания"):
+        await crud.create_event(db_session, payload, user_id=user.id)
+
+
+async def test_update_event_guard(db_session, user_factory):
+    user = await user_factory()
+    starts = datetime.now(timezone.utc)
+    ends = starts + timedelta(hours=1)
+    valid = schemas.EventCreate(
+        title="Valid",
+        starts_at=starts,
+        ends_at=ends,
+    )
+    record = await crud.create_event(db_session, valid, user_id=user.id)
+    invalid_update = schemas.EventUpdate.model_construct(
+        starts_at=starts,
+        ends_at=starts,
+        fields_set={"starts_at", "ends_at"},
+    )
+    with pytest.raises(ValueError, match="Время окончания"):
+        await crud.update_event(db_session, record, invalid_update)
+
+
+async def test_event_model_check_constraint(db_session, user_factory):
+    user = await user_factory()
+    starts = datetime.now(timezone.utc)
+    event = models.Event(
+        title="Broken",
+        starts_at=starts,
+        ends_at=starts,
+        created_by=user.id,
+    )
+    db_session.add(event)
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+    await db_session.rollback()

--- a/root/tests/test_schemas.py
+++ b/root/tests/test_schemas.py
@@ -1,4 +1,4 @@
-from datetime import time
+from datetime import datetime, time, timedelta, timezone
 
 import pytest
 from pydantic import ValidationError
@@ -30,6 +30,37 @@ def test_user_profile_update_accepts_dnd_interval():
         dnd_end=time(7, 0),
     )
     assert payload.dnd_enabled is True
+
+
+def test_event_create_requires_end_after_start():
+    starts = datetime.now(timezone.utc)
+    with pytest.raises(ValidationError):
+        schemas.EventCreate(
+            title="Test",
+            starts_at=starts,
+            ends_at=starts,
+        )
+
+
+def test_event_update_requires_both_timestamps():
+    starts = datetime.now(timezone.utc)
+    with pytest.raises(ValidationError):
+        schemas.EventUpdate(starts_at=starts)
+
+
+def test_event_update_requires_order():
+    starts = datetime.now(timezone.utc)
+    with pytest.raises(ValidationError):
+        schemas.EventUpdate(starts_at=starts, ends_at=starts)
+
+
+def test_event_update_accepts_valid_interval():
+    starts = datetime.now(timezone.utc)
+    payload = schemas.EventUpdate(
+        starts_at=starts,
+        ends_at=starts + timedelta(hours=1),
+    )
+    assert payload.starts_at == starts
 
 
 async def test_user_out_contract(user_factory):


### PR DESCRIPTION
## Summary
- add schema validation and a database constraint to ensure event start/end ordering
- guard CRUD logic and the API to reject invalid timestamp updates
- backfill tests covering schema validators, CRUD guards, and the new constraint

## Testing
- pytest root/tests/test_schemas.py root/tests/test_event_time_constraints.py

------
https://chatgpt.com/codex/tasks/task_e_68ec41f1b17483279ccea6427646c273