### PR TITLE
Adopt secure cookie-based authentication

### DIFF
--- a/root/app/api/deps.py
+++ b/root/app/api/deps.py
@@ -1,6 +1,6 @@
 from typing import Annotated
 
-from fastapi import Depends, HTTPException, status
+from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import OAuth2PasswordBearer
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -8,11 +8,12 @@ from app.auth.security import decode_token
 from app.core.database import get_db
 from app.models.models import User
 
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/login")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/login", auto_error=False)
 
 
 async def get_current_user(
-    token: Annotated[str, Depends(oauth2_scheme)],
+    request: Request,
+    token: Annotated[str | None, Depends(oauth2_scheme)],
     db: Annotated[AsyncSession, Depends(get_db)],
 ) -> User:
     credentials_exception = HTTPException(
@@ -20,7 +21,10 @@ async def get_current_user(
         detail="Could not validate credentials",
         headers={"WWW-Authenticate": "Bearer"},
     )
-    payload = decode_token(token)
+    raw_token = token or request.cookies.get("access_token")
+    if not raw_token:
+        raise credentials_exception
+    payload = decode_token(raw_token)
     if not payload:
         raise credentials_exception
     sub = payload.get("sub")

--- a/root/app/auth/auth.py
+++ b/root/app/auth/auth.py
@@ -1,3 +1,5 @@
+from datetime import UTC, datetime, timedelta
+
 from fastapi import APIRouter, Depends, HTTPException, Response, status
 from fastapi.security import OAuth2PasswordRequestForm
 from pydantic import BaseModel, EmailStr
@@ -9,6 +11,7 @@ from app.auth.security import (
     get_password_hash,
     verify_and_update_password,
 )
+from app.core.config import settings
 from app.core.database import get_db
 from app.models.models import User
 from app.schemas.schemas import Token, UserCreate
@@ -21,8 +24,44 @@ class LoginIn(BaseModel):
     password: str
 
 
+def _token_cookie_expiration() -> tuple[int | None, datetime | None]:
+    try:
+        minutes = int(settings.access_token_expire_minutes)
+    except (TypeError, ValueError):
+        return None, None
+
+    max_age = minutes * 60
+    expires = datetime.now(UTC) + timedelta(minutes=minutes)
+    return max_age, expires
+
+
+def _set_access_token_cookie(response: Response, token: str) -> None:
+    max_age, expires = _token_cookie_expiration()
+    response.set_cookie(
+        "access_token",
+        token,
+        httponly=True,
+        secure=True,
+        samesite="strict",
+        max_age=max_age,
+        expires=expires,
+        path="/",
+    )
+
+
+def _clear_access_token_cookie(response: Response) -> None:
+    response.delete_cookie(
+        "access_token",
+        path="/",
+        httponly=True,
+        secure=True,
+        samesite="strict",
+    )
+
+
 @router.post("/login", response_model=Token)
 async def login(
+    response: Response,
     form_data: OAuth2PasswordRequestForm = Depends(OAuth2PasswordRequestForm),
     db: AsyncSession = Depends(get_db),
 ):
@@ -57,11 +96,16 @@ async def login(
         await db.commit()
         await db.refresh(user)
     token = create_access_token(str(user_id))
+    _set_access_token_cookie(response, token)
     return {"access_token": token, "token_type": "bearer"}
 
 
 @router.post("/login-json", response_model=Token)
-async def login_json(payload: LoginIn, db: AsyncSession = Depends(get_db)):
+async def login_json(
+    payload: LoginIn,
+    response: Response,
+    db: AsyncSession = Depends(get_db),
+):
     email = payload.email.strip().lower()
     res = await db.execute(select(User).where(User.email == email))
     user = res.scalars().first()
@@ -93,6 +137,7 @@ async def login_json(payload: LoginIn, db: AsyncSession = Depends(get_db)):
         await db.commit()
         await db.refresh(user)
     token = create_access_token(str(user_id))
+    _set_access_token_cookie(response, token)
     return {"access_token": token, "token_type": "bearer"}
 
 
@@ -125,7 +170,5 @@ async def register(user: UserCreate, db: AsyncSession = Depends(get_db)):
 async def logout(response: Response):
     """Terminate the client session."""
 
-    response.delete_cookie("Authorization")
-    response.delete_cookie("token")
-    response.delete_cookie("access_token")
+    _clear_access_token_cookie(response)
     return {"status": "ok"}

--- a/root/frontend/src/api/client.ts
+++ b/root/frontend/src/api/client.ts
@@ -19,28 +19,6 @@ const api = axios.create({
   },
 });
 
-export function setAuthToken(token?: string) {
-  if (token) {
-    try { localStorage.setItem("token", token); } catch {}
-    api.defaults.headers.common.Authorization = `Bearer ${token}`;
-  } else {
-    try { localStorage.removeItem("token"); } catch {}
-    delete api.defaults.headers.common.Authorization;
-  }
-}
-
-api.interceptors.request.use(
-  (config) => {
-    const token = typeof localStorage !== "undefined" ? localStorage.getItem("token") : null;
-    if (token) {
-      config.headers = config.headers || {};
-      (config.headers as any).Authorization = `Bearer ${token}`;
-    }
-    return config;
-  },
-  (error) => Promise.reject(error)
-);
-
 api.interceptors.response.use(
   (r) => r,
   (err) => {
@@ -50,7 +28,6 @@ api.interceptors.response.use(
         delete headers[SKIP_UNAUTHORIZED_HEADER];
         return Promise.reject(err);
       }
-      setAuthToken(undefined);
       if (typeof window !== "undefined") {
         window.dispatchEvent(new CustomEvent(API_UNAUTHORIZED_EVENT));
       }

--- a/root/frontend/src/contexts/AuthContext.tsx
+++ b/root/frontend/src/contexts/AuthContext.tsx
@@ -17,7 +17,7 @@ import {
   softSyncPushSubscription,
   unsubscribePush,
 } from "@/push/subscribe"
-import api, { API_UNAUTHORIZED_EVENT, setAuthToken } from "../api/client"
+import api, { API_UNAUTHORIZED_EVENT } from "../api/client"
 import { SPOTIFY_REAUTH_EVENT } from "@/hooks/useNowPlaying"
 import type { User } from "@/types/User"
 
@@ -56,6 +56,7 @@ export const useAuth = () => useContext(AuthContext)
 export const currentUserQueryKey = ["users", "me"] as const
 
 const PROFILE_CACHE_KEY = "ecosystem.profile.cache.v1"
+const PROFILE_CACHE_MIGRATION_KEY = `${PROFILE_CACHE_KEY}:cookie-auth`
 
 const isUser = (value: unknown): value is User => {
   if (!value || typeof value !== "object") return false
@@ -63,7 +64,21 @@ const isUser = (value: unknown): value is User => {
   return typeof candidate.id === "number" && typeof candidate.email === "string"
 }
 
+const migrateProfileCache = () => {
+  if (typeof localStorage === "undefined") return
+  try {
+    const migrated = localStorage.getItem(PROFILE_CACHE_MIGRATION_KEY)
+    if (!migrated) {
+      localStorage.removeItem(PROFILE_CACHE_KEY)
+      localStorage.setItem(PROFILE_CACHE_MIGRATION_KEY, new Date().toISOString())
+    }
+  } catch {
+    /* ignore */
+  }
+}
+
 const readCachedUser = (): User | undefined => {
+  if (typeof localStorage === "undefined") return undefined
   try {
     const raw = localStorage.getItem(PROFILE_CACHE_KEY)
     if (!raw) return undefined
@@ -79,6 +94,7 @@ const readCachedUser = (): User | undefined => {
 }
 
 const persistUserToCache = (value: User | null) => {
+  if (typeof localStorage === "undefined") return
   try {
     if (value != null) {
       localStorage.setItem(
@@ -93,14 +109,6 @@ const persistUserToCache = (value: User | null) => {
   }
 }
 
-const readStoredToken = () => {
-  try {
-    return localStorage.getItem("token")
-  } catch {
-    return null
-  }
-}
-
 type FetchCurrentUserOptions = {
   signal?: AbortSignal
 }
@@ -110,26 +118,19 @@ export const fetchCurrentUser = async ({ signal }: FetchCurrentUserOptions = {})
   return response.data
 }
 
+const initializeCachedUser = (): UserState => {
+  if (typeof window === "undefined") return null
+  migrateProfileCache()
+  return readCachedUser() ?? null
+}
+
 export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const queryClient = useQueryClient()
-  const cachedUserRef = useRef<UserState>(readCachedUser() ?? null)
-  const [token, setToken] = useState<string | null>(() => readStoredToken())
-  const [userState, setUserState] = useState<UserState>(cachedUserRef.current)
-  const [initializing, setInitializing] = useState<boolean>(
-    () => Boolean(cachedUserRef.current || token)
-  )
+  const [userState, setUserState] = useState<UserState>(initializeCachedUser)
+  const cachedUserRef = useRef<UserState>(userState)
+  const [initializing, setInitializing] = useState<boolean>(true)
   const [authOperation, setAuthOperation] = useState(false)
-  const bootstrapSkipRef = useRef(false)
   const activeRequestRef = useRef<AbortController | null>(null)
-
-  const applyToken = useCallback((value: string | null) => {
-    setToken(value)
-    setAuthToken(value ?? undefined)
-  }, [])
-
-  useEffect(() => {
-    setAuthToken(token ?? undefined)
-  }, [token])
 
   const setUser = useCallback(
     (value: SetUserArg) => {
@@ -155,27 +156,22 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   }, [queryClient])
 
   const clearProfile = useCallback(() => {
-    activeRequestRef.current?.abort()
+    const controller = activeRequestRef.current
+    controller?.abort()
+    activeRequestRef.current = null
     setUser(null)
     cachedUserRef.current = null
   }, [setUser])
 
   const handleUnauthorized = useCallback(() => {
-    activeRequestRef.current?.abort()
-    applyToken(null)
     clearProfile()
+    setAuthOperation(false)
     setInitializing(false)
-  }, [applyToken, clearProfile])
+  }, [clearProfile])
 
   useEffect(() => {
-    if (!token) {
-      clearProfile()
+    if (typeof window === "undefined") {
       setInitializing(false)
-      return
-    }
-
-    if (bootstrapSkipRef.current) {
-      bootstrapSkipRef.current = false
       return
     }
 
@@ -196,11 +192,11 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         }
         console.error("Failed to fetch current user", error)
       } finally {
+        if (!controller.signal.aborted && activeRequestRef.current === controller) {
+          activeRequestRef.current = null
+        }
         if (!controller.signal.aborted) {
           setInitializing(false)
-          if (activeRequestRef.current === controller) {
-            activeRequestRef.current = null
-          }
         }
       }
     })()
@@ -208,15 +204,9 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     return () => {
       controller.abort()
     }
-  }, [clearProfile, handleUnauthorized, setUser, token])
+  }, [handleUnauthorized, setUser])
 
   const refresh = useCallback(async () => {
-    if (!token) {
-      clearProfile()
-      setInitializing(false)
-      return
-    }
-
     const controller = new AbortController()
     activeRequestRef.current?.abort()
     activeRequestRef.current = controller
@@ -233,30 +223,14 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       }
       throw error
     } finally {
+      if (!controller.signal.aborted && activeRequestRef.current === controller) {
+        activeRequestRef.current = null
+      }
       if (!controller.signal.aborted) {
         setInitializing(false)
-        if (activeRequestRef.current === controller) {
-          activeRequestRef.current = null
-        }
       }
     }
-  }, [clearProfile, handleUnauthorized, setUser, token])
-
-  useEffect(() => {
-    if (typeof window === "undefined") return
-    const onStorage = (event: StorageEvent) => {
-      if (event.key === "token") {
-        const stored = readStoredToken()
-        if (stored) {
-          applyToken(stored)
-        } else {
-          handleUnauthorized()
-        }
-      }
-    }
-    window.addEventListener("storage", onStorage)
-    return () => window.removeEventListener("storage", onStorage)
-  }, [applyToken, handleUnauthorized])
+  }, [handleUnauthorized, setUser])
 
   useEffect(() => {
     if (typeof window === "undefined") return
@@ -298,20 +272,13 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 
       try {
         setAuthOperation(true)
-        const { data } = await api.post("/auth/login", payload, {
+        setInitializing(true)
+        await api.post("/auth/login", payload, {
           headers: { "Content-Type": "application/x-www-form-urlencoded" },
           signal: controller.signal,
         })
 
-        const nextToken: string | undefined =
-          data?.access_token ?? data?.accessToken ?? data?.token ?? undefined
-
-        if (!nextToken) {
-          throw new Error("Не удалось получить токен авторизации")
-        }
-
-        bootstrapSkipRef.current = true
-        applyToken(nextToken)
+        if (controller.signal.aborted) return
 
         const profile = await fetchCurrentUser({ signal: controller.signal })
         setUser(profile)
@@ -346,16 +313,16 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 
         throw new Error("Не удалось войти")
       } finally {
+        if (activeRequestRef.current === controller) {
+          activeRequestRef.current = null
+        }
+        setAuthOperation(false)
         if (!controller.signal.aborted) {
-          setAuthOperation(false)
           setInitializing(false)
-          if (activeRequestRef.current === controller) {
-            activeRequestRef.current = null
-          }
         }
       }
     },
-    [applyToken, handleUnauthorized, setUser]
+    [handleUnauthorized, setUser]
   )
 
   const logout = useCallback(async () => {
@@ -381,7 +348,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   }, [handleUnauthorized])
 
   const user = userState
-  const isAuth = Boolean(token && user)
+  const isAuth = Boolean(user)
   const loading = initializing || authOperation
 
   const value = useMemo(

--- a/root/tests/test_auth_cookie_flow.py
+++ b/root/tests/test_auth_cookie_flow.py
@@ -1,0 +1,69 @@
+import pytest
+
+from app.auth.security import get_password_hash
+
+pytestmark = pytest.mark.anyio("asyncio")
+
+
+async def _create_active_user(user_factory, password: str):
+    hashed = get_password_hash(password)
+    return await user_factory(hashed_password=hashed, is_active=True)
+
+
+async def _login(async_client, email: str, password: str):
+    return await async_client.post(
+        "/auth/login",
+        data={"username": email, "password": password},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+
+
+async def test_login_issues_secure_cookie(async_client, user_factory):
+    password = "StrongPass123!"
+    user = await _create_active_user(user_factory, password)
+
+    response = await _login(async_client, user.email, password)
+
+    assert response.status_code == 200
+
+    set_cookie_headers = response.headers.get_list("set-cookie")
+    assert any(
+        header.lower().startswith("access_token=")
+        and "httponly" in header.lower()
+        and "secure" in header.lower()
+        and "samesite=strict" in header.lower()
+        for header in set_cookie_headers
+    )
+
+    stored_cookie = async_client.cookies.get("access_token")
+    assert stored_cookie is not None and stored_cookie != ""
+
+    profile_response = await async_client.get(
+        "/users/me",
+        headers={"Cookie": f"access_token={stored_cookie}"},
+    )
+    assert profile_response.status_code == 200
+    assert profile_response.json()["email"] == user.email
+
+
+async def test_logout_clears_cookie(async_client, user_factory):
+    password = "AnotherPass456!"
+    user = await _create_active_user(user_factory, password)
+
+    login_response = await _login(async_client, user.email, password)
+    assert login_response.status_code == 200
+    assert async_client.cookies.get("access_token")
+
+    logout_response = await async_client.post("/auth/logout")
+    assert logout_response.status_code == 200
+
+    logout_cookies = logout_response.headers.get_list("set-cookie")
+    assert any(
+        header.lower().startswith("access_token=") and "max-age=0" in header.lower()
+        for header in logout_cookies
+    )
+
+    assert async_client.cookies.get("access_token") is None
+
+    profile_response = await async_client.get("/users/me")
+    assert profile_response.status_code == 401


### PR DESCRIPTION
## Summary
- issue secure HttpOnly SameSite=Strict cookies from the login endpoints and read them during request authentication
- rework the frontend auth client/context to drop localStorage tokens, migrate cached profiles, and rely on credentialed API calls
- add end-to-end tests covering cookie-based login/logout behaviour

## Testing
- pytest root/tests/test_auth_cookie_flow.py
- pytest root/tests/test_auth_security.py
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68ec445e241483279c498de649b82792