### PR TITLE
Add dependency-based sensitive rate limiter

### DIFF
--- a/root/app/api/users.py
+++ b/root/app/api/users.py
@@ -29,6 +29,7 @@ from app.core.config import settings
 from app.core.database import get_db
 from app.models import models
 from app.schemas import schemas
+from app.utils.ratelimit import sensitive_route_limit
 
 logger = logging.getLogger(__name__)
 
@@ -123,7 +124,10 @@ def _send_reset_email(to_email: str, link: str, full_name: str = "") -> None:
         )
 
 
-@password_router.post("/forgot")
+@password_router.post(
+    "/forgot",
+    dependencies=[Depends(sensitive_route_limit())],
+)
 async def forgot_password(
     payload: schemas.ForgotPasswordIn,
     bg: BackgroundTasks,
@@ -149,7 +153,10 @@ async def forgot_password(
     return {"ok": True}
 
 
-@password_router.post("/reset")
+@password_router.post(
+    "/reset",
+    dependencies=[Depends(sensitive_route_limit())],
+)
 async def reset_password(
     payload: schemas.ResetPasswordIn, db: AsyncSession = Depends(get_db)
 ):

--- a/root/app/auth/auth.py
+++ b/root/app/auth/auth.py
@@ -15,6 +15,7 @@ from app.core.config import settings
 from app.core.database import get_db
 from app.models.models import User
 from app.schemas.schemas import Token, UserCreate
+from app.utils.ratelimit import sensitive_route_limit
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
@@ -59,7 +60,11 @@ def _clear_access_token_cookie(response: Response) -> None:
     )
 
 
-@router.post("/login", response_model=Token)
+@router.post(
+    "/login",
+    response_model=Token,
+    dependencies=[Depends(sensitive_route_limit())],
+)
 async def login(
     response: Response,
     form_data: OAuth2PasswordRequestForm = Depends(OAuth2PasswordRequestForm),
@@ -100,7 +105,11 @@ async def login(
     return {"access_token": token, "token_type": "bearer"}
 
 
-@router.post("/login-json", response_model=Token)
+@router.post(
+    "/login-json",
+    response_model=Token,
+    dependencies=[Depends(sensitive_route_limit())],
+)
 async def login_json(
     payload: LoginIn,
     response: Response,

--- a/root/app/utils/ratelimit.py
+++ b/root/app/utils/ratelimit.py
@@ -1,10 +1,33 @@
 from __future__ import annotations
 
 import time
-from functools import wraps
-from typing import Callable
+from typing import Awaitable, Callable
 
 from fastapi import HTTPException, Request, status
+
+from app.core.config import settings
+
+DEFAULT_LIMIT = 5
+DEFAULT_WINDOW_SECONDS = 60
+
+_TIME_UNITS = {
+    "s": 1,
+    "sec": 1,
+    "second": 1,
+    "seconds": 1,
+    "m": 60,
+    "min": 60,
+    "mins": 60,
+    "minute": 60,
+    "minutes": 60,
+    "h": 3600,
+    "hr": 3600,
+    "hour": 3600,
+    "hours": 3600,
+    "d": 86400,
+    "day": 86400,
+    "days": 86400,
+}
 
 
 class MemoryLimiter:
@@ -12,8 +35,11 @@ class MemoryLimiter:
         self.bucket: dict[str, list[float]] = {}
 
     def check(self, key: str, limit: int, window_sec: int) -> None:
+        if limit <= 0 or window_sec <= 0:
+            return
         now = time.time()
-        arr = [t for t in self.bucket.get(key, []) if now - t < window_sec]
+        cutoff = now - window_sec
+        arr = [timestamp for timestamp in self.bucket.get(key, []) if timestamp > cutoff]
         if len(arr) >= limit:
             raise HTTPException(
                 status_code=status.HTTP_429_TOO_MANY_REQUESTS,
@@ -22,19 +48,69 @@ class MemoryLimiter:
         arr.append(now)
         self.bucket[key] = arr
 
+    def reset(self) -> None:
+        self.bucket.clear()
+
 
 limiter = MemoryLimiter()
 
 
-def sensitive_route_limit(limit: int = 5, window_sec: int = 60) -> Callable:
-    def decorator(func: Callable) -> Callable:
-        @wraps(func)
-        async def wrapper(request: Request, *args, **kwargs):
-            ip = request.client.host if request.client else "unknown"
-            key = f"sensitive:{ip}:{request.url.path}"
-            limiter.check(key, limit, window_sec)
-            return await func(request, *args, **kwargs)
+def _parse_rate_limit(value: str | None) -> tuple[int, int]:
+    if not value:
+        return DEFAULT_LIMIT, DEFAULT_WINDOW_SECONDS
 
-        return wrapper
+    normalized = value.strip().lower()
+    if not normalized:
+        return DEFAULT_LIMIT, DEFAULT_WINDOW_SECONDS
 
-    return decorator
+    normalized = normalized.replace("per", "/")
+    if "/" in normalized:
+        parts = normalized.split("/", 1)
+    else:
+        parts = normalized.split()
+
+    if len(parts) != 2:
+        return DEFAULT_LIMIT, DEFAULT_WINDOW_SECONDS
+
+    count_raw, unit_raw = (part.strip() for part in parts)
+    try:
+        count = int(count_raw)
+    except ValueError:
+        return DEFAULT_LIMIT, DEFAULT_WINDOW_SECONDS
+
+    unit_key = unit_raw.rstrip("s")
+    seconds = _TIME_UNITS.get(unit_raw) or _TIME_UNITS.get(unit_key)
+    if seconds is None:
+        try:
+            seconds = int(unit_raw)
+        except ValueError:
+            return DEFAULT_LIMIT, DEFAULT_WINDOW_SECONDS
+
+    if count <= 0 or seconds <= 0:
+        return DEFAULT_LIMIT, DEFAULT_WINDOW_SECONDS
+
+    return count, seconds
+
+
+def _resolve_limits(override_limit: int | None, override_window: int | None) -> tuple[int, int]:
+    default_limit, default_window = _parse_rate_limit(settings.rate_limit_sensitive_value)
+    limit = default_limit if override_limit is None else override_limit
+    window = default_window if override_window is None else override_window
+    return limit, window
+
+
+def sensitive_route_limit(
+    limit: int | None = None,
+    window_sec: int | None = None,
+    *,
+    key_prefix: str = "sensitive",
+) -> Callable[[Request], Awaitable[None]]:
+    async def dependency(request: Request) -> None:
+        resolved_limit, resolved_window = _resolve_limits(limit, window_sec)
+        if resolved_limit <= 0 or resolved_window <= 0:
+            return
+        ip = request.client.host if request.client else "unknown"
+        key = f"{key_prefix}:{ip}:{request.url.path}"
+        limiter.check(key, resolved_limit, resolved_window)
+
+    return dependency

--- a/root/app/utils/ratelimit.py
+++ b/root/app/utils/ratelimit.py
@@ -39,7 +39,9 @@ class MemoryLimiter:
             return
         now = time.time()
         cutoff = now - window_sec
-        arr = [timestamp for timestamp in self.bucket.get(key, []) if timestamp > cutoff]
+        arr = [
+            timestamp for timestamp in self.bucket.get(key, []) if timestamp > cutoff
+        ]
         if len(arr) >= limit:
             raise HTTPException(
                 status_code=status.HTTP_429_TOO_MANY_REQUESTS,
@@ -92,8 +94,12 @@ def _parse_rate_limit(value: str | None) -> tuple[int, int]:
     return count, seconds
 
 
-def _resolve_limits(override_limit: int | None, override_window: int | None) -> tuple[int, int]:
-    default_limit, default_window = _parse_rate_limit(settings.rate_limit_sensitive_value)
+def _resolve_limits(
+    override_limit: int | None, override_window: int | None
+) -> tuple[int, int]:
+    default_limit, default_window = _parse_rate_limit(
+        settings.rate_limit_sensitive_value
+    )
     limit = default_limit if override_limit is None else override_limit
     window = default_window if override_window is None else override_window
     return limit, window

--- a/root/tests/conftest.py
+++ b/root/tests/conftest.py
@@ -2,7 +2,7 @@ import asyncio
 import os
 import sys
 import uuid
-from collections.abc import AsyncIterator, Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
 from pathlib import Path
 
 import fakeredis.aioredis
@@ -73,6 +73,7 @@ from app.core.database import Base, async_session, engine
 from app.core.rate_limit import set_rate_limit_client_factory
 from app.deps import cache as cache_module
 from app.models import models
+from app.utils import ratelimit as ratelimit_module
 
 
 @pytest.fixture(scope="session")
@@ -122,6 +123,15 @@ async def configure_rate_limit(
         yield
     finally:
         await _rate_limit_redis_client.flushall()
+
+
+@pytest.fixture(autouse=True)
+def reset_sensitive_rate_limiter() -> Iterator[None]:
+    ratelimit_module.limiter.reset()
+    try:
+        yield
+    finally:
+        ratelimit_module.limiter.reset()
 
 
 @pytest.fixture

--- a/root/tests/test_rate_limit.py
+++ b/root/tests/test_rate_limit.py
@@ -1,4 +1,7 @@
 import pytest
+from fastapi import status
+
+from app.auth.security import get_password_hash
 
 
 @pytest.mark.anyio
@@ -25,3 +28,34 @@ async def test_rate_limit_per_token(async_client):
         "/healthz", headers={"Authorization": "Bearer token-b"}
     )
     assert other.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_sensitive_login_rate_limit(async_client, user_factory):
+    password = "ValidPass123!"
+    user = await user_factory(
+        email="login-rate@example.com",
+        hashed_password=get_password_hash(password),
+    )
+    data = {"username": user.email, "password": "wrong-password"}
+    headers = {"Content-Type": "application/x-www-form-urlencoded"}
+
+    for _ in range(5):
+        response = await async_client.post("/auth/login", data=data, headers=headers)
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    blocked = await async_client.post("/auth/login", data=data, headers=headers)
+    assert blocked.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+
+
+@pytest.mark.anyio
+async def test_sensitive_forgot_password_rate_limit(async_client, user_factory):
+    user = await user_factory(email="forgot-rate@example.com")
+    payload = {"email": user.email}
+
+    for _ in range(5):
+        response = await async_client.post("/password/forgot", json=payload)
+        assert response.status_code == status.HTTP_200_OK
+
+    blocked = await async_client.post("/password/forgot", json=payload)
+    assert blocked.status_code == status.HTTP_429_TOO_MANY_REQUESTS


### PR DESCRIPTION
## Summary
- add a dependency-based helper for sensitive rate limiting that reads defaults from configuration
- apply the new limiter to login and password recovery endpoints
- reset the in-memory limiter between tests and cover the new limits with API tests

## Testing
- pytest root/tests/test_rate_limit.py

------
https://chatgpt.com/codex/tasks/task_e_68ecd92cf2f883278c661ecbd3fe31a3