### PR TITLE
Normalize user email updates and add tests

### DIFF
--- a/root/app/api/users.py
+++ b/root/app/api/users.py
@@ -18,6 +18,7 @@ from fastapi import (
     UploadFile,
     status,
 )
+from pydantic import EmailStr, TypeAdapter
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -30,7 +31,6 @@ from app.core.database import get_db
 from app.models import models
 from app.schemas import schemas
 from app.utils.ratelimit import sensitive_route_limit
-from pydantic import EmailStr, TypeAdapter
 
 logger = logging.getLogger(__name__)
 
@@ -215,7 +215,9 @@ async def update_me(
         adapter = TypeAdapter(EmailStr)
         try:
             validated_email = adapter.validate_python(raw_email)
-        except ValueError as exc:  # pragma: no cover - defensive, TypeAdapter raises ValueError
+        except (
+            ValueError
+        ) as exc:  # pragma: no cover - defensive, TypeAdapter raises ValueError
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Некорректный email",

--- a/root/app/api/users.py
+++ b/root/app/api/users.py
@@ -30,6 +30,7 @@ from app.core.database import get_db
 from app.models import models
 from app.schemas import schemas
 from app.utils.ratelimit import sensitive_route_limit
+from pydantic import EmailStr, TypeAdapter
 
 logger = logging.getLogger(__name__)
 
@@ -207,7 +208,34 @@ async def update_me(
     user: models.User = Depends(get_current_user),
 ):
     db_user = await db.get(models.User, user.id)
-    for field, value in data.model_dump(exclude_unset=True).items():
+    update_fields = data.model_dump(exclude_unset=True)
+
+    if "email" in update_fields and update_fields["email"] is not None:
+        raw_email = str(update_fields["email"]).strip().lower()
+        adapter = TypeAdapter(EmailStr)
+        try:
+            validated_email = adapter.validate_python(raw_email)
+        except ValueError as exc:  # pragma: no cover - defensive, TypeAdapter raises ValueError
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Некорректный email",
+            ) from exc
+
+        existing = await db.execute(
+            select(models.User.id).where(
+                models.User.email == validated_email,
+                models.User.id != user.id,
+            )
+        )
+        if existing.scalar_one_or_none() is not None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Указанный email уже используется",
+            )
+
+        update_fields["email"] = validated_email
+
+    for field, value in update_fields.items():
         setattr(db_user, field, value)
     await db.commit()
     await db.refresh(db_user)

--- a/root/tests/test_user_profile_update.py
+++ b/root/tests/test_user_profile_update.py
@@ -1,0 +1,68 @@
+import pytest
+from httpx import AsyncClient
+
+from app.auth.security import get_password_hash
+from app.models import models
+
+
+async def _login(async_client: AsyncClient, email: str, password: str) -> dict[str, str]:
+    response = await async_client.post(
+        "/auth/login",
+        data={"username": email, "password": password},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert response.status_code == 200
+    token = response.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.mark.anyio
+async def test_update_profile_email_normalizes(async_client, user_factory, db_session):
+    password = "ChangeEmail123!"
+    hashed = get_password_hash(password)
+    user = await user_factory(
+        email="original@example.com",
+        hashed_password=hashed,
+        is_active=True,
+    )
+
+    headers = await _login(async_client, user.email, password)
+
+    response = await async_client.put(
+        "/users/me",
+        json={"email": "New.Email@Example.com  "},
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["email"] == "new.email@example.com"
+
+    await db_session.refresh(user)
+    assert user.email == "new.email@example.com"
+
+
+@pytest.mark.anyio
+async def test_update_profile_email_duplicate(async_client, user_factory, db_session):
+    password = "DuplicateEmail123!"
+    hashed = get_password_hash(password)
+    user = await user_factory(
+        email="first-user@example.com",
+        hashed_password=hashed,
+        is_active=True,
+    )
+    await user_factory(email="existing@example.com", is_active=True)
+
+    headers = await _login(async_client, user.email, password)
+
+    response = await async_client.put(
+        "/users/me",
+        json={"email": "Existing@Example.com"},
+        headers=headers,
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Указанный email уже используется"}
+
+    await db_session.refresh(user)
+    assert user.email == "first-user@example.com"

--- a/root/tests/test_user_profile_update.py
+++ b/root/tests/test_user_profile_update.py
@@ -5,7 +5,9 @@ from app.auth.security import get_password_hash
 from app.models import models
 
 
-async def _login(async_client: AsyncClient, email: str, password: str) -> dict[str, str]:
+async def _login(
+    async_client: AsyncClient, email: str, password: str
+) -> dict[str, str]:
     response = await async_client.post(
         "/auth/login",
         data={"username": email, "password": password},


### PR DESCRIPTION
## Summary
- normalize email updates in the user profile endpoint and ensure uniqueness checks
- return clear 400 responses for duplicate or invalid email updates
- add tests covering email normalization and duplicate rejection

## Testing
- pytest root/tests/test_user_profile_update.py

------
https://chatgpt.com/codex/tasks/task_e_68ed196e69ac8327af30b83dd7f1a0fb