### PR TITLE
Improve scheduler loop error handling

### DIFF
--- a/root/app/services/notifications.py
+++ b/root/app/services/notifications.py
@@ -639,9 +639,7 @@ async def _scheduler_loop(
             sleep_for = poll_seconds
             try:
                 async with async_session() as db:
-                    await generate_schedule_reminders(
-                        db, window_minutes=window_minutes
-                    )
+                    await generate_schedule_reminders(db, window_minutes=window_minutes)
             except Exception:
                 consecutive_failures += 1
                 sleep_for = min(

--- a/root/app/services/notifications.py
+++ b/root/app/services/notifications.py
@@ -624,15 +624,38 @@ async def aggregate_notification_delivery_stats(
     return stats
 
 
-async def _scheduler_loop(poll_seconds: int = 30, window_minutes: int = 6):
+async def _scheduler_loop(
+    poll_seconds: int = 30,
+    window_minutes: int = 6,
+    *,
+    max_backoff_seconds: int = 300,
+):
+    """Run reminders scheduler loop with exponential backoff on failures."""
+
+    consecutive_failures = 0
+
     try:
         while True:
+            sleep_for = poll_seconds
             try:
                 async with async_session() as db:
-                    await generate_schedule_reminders(db, window_minutes=window_minutes)
+                    await generate_schedule_reminders(
+                        db, window_minutes=window_minutes
+                    )
             except Exception:
-                pass
-            await asyncio.sleep(poll_seconds)
+                consecutive_failures += 1
+                sleep_for = min(
+                    poll_seconds * (2 ** min(consecutive_failures, 5)),
+                    max_backoff_seconds,
+                )
+                logger.exception(
+                    "Failed to generate schedule reminders (attempt %s)",
+                    consecutive_failures,
+                )
+            else:
+                consecutive_failures = 0
+
+            await asyncio.sleep(sleep_for)
     except asyncio.CancelledError:
         return
 

--- a/root/tests/test_notifications_service.py
+++ b/root/tests/test_notifications_service.py
@@ -1,4 +1,6 @@
+import asyncio
 import datetime as dt
+import logging
 
 import pytest
 from sqlalchemy import select
@@ -166,3 +168,33 @@ async def test_create_notifications_records_skip_without_credentials(
     assert delivery.status == "skipped_no_credentials"
     assert delivery.delivered_at is None
     _reset_vapid_cache()
+
+
+@pytest.mark.anyio
+async def test_scheduler_loop_logs_failures(monkeypatch: pytest.MonkeyPatch, caplog):
+    class _DummySession:
+        async def __aenter__(self):
+            return object()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    async def _failing_generate(*_args, **_kwargs):
+        raise RuntimeError("boom")
+
+    async def _cancel_sleep(_seconds: float):
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(notifications_module, "async_session", lambda: _DummySession())
+    monkeypatch.setattr(
+        notifications_module,
+        "generate_schedule_reminders",
+        _failing_generate,
+    )
+    monkeypatch.setattr(notifications_module.asyncio, "sleep", _cancel_sleep)
+
+    caplog.set_level(logging.ERROR, logger=notifications_module.logger.name)
+
+    await notifications_module._scheduler_loop(poll_seconds=1, window_minutes=1)
+
+    assert any("Failed to generate schedule reminders" in record.getMessage() for record in caplog.records)

--- a/root/tests/test_notifications_service.py
+++ b/root/tests/test_notifications_service.py
@@ -197,4 +197,7 @@ async def test_scheduler_loop_logs_failures(monkeypatch: pytest.MonkeyPatch, cap
 
     await notifications_module._scheduler_loop(poll_seconds=1, window_minutes=1)
 
-    assert any("Failed to generate schedule reminders" in record.getMessage() for record in caplog.records)
+    assert any(
+        "Failed to generate schedule reminders" in record.getMessage()
+        for record in caplog.records
+    )


### PR DESCRIPTION
## Summary
- log scheduler failures and add exponential backoff to avoid tight retry loops
- add a regression test verifying scheduler errors are captured in logs

## Testing
- `pytest root/tests/test_notifications_service.py::test_scheduler_loop_logs_failures`


------
https://chatgpt.com/codex/tasks/task_e_68ed221e8c408327b18c098104fd32d1