### PR TITLE
Clean up static images when updating or deleting news and events

### DIFF
--- a/root/app/api/events.py
+++ b/root/app/api/events.py
@@ -153,10 +153,13 @@ async def update_event(
         raise HTTPException(status_code=404, detail="Событие не найдено")
     if user.role not in ("admin", "teacher") and q.created_by != user.id:
         raise HTTPException(status_code=403, detail="forbidden")
+    old_image_url = q.image_url
     try:
         q = await crud.update_event(db, q, data)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if old_image_url and q.image_url != old_image_url:
+        await delete_static_file(old_image_url)
     files = (
         (
             await db.execute(
@@ -190,6 +193,7 @@ async def delete_event(
         raise HTTPException(status_code=404, detail="Событие не найдено")
     if user.role not in ("admin", "teacher") and q.created_by != user.id:
         raise HTTPException(status_code=403, detail="forbidden")
+    event_image_url = q.image_url
     file_urls = [
         row[0]
         for row in (
@@ -206,6 +210,8 @@ async def delete_event(
     )
     await db.delete(q)
     await db.commit()
+    if event_image_url:
+        await delete_static_file(event_image_url)
     for url in file_urls:
         await delete_static_file(url)
     return {"ok": True}

--- a/root/app/api/news.py
+++ b/root/app/api/news.py
@@ -22,6 +22,7 @@ from app.deps.cache import etag_matches, format_etag, get_cache
 from app.models import models
 from app.schemas import schemas
 from app.services.notifications import notify_about_news
+from app.utils.files import delete_static_file
 
 logger = logging.getLogger(__name__)
 
@@ -127,10 +128,13 @@ async def update_news(
         raise HTTPException(status_code=404, detail="Новость не найдена")
     if user.role != "admin":
         raise HTTPException(status_code=403, detail="forbidden")
+    old_image_url = news.image_url
     for field, value in data.model_dump(exclude_unset=True).items():
         setattr(news, field, value)
     await db.commit()
     await db.refresh(news)
+    if old_image_url and news.image_url != old_image_url:
+        await delete_static_file(old_image_url)
     cache = get_cache()
     await cache.invalidate(_NEWS_LIST_CACHE_KEY, _news_item_cache_key(id))
     return news
@@ -147,8 +151,11 @@ async def delete_news(
         raise HTTPException(status_code=404, detail="Новость не найдена")
     if user.role != "admin":
         raise HTTPException(status_code=403, detail="forbidden")
+    image_url = news.image_url
     await db.delete(news)
     await db.commit()
+    if image_url:
+        await delete_static_file(image_url)
     cache = get_cache()
     await cache.invalidate(_NEWS_LIST_CACHE_KEY, _news_item_cache_key(id))
     return {"ok": True}

--- a/root/tests/test_event_file_upload.py
+++ b/root/tests/test_event_file_upload.py
@@ -10,6 +10,7 @@ from starlette.datastructures import Headers
 from app.api import events
 from app.core.config import settings
 from app.models import models
+from app.schemas import schemas
 from app.utils import files
 
 
@@ -121,6 +122,31 @@ async def test_upload_event_file_rejects_forbidden_type(
 
 
 @pytest.mark.anyio("asyncio")
+async def test_update_event_replaces_image_removes_old_file(
+    tmp_path, monkeypatch, db_session, user_factory
+):
+    admin = await user_factory(role="admin")
+    event = await _create_event(db_session, admin)
+
+    old_filename = "old.png"
+    old_path = tmp_path / "event_images" / old_filename
+    old_path.parent.mkdir(parents=True, exist_ok=True)
+    old_path.write_bytes(b"old")
+
+    event.image_url = f"/static/event_images/{old_filename}"
+    await db_session.commit()
+    await db_session.refresh(event)
+
+    monkeypatch.setattr(settings, "static_dir_path", tmp_path)
+
+    payload = schemas.EventUpdate(image_url="/static/event_images/new.png")
+    result = await events.update_event(event.id, payload, db=db_session, user=admin)
+
+    assert result.image_url == "/static/event_images/new.png"
+    assert not old_path.exists()
+
+
+@pytest.mark.anyio("asyncio")
 async def test_delete_event_file_removes_payload(
     tmp_path, monkeypatch, db_session, user_factory
 ):
@@ -164,6 +190,13 @@ async def test_delete_event_removes_all_files(
     monkeypatch.setattr(settings, "event_file_allowed_extensions", [".txt"])
     monkeypatch.setattr(settings, "event_file_max_size_bytes", 1024)
 
+    image_path = tmp_path / "event_images" / "banner.png"
+    image_path.parent.mkdir(parents=True, exist_ok=True)
+    image_path.write_bytes(b"banner")
+    event.image_url = "/static/event_images/banner.png"
+    await db_session.commit()
+    await db_session.refresh(event)
+
     stored_paths = []
     for idx in range(2):
         upload = UploadFile(
@@ -186,6 +219,7 @@ async def test_delete_event_removes_all_files(
     assert result == {"ok": True}
     for path in stored_paths:
         assert not path.exists()
+    assert not image_path.exists()
     remaining_files = (
         await db_session.execute(
             select(models.EventFile).where(models.EventFile.event_id == event.id)

--- a/root/tests/test_news_image_cleanup.py
+++ b/root/tests/test_news_image_cleanup.py
@@ -11,7 +11,9 @@ async def test_update_news_removes_replaced_image(
     tmp_path, monkeypatch, db_session, user_factory
 ):
     admin = await user_factory(role="admin")
-    record = models.News(title="Title", content="Body", image_url="/static/news_images/old.png")
+    record = models.News(
+        title="Title", content="Body", image_url="/static/news_images/old.png"
+    )
     db_session.add(record)
     await db_session.commit()
     await db_session.refresh(record)
@@ -39,7 +41,9 @@ async def test_delete_news_removes_image_file(
     tmp_path, monkeypatch, db_session, user_factory
 ):
     admin = await user_factory(role="admin")
-    record = models.News(title="Title", content="Body", image_url="/static/news_images/old.png")
+    record = models.News(
+        title="Title", content="Body", image_url="/static/news_images/old.png"
+    )
     db_session.add(record)
     await db_session.commit()
     await db_session.refresh(record)

--- a/root/tests/test_news_image_cleanup.py
+++ b/root/tests/test_news_image_cleanup.py
@@ -1,0 +1,57 @@
+import pytest
+
+from app.api import news
+from app.core.config import settings
+from app.models import models
+from app.schemas import schemas
+
+
+@pytest.mark.anyio("asyncio")
+async def test_update_news_removes_replaced_image(
+    tmp_path, monkeypatch, db_session, user_factory
+):
+    admin = await user_factory(role="admin")
+    record = models.News(title="Title", content="Body", image_url="/static/news_images/old.png")
+    db_session.add(record)
+    await db_session.commit()
+    await db_session.refresh(record)
+
+    old_path = tmp_path / "news_images" / "old.png"
+    old_path.parent.mkdir(parents=True, exist_ok=True)
+    old_path.write_bytes(b"old")
+
+    monkeypatch.setattr(settings, "static_dir_path", tmp_path)
+
+    payload = schemas.NewsCreate(
+        title=record.title,
+        content=record.content,
+        image_url="/static/news_images/new.png",
+    )
+
+    updated = await news.update_news(record.id, payload, db=db_session, user=admin)
+
+    assert updated.image_url == "/static/news_images/new.png"
+    assert not old_path.exists()
+
+
+@pytest.mark.anyio("asyncio")
+async def test_delete_news_removes_image_file(
+    tmp_path, monkeypatch, db_session, user_factory
+):
+    admin = await user_factory(role="admin")
+    record = models.News(title="Title", content="Body", image_url="/static/news_images/old.png")
+    db_session.add(record)
+    await db_session.commit()
+    await db_session.refresh(record)
+
+    image_path = tmp_path / "news_images" / "old.png"
+    image_path.parent.mkdir(parents=True, exist_ok=True)
+    image_path.write_bytes(b"payload")
+
+    monkeypatch.setattr(settings, "static_dir_path", tmp_path)
+
+    result = await news.delete_news(record.id, db=db_session, user=admin)
+
+    assert result == {"ok": True}
+    assert await db_session.get(models.News, record.id) is None
+    assert not image_path.exists()


### PR DESCRIPTION
## Summary
- delete old news and event images from the static directory when records are updated or removed
- extend event cleanup tests to cover image replacement and removal
- add dedicated news image cleanup tests using a temporary static directory

## Testing
- `pytest root/tests/test_event_file_upload.py root/tests/test_news_image_cleanup.py`


------
https://chatgpt.com/codex/tasks/task_e_68ed24894a0c8327b1992388f533968e