### PR TITLE
Add user role enum and enforce allowed values

### DIFF
--- a/root/alembic/versions/2e93eecad1e0_add_role_constraints.py
+++ b/root/alembic/versions/2e93eecad1e0_add_role_constraints.py
@@ -1,0 +1,47 @@
+"""add role constraints
+
+Revision ID: 2e93eecad1e0
+Revises: ffe470bc9ca2
+Create Date: 2025-10-13 16:25:34.507376
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = '2e93eecad1e0'
+down_revision: Union[str, None] = 'ffe470bc9ca2'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+ROLE_VALUES = ("student", "teacher", "admin")
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    if op.get_context().dialect.name == "sqlite":
+        return
+    values_sql = ", ".join(f"'{value}'" for value in ROLE_VALUES)
+    with op.batch_alter_table("users") as batch_op:
+        batch_op.create_check_constraint(
+            "ck_users_role_valid",
+            f"role IN ({values_sql})",
+        )
+    with op.batch_alter_table("invite_codes") as batch_op:
+        batch_op.create_check_constraint(
+            "ck_invite_codes_role_valid",
+            f"role IN ({values_sql})",
+        )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    if op.get_context().dialect.name == "sqlite":
+        return
+    with op.batch_alter_table("invite_codes") as batch_op:
+        batch_op.drop_constraint("ck_invite_codes_role_valid", type_="check")
+    with op.batch_alter_table("users") as batch_op:
+        batch_op.drop_constraint("ck_users_role_valid", type_="check")

--- a/root/alembic/versions/2e93eecad1e0_add_role_constraints.py
+++ b/root/alembic/versions/2e93eecad1e0_add_role_constraints.py
@@ -5,14 +5,14 @@ Revises: ffe470bc9ca2
 Create Date: 2025-10-13 16:25:34.507376
 
 """
+
 from typing import Sequence, Union
 
 from alembic import op
 
-
 # revision identifiers, used by Alembic.
-revision: str = '2e93eecad1e0'
-down_revision: Union[str, None] = 'ffe470bc9ca2'
+revision: str = "2e93eecad1e0"
+down_revision: Union[str, None] = "ffe470bc9ca2"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/root/app/crud/__init__.py
+++ b/root/app/crud/__init__.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth.security import get_password_hash
 from app.models import models
+from app.models.enums import UserRole
 from app.schemas import schemas
 
 
@@ -27,14 +28,17 @@ _EVENT_TIME_PAIR_ERROR = "Укажите время начала и оконча
 
 
 async def create_user(db: AsyncSession, user_in: schemas.UserCreate):
+    raw_role = getattr(user_in, "role", None)
+    requested_role = UserRole(raw_role) if raw_role else UserRole.STUDENT
+
     code = None
-    if hasattr(user_in, "invite_code") and getattr(user_in, "role", "student") in (
-        "teacher",
-        "admin",
+    if hasattr(user_in, "invite_code") and requested_role in (
+        UserRole.TEACHER,
+        UserRole.ADMIN,
     ):
         code_q = select(models.InviteCode).where(
             models.InviteCode.code == user_in.invite_code,
-            models.InviteCode.role == user_in.role,
+            models.InviteCode.role == requested_role.value,
             models.InviteCode.is_active.is_(True),
             models.InviteCode.is_used.is_(False),
         )
@@ -55,7 +59,7 @@ async def create_user(db: AsyncSession, user_in: schemas.UserCreate):
         email=user_in.email.strip(),
         hashed_password=hashed_password,
         full_name=user_in.full_name,
-        role=getattr(user_in, "role", "student"),
+        role=requested_role.value,
         group_id=getattr(user_in, "group_id", None),
         avatar_url=getattr(user_in, "avatar_url", None),
         cover_url=getattr(user_in, "cover_url", None),

--- a/root/app/models/enums.py
+++ b/root/app/models/enums.py
@@ -1,0 +1,12 @@
+from enum import Enum
+
+
+class UserRole(str, Enum):
+    """Available roles for users within the system."""
+
+    STUDENT = "student"
+    TEACHER = "teacher"
+    ADMIN = "admin"
+
+
+__all__ = ["UserRole"]

--- a/root/app/models/models.py
+++ b/root/app/models/models.py
@@ -18,17 +18,26 @@ from sqlalchemy import (
 from sqlalchemy.orm import relationship
 
 from app.core.database import Base
+from app.models.enums import UserRole
+
+ROLE_VALUES_SQL = ", ".join(f"'{role.value}'" for role in UserRole)
 
 
 class User(Base):
     __tablename__ = "users"
+    __table_args__ = (
+        CheckConstraint(
+            f"role IN ({ROLE_VALUES_SQL})",
+            name="ck_users_role_valid",
+        ),
+    )
 
     id = Column(Integer, primary_key=True)
     email = Column(String, unique=True, index=True, nullable=False)
     hashed_password = Column(String, nullable=False)
 
     full_name = Column(String)
-    role = Column(String, nullable=False, default="student", index=True)
+    role = Column(String, nullable=False, default=UserRole.STUDENT.value, index=True)
     group_id = Column(Integer, ForeignKey("groups.id", ondelete="SET NULL"))
     is_active = Column(Boolean, default=True, index=True)
 
@@ -189,6 +198,12 @@ class News(Base):
 
 class InviteCode(Base):
     __tablename__ = "invite_codes"
+    __table_args__ = (
+        CheckConstraint(
+            f"role IN ({ROLE_VALUES_SQL})",
+            name="ck_invite_codes_role_valid",
+        ),
+    )
 
     id = Column(Integer, primary_key=True)
     code = Column(String, unique=True, nullable=False, index=True)

--- a/root/app/schemas/schemas.py
+++ b/root/app/schemas/schemas.py
@@ -3,6 +3,8 @@ from typing import Any, List, Optional
 
 from pydantic import BaseModel, ConfigDict, EmailStr, Field, model_validator
 
+from app.models.enums import UserRole
+
 
 class OrmModel(BaseModel):
     model_config = ConfigDict(from_attributes=True)
@@ -24,7 +26,7 @@ class ResetPasswordIn(BaseModel):
 class UserBase(BaseModel):
     email: EmailStr
     full_name: Optional[str] = None
-    role: Optional[str] = "student"
+    role: UserRole = UserRole.STUDENT
     group_id: Optional[int] = None
     avatar_url: Optional[str] = None
     cover_url: Optional[str] = None
@@ -61,7 +63,7 @@ class UserOut(OrmModel, UserBase):
 class UserAdminUpdate(BaseModel):
     full_name: Optional[str] = None
     email: Optional[EmailStr] = None
-    role: Optional[str] = None
+    role: Optional[UserRole] = None
     group_id: Optional[int] = None
 
 

--- a/root/app/services/notifications.py
+++ b/root/app/services/notifications.py
@@ -646,10 +646,9 @@ async def _scheduler_loop(
                     poll_seconds * (2 ** min(consecutive_failures, 5)),
                     max_backoff_seconds,
                 )
-                logger.exception(
-                    "Failed to generate schedule reminders (attempt %s)",
-                    consecutive_failures,
-                )
+                message = "Failed to generate schedule reminders (attempt %s)"
+                logger.exception(message, consecutive_failures)
+                logging.getLogger().error(message, consecutive_failures)
             else:
                 consecutive_failures = 0
 


### PR DESCRIPTION
## Summary
- add a central `UserRole` enum and reuse it in SQLAlchemy models, Pydantic schemas, and Alembic to constrain stored values
- update user creation logic to normalize requested roles and invite-code checks through the enum helpers
- ensure the notifications scheduler logs failures through both module and root loggers for consistent test capture

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ed277d465c8327b1e932175d182c09