### PR TITLE
Add standalone notifications worker with metrics

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       DATABASE_URL: postgresql+psycopg://postgres:postgres@postgres:5432/university
       FRONTEND_ORIGIN: http://localhost:5173
       FRONTEND_ORIGINS: http://localhost:5173
+      NOTIFICATIONS_SCHEDULER_INLINE_ENABLED: "false"
     depends_on:
       postgres:
         condition: service_healthy
@@ -31,6 +32,25 @@ services:
         condition: service_healthy
     ports:
       - "5173:5173"
+
+  notifications-worker:
+    build:
+      context: .
+      dockerfile: root/backend.Dockerfile
+      target: runtime
+    command: python -m app.workers.notifications
+    env_file:
+      - root/.env
+    environment:
+      DATABASE_URL: postgresql+psycopg://postgres:postgres@postgres:5432/university
+      NOTIFICATIONS_WORKER_METRICS_HOST: 0.0.0.0
+      NOTIFICATIONS_WORKER_METRICS_PORT: "9101"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: unless-stopped
+    ports:
+      - "9101:9101"
 
   postgres:
     image: postgres:16-alpine

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -44,3 +44,10 @@ server {
 ```
 
 > Альтернатива: указывайте `VITE_BACKEND_ORIGIN=https://api.example.com` и отдавайте `/media`/`/static` напрямую с API-домена (без прокси), сохраняя полное HTTPS-соединение.
+
+## Notifications worker
+
+- Для корректной отправки push-уведомлений запустите отдельный воркер: `python -m app.workers.notifications`.
+- При запуске API и воркера в разных процессах выключите встроенный планировщик в API, установив `NOTIFICATIONS_SCHEDULER_INLINE_ENABLED=false`.
+- Воркер публикует здоровье и метрики Prometheus на `http://<host>:9101/healthz` и `http://<host>:9101/metrics` (порт можно изменить через `NOTIFICATIONS_WORKER_METRICS_PORT`).
+- В docker-compose уже добавлен сервис `notifications-worker` с политикой перезапуска `unless-stopped`.

--- a/root/app/core/config.py
+++ b/root/app/core/config.py
@@ -134,6 +134,12 @@ class Settings(BaseSettings):
     cache_enabled: bool = False
     cache_redis_url: str = "redis://127.0.0.1:6379/0"
     cache_default_ttl_seconds: int = 300
+    notifications_scheduler_poll_seconds: int = 30
+    notifications_scheduler_window_minutes: int = 6
+    notifications_scheduler_max_backoff_seconds: int = 300
+    notifications_scheduler_inline_enabled: bool = True
+    notifications_worker_metrics_host: str = "0.0.0.0"
+    notifications_worker_metrics_port: int = 9101
     event_file_allowed_mime_types: str | list[str] = (
         "application/pdf,"
         "text/plain,"

--- a/root/app/core/observability.py
+++ b/root/app/core/observability.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
+import re
 import socket
+import time
 import uuid
 from contextlib import suppress
 from contextvars import ContextVar
-from typing import Any, Iterable, Mapping
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Iterable, Mapping
 
 from fastapi import FastAPI
 from opentelemetry import metrics, trace
@@ -26,7 +30,25 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.sdk.trace.sampling import ParentBased, TraceIdRatioBased
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
-from starlette.responses import Response
+from starlette.responses import JSONResponse, Response
+import uvicorn
+
+try:
+    from prometheus_client import (
+        CONTENT_TYPE_LATEST,
+        CollectorRegistry,
+        Counter,
+        Gauge,
+        generate_latest,
+    )
+except Exception:  # pragma: no cover - optional dependency guard
+    CONTENT_TYPE_LATEST = "text/plain; version=0.0.4; charset=utf-8"
+    CollectorRegistry = None  # type: ignore[assignment]
+    Counter = None  # type: ignore[assignment]
+    Gauge = None  # type: ignore[assignment]
+
+    def generate_latest(_: object) -> bytes:  # type: ignore[misc]
+        raise RuntimeError("prometheus-client is required for worker metrics")
 
 try:
     from sentry_sdk import init as sentry_init
@@ -303,3 +325,186 @@ def shutdown_observability() -> None:
     if _otel_logger_provider is not None:
         with suppress(Exception):
             _otel_logger_provider.shutdown()
+
+
+def _sanitize_metric_name(name: str) -> str:
+    normalized = re.sub(r"[^a-zA-Z0-9_]", "_", name).strip("_")
+    return normalized or "worker"
+
+
+@dataclass
+class WorkerMetrics:
+    """Prometheus-compatible counters for long-running workers."""
+
+    name: str
+    registry: CollectorRegistry
+    runs_total: Counter
+    failures_total: Counter
+    notifications_created_total: Counter
+    last_run_timestamp: Gauge
+    last_success_timestamp: Gauge
+    heartbeat_timestamp: Gauge
+    _last_run: float | None = None
+    _last_success: float | None = None
+    _last_failure: float | None = None
+
+    def mark_startup(self) -> None:
+        now = time.time()
+        self.heartbeat_timestamp.set(now)
+        self._last_run = now
+
+    def record_success(self, notifications_created: int = 0) -> None:
+        self._record_cycle(success=True, notifications_created=notifications_created)
+
+    def record_failure(self) -> None:
+        self._record_cycle(success=False, notifications_created=0)
+
+    def _record_cycle(self, *, success: bool, notifications_created: int) -> None:
+        now = time.time()
+        self.last_run_timestamp.set(now)
+        self.heartbeat_timestamp.set(now)
+        self._last_run = now
+        if notifications_created:
+            self.notifications_created_total.inc(notifications_created)
+        if success:
+            self.runs_total.inc()
+            self.last_success_timestamp.set(now)
+            self._last_success = now
+        else:
+            self.failures_total.inc()
+            self._last_failure = now
+
+    @property
+    def last_run(self) -> float | None:
+        return self._last_run
+
+    @property
+    def last_success(self) -> float | None:
+        return self._last_success
+
+    @property
+    def last_failure(self) -> float | None:
+        return self._last_failure
+
+    @property
+    def status(self) -> str:
+        if (
+            self._last_failure is not None
+            and (self._last_success is None or self._last_failure > self._last_success)
+        ):
+            return "degraded"
+        return "ok"
+
+
+def create_worker_metrics(name: str) -> WorkerMetrics:
+    if CollectorRegistry is None or Counter is None or Gauge is None:  # pragma: no cover - safety
+        raise RuntimeError("prometheus-client is required to create worker metrics")
+
+    metric_name = _sanitize_metric_name(name)
+    registry = CollectorRegistry()
+    runs = Counter(
+        f"{metric_name}_runs_total",
+        "Total successful scheduler iterations",
+        registry=registry,
+    )
+    failures = Counter(
+        f"{metric_name}_failures_total",
+        "Total failed scheduler iterations",
+        registry=registry,
+    )
+    notifications_created = Counter(
+        f"{metric_name}_notifications_created_total",
+        "Total notifications created by the scheduler",
+        registry=registry,
+    )
+    last_run = Gauge(
+        f"{metric_name}_last_run_timestamp_seconds",
+        "Timestamp of the last scheduler iteration",
+        registry=registry,
+    )
+    last_success = Gauge(
+        f"{metric_name}_last_success_timestamp_seconds",
+        "Timestamp of the last successful scheduler iteration",
+        registry=registry,
+    )
+    heartbeat = Gauge(
+        f"{metric_name}_heartbeat_timestamp_seconds",
+        "Heartbeat timestamp updated on every scheduler iteration",
+        registry=registry,
+    )
+
+    metrics = WorkerMetrics(
+        name=name,
+        registry=registry,
+        runs_total=runs,
+        failures_total=failures,
+        notifications_created_total=notifications_created,
+        last_run_timestamp=last_run,
+        last_success_timestamp=last_success,
+        heartbeat_timestamp=heartbeat,
+    )
+    metrics.mark_startup()
+    return metrics
+
+
+def create_worker_monitoring_app(
+    *, worker_name: str, metrics: WorkerMetrics
+) -> FastAPI:
+    """Build a lightweight ASGI app exposing worker metrics and health."""
+
+    app = FastAPI(title=f"{worker_name} worker monitor", docs_url=None, redoc_url=None)
+
+    @app.get("/healthz")
+    async def healthz() -> JSONResponse:
+        payload = {
+            "status": metrics.status,
+            "worker": worker_name,
+            "last_run": metrics.last_run,
+            "last_success": metrics.last_success,
+            "last_failure": metrics.last_failure,
+        }
+        return JSONResponse(payload)
+
+    @app.get("/metrics")
+    async def metrics_endpoint() -> Response:
+        content = generate_latest(metrics.registry)
+        return Response(content, media_type=CONTENT_TYPE_LATEST)
+
+    return app
+
+
+async def start_worker_monitoring_server(
+    app: FastAPI, *, host: str, port: int
+) -> Callable[[], Awaitable[None]]:
+    """Start an embedded Uvicorn server for worker monitoring endpoints."""
+
+    if port <= 0:
+        raise ValueError("port must be a positive integer")
+
+    config = uvicorn.Config(
+        app,
+        host=host,
+        port=port,
+        loop="asyncio",
+        access_log=False,
+        log_config=None,
+        lifespan="on",
+    )
+    server = uvicorn.Server(config)
+    task = asyncio.create_task(server.serve())
+    await server.started.wait()
+
+    async def _stop() -> None:
+        if not server.should_exit:
+            server.should_exit = True
+        await task
+
+    return _stop
+
+
+def configure_worker_observability(*, worker_name: str | None = None) -> None:
+    """Configure logging for standalone worker processes."""
+
+    _configure_logging()
+    if worker_name:
+        logging.getLogger(__name__).info("Worker %s observability configured", worker_name)

--- a/root/app/core/observability.py
+++ b/root/app/core/observability.py
@@ -12,6 +12,7 @@ from contextvars import ContextVar
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Iterable, Mapping
 
+import uvicorn
 from fastapi import FastAPI
 from opentelemetry import metrics, trace
 from opentelemetry._logs import set_logger_provider
@@ -31,7 +32,6 @@ from opentelemetry.sdk.trace.sampling import ParentBased, TraceIdRatioBased
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
-import uvicorn
 
 try:
     from prometheus_client import (
@@ -49,6 +49,7 @@ except Exception:  # pragma: no cover - optional dependency guard
 
     def generate_latest(_: object) -> bytes:  # type: ignore[misc]
         raise RuntimeError("prometheus-client is required for worker metrics")
+
 
 try:
     from sentry_sdk import init as sentry_init
@@ -388,16 +389,17 @@ class WorkerMetrics:
 
     @property
     def status(self) -> str:
-        if (
-            self._last_failure is not None
-            and (self._last_success is None or self._last_failure > self._last_success)
+        if self._last_failure is not None and (
+            self._last_success is None or self._last_failure > self._last_success
         ):
             return "degraded"
         return "ok"
 
 
 def create_worker_metrics(name: str) -> WorkerMetrics:
-    if CollectorRegistry is None or Counter is None or Gauge is None:  # pragma: no cover - safety
+    if (
+        CollectorRegistry is None or Counter is None or Gauge is None
+    ):  # pragma: no cover - safety
         raise RuntimeError("prometheus-client is required to create worker metrics")
 
     metric_name = _sanitize_metric_name(name)
@@ -507,4 +509,6 @@ def configure_worker_observability(*, worker_name: str | None = None) -> None:
 
     _configure_logging()
     if worker_name:
-        logging.getLogger(__name__).info("Worker %s observability configured", worker_name)
+        logging.getLogger(__name__).info(
+            "Worker %s observability configured", worker_name
+        )

--- a/root/app/main.py
+++ b/root/app/main.py
@@ -37,7 +37,13 @@ async def lifespan(app: FastAPI):
     if settings.auto_create_schema:
         async with engine.begin() as conn:
             await conn.run_sync(Base.metadata.create_all)
-    stop_scheduler = await start_notifications_scheduler()
+    stop_scheduler = None
+    if settings.is_development and settings.notifications_scheduler_inline_enabled:
+        stop_scheduler = await start_notifications_scheduler(
+            poll_seconds=settings.notifications_scheduler_poll_seconds,
+            window_minutes=settings.notifications_scheduler_window_minutes,
+            max_backoff_seconds=settings.notifications_scheduler_max_backoff_seconds,
+        )
     try:
         yield
     finally:

--- a/root/app/services/notifications.py
+++ b/root/app/services/notifications.py
@@ -12,7 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.core.config import settings
-from app.core.database import async_session
+from app.core.database import async_session as _async_session
 from app.models.models import (
     Event,
     News,
@@ -624,83 +624,53 @@ async def aggregate_notification_delivery_stats(
     return stats
 
 
+async def start_notifications_scheduler(
+    *,
+    poll_seconds: int = 30,
+    window_minutes: int = 6,
+    max_backoff_seconds: int = 300,
+) -> Callable[[], Awaitable[None]]:
+    """Start background notifications scheduler via the worker implementation."""
+
+    from app.workers.notifications import start_notifications_scheduler as _start
+
+    return await _start(
+        poll_seconds=poll_seconds,
+        window_minutes=window_minutes,
+        max_backoff_seconds=max_backoff_seconds,
+    )
+
+
+# Backwards compatibility for tests that patch async_session on this module.
+async_session = _async_session
+
+
 async def _scheduler_loop(
     poll_seconds: int = 30,
     window_minutes: int = 6,
     *,
     max_backoff_seconds: int = 300,
-):
-    """Run reminders scheduler loop with exponential backoff on failures."""
+) -> None:
+    """Compatibility wrapper delegating to the worker scheduler loop."""
 
-    consecutive_failures = 0
+    from app.workers import notifications as worker_module
 
-    try:
-        while True:
-            sleep_for = poll_seconds
-            try:
-                async with async_session() as db:
-                    await generate_schedule_reminders(db, window_minutes=window_minutes)
-            except Exception:
-                consecutive_failures += 1
-                sleep_for = min(
-                    poll_seconds * (2 ** min(consecutive_failures, 5)),
-                    max_backoff_seconds,
-                )
-                message = "Failed to generate schedule reminders (attempt %s)"
-                logger.exception(message, consecutive_failures)
-                logging.getLogger().error(message, consecutive_failures)
-            else:
-                consecutive_failures = 0
-
-            await asyncio.sleep(sleep_for)
-    except asyncio.CancelledError:
-        return
-
-
-_scheduler_task: asyncio.Task[None] | None = None
-
-
-async def start_notifications_scheduler(
-    *, poll_seconds: int = 30, window_minutes: int = 6
-) -> Callable[[], Awaitable[None]]:
-    """Start background notifications scheduler and return a stopper."""
-
-    global _scheduler_task
-
-    async def _stop_task(task: asyncio.Task[None]) -> None:
-        if task.done():
-            try:
-                task.result()
-            except Exception:
-                pass
-            return
-        task.cancel()
-        try:
-            await task
-        except asyncio.CancelledError:
-            pass
-
-    if _scheduler_task and not _scheduler_task.done():
-        existing = _scheduler_task
-
-        async def _stop_existing() -> None:
-            global _scheduler_task
-            await _stop_task(existing)
-            if _scheduler_task is existing:
-                _scheduler_task = None
-
-        return _stop_existing
-
-    loop = asyncio.get_running_loop()
-    task = loop.create_task(
-        _scheduler_loop(poll_seconds=poll_seconds, window_minutes=window_minutes)
+    scheduler = worker_module.NotificationsScheduler(
+        poll_seconds=poll_seconds,
+        window_minutes=window_minutes,
+        max_backoff_seconds=max_backoff_seconds,
+        metrics=None,
     )
-    _scheduler_task = task
 
-    async def _stop() -> None:
-        global _scheduler_task
-        await _stop_task(task)
-        if _scheduler_task is task:
-            _scheduler_task = None
-
-    return _stop
+    original_sleep = worker_module.asyncio.sleep
+    original_session = worker_module.async_session
+    try:
+        worker_module.asyncio.sleep = asyncio.sleep
+        worker_module.async_session = async_session  # type: ignore[attr-defined]
+        try:
+            await scheduler.run_forever()
+        except asyncio.CancelledError:
+            return
+    finally:
+        worker_module.asyncio.sleep = original_sleep
+        worker_module.async_session = original_session

--- a/root/app/workers/__init__.py
+++ b/root/app/workers/__init__.py
@@ -1,0 +1,1 @@
+"""Worker entrypoints for background tasks."""

--- a/root/app/workers/notifications.py
+++ b/root/app/workers/notifications.py
@@ -1,0 +1,239 @@
+"""Async worker responsible for generating notification reminders."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import signal
+from contextlib import suppress
+from typing import Awaitable, Callable
+
+from app.core.config import settings
+from app.core.database import async_session, wait_db
+from app.core.observability import (
+    WorkerMetrics,
+    configure_worker_observability,
+    create_worker_metrics,
+    create_worker_monitoring_app,
+    start_worker_monitoring_server,
+)
+from app.services.notifications import generate_schedule_reminders
+
+logger = logging.getLogger(__name__)
+
+
+class NotificationsScheduler:
+    """Run the schedule reminder generator on a fixed interval."""
+
+    def __init__(
+        self,
+        *,
+        poll_seconds: int,
+        window_minutes: int,
+        max_backoff_seconds: int,
+        metrics: WorkerMetrics | None = None,
+    ) -> None:
+        self.poll_seconds = max(1, int(poll_seconds))
+        self.window_minutes = max(1, int(window_minutes))
+        self.max_backoff_seconds = max(1, int(max_backoff_seconds))
+        self.metrics = metrics
+
+    async def run_once(self) -> int:
+        async with async_session() as db:
+            created = await generate_schedule_reminders(
+                db, window_minutes=self.window_minutes
+            )
+        return created
+
+    async def run_forever(self) -> None:
+        consecutive_failures = 0
+
+        try:
+            while True:
+                sleep_for = self.poll_seconds
+                try:
+                    created = await self.run_once()
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    consecutive_failures += 1
+                    sleep_for = min(
+                        self.poll_seconds * (2 ** min(consecutive_failures, 5)),
+                        self.max_backoff_seconds,
+                    )
+                    if self.metrics is not None:
+                        self.metrics.record_failure()
+                    logger.exception(
+                        "Failed to generate schedule reminders (attempt %s)",
+                        consecutive_failures,
+                    )
+                    logging.getLogger().error(
+                        "Failed to generate schedule reminders (attempt %s)",
+                        consecutive_failures,
+                    )
+                else:
+                    consecutive_failures = 0
+                    if self.metrics is not None:
+                        self.metrics.record_success(created)
+                    if created:
+                        logger.info(
+                            "Generated %s schedule reminder notifications", created
+                        )
+                await asyncio.sleep(sleep_for)
+        except asyncio.CancelledError:
+            logger.info("Notifications scheduler loop cancelled")
+            raise
+
+
+_scheduler_task: asyncio.Task[None] | None = None
+
+
+async def start_notifications_scheduler(
+    *,
+    poll_seconds: int | None = None,
+    window_minutes: int | None = None,
+    max_backoff_seconds: int | None = None,
+    metrics: WorkerMetrics | None = None,
+) -> Callable[[], Awaitable[None]]:
+    """Start the notifications scheduler in the current event loop."""
+
+    global _scheduler_task
+
+    poll = (
+        poll_seconds
+        if poll_seconds is not None
+        else settings.notifications_scheduler_poll_seconds
+    )
+    window = (
+        window_minutes
+        if window_minutes is not None
+        else settings.notifications_scheduler_window_minutes
+    )
+    backoff = (
+        max_backoff_seconds
+        if max_backoff_seconds is not None
+        else settings.notifications_scheduler_max_backoff_seconds
+    )
+
+    async def _stop_task(task: asyncio.Task[None]) -> None:
+        if task.done():
+            with suppress(Exception):
+                task.result()
+            return
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+
+    if _scheduler_task and not _scheduler_task.done():
+        existing = _scheduler_task
+
+        async def _stop_existing() -> None:
+            global _scheduler_task
+            await _stop_task(existing)
+            if _scheduler_task is existing:
+                _scheduler_task = None
+
+        return _stop_existing
+
+    scheduler = NotificationsScheduler(
+        poll_seconds=poll,
+        window_minutes=window,
+        max_backoff_seconds=backoff,
+        metrics=metrics,
+    )
+    loop = asyncio.get_running_loop()
+    task = loop.create_task(scheduler.run_forever())
+    _scheduler_task = task
+
+    async def _stop() -> None:
+        global _scheduler_task
+        await _stop_task(task)
+        if _scheduler_task is task:
+            _scheduler_task = None
+
+    return _stop
+
+
+async def _wait_for_signals(stop_event: asyncio.Event) -> None:
+    loop = asyncio.get_running_loop()
+    handled_signals = [signal.SIGINT, signal.SIGTERM]
+
+    def _handler(*_: object) -> None:
+        stop_event.set()
+
+    for sig in handled_signals:
+        try:
+            loop.add_signal_handler(sig, _handler)
+        except NotImplementedError:  # pragma: no cover - Windows fallback
+            signal.signal(sig, lambda *_: stop_event.set())
+
+    await stop_event.wait()
+
+
+async def run_worker() -> None:
+    """Entrypoint for the standalone notifications worker."""
+
+    configure_worker_observability(worker_name="notifications")
+    metrics = create_worker_metrics("notifications_scheduler")
+
+    monitor_stop: Callable[[], Awaitable[None]] | None = None
+    metrics_port = settings.notifications_worker_metrics_port
+    if metrics_port and metrics_port > 0:
+        monitor_app = create_worker_monitoring_app(
+            worker_name="notifications", metrics=metrics
+        )
+        monitor_stop = await start_worker_monitoring_server(
+            monitor_app,
+            host=settings.notifications_worker_metrics_host,
+            port=metrics_port,
+        )
+
+    await wait_db(max_attempts=10, delay=1.0)
+
+    scheduler = NotificationsScheduler(
+        poll_seconds=settings.notifications_scheduler_poll_seconds,
+        window_minutes=settings.notifications_scheduler_window_minutes,
+        max_backoff_seconds=settings.notifications_scheduler_max_backoff_seconds,
+        metrics=metrics,
+    )
+
+    logger.info(
+        "Notifications worker starting (poll=%ss, window=%smin)",
+        scheduler.poll_seconds,
+        scheduler.window_minutes,
+    )
+
+    scheduler_task = asyncio.create_task(scheduler.run_forever())
+    stop_event = asyncio.Event()
+    signal_task = asyncio.create_task(_wait_for_signals(stop_event))
+
+    done, pending = await asyncio.wait(
+        {scheduler_task, signal_task}, return_when=asyncio.FIRST_COMPLETED
+    )
+
+    if scheduler_task in done:
+        with suppress(asyncio.CancelledError):
+            await scheduler_task
+        stop_event.set()
+    else:
+        scheduler_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await scheduler_task
+
+    for task in pending:
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+
+    if monitor_stop is not None:
+        await monitor_stop()
+
+    logger.info("Notifications worker stopped")
+
+
+async def main() -> None:
+    await run_worker()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/root/requirements.txt
+++ b/root/requirements.txt
@@ -27,6 +27,7 @@ pre-commit>=3.8
 pytest-asyncio>=0.23
 pytest-cov>=5
 asgi-lifespan>=2.1.0
+prometheus-client>=0.20
 
 opentelemetry-api==1.37.0
 opentelemetry-sdk==1.37.0


### PR DESCRIPTION
## Summary
- add a dedicated notifications scheduler worker with Prometheus metrics and graceful shutdown
- extend observability utilities and settings to expose worker health endpoints and gate the inline scheduler to dev mode
- update docker-compose and deployment docs to run the worker alongside the API with restart policies

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ed4aab9df883278bd0f1175be0dc6f