### PR TITLE
Refactor navbar utilities into shared hooks

### DIFF
--- a/root/frontend/package-lock.json
+++ b/root/frontend/package-lock.json
@@ -19,6 +19,7 @@
         "axios": "^1.12.2",
         "dayjs": "^1.11.13",
         "dompurify": "^3.2.7",
+        "focus-trap": "^7.6.5",
         "framer-motion": "^12.23.13",
         "i18next": "^25.6.0",
         "jspdf": "^3.0.2",
@@ -8169,6 +8170,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/focus-trap": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.5.tgz",
+      "integrity": "sha512-7Ke1jyybbbPZyZXFxEftUtxFGLMpE2n6A+z//m4CRDlj0hW+o3iYSmh8nFlYMurOiJVDmJRilUQtJr08KfIxlg==",
+      "license": "MIT",
+      "dependencies": {
+        "tabbable": "^6.2.0"
+      }
+    },
     "node_modules/follow-redirects": {
       "version": "1.15.9",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
@@ -13861,6 +13871,12 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tabbable": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
       "license": "MIT"
     },
     "node_modules/tar-fs": {

--- a/root/frontend/package.json
+++ b/root/frontend/package.json
@@ -38,6 +38,7 @@
     "axios": "^1.12.2",
     "dayjs": "^1.11.13",
     "dompurify": "^3.2.7",
+    "focus-trap": "^7.6.5",
     "framer-motion": "^12.23.13",
     "i18next": "^25.6.0",
     "jspdf": "^3.0.2",

--- a/root/frontend/src/App.tsx
+++ b/root/frontend/src/App.tsx
@@ -18,6 +18,7 @@ import LivePushToasts from "./components/LivePushToasts"
 import { useQueryClient } from "@tanstack/react-query"
 import { nowPlayingQueryKey } from "./hooks/useNowPlaying"
 import { useTranslation } from "react-i18next"
+import { AppShellProvider } from "./contexts/AppShellContext"
 
 const PageTransition = lazy(() => import("./components/PageTransition"))
 const Dashboard = lazy(() => import("./pages/Dashboard"))
@@ -154,15 +155,17 @@ function AppShell() {
       <a href="#main" className="skip-link">
         {t("skipToContent")}
       </a>
-      <AuthProvider>
-        <LocalizationProvider key={language} dateAdapter={AdapterDayjs} adapterLocale={language}>
-          <ErrorBoundary>
-            <Router future={routerFutureFlags}>
-              <AppContent />
-            </Router>
-          </ErrorBoundary>
-        </LocalizationProvider>
-      </AuthProvider>
+      <AppShellProvider>
+        <AuthProvider>
+          <LocalizationProvider key={language} dateAdapter={AdapterDayjs} adapterLocale={language}>
+            <ErrorBoundary>
+              <Router future={routerFutureFlags}>
+                <AppContent />
+              </Router>
+            </ErrorBoundary>
+          </LocalizationProvider>
+        </AuthProvider>
+      </AppShellProvider>
     </>
   )
 }

--- a/root/frontend/src/app/__tests__/a11y.test.tsx
+++ b/root/frontend/src/app/__tests__/a11y.test.tsx
@@ -16,6 +16,7 @@ import type { User } from "@/types/User";
 import { LanguageProvider } from "@/contexts/LanguageContext";
 import { CssVarsProvider } from "@mui/material/styles";
 import theme from "@/theme";
+import { AppShellProvider } from "@/contexts/AppShellContext";
 
 vi.mock("@/components/NotificationsBell", () => ({
   default: ({ iconColor }: { iconColor?: string }) => (
@@ -107,7 +108,9 @@ const createWrapper = (route = "/dashboard") => {
       <QueryClientProvider client={queryClient}>
         <CssVarsProvider theme={theme}>
           <LanguageProvider>
-            <AuthContext.Provider value={authValue}>{children}</AuthContext.Provider>
+            <AppShellProvider>
+              <AuthContext.Provider value={authValue}>{children}</AuthContext.Provider>
+            </AppShellProvider>
           </LanguageProvider>
         </CssVarsProvider>
       </QueryClientProvider>

--- a/root/frontend/src/components/Navbar.tsx
+++ b/root/frontend/src/components/Navbar.tsx
@@ -1,5 +1,5 @@
 import { Link, useNavigate, useLocation } from "react-router-dom";
-import { useState, useEffect, useRef, useMemo, useCallback, useLayoutEffect } from "react";
+import { useState, useEffect, useRef, useMemo, useCallback } from "react";
 import Skeleton from "@mui/material/Skeleton";
 import { useAuth } from "../contexts/AuthContext";
 import guuLogo from "../assets/guu_logo.png";
@@ -7,127 +7,15 @@ import SmartImage from "@/components/SmartImage";
 import NotificationsBell from "@/components/NotificationsBell";
 import { AVATAR_PLACEHOLDER_URL } from "@/constants/placeholders";
 import { useTranslation } from "react-i18next";
+import useMediaQuery from "@/hooks/useMediaQuery";
+import useFocusTrap from "@/hooks/useFocusTrap";
+import useScrollRestoration from "@/hooks/useScrollRestoration";
+import { useAppShell } from "@/contexts/AppShellContext";
 
 const AVATAR_FALLBACK = AVATAR_PLACEHOLDER_URL;
 
 const navTextColor = "var(--nav-text)";
 const navBgColor = "var(--nav-bg)";
-
-const focusableSelectors =
-  'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"]), input:not([disabled]), select:not([disabled]), textarea:not([disabled])';
-function useIsMobile() {
-  const getMatch = useCallback(() => {
-    if (typeof window === "undefined" || !("matchMedia" in window)) return false;
-    return window.matchMedia("(max-width: 1350px)").matches;
-  }, []);
-  const [match, setMatch] = useState(getMatch);
-  useEffect(() => {
-    if (typeof window === "undefined" || !("matchMedia" in window)) return;
-    const mql = window.matchMedia("(max-width: 1350px)");
-    const onChange = (e: MediaQueryListEvent | MediaQueryList) => {
-      setMatch("matches" in e ? e.matches : (e as MediaQueryList).matches);
-    };
-    if (mql.addEventListener) mql.addEventListener("change", onChange as EventListener);
-    else mql.addListener(onChange as (this: MediaQueryList, ev: MediaQueryListEvent) => any);
-    setMatch(mql.matches);
-    return () => {
-      if (mql.removeEventListener) mql.removeEventListener("change", onChange as EventListener);
-      else mql.removeListener(onChange as (this: MediaQueryList, ev: MediaQueryListEvent) => any);
-    };
-  }, [getMatch]);
-  return match;
-}
-
-function usePrefersReducedMotion() {
-  const getMatch = useCallback(() => {
-    if (typeof window === "undefined" || !("matchMedia" in window)) return false;
-    return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-  }, []);
-  const [match, setMatch] = useState(getMatch);
-  useEffect(() => {
-    if (typeof window === "undefined" || !("matchMedia" in window)) return;
-    const mql = window.matchMedia("(prefers-reduced-motion: reduce)");
-    const onChange = (event: MediaQueryListEvent | MediaQueryList) => {
-      setMatch("matches" in event ? event.matches : (event as MediaQueryList).matches);
-    };
-    if (mql.addEventListener) mql.addEventListener("change", onChange as EventListener);
-    else mql.addListener(onChange as (this: MediaQueryList, ev: MediaQueryListEvent) => any);
-    setMatch(mql.matches);
-    return () => {
-      if (mql.removeEventListener) mql.removeEventListener("change", onChange as EventListener);
-      else mql.removeListener(onChange as (this: MediaQueryList, ev: MediaQueryListEvent) => any);
-    };
-  }, [getMatch]);
-  return match;
-}
-
-function getScrollRoot(): HTMLElement {
-  const cands: (Element | null | Document | HTMLElement)[] = [
-    document.querySelector("[data-scroll-root]"),
-    document.querySelector("main[role='main']"),
-    document.querySelector("main"),
-    document.getElementById("scroll-root"),
-    document.querySelector("#root"),
-    (document as any).scrollingElement,
-    document.documentElement,
-    document.body
-  ];
-  for (const el of cands) {
-    if (!el) continue;
-    const e = el as HTMLElement;
-    const oy = getComputedStyle(e).overflowY;
-    const scrollable = (oy === "auto" || oy === "scroll") && e.scrollHeight > e.clientHeight;
-    if (scrollable) return e;
-  }
-  return (document.scrollingElement || document.documentElement) as HTMLElement;
-}
-
-function prefersReducedMotionGlobal() {
-  if (typeof window === "undefined" || !("matchMedia" in window)) return false;
-  try {
-    return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-  } catch {
-    return false;
-  }
-}
-
-function smoothToTop(target: HTMLElement) {
-  if (prefersReducedMotionGlobal()) {
-    try {
-      target.scrollTo({ top: 0, behavior: "auto" });
-    } catch {
-      target.scrollTop = 0;
-    }
-    return;
-  }
-  try {
-    (target as any).scrollTo({ top: 0, behavior: "smooth" });
-  } catch {
-    const start = target.scrollTop;
-    const duration = 420;
-    let t0 = 0;
-    const step = (ts: number) => {
-      if (!t0) t0 = ts;
-      const p = Math.min(1, (ts - t0) / duration);
-      const eased = 1 - Math.pow(1 - p, 3);
-      target.scrollTop = Math.round(start * (1 - eased));
-      if (p < 1) requestAnimationFrame(step);
-    };
-    requestAnimationFrame(step);
-  }
-}
-
-function markIfFromBottom() {
-  const el = getScrollRoot();
-  const nearBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 24;
-  if (nearBottom) sessionStorage.setItem("__scrollTopNext", "1");
-}
-
-function samePath(a: string, b: string) {
-  const na = a.replace(/\/+$/, "") || "/";
-  const nb = b.replace(/\/+$/, "") || "/";
-  return na === nb;
-}
 
 function parseCacheVersion(input: unknown): number | undefined {
   if (typeof input === "number" && Number.isFinite(input)) return input;
@@ -145,18 +33,23 @@ const Navbar = () => {
   const location = useLocation();
   const { user, isAuth, loading } = useAuth();
   const { t } = useTranslation(["navigation"]);
+  const { setOverlayState } = useAppShell();
 
   const [mobileMenu, setMobileMenu] = useState(false);
 
-  const isMobile = useIsMobile();
-  const prefersReducedMotion = usePrefersReducedMotion();
+  const isMobile = useMediaQuery("(max-width: 1350px)");
+  const prefersReducedMotion = useMediaQuery("(prefers-reduced-motion: reduce)");
+  const { scrollToTop, markScrollFromBottom, isSamePath } = useScrollRestoration(location.pathname);
   const prevIsMobile = useRef(isMobile);
   const navRef = useRef<HTMLDivElement | null>(null);
   const burgerBtnRef = useRef<HTMLButtonElement | null>(null);
-  const drawerNavRef = useRef<HTMLDivElement | null>(null);
   const closeButtonRef = useRef<HTMLButtonElement | null>(null);
-  const drawerWasOpenRef = useRef(false);
-  const previousFocusRef = useRef<HTMLElement | null>(null);
+  const drawerTrapRef = useFocusTrap<HTMLDivElement>({
+    active: mobileMenu && isMobile,
+    initialFocus: () => closeButtonRef.current ?? undefined,
+    fallbackFocus: () => closeButtonRef.current ?? undefined,
+    onDeactivate: () => setMobileMenu(false),
+  });
 
   useEffect(() => {
     if (prevIsMobile.current !== isMobile && !isMobile) setMobileMenu(false);
@@ -164,90 +57,24 @@ const Navbar = () => {
   }, [isMobile]);
 
   useEffect(() => {
-    document.body.style.overflow = mobileMenu ? "hidden" : "";
-    return () => {
-      document.body.style.overflow = "";
-    };
-  }, [mobileMenu]);
-
-  useEffect(() => {
     setMobileMenu(false);
   }, [location.pathname]);
 
   useEffect(() => {
-    const opened = mobileMenu && isMobile;
-    document.body.classList.toggle("blurred", opened && !prefersReducedMotion);
+    if (mobileMenu && isMobile) {
+      setOverlayState("mobile-drawer", { scrollLocked: true, blurred: !prefersReducedMotion });
+    } else {
+      setOverlayState("mobile-drawer", null);
+    }
     return () => {
-      document.body.classList.remove("blurred");
+      setOverlayState("mobile-drawer", null);
     };
-  }, [mobileMenu, isMobile, prefersReducedMotion]);
+  }, [isMobile, mobileMenu, prefersReducedMotion, setOverlayState]);
 
   useEffect(() => {
     if (prefersReducedMotion) return;
     navRef.current?.classList.add("navbar-animate-in");
   }, [prefersReducedMotion]);
-
-  useLayoutEffect(() => {
-    if (sessionStorage.getItem("__scrollTopNext") === "1") {
-      sessionStorage.removeItem("__scrollTopNext");
-      const el = getScrollRoot();
-      requestAnimationFrame(() => requestAnimationFrame(() => smoothToTop(el)));
-    }
-  }, [location.pathname]);
-
-  const getDrawerFocusables = useCallback(() => {
-    const root = drawerNavRef.current;
-    if (!root) return [] as HTMLElement[];
-    const nodes = Array.from(root.querySelectorAll<HTMLElement>(focusableSelectors));
-    return nodes.filter((node) => !node.hasAttribute("disabled") && node.getAttribute("aria-hidden") !== "true");
-  }, []);
-
-  useEffect(() => {
-    if (!(mobileMenu && isMobile)) return;
-    drawerWasOpenRef.current = true;
-    previousFocusRef.current = (document.activeElement as HTMLElement) ?? null;
-    const focusables = getDrawerFocusables();
-    const fallback = closeButtonRef.current ?? focusables[0];
-    if (fallback) {
-      window.setTimeout(() => fallback.focus(), 0);
-    }
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        event.preventDefault();
-        setMobileMenu(false);
-        return;
-      }
-      if (event.key !== "Tab") return;
-      const elements = getDrawerFocusables();
-      if (!elements.length) {
-        event.preventDefault();
-        return;
-      }
-      const current = document.activeElement as HTMLElement | null;
-      let index = elements.indexOf(current ?? elements[0]);
-      if (index === -1) index = 0;
-      index += event.shiftKey ? -1 : 1;
-      if (index < 0) index = elements.length - 1;
-      if (index >= elements.length) index = 0;
-      elements[index].focus();
-      event.preventDefault();
-    };
-    document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [getDrawerFocusables, isMobile, mobileMenu]);
-
-  useEffect(() => {
-    if (mobileMenu || !drawerWasOpenRef.current || !isMobile) return;
-    const previous = previousFocusRef.current;
-    const target = previous ?? burgerBtnRef.current;
-    if (target) {
-      window.setTimeout(() => target.focus(), 0);
-    }
-    previousFocusRef.current = null;
-    drawerWasOpenRef.current = false;
-  }, [isMobile, mobileMenu]);
 
   const avatarCacheV = useMemo(() => {
     const raw =
@@ -288,20 +115,16 @@ const Navbar = () => {
     return location.pathname === to || location.pathname.startsWith(to + "/");
   };
 
-  const isSameTarget = (to: string) => {
-    if (to === "/dashboard") return location.pathname === "/" || samePath(location.pathname, "/dashboard");
-    return samePath(location.pathname, to);
-  };
+  const isSameTarget = useCallback((to: string) => isSamePath(to), [isSamePath]);
 
-  const go = (to: string) => {
+  const go = useCallback((to: string) => {
     if (isSameTarget(to)) {
-      const el = getScrollRoot();
-      smoothToTop(el);
+      scrollToTop(prefersReducedMotion ? "auto" : "smooth");
     } else {
-      markIfFromBottom();
+      markScrollFromBottom();
       navigate(to);
     }
-  };
+  }, [isSameTarget, markScrollFromBottom, navigate, prefersReducedMotion, scrollToTop]);
 
   const logoWrapSize = isMobile ? 44 : 52;
   const logoImgSize = isMobile ? 34 : 42;
@@ -334,12 +157,11 @@ const Navbar = () => {
             to="/dashboard"
             aria-label={t("navigation:aria.homeLink")}
             className="brand"
-            onPointerDown={markIfFromBottom}
+            onPointerDown={markScrollFromBottom}
             onClick={(e) => {
               if (isSameTarget("/dashboard")) {
                 e.preventDefault();
-                const el = getScrollRoot();
-                smoothToTop(el);
+                scrollToTop(prefersReducedMotion ? "auto" : "smooth");
               }
             }}
             style={{ display: "inline-flex", alignItems: "center", gap: isMobile ? "8px" : "10px", minWidth: 0, padding: "6px 6px", borderRadius: 12, textDecoration: "none" }}
@@ -417,12 +239,11 @@ const Navbar = () => {
                   <Link
                     to={item.to}
                     className={`menu-link${isActive(item.to) ? " active" : ""}`}
-                    onPointerDown={markIfFromBottom}
+                    onPointerDown={markScrollFromBottom}
                     onClick={(e) => {
                       if (isSameTarget(item.to)) {
                         e.preventDefault();
-                        const el = getScrollRoot();
-                        smoothToTop(el);
+                        scrollToTop(prefersReducedMotion ? "auto" : "smooth");
                       }
                     }}
                   >
@@ -524,7 +345,7 @@ const Navbar = () => {
           aria-label={t("navigation:aria.mobileMenu")}
         >
           <nav
-            ref={drawerNavRef}
+            ref={drawerTrapRef}
             style={{ width: 270, maxWidth: "88vw", background: navBgColor, height: "100vh", boxShadow: "2px 0 22px #0003", padding: 0, display: "flex", flexDirection: "column", alignItems: "flex-start", transition: prefersReducedMotion ? "none" : "transform 0.35s cubic-bezier(.52,1.29,.47,.97)", transform: mobileMenu ? "translateX(0)" : "translateX(-120%)", justifyContent: "flex-start", position: "relative" }}
             onClick={e => e.stopPropagation()}
           >
@@ -561,13 +382,12 @@ const Navbar = () => {
                   <Link
                     to={item.to}
                     className={`menu-link${isActive(item.to) ? " active" : ""}`}
-                    onPointerDown={markIfFromBottom}
+                    onPointerDown={markScrollFromBottom}
                     onClick={(e) => {
                       setMobileMenu(false);
                       if (isSameTarget(item.to)) {
                         e.preventDefault();
-                        const el = getScrollRoot();
-                        smoothToTop(el);
+                        scrollToTop(prefersReducedMotion ? "auto" : "smooth");
                       }
                     }}
                   >
@@ -580,7 +400,7 @@ const Navbar = () => {
                   <button
                     type="button"
                     className="menu-link settings"
-                    onPointerDown={markIfFromBottom}
+                    onPointerDown={markScrollFromBottom}
                     onClick={e => { e.stopPropagation(); setMobileMenu(false); go("/settings"); }}
                     aria-label={t("navigation:menu.settings")}
                     title={t("navigation:menu.settings")}

--- a/root/frontend/src/components/__tests__/Navbar.test.tsx
+++ b/root/frontend/src/components/__tests__/Navbar.test.tsx
@@ -1,0 +1,154 @@
+import { MemoryRouter, useLocation } from "react-router-dom";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import Navbar from "../Navbar";
+import { AppShellProvider } from "@/contexts/AppShellContext";
+
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => ({
+    user: {
+      full_name: "Jane Doe",
+      role: "student",
+      avatar_url: "",
+      avatar_updated_at: 1,
+    },
+    isAuth: true,
+    loading: false,
+  }),
+}));
+
+const translations: Record<string, string> = {
+  "navigation:aria.homeLink": "Home",
+  "navigation:brandAlt": "Brand",
+  "navigation:brandName": "Great University",
+  "navigation:aria.openMenu": "Open menu",
+  "navigation:aria.closeMenu": "Close menu",
+  "navigation:aria.mobileMenu": "Mobile navigation",
+  "navigation:aria.close": "Close",
+  "navigation:aria.profileAvatar": "Profile avatar",
+  "navigation:aria.openProfile": "Open profile",
+  "navigation:menu.dashboard": "Dashboard",
+  "navigation:menu.news": "News",
+  "navigation:menu.schedule": "Schedule",
+  "navigation:menu.events": "Events",
+  "navigation:menu.activity": "Activity",
+  "navigation:menu.map": "Map",
+  "navigation:menu.settings": "Settings",
+};
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, string>) => {
+      if (key === "navigation:aria.profileAvatarNamed") {
+        return `Profile avatar for ${options?.name ?? "user"}`;
+      }
+      return translations[key] ?? key;
+    },
+  }),
+}));
+
+vi.mock("@/components/NotificationsBell", () => ({
+  default: () => <div data-testid="notifications-bell" />,
+}));
+
+vi.mock("@/components/SmartImage", () => ({
+  default: ({ alt, onClick }: { alt: string; onClick?: () => void }) => (
+    <img src="avatar" alt={alt} role="img" data-testid="smart-image" onClick={onClick} />
+  ),
+}));
+
+const LocationDisplay = () => {
+  const location = useLocation();
+  return <div data-testid="location-display">{location.pathname}</div>;
+};
+
+describe("Navbar", () => {
+  const setupMatchMedia = ({ mobile, reducedMotion }: { mobile: boolean; reducedMotion: boolean }) => {
+    vi.spyOn(window, "matchMedia").mockImplementation((query: string) => ({
+      media: query,
+      matches: query.includes("max-width") ? mobile : query.includes("prefers-reduced-motion") ? reducedMotion : false,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }) as unknown as MediaQueryList);
+  };
+
+  const renderNavbar = () =>
+    render(
+      <AppShellProvider>
+        <MemoryRouter initialEntries={["/dashboard"]}>
+          <Navbar />
+          <LocationDisplay />
+        </MemoryRouter>
+      </AppShellProvider>
+    );
+
+  beforeEach(() => {
+    setupMatchMedia({ mobile: true, reducedMotion: false });
+    document.body.className = "";
+    document.body.style.overflow = "";
+    window.sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    document.body.className = "";
+    document.body.style.overflow = "";
+  });
+
+  it("traps focus within the mobile drawer and closes on Escape", async () => {
+    const user = userEvent.setup();
+    renderNavbar();
+
+    const burger = await screen.findByRole("button", { name: "Open menu" });
+    await user.click(burger);
+
+    const closeButton = await screen.findByRole("button", { name: "Close" });
+    await waitFor(() => expect(closeButton).toHaveFocus());
+    expect(document.body.classList.contains("blurred")).toBe(true);
+    expect(document.body.style.overflow).toBe("hidden");
+
+    const drawer = screen.getByRole("dialog");
+
+    await user.tab();
+    expect(drawer).toContainElement(document.activeElement as HTMLElement);
+
+    await user.tab({ shift: true });
+    expect(drawer).toContainElement(document.activeElement as HTMLElement);
+
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => expect(burger).toHaveAttribute("aria-expanded", "false"));
+    await waitFor(() => expect(burger).toHaveFocus());
+    expect(document.body.classList.contains("blurred")).toBe(false);
+    expect(document.body.style.overflow).toBe("");
+    expect(drawer).toHaveStyle({ pointerEvents: "none" });
+    const drawerNav = drawer.querySelector("nav");
+    expect(drawerNav).not.toBeNull();
+    expect(drawerNav).toHaveStyle({ transform: "translateX(-120%)" });
+  });
+
+  it("closes the drawer when navigating to another route", async () => {
+    const user = userEvent.setup();
+    renderNavbar();
+
+    const burger = await screen.findByRole("button", { name: "Open menu" });
+    await user.click(burger);
+    const newsLink = await screen.findByRole("link", { name: "News" });
+
+    expect(document.body.style.overflow).toBe("hidden");
+
+    await user.click(newsLink);
+
+    await waitFor(() => expect(burger).toHaveAttribute("aria-expanded", "false"));
+    const drawer = screen.getByRole("dialog");
+    expect(drawer).toHaveStyle({ pointerEvents: "none" });
+    expect(drawer.querySelector("nav")).toHaveStyle({ transform: "translateX(-120%)" });
+    expect(document.body.style.overflow).toBe("");
+    expect(screen.getByTestId("location-display")).toHaveTextContent("/news");
+  });
+});

--- a/root/frontend/src/contexts/AppShellContext.tsx
+++ b/root/frontend/src/contexts/AppShellContext.tsx
@@ -1,0 +1,203 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  type PropsWithChildren,
+} from "react";
+
+interface OverlayState {
+  blurred: boolean;
+  scrollLocked: boolean;
+}
+
+type OverlayMap = Map<string, OverlayState>;
+
+type ScrollBehaviorOption = "auto" | "smooth";
+
+interface AppShellContextValue {
+  setOverlayState: (id: string, state: OverlayState | null) => void;
+  scrollToTop: (behavior?: ScrollBehaviorOption) => void;
+  markScrollSnapshot: () => void;
+  restoreScrollIfNeeded: () => void;
+}
+
+const AppShellContext = createContext<AppShellContextValue | undefined>(undefined);
+
+const isBrowser = typeof window !== "undefined";
+
+const prefersReducedMotionGlobal = () => {
+  if (!isBrowser || typeof window.matchMedia !== "function") return false;
+  try {
+    return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  } catch {
+    return false;
+  }
+};
+
+const getScrollRoot = (): HTMLElement | null => {
+  if (!isBrowser) return null;
+  const candidates: (Element | Document | null | undefined)[] = [
+    document.querySelector("[data-scroll-root]"),
+    document.querySelector("main[role='main']"),
+    document.querySelector("main"),
+    document.getElementById("scroll-root"),
+    document.querySelector("#root"),
+    (document as unknown as { scrollingElement?: Element }).scrollingElement,
+    document.documentElement,
+    document.body,
+  ];
+
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    const element = candidate as HTMLElement;
+    const overflowY = window.getComputedStyle(element).overflowY;
+    const scrollable = (overflowY === "auto" || overflowY === "scroll") && element.scrollHeight > element.clientHeight;
+    if (scrollable) return element;
+  }
+
+  return (document.scrollingElement || document.documentElement || null) as HTMLElement | null;
+};
+
+const smoothScrollToTop = (target: HTMLElement, behavior: ScrollBehaviorOption) => {
+  if (behavior === "auto") {
+    try {
+      target.scrollTo({ top: 0, behavior: "auto" });
+    } catch {
+      target.scrollTop = 0;
+    }
+    return;
+  }
+
+  try {
+    target.scrollTo({ top: 0, behavior: "smooth" });
+  } catch {
+    const start = target.scrollTop;
+    const duration = 420;
+    let startTimestamp = 0;
+    const step = (timestamp: number) => {
+      if (!startTimestamp) startTimestamp = timestamp;
+      const progress = Math.min(1, (timestamp - startTimestamp) / duration);
+      const eased = 1 - Math.pow(1 - progress, 3);
+      target.scrollTop = Math.round(start * (1 - eased));
+      if (progress < 1) requestAnimationFrame(step);
+    };
+    requestAnimationFrame(step);
+  }
+};
+
+const markScrollTopNext = () => {
+  if (!isBrowser) return;
+  try {
+    window.sessionStorage.setItem("__scrollTopNext", "1");
+  } catch {
+    /* noop */
+  }
+};
+
+const consumeScrollTopNext = (): boolean => {
+  if (!isBrowser) return false;
+  try {
+    const value = window.sessionStorage.getItem("__scrollTopNext");
+    if (value === "1") {
+      window.sessionStorage.removeItem("__scrollTopNext");
+      return true;
+    }
+  } catch {
+    return false;
+  }
+  return false;
+};
+
+export const AppShellProvider = ({ children }: PropsWithChildren) => {
+  const overlaysRef = useRef<OverlayMap>(new Map());
+  const previousOverflowRef = useRef<string>("");
+
+  const applyOverlayState = useCallback(() => {
+    if (!isBrowser) return;
+    const overlays = overlaysRef.current;
+    const values = Array.from(overlays.values());
+    const shouldBlur = values.some((state) => state.blurred);
+    const shouldLockScroll = values.some((state) => state.scrollLocked);
+
+    if (shouldBlur) {
+      document.body.classList.add("blurred");
+    } else {
+      document.body.classList.remove("blurred");
+    }
+
+    if (shouldLockScroll) {
+      previousOverflowRef.current = document.body.style.overflow;
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = previousOverflowRef.current || "";
+    }
+  }, []);
+
+  const setOverlayState = useCallback(
+    (id: string, state: OverlayState | null) => {
+      const map = overlaysRef.current;
+      if (state) {
+        map.set(id, state);
+      } else {
+        map.delete(id);
+      }
+      applyOverlayState();
+    },
+    [applyOverlayState]
+  );
+
+  useEffect(() => () => {
+    if (!isBrowser) return;
+    document.body.classList.remove("blurred");
+    document.body.style.overflow = "";
+  }, []);
+
+  const scrollToTop = useCallback(
+    (behavior?: ScrollBehaviorOption) => {
+      if (!isBrowser) return;
+      const target = getScrollRoot();
+      if (!target) return;
+      const resolvedBehavior = behavior ?? (prefersReducedMotionGlobal() ? "auto" : "smooth");
+      smoothScrollToTop(target, resolvedBehavior);
+    },
+    []
+  );
+
+  const markScrollSnapshot = useCallback(() => {
+    if (!isBrowser) return;
+    const target = getScrollRoot();
+    if (!target) return;
+    const nearBottom = target.scrollTop + target.clientHeight >= target.scrollHeight - 24;
+    if (nearBottom) {
+      markScrollTopNext();
+    }
+  }, []);
+
+  const restoreScrollIfNeeded = useCallback(() => {
+    if (!isBrowser) return;
+    if (!consumeScrollTopNext()) return;
+    const target = getScrollRoot();
+    if (!target) return;
+    requestAnimationFrame(() => requestAnimationFrame(() => smoothScrollToTop(target, prefersReducedMotionGlobal() ? "auto" : "smooth")));
+  }, []);
+
+  const value = useMemo<AppShellContextValue>(
+    () => ({ setOverlayState, scrollToTop, markScrollSnapshot, restoreScrollIfNeeded }),
+    [markScrollSnapshot, restoreScrollIfNeeded, scrollToTop, setOverlayState]
+  );
+
+  return <AppShellContext.Provider value={value}>{children}</AppShellContext.Provider>;
+};
+
+export const useAppShell = () => {
+  const context = useContext(AppShellContext);
+  if (!context) {
+    throw new Error("useAppShell must be used within an AppShellProvider");
+  }
+  return context;
+};
+
+export type { AppShellContextValue };

--- a/root/frontend/src/hooks/__tests__/useFocusTrap.test.tsx
+++ b/root/frontend/src/hooks/__tests__/useFocusTrap.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useRef, useState } from "react";
+import useFocusTrap from "../useFocusTrap";
+
+describe("useFocusTrap", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
+  });
+
+  it("focuses the initial element and restores focus on close", async () => {
+    const user = userEvent.setup();
+
+    const Trigger = () => {
+      const [open, setOpen] = useState(false);
+      const closeRef = useRef<HTMLButtonElement | null>(null);
+      const containerRef = useFocusTrap<HTMLDivElement>({
+        active: open,
+        initialFocus: () => closeRef.current ?? undefined,
+        onDeactivate: () => setOpen(false),
+      });
+
+      return (
+        <div>
+          <button type="button" onClick={() => setOpen(true)}>
+            Open drawer
+          </button>
+          {open && (
+            <div ref={containerRef}>
+              <button ref={closeRef} type="button">
+                Close
+              </button>
+              <button type="button">Next</button>
+            </div>
+          )}
+        </div>
+      );
+    };
+
+    render(<Trigger />);
+
+    const opener = screen.getByRole("button", { name: "Open drawer" });
+    opener.focus();
+
+    await user.click(opener);
+
+    const closeButton = await screen.findByRole("button", { name: "Close" });
+    const container = closeButton.parentElement;
+    expect(container).not.toBeNull();
+    await waitFor(() => expect(container).toContainElement(document.activeElement as HTMLElement));
+
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => expect(screen.queryByRole("button", { name: "Close" })).not.toBeInTheDocument());
+    await waitFor(() => expect(opener).toHaveFocus());
+  });
+
+  it("invokes onDeactivate when trap deactivates", async () => {
+    const user = userEvent.setup();
+    const onDeactivate = vi.fn();
+
+    const Wrapper = () => {
+      const [active, setActive] = useState(true);
+      const closeRef = useRef<HTMLButtonElement | null>(null);
+      const containerRef = useFocusTrap<HTMLDivElement>({
+        active,
+        initialFocus: () => closeRef.current ?? undefined,
+        onDeactivate: () => {
+          onDeactivate();
+          setActive(false);
+        },
+      });
+
+      return (
+        <div>
+          {active && (
+            <div ref={containerRef}>
+              <button ref={closeRef} type="button">
+                Close trap
+              </button>
+            </div>
+          )}
+        </div>
+      );
+    };
+
+    render(<Wrapper />);
+
+    await user.keyboard("{Escape}");
+
+    expect(onDeactivate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/root/frontend/src/hooks/__tests__/useMediaQuery.test.tsx
+++ b/root/frontend/src/hooks/__tests__/useMediaQuery.test.tsx
@@ -1,0 +1,60 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import useMediaQuery from "../useMediaQuery";
+
+declare global {
+  interface Window {
+    matchMedia: (query: string) => MediaQueryList;
+  }
+}
+
+describe("useMediaQuery", () => {
+  const listeners = new Map<string, (event: MediaQueryListEvent) => void>();
+
+  const createMediaQueryList = (query: string, initial = false): MediaQueryList => {
+    let matches = initial;
+    return {
+      media: query,
+      matches,
+      onchange: null,
+      addEventListener: vi.fn((_, cb) => {
+        listeners.set(query, cb as (event: MediaQueryListEvent) => void);
+      }),
+      removeEventListener: vi.fn((_, cb) => {
+        const stored = listeners.get(query);
+        if (stored === cb) listeners.delete(query);
+      }),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    } as unknown as MediaQueryList;
+  };
+
+  beforeEach(() => {
+    listeners.clear();
+    vi.spyOn(window, "matchMedia").mockImplementation((query: string) => createMediaQueryList(query, query.includes("max-width")));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns the current match result", () => {
+    const { result } = renderHook(() => useMediaQuery("(max-width: 1350px)"));
+    expect(result.current).toBe(true);
+  });
+
+  it("updates when the media query changes", () => {
+    const { result } = renderHook(() => useMediaQuery("(prefers-reduced-motion: reduce)"));
+    expect(result.current).toBe(false);
+
+    const listener = listeners.get("(prefers-reduced-motion: reduce)");
+    expect(listener).toBeDefined();
+
+    act(() => {
+      listener?.({ matches: true } as MediaQueryListEvent);
+    });
+
+    expect(result.current).toBe(true);
+  });
+});

--- a/root/frontend/src/hooks/__tests__/useScrollRestoration.test.tsx
+++ b/root/frontend/src/hooks/__tests__/useScrollRestoration.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useEffect } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AppShellProvider } from "@/contexts/AppShellContext";
+import useScrollRestoration from "../useScrollRestoration";
+
+declare global {
+  interface Window {
+    matchMedia: (query: string) => MediaQueryList;
+  }
+}
+
+const ScrollHarness = ({ path, mark }: { path: string; mark?: boolean }) => {
+  const { markScrollFromBottom, scrollToTop } = useScrollRestoration(path);
+
+  useEffect(() => {
+    if (mark) {
+      markScrollFromBottom();
+    }
+  }, [mark, markScrollFromBottom]);
+
+  return (
+    <button type="button" onClick={() => scrollToTop("auto")}>
+      Scroll Top
+    </button>
+  );
+};
+
+describe("useScrollRestoration", () => {
+  let scrollRoot: HTMLDivElement;
+
+  beforeEach(() => {
+    vi.spyOn(window, "matchMedia").mockImplementation((query: string) => ({
+      media: query,
+      matches: query.includes("prefers-reduced-motion"),
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }) as unknown as MediaQueryList);
+
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((cb: FrameRequestCallback) => {
+      cb(0);
+      return 0;
+    });
+
+    scrollRoot = document.createElement("div");
+    scrollRoot.setAttribute("data-scroll-root", "");
+    scrollRoot.style.overflowY = "auto";
+    Object.defineProperty(scrollRoot, "scrollHeight", { value: 600, configurable: true });
+    Object.defineProperty(scrollRoot, "clientHeight", { value: 500, configurable: true });
+    Object.defineProperty(scrollRoot, "scrollTop", { value: 120, writable: true, configurable: true });
+    scrollRoot.scrollTo = vi.fn(({ top }: ScrollToOptions) => {
+      scrollRoot.scrollTop = typeof top === "number" ? top : 0;
+    }) as unknown as (options: ScrollToOptions) => void;
+    document.body.appendChild(scrollRoot);
+
+    window.sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    document.body.removeChild(scrollRoot);
+    vi.restoreAllMocks();
+  });
+
+  it("marks and restores scroll position around navigation", async () => {
+    const user = userEvent.setup();
+
+    const { rerender } = render(
+      <AppShellProvider>
+        <ScrollHarness path="/dashboard" />
+      </AppShellProvider>
+    );
+
+    expect(window.sessionStorage.getItem("__scrollTopNext")).toBeNull();
+
+    rerender(
+      <AppShellProvider>
+        <ScrollHarness path="/dashboard" mark />
+      </AppShellProvider>
+    );
+
+    expect(window.sessionStorage.getItem("__scrollTopNext")).toBe("1");
+
+    rerender(
+      <AppShellProvider>
+        <ScrollHarness path="/news" />
+      </AppShellProvider>
+    );
+
+    expect(scrollRoot.scrollTop).toBe(0);
+
+    const button = screen.getByRole("button", { name: "Scroll Top" });
+    scrollRoot.scrollTop = 200;
+
+    await user.click(button);
+
+    expect(scrollRoot.scrollTop).toBe(0);
+  });
+});

--- a/root/frontend/src/hooks/__tests__/useScrollRestoration.test.tsx
+++ b/root/frontend/src/hooks/__tests__/useScrollRestoration.test.tsx
@@ -53,9 +53,23 @@ describe("useScrollRestoration", () => {
     Object.defineProperty(scrollRoot, "scrollHeight", { value: 600, configurable: true });
     Object.defineProperty(scrollRoot, "clientHeight", { value: 500, configurable: true });
     Object.defineProperty(scrollRoot, "scrollTop", { value: 120, writable: true, configurable: true });
-    scrollRoot.scrollTo = vi.fn(({ top }: ScrollToOptions) => {
-      scrollRoot.scrollTop = typeof top === "number" ? top : 0;
-    }) as unknown as (options: ScrollToOptions) => void;
+    scrollRoot.scrollTo = vi
+      .fn((options?: ScrollToOptions | number, y?: number) => {
+        if (typeof options === "number") {
+          scrollRoot.scrollTop = options;
+          return;
+        }
+
+        if (typeof options === "object" && options !== null) {
+          const { top } = options;
+          scrollRoot.scrollTop = typeof top === "number" ? top : 0;
+          return;
+        }
+
+        if (typeof y === "number") {
+          scrollRoot.scrollTop = y;
+        }
+      }) as typeof scrollRoot.scrollTo;
     document.body.appendChild(scrollRoot);
 
     window.sessionStorage.clear();

--- a/root/frontend/src/hooks/useFocusTrap.ts
+++ b/root/frontend/src/hooks/useFocusTrap.ts
@@ -1,0 +1,82 @@
+import { useEffect, useRef } from "react";
+import type { FocusTrap, Options as FocusTrapOptions } from "focus-trap";
+import { createFocusTrap } from "focus-trap";
+
+type FocusTarget = FocusTrapOptions["initialFocus"];
+
+export interface UseFocusTrapOptions {
+  /** Whether the focus trap should be active. */
+  active: boolean;
+  /** Callback invoked when the underlying trap deactivates. */
+  onDeactivate?: () => void;
+  /** Element focused when the trap activates. */
+  initialFocus?: FocusTarget;
+  /** Fallback target if no focusable element is found. */
+  fallbackFocus?: FocusTarget;
+  /** Allow clicks outside of the trap without deactivating it. */
+  allowOutsideClick?: boolean;
+  /** Whether focus should return to the previously focused element. */
+  returnFocus?: boolean;
+}
+
+const isBrowser = typeof document !== "undefined";
+
+export default function useFocusTrap<T extends HTMLElement>({
+  active,
+  onDeactivate,
+  initialFocus,
+  fallbackFocus,
+  allowOutsideClick = true,
+  returnFocus = true,
+}: UseFocusTrapOptions) {
+  const containerRef = useRef<T | null>(null);
+  const trapRef = useRef<FocusTrap | null>(null);
+  const deactivateRef = useRef(onDeactivate);
+
+  deactivateRef.current = onDeactivate;
+
+  useEffect(() => {
+    if (!isBrowser) return undefined;
+
+    const container = containerRef.current;
+    if (!container || !active) {
+      if (trapRef.current) {
+        trapRef.current.deactivate({ returnFocus });
+        trapRef.current = null;
+      }
+      return undefined;
+    }
+
+    const fallbackTarget =
+      fallbackFocus ?? (() => {
+        if (container.tabIndex < 0) container.tabIndex = -1;
+        return container;
+      });
+
+    const options: FocusTrapOptions = {
+      allowOutsideClick,
+      escapeDeactivates: true,
+      returnFocusOnDeactivate: returnFocus,
+      fallbackFocus: fallbackTarget,
+    };
+
+    if (initialFocus) options.initialFocus = initialFocus;
+
+    const trap = createFocusTrap(container, {
+      ...options,
+      onDeactivate: () => {
+        deactivateRef.current?.();
+      },
+    });
+
+    trap.activate();
+    trapRef.current = trap;
+
+    return () => {
+      trap.deactivate();
+      trapRef.current = null;
+    };
+  }, [active, allowOutsideClick, fallbackFocus, initialFocus, returnFocus]);
+
+  return containerRef;
+}

--- a/root/frontend/src/hooks/useFocusTrap.ts
+++ b/root/frontend/src/hooks/useFocusTrap.ts
@@ -47,11 +47,13 @@ export default function useFocusTrap<T extends HTMLElement>({
       return undefined;
     }
 
-    const fallbackTarget =
-      fallbackFocus ?? (() => {
-        if (container.tabIndex < 0) container.tabIndex = -1;
-        return container;
-      });
+    const fallbackTarget: FocusTarget =
+      typeof fallbackFocus !== "undefined"
+        ? fallbackFocus
+        : (() => {
+            if (container.tabIndex < 0) container.tabIndex = -1;
+            return container;
+          }) as FocusTarget;
 
     const options: FocusTrapOptions = {
       allowOutsideClick,

--- a/root/frontend/src/hooks/useMediaQuery.ts
+++ b/root/frontend/src/hooks/useMediaQuery.ts
@@ -1,0 +1,68 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+type MediaQueryCallback = (event: MediaQueryListEvent | MediaQueryList) => void;
+
+export interface UseMediaQueryOptions {
+  /** Value used before the first client render when matchMedia is unavailable. */
+  defaultValue?: boolean;
+}
+
+const getMatchMedia = (): ((query: string) => MediaQueryList) | undefined => {
+  if (typeof window === "undefined") return undefined;
+  const matchMedia = window.matchMedia;
+  if (typeof matchMedia !== "function") return undefined;
+  return matchMedia.bind(window);
+};
+
+const toMediaQueryList = (query: string): MediaQueryList | null => {
+  const matchMedia = getMatchMedia();
+  if (!matchMedia) return null;
+  try {
+    return matchMedia(query);
+  } catch {
+    return null;
+  }
+};
+
+export default function useMediaQuery(
+  query: string,
+  { defaultValue = false }: UseMediaQueryOptions = {}
+): boolean {
+  const getMatch = useCallback(() => {
+    const mql = toMediaQueryList(query);
+    return mql ? mql.matches : defaultValue;
+  }, [defaultValue, query]);
+
+  const [matches, setMatches] = useState<boolean>(() => getMatch());
+
+  useEffect(() => {
+    const mql = toMediaQueryList(query);
+    if (!mql) {
+      setMatches(defaultValue);
+      return;
+    }
+
+    const handleChange: MediaQueryCallback = (event) => {
+      const next = "matches" in event ? event.matches : (event as MediaQueryList).matches;
+      setMatches(next);
+    };
+
+    if (typeof mql.addEventListener === "function") {
+      mql.addEventListener("change", handleChange);
+    } else if (typeof mql.addListener === "function") {
+      mql.addListener(handleChange);
+    }
+
+    setMatches(mql.matches);
+
+    return () => {
+      if (typeof mql.removeEventListener === "function") {
+        mql.removeEventListener("change", handleChange);
+      } else if (typeof mql.removeListener === "function") {
+        mql.removeListener(handleChange);
+      }
+    };
+  }, [defaultValue, query]);
+
+  return useMemo(() => matches, [matches]);
+}

--- a/root/frontend/src/hooks/useScrollRestoration.ts
+++ b/root/frontend/src/hooks/useScrollRestoration.ts
@@ -1,0 +1,44 @@
+import { useCallback, useLayoutEffect } from "react";
+import { useAppShell } from "@/contexts/AppShellContext";
+
+const normalizePath = (input: string) => (input.replace(/\/+$/, "") || "/");
+
+export interface ScrollRestorationApi {
+  scrollToTop: (behavior?: ScrollBehavior) => void;
+  markScrollFromBottom: () => void;
+  isSamePath: (target: string) => boolean;
+}
+
+type ScrollBehavior = "auto" | "smooth";
+
+export default function useScrollRestoration(currentPath: string): ScrollRestorationApi {
+  const { scrollToTop: scrollToTopGlobal, markScrollSnapshot, restoreScrollIfNeeded } = useAppShell();
+
+  useLayoutEffect(() => {
+    restoreScrollIfNeeded();
+  }, [restoreScrollIfNeeded, currentPath]);
+
+  const scrollToTop = useCallback(
+    (behavior?: ScrollBehavior) => {
+      scrollToTopGlobal(behavior);
+    },
+    [scrollToTopGlobal]
+  );
+
+  const markScrollFromBottom = useCallback(() => {
+    markScrollSnapshot();
+  }, [markScrollSnapshot]);
+
+  const isSamePath = useCallback(
+    (target: string) => {
+      if (target === "/dashboard") {
+        const normalized = normalizePath(currentPath);
+        return normalized === "/" || normalized === normalizePath(target);
+      }
+      return normalizePath(currentPath) === normalizePath(target);
+    },
+    [currentPath]
+  );
+
+  return { scrollToTop, markScrollFromBottom, isSamePath };
+}


### PR DESCRIPTION
## Summary
- introduce an AppShellProvider that centralizes body scroll locking, background blur and scroll restoration, and wrap the React tree with it
- extract the navbar-specific utilities into shared hooks (useMediaQuery, useScrollRestoration, useFocusTrap) and swap the manual focus loop for the focus-trap helper
- add unit tests for the new hooks plus RTL coverage for the mobile drawer and keyboard flow, updating existing accessibility tests accordingly

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68ed687627c88327a9a6e0b832e63b34