### PR TITLE
feat(frontend): add event detail typings and tests

### DIFF
--- a/root/frontend/src/api/client.ts
+++ b/root/frontend/src/api/client.ts
@@ -1,4 +1,4 @@
-import axios from "axios";
+import axios, { type AxiosInstance, type AxiosRequestConfig, type AxiosResponse } from "axios";
 
 export const API_UNAUTHORIZED_EVENT = "auth:unauthorized";
 export const SKIP_UNAUTHORIZED_HEADER = "X-Client-Skip-Unauthorized";
@@ -6,7 +6,31 @@ export const SKIP_UNAUTHORIZED_HEADER = "X-Client-Skip-Unauthorized";
 const devBase = "/api";
 const prodBase = import.meta.env.VITE_BACKEND_ORIGIN || "/api";
 
-const api = axios.create({
+export type ApiRequestConfig<D = unknown> = AxiosRequestConfig<D> & {
+  signal?: AbortSignal
+};
+
+type ApiInstance = Omit<AxiosInstance, "get" | "delete" | "post" | "patch" | "put"> & {
+  get<T = unknown, R = AxiosResponse<T>, D = unknown>(url: string, config?: ApiRequestConfig<D>): Promise<R>;
+  delete<T = unknown, R = AxiosResponse<T>, D = unknown>(url: string, config?: ApiRequestConfig<D>): Promise<R>;
+  post<T = unknown, R = AxiosResponse<T>, D = unknown>(
+    url: string,
+    data?: D,
+    config?: ApiRequestConfig<D>
+  ): Promise<R>;
+  patch<T = unknown, R = AxiosResponse<T>, D = unknown>(
+    url: string,
+    data?: D,
+    config?: ApiRequestConfig<D>
+  ): Promise<R>;
+  put<T = unknown, R = AxiosResponse<T>, D = unknown>(
+    url: string,
+    data?: D,
+    config?: ApiRequestConfig<D>
+  ): Promise<R>;
+};
+
+const api: ApiInstance = axios.create({
   baseURL: import.meta.env.DEV ? devBase : prodBase,
   withCredentials: true,
   timeout: 8000,
@@ -17,7 +41,7 @@ const api = axios.create({
     "Content-Type": "application/json",
     "X-Requested-With": "XMLHttpRequest",
   },
-});
+}) as ApiInstance;
 
 api.interceptors.response.use(
   (r) => r,

--- a/root/frontend/src/components/EventCard.tsx
+++ b/root/frontend/src/components/EventCard.tsx
@@ -12,6 +12,7 @@ import {
 import { useNavigate } from "react-router-dom"
 import { isAxiosError } from "axios"
 import api from "../api/client"
+import type { Event } from "@/types/Event"
 import {
   Typography, Button, Box, Stack, TextField,
   Dialog, DialogTitle, DialogContent, DialogActions,
@@ -38,19 +39,19 @@ dayjs.extend(timezone)
 type EventCardProps = {
   id: number
   title: string
-  description: string
-  event_type?: string
-  location: string
+  description: string | null
+  event_type?: string | null
+  location: string | null
   starts_at: string
   ends_at: string
   created_by: number
   participant_count: number
-  files: any[]
+  files: Event["files"]
   is_active: boolean
-  is_registered?: boolean
-  my_qr_code?: string
-  speaker?: string
-  image_url?: string
+  is_registered?: boolean | null
+  my_qr_code?: string | null
+  speaker?: string | null
+  image_url?: string | null
   onChange?: () => void
   maxWidth?: number | string
 }
@@ -129,7 +130,7 @@ const EventCardComponent: FC<EventCardProps> = ({
     "registered" | "unregistered" | null
   > => {
     try {
-      const res = await api.get(`/events/${id}`)
+      const res = await api.get<Event>(`/events/${id}`)
       const event = res.data
       const nextRegistered = Boolean(event?.is_registered)
       if (typeof event?.participant_count === "number") {
@@ -257,7 +258,7 @@ const EventCardComponent: FC<EventCardProps> = ({
     if (e) e.stopPropagation()
     setLoading(true)
     try {
-      const res = await api.post("/events/attendance", { event_id: id })
+      const res = await api.post<{ qr_code: string }>("/events/attendance", { event_id: id })
       const code: string = res.data.qr_code
       setRegistered(true)
       setQr(code)
@@ -345,7 +346,7 @@ const EventCardComponent: FC<EventCardProps> = ({
         setImageLoading(true)
         const data = new FormData()
         data.append("file", newImage)
-        const uploadRes = await api.post(`/events/upload_image`, data, {
+        const uploadRes = await api.post<{ url: string }>(`/events/upload_image`, data, {
           headers: { "Content-Type": "multipart/form-data" }
         })
         imgUrl = uploadRes.data.url

--- a/root/frontend/src/components/EventDetail.helpers.ts
+++ b/root/frontend/src/components/EventDetail.helpers.ts
@@ -1,0 +1,32 @@
+import type { EventFile } from '@/types/Event'
+
+type UploadIdleState = { status: 'idle' }
+type UploadSuccessState = { status: 'success' }
+export type UploadErrorState = { status: 'error'; error: string }
+
+export type UploadState = UploadIdleState | UploadSuccessState | UploadErrorState
+
+export const isUploadErrorState = (state: UploadState): state is UploadErrorState => state.status === 'error'
+
+export type OptimisticEventFile = Omit<EventFile, 'id'> & {
+  id: EventFile['id'] | string
+  pending?: boolean
+}
+
+export type FileOptimisticAction =
+  | { type: 'add'; file: OptimisticEventFile }
+  | { type: 'remove'; id: OptimisticEventFile['id'] }
+
+export const applyOptimisticFileAction = (
+  current: OptimisticEventFile[],
+  action: FileOptimisticAction
+): OptimisticEventFile[] => {
+  switch (action.type) {
+    case 'add':
+      return [...current, action.file]
+    case 'remove':
+      return current.filter(file => file.id !== action.id)
+    default:
+      return current
+  }
+}

--- a/root/frontend/src/components/EventDetail.tsx
+++ b/root/frontend/src/components/EventDetail.tsx
@@ -16,6 +16,14 @@ import { useAuth } from '../contexts/AuthContext'
 import Layout from '../components/Layout'
 import { resolveMediaUrl } from '@/utils/media'
 import SmartImage from '@/components/SmartImage'
+import type { Event } from '@/types/Event'
+import {
+  applyOptimisticFileAction,
+  isUploadErrorState,
+  type FileOptimisticAction,
+  type OptimisticEventFile,
+  type UploadState
+} from './EventDetail.helpers'
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
 import timezone from 'dayjs/plugin/timezone'
@@ -32,21 +40,17 @@ const formatLocalDateTime = (s?: string) => {
 }
 const formatDateSafe = (v?: string) => formatLocalDateTime(v)
 
-type UploadState = {
-  status: 'idle' | 'success' | 'error'
-  error?: string
-}
+const isCanceledRequestError = (err: unknown): boolean => {
+  if (typeof err !== 'object' || err === null) {
+    return false
+  }
 
-type OptimisticEventFile = {
-  id: number | string
-  description?: string
-  file_url?: string
-  pending?: boolean
-}
+  const record = err as Record<string, unknown>
+  const name = record.name
+  const code = record.code
 
-type FileOptimisticAction =
-  | { type: 'add'; file: OptimisticEventFile }
-  | { type: 'remove'; id: number | string }
+  return (typeof name === 'string' && name === 'CanceledError') || (typeof code === 'string' && code === 'ERR_CANCELED')
+}
 
 const EventDetail = () => {
   const { id } = useParams()
@@ -54,34 +58,41 @@ const EventDetail = () => {
   const { user } = useAuth()
   const isMobile = useMediaQuery('(max-width: 900px)')
 
-  const [event, setEvent] = useState<any>(null)
+  const [event, setEvent] = useState<Event | null>(null)
   const [loading, setLoading] = useState(true)
 
   const [selectedFile, setSelectedFile] = useState<File | null>(null)
   const fileInputRef = useRef<HTMLInputElement | null>(null)
-  const [optimisticFiles, mutateFiles] = useOptimistic<OptimisticEventFile[], FileOptimisticAction>(event?.files ?? [], (current, action) => {
-    switch (action.type) {
-      case 'add':
-        return [...current, action.file]
-      case 'remove':
-        return current.filter(f => f.id !== action.id)
-      default:
-        return current
-    }
-  })
+  const [optimisticFiles, mutateFiles] = useOptimistic<OptimisticEventFile[], FileOptimisticAction>(
+    event?.files ?? [],
+    applyOptimisticFileAction
+  )
 
   const [uploadState, uploadAction, uploadPending] = useActionState<UploadState, FormData>(async (_prev, input) => {
     if (input.get('__upload_reset__') === '1') {
-      return { status: 'idle' as const }
+      return { status: 'idle' }
     }
 
     const file = input.get('file')
     if (!(file instanceof File) || file.size === 0) {
-      return { status: 'error' as const, error: 'Выберите файл' }
+      return { status: 'error', error: 'Выберите файл' }
+    }
+
+    if (!event) {
+      return { status: 'error', error: 'Мероприятие не найдено' }
     }
 
     const optimisticId = `pending-${Date.now()}`
-    mutateFiles({ type: 'add', file: { id: optimisticId, description: file.name, file_url: '', pending: true } })
+    mutateFiles({
+      type: 'add',
+      file: {
+        id: optimisticId,
+        event_id: event.id,
+        description: file.name,
+        file_url: '',
+        pending: true
+      }
+    })
 
     try {
       const data = new FormData()
@@ -94,13 +105,13 @@ const EventDetail = () => {
       setSelectedFile(null)
       if (fileInputRef.current) fileInputRef.current.value = ''
       await refreshEvent().catch(() => {})
-      return { status: 'success' as const }
+      return { status: 'success' }
     } catch (err) {
       mutateFiles({ type: 'remove', id: optimisticId })
       setSnack('Ошибка добавления файла')
-      return { status: 'error' as const, error: 'Не удалось добавить файл' }
+      return { status: 'error', error: 'Не удалось добавить файл' }
     }
-  }, { status: 'idle' as const })
+  }, { status: 'idle' })
 
   const [editingAbout, setEditingAbout] = useState(false)
   const [aboutDraft, setAboutDraft] = useState('')
@@ -127,7 +138,7 @@ const EventDetail = () => {
   }, [imageUrl])
 
   const fetchEvent = useCallback(async (signal?: AbortSignal) => {
-    const res = await api.get(`/events/${id}`, signal ? { signal } as any : undefined)
+    const res = await api.get<Event>(`/events/${id}`, signal ? { signal } : undefined)
     return res.data
   }, [id])
 
@@ -139,8 +150,8 @@ const EventDetail = () => {
         setEvent(data)
       }
       return data
-    } catch (err: any) {
-      if (err?.name !== 'CanceledError' && err?.code !== 'ERR_CANCELED' && !signal?.aborted) {
+    } catch (err) {
+      if (!isCanceledRequestError(err) && !signal?.aborted) {
         setSnack('Ошибка загрузки')
       }
       throw err
@@ -160,7 +171,7 @@ const EventDetail = () => {
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const nextFile = e.target.files?.[0] || null
     setSelectedFile(nextFile)
-    if (uploadState.status === 'error' && !uploadPending) {
+    if (isUploadErrorState(uploadState) && !uploadPending) {
       const marker = new FormData()
       marker.append('__upload_reset__', '1')
       uploadAction(marker)
@@ -180,11 +191,20 @@ const EventDetail = () => {
   }
 
   const handleEditAbout = () => {
-    setAboutDraft(event.about || '')
+    if (!event) {
+      return
+    }
+
+    setAboutDraft(event.about ?? '')
     setEditingAbout(true)
   }
 
   const handleSaveAbout = async () => {
+    if (!event) {
+      setSnack('Ошибка сохранения описания')
+      return
+    }
+
     setSavingAbout(true)
     try {
       await api.patch(`/events/${event.id}`, { about: aboutDraft.trim() })
@@ -418,7 +438,7 @@ const EventDetail = () => {
                       </Typography>
                     )}
                   </Stack>
-                  {uploadState.status === 'error' && (
+                  {isUploadErrorState(uploadState) && (
                     <Typography color="error" fontSize={12} sx={{ mt: 0.5 }}>
                       {uploadState.error}
                     </Typography>
@@ -431,8 +451,10 @@ const EventDetail = () => {
               <Box>
                 <Typography variant="subtitle1" fontWeight={600}>Файлы:</Typography>
                 <Stack spacing={1}>
-                  {optimisticFiles.map((f: any) => {
-                    const isPendingFile = !!f.pending || typeof f.id !== 'number'
+                  {optimisticFiles.map(f => {
+                    const isPendingFile = f.pending === true || typeof f.id !== 'number'
+                    const fallbackName = f.file_url.split('/').pop() || f.file_url
+                    const fileLabel = f.description || fallbackName
                     return (
                       <Box key={f.id} display="flex" alignItems="center">
                         {isPendingFile ? (
@@ -445,11 +467,11 @@ const EventDetail = () => {
                             target="_blank"
                             rel="noopener noreferrer"
                             download
-                            title={f.description || (f.file_url?.split('/').pop())}
-                            aria-label={`Скачать файл ${f.description || f.file_url?.split('/').pop()}`}
+                            title={fileLabel}
+                            aria-label={`Скачать файл ${fileLabel}`}
                             style={{ color: '#1976d2', fontWeight: 500, textDecoration: 'underline', flex: 1 }}
                           >
-                            {f.description || (f.file_url?.split('/').pop())}
+                            {fileLabel}
                           </a>
                         )}
                         {(user?.role === 'admin' || user?.role === 'teacher') && (
@@ -644,7 +666,7 @@ const EventDetail = () => {
                       </Typography>
                     )}
                   </Stack>
-                  {uploadState.status === 'error' && (
+                  {isUploadErrorState(uploadState) && (
                     <Typography color="error" fontSize={13} sx={{ mt: 0.75 }}>
                       {uploadState.error}
                     </Typography>
@@ -658,8 +680,10 @@ const EventDetail = () => {
                 <Divider sx={{ my: 1 }} />
                 <Typography variant="subtitle1" fontWeight={600}>Файлы:</Typography>
                 <Stack spacing={1}>
-                  {optimisticFiles.map((f: any) => {
-                    const isPendingFile = !!f.pending || typeof f.id !== 'number'
+                  {optimisticFiles.map(f => {
+                    const isPendingFile = f.pending === true || typeof f.id !== 'number'
+                    const fallbackName = f.file_url.split('/').pop() || f.file_url
+                    const fileLabel = f.description || fallbackName
                     return (
                       <Box key={f.id} display="flex" alignItems="center">
                         {isPendingFile ? (
@@ -672,11 +696,11 @@ const EventDetail = () => {
                             target="_blank"
                             rel="noopener noreferrer"
                             download
-                            title={f.description || (f.file_url?.split('/').pop())}
-                            aria-label={`Скачать файл ${f.description || f.file_url?.split('/').pop()}`}
+                            title={fileLabel}
+                            aria-label={`Скачать файл ${fileLabel}`}
                             style={{ color: '#1976d2', fontWeight: 500, textDecoration: 'underline', flex: 1 }}
                           >
-                            {f.description || (f.file_url?.split('/').pop())}
+                            {fileLabel}
                           </a>
                         )}
                         {(user?.role === 'admin' || user?.role === 'teacher') && (

--- a/root/frontend/src/components/NewsCard.tsx
+++ b/root/frontend/src/components/NewsCard.tsx
@@ -134,7 +134,7 @@ const NewsCardComponent: FC<NewsCardProps> = ({
           const data = new FormData()
           data.append("file", newImage)
           // единый эндпоинт загрузки
-          const res = await api.post(`/news/upload_image`, data, {
+          const res = await api.post<{ url: string }>(`/news/upload_image`, data, {
             headers: { "Content-Type": "multipart/form-data" }
           })
           imgUrl = res.data.url

--- a/root/frontend/src/hooks/useFocusTrap.ts
+++ b/root/frontend/src/hooks/useFocusTrap.ts
@@ -2,7 +2,8 @@ import { useEffect, useRef } from "react";
 import type { FocusTrap, Options as FocusTrapOptions } from "focus-trap";
 import { createFocusTrap } from "focus-trap";
 
-type FocusTarget = FocusTrapOptions["initialFocus"];
+type InitialFocusTarget = FocusTrapOptions["initialFocus"];
+type FallbackFocusTarget = FocusTrapOptions["fallbackFocus"];
 
 export interface UseFocusTrapOptions {
   /** Whether the focus trap should be active. */
@@ -10,9 +11,9 @@ export interface UseFocusTrapOptions {
   /** Callback invoked when the underlying trap deactivates. */
   onDeactivate?: () => void;
   /** Element focused when the trap activates. */
-  initialFocus?: FocusTarget;
+  initialFocus?: InitialFocusTarget;
   /** Fallback target if no focusable element is found. */
-  fallbackFocus?: FocusTarget;
+  fallbackFocus?: FallbackFocusTarget;
   /** Allow clicks outside of the trap without deactivating it. */
   allowOutsideClick?: boolean;
   /** Whether focus should return to the previously focused element. */
@@ -47,13 +48,13 @@ export default function useFocusTrap<T extends HTMLElement>({
       return undefined;
     }
 
-    const fallbackTarget: FocusTarget =
+    const fallbackTarget: FallbackFocusTarget =
       typeof fallbackFocus !== "undefined"
         ? fallbackFocus
         : (() => {
             if (container.tabIndex < 0) container.tabIndex = -1;
             return container;
-          }) as FocusTarget;
+          }) as FallbackFocusTarget;
 
     const options: FocusTrapOptions = {
       allowOutsideClick,

--- a/root/frontend/src/pages/Activity.tsx
+++ b/root/frontend/src/pages/Activity.tsx
@@ -69,6 +69,30 @@ type ParticipationStats = {
   recent: Array<{ title: string; date: string; role?: string }>
 }
 
+type AttendanceSummaryResponse = {
+  percent?: unknown
+  present?: unknown
+  total?: unknown
+  trend?: unknown
+  window_label?: string
+  recent?: unknown
+}
+
+type GradeSummaryResponse = {
+  average?: unknown
+  scale?: unknown
+  trend?: unknown
+  recent?: unknown
+}
+
+type ParticipationSummaryResponse = {
+  events?: unknown
+  hours?: unknown
+  groups?: unknown
+  trend?: unknown
+  recent?: unknown
+}
+
 const MotionBox = motion(Box)
 const MotionCard = motion(Card)
 const MotionListItem = motion(ListItem)
@@ -195,9 +219,9 @@ export default function Activity() {
     setLoading(true)
     try {
       const [a, g, p] = await Promise.allSettled([
-        axios.get("/stats/attendance", { params: { period } }),
-        axios.get("/stats/grades", { params: { period } }),
-        axios.get("/stats/participation", { params: { period } }),
+        axios.get<AttendanceSummaryResponse>("/stats/attendance", { params: { period } }),
+        axios.get<GradeSummaryResponse>("/stats/grades", { params: { period } }),
+        axios.get<ParticipationSummaryResponse>("/stats/participation", { params: { period } }),
       ])
       if (a.status === "fulfilled" && a.value?.data) {
         const d = a.value.data

--- a/root/frontend/src/pages/Events.tsx
+++ b/root/frontend/src/pages/Events.tsx
@@ -3,6 +3,7 @@ import PageFadeIn from "../components/PageFadeIn"
 import EventCard from "../components/EventCard"
 import { useEffect, useState, useCallback, useMemo, type SyntheticEvent, type CSSProperties } from "react"
 import axios from "../api/client"
+import type { Event } from "@/types/Event"
 import {
   Box, Tabs, Tab, TextField, Typography, Button,
   Dialog, DialogTitle, DialogContent, Stack, useMediaQuery,
@@ -49,7 +50,7 @@ const Events = () => {
   const { user } = useAuth()
   const [searchParams, setSearchParams] = useSearchParams()
 
-  const [events, setEvents] = useState<any[]>([])
+  const [events, setEvents] = useState<Event[]>([])
   const [tab, setTab] = useState<EventTabKey>("active")
   const [search, setSearch] = useState("")
   const [type, setType] = useState("")
@@ -108,8 +109,8 @@ const Events = () => {
 
       const res =
         tab === "my"
-          ? await axios.get("/events/my", { signal })
-          : await axios.get("/events", { params, signal })
+          ? await axios.get<Event[]>("/events/my", { signal })
+          : await axios.get<Event[]>("/events", { params, signal })
 
       setEvents(Array.isArray(res.data) ? res.data : [])
     } catch (err: any) {
@@ -139,7 +140,7 @@ const Events = () => {
     try {
       const formData = new FormData()
       formData.append("file", file)
-      const res = await axios.post("/events/upload_image", formData, {
+      const res = await axios.post<{ url: string }>("/events/upload_image", formData, {
         headers: { "Content-Type": "multipart/form-data" },
       })
       setEventData((prev) => ({ ...prev, image_url: res.data.url }))
@@ -150,7 +151,7 @@ const Events = () => {
 
   const handleCreateEvent = async () => {
     try {
-      const res = await axios.post("/events", {
+      const res = await axios.post<Event>("/events", {
         ...eventData,
         starts_at: eventData.starts_at,
         ends_at: eventData.ends_at,

--- a/root/frontend/src/pages/News.tsx
+++ b/root/frontend/src/pages/News.tsx
@@ -167,7 +167,7 @@ const News = () => {
       if (imageFile) {
         const data = new FormData()
         data.append("file", imageFile)
-        const res = await axios.post("/news/upload_image", data, {
+        const res = await axios.post<{ url: string }>("/news/upload_image", data, {
           headers: { "Content-Type": "multipart/form-data" },
         })
         image_url = res.data?.url || ""

--- a/root/frontend/src/pages/Profile.tsx
+++ b/root/frontend/src/pages/Profile.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useMemo, useState, useRef, useCallback, memo } from "
 import { useLocation, useNavigate } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
 import api from "../api/client";
+import type { User } from "@/types/User";
 import profileBg from "../assets/background.jpg";
 import guuLogo from "../assets/guu_logo.png";
 import { AVATAR_PLACEHOLDER_URL } from "@/constants/placeholders";
@@ -591,7 +592,7 @@ export default function Profile() {
   const handleSave = async () => {
     setSaving(true);
     try {
-      const res = await api.put("/users/me", {
+      const res = await api.put<User>("/users/me", {
         full_name: fullName,
         email,
         about,

--- a/root/frontend/src/tests/components/EventDetail.helpers.test.ts
+++ b/root/frontend/src/tests/components/EventDetail.helpers.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import {
+  applyOptimisticFileAction,
+  isUploadErrorState,
+  type FileOptimisticAction,
+  type OptimisticEventFile,
+  type UploadState
+} from '@/components/EventDetail.helpers'
+
+describe('applyOptimisticFileAction', () => {
+  const baseFile: OptimisticEventFile = {
+    id: 1,
+    event_id: 1,
+    file_url: 'https://example.com/file.pdf',
+    description: 'file.pdf'
+  }
+
+  it('appends new files during optimistic upload', () => {
+    const pendingFile: OptimisticEventFile = {
+      id: 'pending-1',
+      event_id: 1,
+      file_url: '',
+      description: 'uploading.pdf',
+      pending: true
+    }
+
+    const action: FileOptimisticAction = { type: 'add', file: pendingFile }
+
+    const result = applyOptimisticFileAction([baseFile], action)
+
+    expect(result).toHaveLength(2)
+    expect(result[1]).toMatchObject({ id: 'pending-1', pending: true })
+  })
+
+  it('removes files when upload completes', () => {
+    const optimisticId = 'pending-2'
+    const pending: OptimisticEventFile = {
+      id: optimisticId,
+      event_id: 7,
+      file_url: '',
+      description: 'processing.docx',
+      pending: true
+    }
+
+    const action: FileOptimisticAction = { type: 'remove', id: optimisticId }
+    const result = applyOptimisticFileAction([baseFile, pending], action)
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toEqual(baseFile)
+  })
+})
+
+describe('isUploadErrorState', () => {
+  it('narrows upload states to those with an error message', () => {
+    const states: UploadState[] = [
+      { status: 'idle' },
+      { status: 'success' },
+      { status: 'error', error: 'failed to upload' }
+    ]
+
+    const errors = states.filter(isUploadErrorState)
+
+    expect(errors).toHaveLength(1)
+    expect(errors[0].error).toBe('failed to upload')
+  })
+})

--- a/root/frontend/src/types/Event.ts
+++ b/root/frontend/src/types/Event.ts
@@ -1,0 +1,26 @@
+export interface EventFile {
+  id: number
+  event_id: number
+  file_url: string
+  description: string | null
+}
+
+export interface Event {
+  id: number
+  title: string
+  description: string | null
+  location: string | null
+  event_type: string | null
+  starts_at: string
+  ends_at: string
+  created_by: number
+  created_at: string
+  is_active: boolean
+  speaker: string | null
+  image_url: string | null
+  about: string | null
+  files: EventFile[]
+  participant_count: number
+  is_registered: boolean | null
+  my_qr_code: string | null
+}


### PR DESCRIPTION
## Summary
- add event and event file interfaces that mirror the backend serializer
- refactor EventDetail to consume the new types, typed optimistic helpers, and a typed API config for abort signals
- introduce unit tests covering optimistic file updates and upload error guards

## Testing
- npm run test -- EventDetail.helpers

------
https://chatgpt.com/codex/tasks/task_e_68ed86ff3a288327a385583d19e7d000