### PR TITLE
Add Lighthouse budget enforcement in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,6 +235,35 @@ jobs:
           path: root/frontend/dist
           if-no-files-found: error
 
+  lighthouse-budgets:
+    name: Lighthouse budgets
+    runs-on: ubuntu-latest
+    needs: run-hooks
+    defaults:
+      run:
+        working-directory: root/frontend
+    steps:
+      - uses: actions/checkout@v5
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: root/frontend/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Build frontend
+        run: npm run build
+      - name: Run Lighthouse CI budgets
+        run: npm run lhci
+      - name: Upload Lighthouse HTML reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lighthouse-budget-reports
+          path: root/frontend/.lighthouseci
+          if-no-files-found: warn
+
   lighthouse:
     name: Lighthouse CI
     needs:

--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ Content-Security-Policy:
 - `npm run dev --prefix frontend` — запустить Vite dev-сервер на `localhost:5173` (прокси к API и статику backend).
 - `ENABLE_STRICT_SECURITY_HEADERS=true ENABLE_COOP=true uvicorn app.main:app --host 0.0.0.0 --port 8000` — пример запуска production-инстанса со строгими заголовками (COOP/COEP включайте по необходимости, проксируйте статику через reverse-proxy).
 - `pytest` — прогнать автотесты (включая smoke-тесты заголовков, статики и Alembic).
+- `npm run lhci --prefix root/frontend` — собрать фронтенд, запустить Lighthouse CI с бюджетами (`budget.json`) и сохранить HTML-отчёты в `root/frontend/.lighthouseci`.
+
+> 💡 Перед пушем прогоните Lighthouse локально: CI падает при регрессе бюджетов, зато отчёты можно посмотреть в `root/frontend/.lighthouseci/*.report.html`.
 
 ## Проверка
 

--- a/root/frontend/package.json
+++ b/root/frontend/package.json
@@ -17,6 +17,7 @@
     "test:ci": "vitest run --reporter=default --reporter=junit --outputFile=vitest-report.xml",
     "test:watch": "vitest",
     "test:e2e": "playwright test",
+    "lhci": "lhci autorun --budget-path=../../budget.json --upload.target=filesystem --upload.outputDir=.lighthouseci",
     "analyze": "ANALYZE=1 vite build",
     "lint-staged": "lint-staged",
     "prepare": "husky ../.husky"


### PR DESCRIPTION
## Summary
- add an npm script for running Lighthouse CI with the shared budget
- extend the CI workflow with a dedicated job that builds the frontend, runs lhci autorun, and uploads reports
- document how contributors can execute the new Lighthouse budget check locally

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ed90588d9883278d64c69ddf399820