### PR TITLE
Add localization support and update APIs for locale-aware responses

### DIFF
--- a/root/app/api/deps.py
+++ b/root/app/api/deps.py
@@ -6,6 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth.security import decode_token
 from app.core.database import get_db
+from app.localization import resolve_locale, translate
 from app.models.models import User
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/login", auto_error=False)
@@ -16,9 +17,10 @@ async def get_current_user(
     token: Annotated[str | None, Depends(oauth2_scheme)],
     db: Annotated[AsyncSession, Depends(get_db)],
 ) -> User:
+    locale = resolve_locale(request=request)
     credentials_exception = HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
-        detail="Could not validate credentials",
+        detail=translate("errors.auth.credentials_invalid", locale=locale),
         headers={"WWW-Authenticate": "Bearer"},
     )
     raw_token = token or request.cookies.get("access_token")

--- a/root/app/api/events.py
+++ b/root/app/api/events.py
@@ -83,9 +83,7 @@ async def attend(
     if user.role in ("admin", "teacher"):
         raise HTTPException(
             status_code=403,
-            detail=translate(
-                "errors.events.registration_forbidden", locale=locale
-            ),
+            detail=translate("errors.events.registration_forbidden", locale=locale),
         )
     return await crud.register_attendance(db, data, user_id=user.id)
 

--- a/root/app/api/events.py
+++ b/root/app/api/events.py
@@ -7,6 +7,7 @@ from fastapi import (
     File,
     HTTPException,
     Query,
+    Request,
     UploadFile,
     status,
 )
@@ -17,6 +18,7 @@ from app import crud
 from app.api.deps import get_current_user
 from app.api.utils import save_upload
 from app.core.database import get_db
+from app.localization import resolve_locale, translate
 from app.models import models
 from app.schemas import schemas
 from app.services.notifications import notify_about_event
@@ -31,14 +33,19 @@ router = APIRouter(prefix="/events", tags=["events"])
 @router.post("", response_model=schemas.EventOut)
 async def create_event(
     data: schemas.EventCreate,
+    request: Request,
     db: AsyncSession = Depends(get_db),
     user: models.User = Depends(get_current_user),
 ):
+    locale = resolve_locale(request=request, user=user)
     if user.role not in ("teacher", "admin"):
-        raise HTTPException(status_code=403, detail="forbidden")
+        raise HTTPException(
+            status_code=403,
+            detail=translate("errors.forbidden", locale=locale),
+        )
     record = await crud.create_event(db, data, user_id=user.id)
     try:
-        await notify_about_event(db, record)
+        await notify_about_event(db, record, locale=locale)
     except Exception:
         logger.exception(
             "Failed to dispatch event notification", extra={"event_id": record.id}
@@ -68,13 +75,17 @@ async def all_events(
 @router.post("/attendance", response_model=schemas.EventAttendanceOut)
 async def attend(
     data: schemas.EventAttendanceCreate,
+    request: Request,
     db: AsyncSession = Depends(get_db),
     user: models.User = Depends(get_current_user),
 ):
+    locale = resolve_locale(request=request, user=user)
     if user.role in ("admin", "teacher"):
         raise HTTPException(
             status_code=403,
-            detail="Регистрация на мероприятия недоступна для вашей роли",
+            detail=translate(
+                "errors.events.registration_forbidden", locale=locale
+            ),
         )
     return await crud.register_attendance(db, data, user_id=user.id)
 
@@ -99,14 +110,23 @@ async def my_events(
 async def upload_event_file(
     id: int,
     file: UploadFile = File(...),
+    *,
+    request: Request,
     db: AsyncSession = Depends(get_db),
     user: models.User = Depends(get_current_user),
 ):
+    locale = resolve_locale(request=request, user=user)
     event = await db.get(models.Event, id)
     if not event:
-        raise HTTPException(status_code=404, detail="Событие не найдено")
+        raise HTTPException(
+            status_code=404,
+            detail=translate("errors.events.not_found", locale=locale),
+        )
     if user.role not in ("admin", "teacher") and event.created_by != user.id:
-        raise HTTPException(status_code=403, detail="forbidden")
+        raise HTTPException(
+            status_code=403,
+            detail=translate("errors.forbidden", locale=locale),
+        )
     url = await save_attachment(file, "event_files", f"event_{id}")
     ef = models.EventFile(event_id=id, file_url=url)
     db.add(ef)
@@ -132,11 +152,17 @@ async def get_event_files(id: int, db: AsyncSession = Depends(get_db)):
 @router.post("/upload_image")
 async def upload_event_image(
     file: UploadFile = File(...),
+    *,
+    request: Request,
     user: models.User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
+    locale = resolve_locale(request=request, user=user)
     if user.role not in ("admin", "teacher"):
-        raise HTTPException(status_code=403, detail="forbidden")
+        raise HTTPException(
+            status_code=403,
+            detail=translate("errors.forbidden", locale=locale),
+        )
     url = await save_upload(file, "event_images", "event")
     return {"url": url}
 
@@ -145,14 +171,22 @@ async def upload_event_image(
 async def update_event(
     event_id: int,
     data: schemas.EventUpdate,
+    request: Request,
     db: AsyncSession = Depends(get_db),
     user: models.User = Depends(get_current_user),
 ):
+    locale = resolve_locale(request=request, user=user)
     q = await db.get(models.Event, event_id)
     if not q:
-        raise HTTPException(status_code=404, detail="Событие не найдено")
+        raise HTTPException(
+            status_code=404,
+            detail=translate("errors.events.not_found", locale=locale),
+        )
     if user.role not in ("admin", "teacher") and q.created_by != user.id:
-        raise HTTPException(status_code=403, detail="forbidden")
+        raise HTTPException(
+            status_code=403,
+            detail=translate("errors.forbidden", locale=locale),
+        )
     old_image_url = q.image_url
     try:
         q = await crud.update_event(db, q, data)
@@ -185,14 +219,22 @@ async def update_event(
 @router.delete("/{event_id}", response_model=dict)
 async def delete_event(
     event_id: int,
+    request: Request,
     db: AsyncSession = Depends(get_db),
     user: models.User = Depends(get_current_user),
 ):
+    locale = resolve_locale(request=request, user=user)
     q = await db.get(models.Event, event_id)
     if not q:
-        raise HTTPException(status_code=404, detail="Событие не найдено")
+        raise HTTPException(
+            status_code=404,
+            detail=translate("errors.events.not_found", locale=locale),
+        )
     if user.role not in ("admin", "teacher") and q.created_by != user.id:
-        raise HTTPException(status_code=403, detail="forbidden")
+        raise HTTPException(
+            status_code=403,
+            detail=translate("errors.forbidden", locale=locale),
+        )
     event_image_url = q.image_url
     file_urls = [
         row[0]
@@ -220,12 +262,17 @@ async def delete_event(
 @router.get("/{id}", response_model=schemas.EventOut)
 async def get_event(
     id: int,
+    request: Request,
     db: AsyncSession = Depends(get_db),
     user: models.User = Depends(get_current_user),
 ):
+    locale = resolve_locale(request=request, user=user)
     q = await db.get(models.Event, id)
     if not q:
-        raise HTTPException(status_code=404, detail="Событие не найдено")
+        raise HTTPException(
+            status_code=404,
+            detail=translate("errors.events.not_found", locale=locale),
+        )
     attendance = (
         await db.execute(
             select(models.EventAttendance).where(
@@ -267,15 +314,23 @@ async def get_event(
 @router.delete("/file/{file_id}", response_model=dict)
 async def delete_event_file(
     file_id: int,
+    request: Request,
     db: AsyncSession = Depends(get_db),
     user: models.User = Depends(get_current_user),
 ):
+    locale = resolve_locale(request=request, user=user)
     ef = await db.get(models.EventFile, file_id)
     if not ef:
-        raise HTTPException(status_code=404, detail="Файл не найден")
+        raise HTTPException(
+            status_code=404,
+            detail=translate("errors.events.file_not_found", locale=locale),
+        )
     event = await db.get(models.Event, ef.event_id)
     if user.role not in ("admin", "teacher") and event.created_by != user.id:
-        raise HTTPException(status_code=403, detail="forbidden")
+        raise HTTPException(
+            status_code=403,
+            detail=translate("errors.forbidden", locale=locale),
+        )
     file_url = ef.file_url
     await db.delete(ef)
     await db.commit()

--- a/root/app/api/news.py
+++ b/root/app/api/news.py
@@ -194,7 +194,7 @@ async def upload_news_image(
     file: UploadFile = File(...),
     *,
     request: Request,
-    user: models.User = Depends(get_current_user)
+    user: models.User = Depends(get_current_user),
 ):
     locale = resolve_locale(request=request, user=user)
     if user.role != "admin":

--- a/root/app/api/news.py
+++ b/root/app/api/news.py
@@ -7,6 +7,7 @@ from fastapi import (
     File,
     Header,
     HTTPException,
+    Request,
     Response,
     UploadFile,
     status,
@@ -19,6 +20,7 @@ from app.api.deps import get_current_user
 from app.api.utils import save_upload
 from app.core.database import get_db
 from app.deps.cache import etag_matches, format_etag, get_cache
+from app.localization import resolve_locale, translate
 from app.models import models
 from app.schemas import schemas
 from app.services.notifications import notify_about_news
@@ -39,16 +41,21 @@ def _news_item_cache_key(news_id: int) -> str:
 @router.post("", response_model=schemas.NewsOut)
 async def create_news(
     data: schemas.NewsCreate,
+    request: Request,
     db: AsyncSession = Depends(get_db),
     user: models.User = Depends(get_current_user),
 ):
+    locale = resolve_locale(request=request, user=user)
     if user.role != "admin":
-        raise HTTPException(status_code=403, detail="forbidden")
+        raise HTTPException(
+            status_code=403,
+            detail=translate("errors.forbidden", locale=locale),
+        )
     record = await crud.create_news(db, data)
     cache = get_cache()
     await cache.invalidate(_NEWS_LIST_CACHE_KEY)
     try:
-        await notify_about_news(db, record)
+        await notify_about_news(db, record, locale=locale)
     except Exception:
         logger.exception(
             "Failed to dispatch news notification", extra={"news_id": record.id}
@@ -88,10 +95,12 @@ async def news_list(
 @router.get("/{id}", response_model=schemas.NewsOut)
 async def get_news(
     id: int,
+    request: Request,
     response: Response,
     if_none_match: str | None = Header(default=None),
     db: AsyncSession = Depends(get_db),
 ):
+    locale = resolve_locale(request=request)
     cache = get_cache()
     cache_key = _news_item_cache_key(id)
     if cache.enabled:
@@ -107,7 +116,10 @@ async def get_news(
             return cached.payload
     q = await db.get(models.News, id)
     if not q:
-        raise HTTPException(status_code=404, detail="Новость не найдена")
+        raise HTTPException(
+            status_code=404,
+            detail=translate("errors.news.not_found", locale=locale),
+        )
     model_out = schemas.NewsOut.model_validate(q)
     payload = jsonable_encoder(model_out)
     if cache.enabled:
@@ -120,14 +132,22 @@ async def get_news(
 async def update_news(
     id: int,
     data: schemas.NewsCreate,
+    request: Request,
     db: AsyncSession = Depends(get_db),
     user: models.User = Depends(get_current_user),
 ):
+    locale = resolve_locale(request=request, user=user)
     news = await db.get(models.News, id)
     if not news:
-        raise HTTPException(status_code=404, detail="Новость не найдена")
+        raise HTTPException(
+            status_code=404,
+            detail=translate("errors.news.not_found", locale=locale),
+        )
     if user.role != "admin":
-        raise HTTPException(status_code=403, detail="forbidden")
+        raise HTTPException(
+            status_code=403,
+            detail=translate("errors.forbidden", locale=locale),
+        )
     old_image_url = news.image_url
     for field, value in data.model_dump(exclude_unset=True).items():
         setattr(news, field, value)
@@ -143,14 +163,22 @@ async def update_news(
 @router.delete("/{id}", response_model=dict)
 async def delete_news(
     id: int,
+    request: Request,
     db: AsyncSession = Depends(get_db),
     user: models.User = Depends(get_current_user),
 ):
+    locale = resolve_locale(request=request, user=user)
     news = await db.get(models.News, id)
     if not news:
-        raise HTTPException(status_code=404, detail="Новость не найдена")
+        raise HTTPException(
+            status_code=404,
+            detail=translate("errors.news.not_found", locale=locale),
+        )
     if user.role != "admin":
-        raise HTTPException(status_code=403, detail="forbidden")
+        raise HTTPException(
+            status_code=403,
+            detail=translate("errors.forbidden", locale=locale),
+        )
     image_url = news.image_url
     await db.delete(news)
     await db.commit()
@@ -163,10 +191,17 @@ async def delete_news(
 
 @router.post("/upload_image")
 async def upload_news_image(
-    file: UploadFile = File(...), user: models.User = Depends(get_current_user)
+    file: UploadFile = File(...),
+    *,
+    request: Request,
+    user: models.User = Depends(get_current_user)
 ):
+    locale = resolve_locale(request=request, user=user)
     if user.role != "admin":
-        raise HTTPException(status_code=403, detail="forbidden")
+        raise HTTPException(
+            status_code=403,
+            detail=translate("errors.forbidden", locale=locale),
+        )
     url = await save_upload(file, "news_images", "news")
     return {"url": url}
 

--- a/root/app/api/notifications.py
+++ b/root/app/api/notifications.py
@@ -1,12 +1,13 @@
 from datetime import UTC, datetime, timedelta
 from typing import Optional, Tuple
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from sqlalchemy import and_, delete, desc, func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps import get_current_user
 from app.core.database import get_db
+from app.localization import resolve_locale, translate
 from app.models.models import Notification, Schedule, User
 from app.schemas.schemas import NotificationOut, NotificationsListOut
 from app.services.notifications import (
@@ -38,16 +39,21 @@ def _decode_cursor(value: Optional[str]) -> Optional[Tuple[datetime, int]]:
 
 @router.get("", response_model=NotificationsListOut)
 async def list_notifications(
+    request: Request,
     cursor: Optional[str] = Query(None),
     limit: int = Query(20, ge=1, le=100),
     db: AsyncSession = Depends(get_db),
     user: User = Depends(get_current_user),
 ):
+    locale = resolve_locale(request=request, user=user)
     where = [Notification.user_id == user.id]
     if cursor:
         parsed = _decode_cursor(cursor)
         if not parsed:
-            raise HTTPException(status_code=400, detail="bad cursor")
+            raise HTTPException(
+                status_code=400,
+                detail=translate("errors.notifications.bad_cursor", locale=locale),
+            )
         c_dt, c_id = parsed
         c_dt = _ensure_utc(c_dt)
         where.append(
@@ -89,12 +95,17 @@ async def list_notifications(
 @router.patch("/{notif_id}/read")
 async def mark_read_single(
     notif_id: int,
+    request: Request,
     db: AsyncSession = Depends(get_db),
     user: User = Depends(get_current_user),
 ):
+    locale = resolve_locale(request=request, user=user)
     notif = await db.get(Notification, notif_id)
     if not notif or notif.user_id != user.id:
-        raise HTTPException(status_code=404, detail="notification not found")
+        raise HTTPException(
+            status_code=404,
+            detail=translate("errors.notifications.not_found", locale=locale),
+        )
 
     if notif.read:
         return {"ok": True}
@@ -137,12 +148,16 @@ async def clear_notifications(
 
 @router.post("/check-schedule", response_model=NotificationsListOut)
 async def check_schedule_and_generate(
+    request: Request,
     lookahead_minutes: int = Query(15, ge=1, le=180),
     db: AsyncSession = Depends(get_db),
     user: User = Depends(get_current_user),
 ):
+    locale = resolve_locale(request=request, user=user)
     if not user.group_id:
-        return await list_notifications(db=db, user=user, limit=20, cursor=None)
+        return await list_notifications(
+            request=request, db=db, user=user, limit=20, cursor=None
+        )
 
     now = datetime.now(UTC)
     soon = now + timedelta(minutes=lookahead_minutes)
@@ -161,7 +176,9 @@ async def check_schedule_and_generate(
     lessons = (await db.execute(q)).scalars().all()
 
     for les in lessons:
-        title, body, tag, data_payload = build_schedule_reminder_message(les)
+        title, body, tag, data_payload = build_schedule_reminder_message(
+            les, locale=locale
+        )
         url = "/schedule"
 
         dupe = select(func.count(Notification.id)).where(
@@ -175,6 +192,7 @@ async def check_schedule_and_generate(
         exists = (await db.execute(dupe)).scalar_one() or 0
         if exists:
             continue
+        action_title = translate("notifications.actions.open_schedule", locale=locale)
         await create_notifications_for_users(
             db,
             title=title,
@@ -186,7 +204,7 @@ async def check_schedule_and_generate(
             actions=[
                 {
                     "action": "open-schedule",
-                    "title": "Открыть расписание",
+                    "title": action_title,
                     "url": url,
                 }
             ],
@@ -194,4 +212,6 @@ async def check_schedule_and_generate(
             topic="schedule",
         )
 
-    return await list_notifications(db=db, user=user, limit=20, cursor=None)
+    return await list_notifications(
+        request=request, db=db, user=user, limit=20, cursor=None
+    )

--- a/root/app/api/schedule.py
+++ b/root/app/api/schedule.py
@@ -1,6 +1,14 @@
 from typing import List
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Response, status
+from fastapi import (
+    APIRouter,
+    Depends,
+    Header,
+    HTTPException,
+    Request,
+    Response,
+    status,
+)
 from fastapi.encoders import jsonable_encoder
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -8,6 +16,7 @@ from app import crud
 from app.api.deps import get_current_user
 from app.core.database import get_db
 from app.deps.cache import etag_matches, format_etag, get_cache
+from app.localization import resolve_locale, translate
 from app.models import models
 from app.schemas import schemas
 
@@ -21,11 +30,16 @@ def _schedule_cache_key(group_id: int) -> str:
 @router.post("", response_model=schemas.ScheduleOut)
 async def add_schedule(
     data: schemas.ScheduleCreate,
+    request: Request,
     db: AsyncSession = Depends(get_db),
     user: models.User = Depends(get_current_user),
 ):
+    locale = resolve_locale(request=request, user=user)
     if user.role not in ("teacher", "admin"):
-        raise HTTPException(status_code=403, detail="forbidden")
+        raise HTTPException(
+            status_code=403,
+            detail=translate("errors.forbidden", locale=locale),
+        )
     result = await crud.create_schedule(db, data)
     cache = get_cache()
     await cache.invalidate(_schedule_cache_key(result.group_id))
@@ -67,14 +81,22 @@ async def get_schedule(
 async def update_schedule(
     schedule_id: int,
     data: schemas.ScheduleUpdate,
+    request: Request,
     db: AsyncSession = Depends(get_db),
     user: models.User = Depends(get_current_user),
 ):
+    locale = resolve_locale(request=request, user=user)
     if user.role not in ("teacher", "admin"):
-        raise HTTPException(status_code=403, detail="forbidden")
+        raise HTTPException(
+            status_code=403,
+            detail=translate("errors.forbidden", locale=locale),
+        )
     sched = await db.get(models.Schedule, schedule_id)
     if not sched:
-        raise HTTPException(status_code=404, detail="Schedule not found")
+        raise HTTPException(
+            status_code=404,
+            detail=translate("errors.schedule.not_found", locale=locale),
+        )
     previous_group = sched.group_id
     for field, value in data.model_dump(exclude_unset=True).items():
         setattr(sched, field, value)
@@ -91,14 +113,22 @@ async def update_schedule(
 @router.delete("/{schedule_id}", response_model=dict)
 async def delete_schedule(
     schedule_id: int,
+    request: Request,
     db: AsyncSession = Depends(get_db),
     user: models.User = Depends(get_current_user),
 ):
+    locale = resolve_locale(request=request, user=user)
     if user.role not in ("teacher", "admin"):
-        raise HTTPException(status_code=403, detail="forbidden")
+        raise HTTPException(
+            status_code=403,
+            detail=translate("errors.forbidden", locale=locale),
+        )
     sched = await db.get(models.Schedule, schedule_id)
     if not sched:
-        raise HTTPException(status_code=404, detail="Schedule not found")
+        raise HTTPException(
+            status_code=404,
+            detail=translate("errors.schedule.not_found", locale=locale),
+        )
     group_id = sched.group_id
     await db.delete(sched)
     await db.commit()

--- a/root/app/api/spotify.py
+++ b/root/app/api/spotify.py
@@ -4,7 +4,7 @@ from typing import Optional
 from urllib.parse import urlencode
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException, Query, Response
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from fastapi.responses import RedirectResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -12,6 +12,7 @@ from app.api.deps import get_current_user
 from app.auth.security import create_access_token, decode_token
 from app.core.config import settings
 from app.core.database import get_db
+from app.localization import resolve_locale, translate
 from app.models.models import User
 from app.schemas.schemas import SpotifyAuthURL, SpotifyNowPlayingOut
 
@@ -112,7 +113,9 @@ async def _save_tokens(
     await db.refresh(user)
 
 
-async def _ensure_access_token(db: AsyncSession, user: User) -> Optional[str]:
+async def _ensure_access_token(
+    db: AsyncSession, user: User, *, locale: str | None = None
+) -> Optional[str]:
     """Return a usable Spotify access token, refreshing it when possible.
 
     Previously we returned ``None`` when ``spotify_access_token`` was empty,
@@ -135,7 +138,10 @@ async def _ensure_access_token(db: AsyncSession, user: User) -> Optional[str]:
             return None
         _disconnect_user(user, clear_refresh=True)
         await db.commit()
-        raise HTTPException(status_code=401, detail="Требуется переподключить Spotify")
+        raise HTTPException(
+            status_code=401,
+            detail=translate("errors.spotify.reconnect_required", locale=locale),
+        )
     async with httpx.AsyncClient(timeout=15) as client:
         r = await client.post(
             "https://accounts.spotify.com/api/token",
@@ -151,13 +157,19 @@ async def _ensure_access_token(db: AsyncSession, user: User) -> Optional[str]:
     if r.status_code != 200:
         _disconnect_user(user, clear_refresh=True)
         await db.commit()
-        raise HTTPException(status_code=401, detail="Требуется переподключить Spotify")
+        raise HTTPException(
+            status_code=401,
+            detail=translate("errors.spotify.reconnect_required", locale=locale),
+        )
     data = r.json()
     access_token = data.get("access_token")
     if not access_token:
         _disconnect_user(user, clear_refresh=True)
         await db.commit()
-        raise HTTPException(status_code=401, detail="Требуется переподключить Spotify")
+        raise HTTPException(
+            status_code=401,
+            detail=translate("errors.spotify.reconnect_required", locale=locale),
+        )
     await _save_tokens(
         db,
         user,
@@ -186,14 +198,25 @@ async def spotify_auth_url(user: User = Depends(get_current_user)):
 
 @router.get("/callback")
 async def spotify_callback(
-    code: str = Query(...), state: str = Query(...), db: AsyncSession = Depends(get_db)
+    request: Request,
+    code: str = Query(...),
+    state: str = Query(...),
+    db: AsyncSession = Depends(get_db),
 ):
+    locale = resolve_locale(request=request)
     payload = decode_token(state) or {}
     if not payload.get("sub"):
-        raise HTTPException(status_code=400, detail="invalid state")
+        raise HTTPException(
+            status_code=400,
+            detail=translate("errors.spotify.invalid_state", locale=locale),
+        )
     user = await db.get(User, int(payload["sub"]))
     if not user:
-        raise HTTPException(status_code=400, detail="user not found")
+        raise HTTPException(
+            status_code=400,
+            detail=translate("errors.spotify.user_not_found", locale=locale),
+        )
+    locale = resolve_locale(request=request, user=user)
     async with httpx.AsyncClient(timeout=15) as client:
         r = await client.post(
             "https://accounts.spotify.com/api/token",
@@ -208,7 +231,10 @@ async def spotify_callback(
             },
         )
     if r.status_code != 200:
-        raise HTTPException(status_code=400, detail="token exchange failed")
+        raise HTTPException(
+            status_code=400,
+            detail=translate("errors.spotify.token_exchange_failed", locale=locale),
+        )
     data = r.json()
     await _save_tokens(
         db,
@@ -234,14 +260,17 @@ async def spotify_callback(
 
 @router.get("/now-playing", response_model=SpotifyNowPlayingOut)
 async def now_playing(
-    db: AsyncSession = Depends(get_db), user: User = Depends(get_current_user)
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_current_user),
 ):
+    locale = resolve_locale(request=request, user=user)
     def _as_response(data: SpotifyNowPlayingOut):
         if data.track_id or data.track_name or data.artists:
             return data
         return Response(status_code=204)
 
-    token = await _ensure_access_token(db, user)
+    token = await _ensure_access_token(db, user, locale=locale)
     if not token:
         return _as_response(_fallback_now_playing(user))
     async with httpx.AsyncClient(timeout=15) as client:
@@ -257,7 +286,10 @@ async def now_playing(
     if r.status_code == 401:
         _disconnect_user(user, clear_refresh=True)
         await db.commit()
-        raise HTTPException(status_code=401, detail="Требуется переподключить Spotify")
+        raise HTTPException(
+            status_code=401,
+            detail=translate("errors.spotify.reconnect_required", locale=locale),
+        )
     if r.status_code == 429:
         retry_after_header = r.headers.get("Retry-After")
         try:
@@ -270,7 +302,7 @@ async def now_playing(
         await db.commit()
         raise HTTPException(
             status_code=429,
-            detail="Rate limited by Spotify",
+            detail=translate("errors.spotify.rate_limited", locale=locale),
             headers={"Retry-After": str(retry_after)},
         )
     if r.status_code != 200:

--- a/root/app/api/spotify.py
+++ b/root/app/api/spotify.py
@@ -265,6 +265,7 @@ async def now_playing(
     user: User = Depends(get_current_user),
 ):
     locale = resolve_locale(request=request, user=user)
+
     def _as_response(data: SpotifyNowPlayingOut):
         if data.track_id or data.track_name or data.artists:
             return data

--- a/root/app/api/users.py
+++ b/root/app/api/users.py
@@ -29,9 +29,9 @@ from app.api.utils import save_upload
 from app.auth.security import get_password_hash
 from app.core.config import settings
 from app.core.database import get_db
+from app.localization import resolve_locale, translate
 from app.models import models
 from app.schemas import schemas
-from app.localization import resolve_locale, translate
 from app.utils.email import (
     RESET_TOKEN_EXPIRY_MINUTES,
     build_reset_email_content,
@@ -81,9 +81,7 @@ def _send_reset_email(
     security = (
         settings.smtp_security or ("starttls" if settings.smtp_starttls else "none")
     ).lower()
-    subject, plain, html = build_reset_email_content(
-        link, full_name, locale=locale
-    )
+    subject, plain, html = build_reset_email_content(link, full_name, locale=locale)
     msg = EmailMessage()
     msg["Subject"] = subject
     msg["From"] = mail_from
@@ -186,9 +184,7 @@ async def reset_password(
     if not rec or rec.expires_at < datetime.now(timezone.utc):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=translate(
-                "errors.password.invalid_or_expired_link", locale=locale
-            ),
+            detail=translate("errors.password.invalid_or_expired_link", locale=locale),
         )
     user = await db.get(models.User, rec.user_id)
     if not user or not getattr(user, "is_active", True):

--- a/root/app/api/users.py
+++ b/root/app/api/users.py
@@ -15,6 +15,7 @@ from fastapi import (
     File,
     HTTPException,
     Query,
+    Request,
     UploadFile,
     status,
 )
@@ -30,6 +31,11 @@ from app.core.config import settings
 from app.core.database import get_db
 from app.models import models
 from app.schemas import schemas
+from app.localization import resolve_locale, translate
+from app.utils.email import (
+    RESET_TOKEN_EXPIRY_MINUTES,
+    build_reset_email_content,
+)
 from app.utils.ratelimit import sensitive_route_limit
 
 logger = logging.getLogger(__name__)
@@ -64,7 +70,9 @@ def _redact_sensitive_query(url: str) -> str:
     return result or "[redacted]"
 
 
-def _send_reset_email(to_email: str, link: str, full_name: str = "") -> None:
+def _send_reset_email(
+    to_email: str, link: str, full_name: str = "", locale: str | None = None
+) -> None:
     host = settings.smtp_host or ""
     port = int(settings.smtp_port or 0)
     user = settings.smtp_user or ""
@@ -73,21 +81,14 @@ def _send_reset_email(to_email: str, link: str, full_name: str = "") -> None:
     security = (
         settings.smtp_security or ("starttls" if settings.smtp_starttls else "none")
     ).lower()
-    name = f", {full_name}" if full_name else ""
-    html = f"""
-    <div style="font-family:Inter,Arial,sans-serif">
-      <h2>Сброс пароля</h2>
-      <p>Здравствуйте{name}!</p>
-      <p>Вы запросили сброс пароля в Экосистеме ГУУ. Ссылка действует 45 минут.</p>
-      <p><a href="{link}" style="display:inline-block;padding:10px 16px;background:#1d5fff;color:#fff;border-radius:8px;text-decoration:none">Сбросить пароль</a></p>
-      <p>Если вы не запрашивали сброс, проигнорируйте это письмо.</p>
-    </div>
-    """
+    subject, plain, html = build_reset_email_content(
+        link, full_name, locale=locale
+    )
     msg = EmailMessage()
-    msg["Subject"] = "Сброс пароля — Экосистема ГУУ"
+    msg["Subject"] = subject
     msg["From"] = mail_from
     msg["To"] = to_email
-    msg.set_content(f"Ссылка для сброса пароля: {link}\nОна действует 45 минут.")
+    msg.set_content(plain)
     msg.add_alternative(html, subtype="html")
     try:
         if not host or not port:
@@ -131,6 +132,7 @@ def _send_reset_email(to_email: str, link: str, full_name: str = "") -> None:
 )
 async def forgot_password(
     payload: schemas.ForgotPasswordIn,
+    request: Request,
     bg: BackgroundTasks,
     db: AsyncSession = Depends(get_db),
 ):
@@ -141,7 +143,9 @@ async def forgot_password(
     if user:
         token = secrets.token_urlsafe(32)
         token_hash = _hash_token(token)
-        expires = datetime.now(timezone.utc) + timedelta(minutes=45)
+        expires = datetime.now(timezone.utc) + timedelta(
+            minutes=RESET_TOKEN_EXPIRY_MINUTES
+        )
         db.add(
             models.PasswordResetToken(
                 user_id=user.id, token_hash=token_hash, expires_at=expires, used=False
@@ -150,7 +154,14 @@ async def forgot_password(
         await db.commit()
         base = settings.app_base_url_clean
         reset_link = f"{base}/reset-password?token={token}"
-        bg.add_task(_send_reset_email, user.email, reset_link, user.full_name or "")
+        locale = resolve_locale(request=request, user=user)
+        bg.add_task(
+            _send_reset_email,
+            user.email,
+            reset_link,
+            user.full_name or "",
+            locale,
+        )
     return {"ok": True}
 
 
@@ -159,8 +170,11 @@ async def forgot_password(
     dependencies=[Depends(sensitive_route_limit())],
 )
 async def reset_password(
-    payload: schemas.ResetPasswordIn, db: AsyncSession = Depends(get_db)
+    payload: schemas.ResetPasswordIn,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
 ):
+    locale = resolve_locale(request=request)
     token_hash = _hash_token(payload.token)
     result = await db.execute(
         select(models.PasswordResetToken).where(
@@ -172,12 +186,15 @@ async def reset_password(
     if not rec or rec.expires_at < datetime.now(timezone.utc):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Недействительная или просроченная ссылка",
+            detail=translate(
+                "errors.password.invalid_or_expired_link", locale=locale
+            ),
         )
     user = await db.get(models.User, rec.user_id)
     if not user or not getattr(user, "is_active", True):
         raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST, detail="Недействительная ссылка"
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=translate("errors.password.invalid_link", locale=locale),
         )
     try:
         user.hashed_password = get_password_hash(payload.password)
@@ -204,11 +221,13 @@ async def me(user: models.User = Depends(get_current_user)):
 @users_router.put("/me", response_model=schemas.UserOut)
 async def update_me(
     data: schemas.UserProfileUpdate,
+    request: Request,
     db: AsyncSession = Depends(get_db),
     user: models.User = Depends(get_current_user),
 ):
     db_user = await db.get(models.User, user.id)
     update_fields = data.model_dump(exclude_unset=True)
+    locale = resolve_locale(request=request, user=user)
 
     if "email" in update_fields and update_fields["email"] is not None:
         raw_email = str(update_fields["email"]).strip().lower()
@@ -220,7 +239,7 @@ async def update_me(
         ) as exc:  # pragma: no cover - defensive, TypeAdapter raises ValueError
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Некорректный email",
+                detail=translate("errors.users.invalid_email", locale=locale),
             ) from exc
 
         existing = await db.execute(
@@ -232,7 +251,7 @@ async def update_me(
         if existing.scalar_one_or_none() is not None:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Указанный email уже используется",
+                detail=translate("errors.users.email_in_use", locale=locale),
             )
 
         update_fields["email"] = validated_email
@@ -273,12 +292,17 @@ async def upload_cover(
 
 
 @users_router.post("", response_model=schemas.UserOut)
-async def create_user(data: schemas.UserCreate, db: AsyncSession = Depends(get_db)):
+async def create_user(
+    data: schemas.UserCreate,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+):
+    locale = resolve_locale(request=request)
     if data.role in ["teacher", "admin"]:
         if not data.invite_code:
             raise HTTPException(
                 status_code=400,
-                detail="Необходим уникальный код для регистрации преподавателя/админа",
+                detail=translate("errors.users.invite_required", locale=locale),
             )
         q = select(models.InviteCode).where(
             models.InviteCode.code == data.invite_code,
@@ -287,21 +311,29 @@ async def create_user(data: schemas.UserCreate, db: AsyncSession = Depends(get_d
         )
         code_obj = (await db.execute(q)).scalar_one_or_none()
         if not code_obj:
-            raise HTTPException(status_code=400, detail="Неверный или неактивный код")
+            raise HTTPException(
+                status_code=400,
+                detail=translate("errors.users.invalid_invite", locale=locale),
+            )
     user = await crud.create_user(db, data)
     return user
 
 
 @users_router.get("", response_model=List[schemas.UserOut])
 async def get_users(
+    request: Request,
     db: AsyncSession = Depends(get_db),
     full_name: Optional[str] = Query(None),
     group_id: Optional[int] = Query(None),
     role: Optional[str] = Query(None),
     user: models.User = Depends(get_current_user),
 ):
+    locale = resolve_locale(request=request, user=user)
     if user.role != "admin":
-        raise HTTPException(status_code=403, detail="forbidden")
+        raise HTTPException(
+            status_code=403,
+            detail=translate("errors.forbidden", locale=locale),
+        )
     return await crud.get_users(db, full_name=full_name, group_id=group_id, role=role)
 
 
@@ -309,11 +341,16 @@ async def get_users(
 async def update_user_admin(
     user_id: int,
     data: schemas.UserAdminUpdate,
+    request: Request,
     db: AsyncSession = Depends(get_db),
     user: models.User = Depends(get_current_user),
 ):
+    locale = resolve_locale(request=request, user=user)
     if user.role != "admin":
-        raise HTTPException(status_code=403, detail="forbidden")
+        raise HTTPException(
+            status_code=403,
+            detail=translate("errors.forbidden", locale=locale),
+        )
     return await crud.admin_update_user(db, user_id, data)
 
 
@@ -340,13 +377,21 @@ async def delete_avatar(
 @users_router.delete("/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_user(
     user_id: int,
+    request: Request,
     db: AsyncSession = Depends(get_db),
     user: models.User = Depends(get_current_user),
 ):
+    locale = resolve_locale(request=request, user=user)
     if user.role != "admin":
-        raise HTTPException(status_code=403, detail="forbidden")
+        raise HTTPException(
+            status_code=403,
+            detail=translate("errors.forbidden", locale=locale),
+        )
     if user.id == user_id:
-        raise HTTPException(status_code=400, detail="Нельзя удалить самого себя")
+        raise HTTPException(
+            status_code=400,
+            detail=translate("errors.users.cannot_delete_self", locale=locale),
+        )
     await crud.delete_user(db, user_id)
     return None
 
@@ -354,11 +399,16 @@ async def delete_user(
 @groups_router.post("", response_model=schemas.GroupOut)
 async def create_group(
     data: schemas.GroupCreate,
+    request: Request,
     db: AsyncSession = Depends(get_db),
     user: models.User = Depends(get_current_user),
 ):
+    locale = resolve_locale(request=request, user=user)
     if user.role != "admin":
-        raise HTTPException(status_code=403, detail="forbidden")
+        raise HTTPException(
+            status_code=403,
+            detail=translate("errors.forbidden", locale=locale),
+        )
     return await crud.create_group(db, data)
 
 

--- a/root/app/localization.py
+++ b/root/app/localization.py
@@ -1,0 +1,327 @@
+"""Simple localization utilities for backend responses."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+SUPPORTED_LOCALES: set[str] = {"en", "ru"}
+DEFAULT_LOCALE = "en"
+
+_QUERY_PARAM_KEYS: tuple[str, ...] = ("lang", "locale", "language")
+_USER_ATTR_KEYS: tuple[str, ...] = (
+    "preferred_locale",
+    "preferred_language",
+    "locale",
+    "language",
+)
+
+_TRANSLATIONS: Mapping[str, Mapping[str, str]] = {
+    "email.reset.subject": {
+        "ru": "Сброс пароля — Экосистема ГУУ",
+        "en": "Password reset — GUU Ecosystem",
+    },
+    "email.reset.heading": {"ru": "Сброс пароля", "en": "Password reset"},
+    "email.reset.greeting": {
+        "ru": "Здравствуйте{name}!",
+        "en": "Hello{name}!",
+    },
+    "email.reset.instructions": {
+        "ru": "Вы запросили сброс пароля в Экосистеме ГУУ. Ссылка действует {minutes} минут.",
+        "en": "You requested a password reset in the GUU Ecosystem. The link is valid for {minutes} minutes.",
+    },
+    "email.reset.button": {
+        "ru": "Сбросить пароль",
+        "en": "Reset password",
+    },
+    "email.reset.ignore": {
+        "ru": "Если вы не запрашивали сброс, проигнорируйте это письмо.",
+        "en": "If you did not request this reset, please ignore this email.",
+    },
+    "email.reset.plain": {
+        "ru": "Ссылка для сброса пароля: {link}\nОна действует {minutes} минут.",
+        "en": "Password reset link: {link}\nIt is valid for {minutes} minutes.",
+    },
+    "notifications.schedule.room_label": {
+        "ru": "ауд. {room}",
+        "en": "room {room}",
+    },
+    "notifications.schedule.change.no_details": {
+        "ru": "Проверьте расписание для актуальной информации.",
+        "en": "Check the schedule for the latest information.",
+    },
+    "notifications.schedule.change.title_with_subject": {
+        "ru": "Изменение пары: {subject}",
+        "en": "Class change: {subject}",
+    },
+    "notifications.schedule.change.title": {
+        "ru": "Изменение пары",
+        "en": "Class change",
+    },
+    "notifications.schedule.reminder.start_line": {
+        "ru": "Начало: {start}",
+        "en": "Starts at: {start}",
+    },
+    "notifications.schedule.reminder.no_details": {
+        "ru": "Проверьте расписание для подробностей.",
+        "en": "Check the schedule for details.",
+    },
+    "notifications.schedule.reminder.title_with_subject": {
+        "ru": "Скоро пара: {subject}",
+        "en": "Upcoming class: {subject}",
+    },
+    "notifications.schedule.reminder.title": {
+        "ru": "Скоро пара",
+        "en": "Upcoming class",
+    },
+    "notifications.news.no_summary": {
+        "ru": "Откройте новость, чтобы узнать подробности.",
+        "en": "Open the article to learn more.",
+    },
+    "notifications.news.title_with_headline": {
+        "ru": "Новая новость: {headline}",
+        "en": "New article: {headline}",
+    },
+    "notifications.news.title": {
+        "ru": "Новая новость",
+        "en": "New article",
+    },
+    "notifications.events.no_details": {
+        "ru": "Подробнее в карточке события.",
+        "en": "See the event card for more information.",
+    },
+    "notifications.events.title_with_name": {
+        "ru": "Новое мероприятие: {title}",
+        "en": "New event: {title}",
+    },
+    "notifications.events.title": {
+        "ru": "Новое мероприятие",
+        "en": "New event",
+    },
+    "notifications.system.no_details": {
+        "ru": "Подробности доступны в приложении.",
+        "en": "More details are available in the app.",
+    },
+    "notifications.system.title": {
+        "ru": "Системное сообщение",
+        "en": "System message",
+    },
+    "notifications.actions.open_schedule": {
+        "ru": "Открыть расписание",
+        "en": "Open schedule",
+    },
+    "notifications.default_title": {
+        "ru": "Уведомление",
+        "en": "Notification",
+    },
+    "errors.auth.credentials_invalid": {
+        "ru": "Не удалось подтвердить учётные данные",
+        "en": "Could not validate credentials",
+    },
+    "errors.forbidden": {
+        "ru": "Доступ запрещён",
+        "en": "Access denied",
+    },
+    "errors.events.registration_forbidden": {
+        "ru": "Регистрация на мероприятия недоступна для вашей роли",
+        "en": "Event registration is not available for your role",
+    },
+    "errors.events.not_found": {
+        "ru": "Событие не найдено",
+        "en": "Event not found",
+    },
+    "errors.events.file_not_found": {
+        "ru": "Файл не найден",
+        "en": "File not found",
+    },
+    "errors.news.not_found": {
+        "ru": "Новость не найдена",
+        "en": "News item not found",
+    },
+    "errors.notifications.bad_cursor": {
+        "ru": "Некорректный курсор",
+        "en": "Invalid cursor",
+    },
+    "errors.notifications.not_found": {
+        "ru": "Уведомление не найдено",
+        "en": "Notification not found",
+    },
+    "errors.schedule.not_found": {
+        "ru": "Запись расписания не найдена",
+        "en": "Schedule entry not found",
+    },
+    "errors.spotify.reconnect_required": {
+        "ru": "Требуется переподключить Spotify",
+        "en": "Spotify connection needs to be re-authorized",
+    },
+    "errors.spotify.invalid_state": {
+        "ru": "Некорректный параметр state",
+        "en": "Invalid state parameter",
+    },
+    "errors.spotify.user_not_found": {
+        "ru": "Пользователь не найден",
+        "en": "User not found",
+    },
+    "errors.spotify.token_exchange_failed": {
+        "ru": "Не удалось обменять код на токен",
+        "en": "Token exchange failed",
+    },
+    "errors.spotify.rate_limited": {
+        "ru": "Превышен лимит запросов Spotify",
+        "en": "Rate limited by Spotify",
+    },
+    "errors.password.invalid_or_expired_link": {
+        "ru": "Недействительная или просроченная ссылка",
+        "en": "The reset link is invalid or has expired",
+    },
+    "errors.password.invalid_link": {
+        "ru": "Недействительная ссылка",
+        "en": "Invalid link",
+    },
+    "errors.users.invalid_email": {
+        "ru": "Некорректный email",
+        "en": "Invalid email address",
+    },
+    "errors.users.email_in_use": {
+        "ru": "Указанный email уже используется",
+        "en": "The specified email is already in use",
+    },
+    "errors.users.invite_required": {
+        "ru": "Необходим уникальный код для регистрации преподавателя/админа",
+        "en": "A unique invite code is required to register a teacher or admin",
+    },
+    "errors.users.invalid_invite": {
+        "ru": "Неверный или неактивный код",
+        "en": "Invite code is invalid or inactive",
+    },
+    "errors.users.cannot_delete_self": {
+        "ru": "Нельзя удалить самого себя",
+        "en": "You cannot delete yourself",
+    },
+}
+
+
+def _normalize_locale(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip().lower()
+    if not text:
+        return None
+    for separator in ("-", "_"):
+        if separator in text:
+            text = text.split(separator, 1)[0]
+            break
+    return text if text in SUPPORTED_LOCALES else None
+
+
+def _locale_from_accept_language(header_value: Any) -> str | None:
+    if not header_value:
+        return None
+    try:
+        header = str(header_value)
+    except Exception:  # pragma: no cover - defensive
+        return None
+    candidates: list[tuple[float, str]] = []
+    for part in header.split(","):
+        token = part.strip()
+        if not token:
+            continue
+        lang, _, params = token.partition(";")
+        quality = 1.0
+        if params:
+            for param in params.split(";"):
+                param = param.strip()
+                if param.startswith("q="):
+                    try:
+                        quality = float(param[2:])
+                    except ValueError:
+                        quality = 0.0
+        normalized = _normalize_locale(lang)
+        if normalized:
+            candidates.append((quality, normalized))
+    if not candidates:
+        return None
+    candidates.sort(key=lambda item: item[0], reverse=True)
+    for _, locale in candidates:
+        if locale in SUPPORTED_LOCALES:
+            return locale
+    return None
+
+
+def resolve_locale(
+    locale: str | None = None,
+    *,
+    request: Any = None,
+    user: Any = None,
+    default: str = DEFAULT_LOCALE,
+) -> str:
+    candidate = _normalize_locale(locale)
+    if candidate:
+        return candidate
+
+    if request is not None:
+        params = getattr(request, "query_params", None)
+        if params is not None:
+            for key in _QUERY_PARAM_KEYS:
+                try:
+                    raw = params.get(key)
+                except Exception:  # pragma: no cover - defensive
+                    raw = None
+                normalized = _normalize_locale(raw)
+                if normalized:
+                    return normalized
+
+    if user is not None:
+        for attr in _USER_ATTR_KEYS:
+            normalized = _normalize_locale(getattr(user, attr, None))
+            if normalized:
+                return normalized
+
+    if request is not None:
+        headers = getattr(request, "headers", None)
+        if headers is not None:
+            try:
+                header_value = headers.get("Accept-Language")
+            except AttributeError:  # pragma: no cover - defensive
+                header_value = None
+            normalized = _locale_from_accept_language(header_value)
+            if normalized:
+                return normalized
+
+    fallback = _normalize_locale(default) or DEFAULT_LOCALE
+    return fallback
+
+
+def translate(
+    key: str,
+    *,
+    locale: str | None = None,
+    request: Any = None,
+    user: Any = None,
+    default: str | None = None,
+    **kwargs: Any,
+) -> str:
+    resolved = resolve_locale(locale=locale, request=request, user=user)
+    entry = _TRANSLATIONS.get(key)
+
+    text: str | None = None
+    if entry:
+        for candidate in (resolved, DEFAULT_LOCALE):
+            value = entry.get(candidate)
+            if value:
+                text = value
+                break
+        if text is None:
+            text = next((value for value in entry.values() if value), None)
+
+    if text is None:
+        text = default if default is not None else key
+
+    if kwargs and isinstance(text, str):
+        try:
+            return text.format(**kwargs)
+        except KeyError:  # pragma: no cover - defensive
+            return text
+    return text
+
+
+__all__ = ["SUPPORTED_LOCALES", "DEFAULT_LOCALE", "resolve_locale", "translate"]

--- a/root/app/services/notification_templates.py
+++ b/root/app/services/notification_templates.py
@@ -9,6 +9,8 @@ from html import unescape
 from textwrap import shorten
 from typing import Any, Mapping
 
+from app.localization import translate
+
 _DEFAULT_ICON = "/maskable-icon-192.png"
 _DEFAULT_BADGE = _DEFAULT_ICON
 _SYSTEM_ICON = "/guu_logo.png"
@@ -33,14 +35,14 @@ def _clean_text(value: Any, *, limit: int | None = None) -> str | None:
     return text
 
 
-def _format_room(value: Any) -> str | None:
+def _format_room(value: Any, *, locale: str | None = None) -> str | None:
     room = _clean_text(value)
     if not room:
         return None
     normalized = room.lower()
-    if normalized.startswith("ауд"):
+    if normalized.startswith("ауд") or normalized.startswith("aud") or normalized.startswith("room"):
         return room
-    return f"ауд. {room}"
+    return translate("notifications.schedule.room_label", locale=locale, room=room)
 
 
 def _parse_datetime_like(value: Any) -> datetime | None:
@@ -119,7 +121,9 @@ class ScenarioContext:
         return text or default
 
 
-def _build_schedule_change(context: ScenarioContext) -> dict[str, Any]:
+def _build_schedule_change(
+    context: ScenarioContext, *, locale: str | None = None
+) -> dict[str, Any]:
     subject = context.get_text("subject", "subject_name", "title", "name")
     group = context.get_text("group", "group_name", "group_title")
     change_summary = context.get_text("summary", "change", "status", "state")
@@ -127,7 +131,8 @@ def _build_schedule_change(context: ScenarioContext) -> dict[str, Any]:
     teacher = context.get_text("teacher", "lecturer", "professor")
     date_text = context.get_text("date", "day", "date_text")
     time_text = context.get_text("time", "start_time", "starts_at", "start")
-    room = context.get_text("room", "auditory", "location")
+    room_text = context.get_text("room", "auditory", "location")
+    room_display = _format_room(room_text, locale=locale)
     url = context.get_url("url", "link", default="/schedule")
     identifier = context.get_identifier(
         "lesson_id",
@@ -147,8 +152,8 @@ def _build_schedule_change(context: ScenarioContext) -> dict[str, Any]:
             detail_parts.append(date_text)
         if time_text:
             detail_parts.append(time_text)
-    if room:
-        detail_parts.append(f"ауд. {room}")
+    if room_display:
+        detail_parts.append(room_display)
     if teacher:
         detail_parts.append(teacher)
     if group:
@@ -162,9 +167,18 @@ def _build_schedule_change(context: ScenarioContext) -> dict[str, Any]:
     if detail_parts:
         lines.append(" · ".join(detail_parts))
     if not lines:
-        lines.append("Проверьте расписание для актуальной информации.")
+        lines.append(
+            translate("notifications.schedule.change.no_details", locale=locale)
+        )
 
-    title = f"Изменение пары: {subject}" if subject else "Изменение пары"
+    if subject:
+        title = translate(
+            "notifications.schedule.change.title_with_subject",
+            locale=locale,
+            subject=subject,
+        )
+    else:
+        title = translate("notifications.schedule.change.title", locale=locale)
     tag = f"schedule-change:{identifier}" if identifier else "schedule-change"
 
     data_payload = {
@@ -192,12 +206,15 @@ def _build_schedule_change(context: ScenarioContext) -> dict[str, Any]:
     }
 
 
-def _build_schedule_reminder(context: ScenarioContext) -> dict[str, Any]:
+def _build_schedule_reminder(
+    context: ScenarioContext, *, locale: str | None = None
+) -> dict[str, Any]:
     subject = context.get_text("subject", "subject_name", "title", "name")
     group = context.get_text("group", "group_name", "group_title")
     lesson_type = context.get_text("lesson_type", "type", "format")
     teacher = context.get_text("teacher", "lecturer", "professor")
-    room = _format_room(context.get("room", "auditory", "location"))
+    room_text = context.get_text("room", "auditory", "location")
+    room = _format_room(room_text, locale=locale)
     manual_date = context.get_text("date", "day", "date_text")
     manual_time = context.get_text("time", "start_time_text", "start_text")
     start_source = context.get(
@@ -238,13 +255,30 @@ def _build_schedule_reminder(context: ScenarioContext) -> dict[str, Any]:
 
     lines: list[str] = []
     if when_line:
-        lines.append(f"Начало: {when_line}")
+        lines.append(
+            translate(
+                "notifications.schedule.reminder.start_line",
+                locale=locale,
+                start=when_line,
+            )
+        )
     if summary_parts:
         lines.append(" · ".join(summary_parts))
     if not lines:
-        lines.append("Проверьте расписание для подробностей.")
+        lines.append(
+            translate("notifications.schedule.reminder.no_details", locale=locale)
+        )
 
-    title = f"Скоро пара: {subject}" if subject else "Скоро пара"
+    if subject:
+        title = translate(
+            "notifications.schedule.reminder.title_with_subject",
+            locale=locale,
+            subject=subject,
+        )
+    else:
+        title = translate(
+            "notifications.schedule.reminder.title", locale=locale
+        )
     tag = f"schedule-reminder:{identifier}" if identifier else "schedule-reminder"
 
     data_payload = {
@@ -263,6 +297,8 @@ def _build_schedule_reminder(context: ScenarioContext) -> dict[str, Any]:
         data_payload["teacher"] = teacher
     if room:
         data_payload["room"] = room
+    elif room_text:
+        data_payload["room"] = room_text
     if when_line:
         data_payload["startText"] = when_line
     if start_iso:
@@ -284,7 +320,7 @@ def _build_schedule_reminder(context: ScenarioContext) -> dict[str, Any]:
     }
 
 
-def _build_news(context: ScenarioContext) -> dict[str, Any]:
+def _build_news(context: ScenarioContext, *, locale: str | None = None) -> dict[str, Any]:
     headline = context.get_text("headline", "title", "subject", "name")
     summary = _clean_text(
         context.get("summary", "body", "excerpt", "description"),
@@ -304,9 +340,16 @@ def _build_news(context: ScenarioContext) -> dict[str, Any]:
     if detail_parts:
         lines.append(" · ".join(detail_parts))
     if not lines:
-        lines.append("Откройте новость, чтобы узнать подробности.")
+        lines.append(
+            translate("notifications.news.no_summary", locale=locale)
+        )
 
-    title = f"Новая новость: {headline}" if headline else "Новая новость"
+    if headline:
+        title = translate(
+            "notifications.news.title_with_headline", locale=locale, headline=headline
+        )
+    else:
+        title = translate("notifications.news.title", locale=locale)
     tag = f"news:{identifier}" if identifier else "news"
 
     data_payload = {
@@ -334,7 +377,9 @@ def _build_news(context: ScenarioContext) -> dict[str, Any]:
     }
 
 
-def _build_event(context: ScenarioContext) -> dict[str, Any]:
+def _build_event(
+    context: ScenarioContext, *, locale: str | None = None
+) -> dict[str, Any]:
     title = context.get_text("title", "name", "headline")
     summary = _clean_text(
         context.get("summary", "description", "about", "details"),
@@ -381,9 +426,16 @@ def _build_event(context: ScenarioContext) -> dict[str, Any]:
     if details:
         lines.append(" · ".join(details))
     if not lines:
-        lines.append("Подробнее в карточке события.")
+        lines.append(
+            translate("notifications.events.no_details", locale=locale)
+        )
 
-    notif_title = f"Новое мероприятие: {title}" if title else "Новое мероприятие"
+    if title:
+        notif_title = translate(
+            "notifications.events.title_with_name", locale=locale, title=title
+        )
+    else:
+        notif_title = translate("notifications.events.title", locale=locale)
     tag = f"event:{identifier}" if identifier else "event"
 
     data_payload = {
@@ -423,7 +475,9 @@ def _build_event(context: ScenarioContext) -> dict[str, Any]:
     }
 
 
-def _build_system(context: ScenarioContext) -> dict[str, Any]:
+def _build_system(
+    context: ScenarioContext, *, locale: str | None = None
+) -> dict[str, Any]:
     subject = context.get_text("title", "subject", "heading")
     message = context.get_text("message", "body", "text")
     url = context.get_url("url", "link", default="/")
@@ -433,9 +487,11 @@ def _build_system(context: ScenarioContext) -> dict[str, Any]:
     if message:
         lines.append(message)
     if not lines:
-        lines.append("Подробности доступны в приложении.")
+        lines.append(
+            translate("notifications.system.no_details", locale=locale)
+        )
 
-    title = subject or "Системное сообщение"
+    title = subject or translate("notifications.system.title", locale=locale)
     tag = f"system-message:{identifier}" if identifier else "system-message"
 
     data_payload = {
@@ -500,6 +556,8 @@ def _normalize_type(notification_type: str | None) -> str:
 def render_notification_template(
     notification_type: str | None,
     data: Mapping[str, Any] | None,
+    *,
+    locale: str | None = None,
 ) -> dict[str, Any] | None:
     """Return payload defaults for a known notification scenario."""
 
@@ -511,7 +569,7 @@ def render_notification_template(
     if not builder:
         return None
     context = ScenarioContext(data or {})
-    return builder(context)
+    return builder(context, locale=locale)
 
 
 __all__ = ["render_notification_template"]

--- a/root/app/services/notification_templates.py
+++ b/root/app/services/notification_templates.py
@@ -40,7 +40,11 @@ def _format_room(value: Any, *, locale: str | None = None) -> str | None:
     if not room:
         return None
     normalized = room.lower()
-    if normalized.startswith("ауд") or normalized.startswith("aud") or normalized.startswith("room"):
+    if (
+        normalized.startswith("ауд")
+        or normalized.startswith("aud")
+        or normalized.startswith("room")
+    ):
         return room
     return translate("notifications.schedule.room_label", locale=locale, room=room)
 
@@ -276,9 +280,7 @@ def _build_schedule_reminder(
             subject=subject,
         )
     else:
-        title = translate(
-            "notifications.schedule.reminder.title", locale=locale
-        )
+        title = translate("notifications.schedule.reminder.title", locale=locale)
     tag = f"schedule-reminder:{identifier}" if identifier else "schedule-reminder"
 
     data_payload = {
@@ -320,7 +322,9 @@ def _build_schedule_reminder(
     }
 
 
-def _build_news(context: ScenarioContext, *, locale: str | None = None) -> dict[str, Any]:
+def _build_news(
+    context: ScenarioContext, *, locale: str | None = None
+) -> dict[str, Any]:
     headline = context.get_text("headline", "title", "subject", "name")
     summary = _clean_text(
         context.get("summary", "body", "excerpt", "description"),
@@ -340,9 +344,7 @@ def _build_news(context: ScenarioContext, *, locale: str | None = None) -> dict[
     if detail_parts:
         lines.append(" · ".join(detail_parts))
     if not lines:
-        lines.append(
-            translate("notifications.news.no_summary", locale=locale)
-        )
+        lines.append(translate("notifications.news.no_summary", locale=locale))
 
     if headline:
         title = translate(
@@ -426,9 +428,7 @@ def _build_event(
     if details:
         lines.append(" · ".join(details))
     if not lines:
-        lines.append(
-            translate("notifications.events.no_details", locale=locale)
-        )
+        lines.append(translate("notifications.events.no_details", locale=locale))
 
     if title:
         notif_title = translate(
@@ -487,9 +487,7 @@ def _build_system(
     if message:
         lines.append(message)
     if not lines:
-        lines.append(
-            translate("notifications.system.no_details", locale=locale)
-        )
+        lines.append(translate("notifications.system.no_details", locale=locale))
 
     title = subject or translate("notifications.system.title", locale=locale)
     tag = f"system-message:{identifier}" if identifier else "system-message"

--- a/root/app/services/notifications.py
+++ b/root/app/services/notifications.py
@@ -496,9 +496,7 @@ async def notify_about_news(
         )
     else:
         default_title = translate("notifications.news.title", locale=locale)
-    default_body = summary or translate(
-        "notifications.news.no_summary", locale=locale
-    )
+    default_body = summary or translate("notifications.news.no_summary", locale=locale)
     default_tag = f"news:{news.id}" if getattr(news, "id", None) else "news"
     if template:
         title = str(template.get("title") or default_title)

--- a/root/app/services/notifications.py
+++ b/root/app/services/notifications.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import selectinload
 
 from app.core.config import settings
 from app.core.database import async_session as _async_session
+from app.localization import translate
 from app.models.models import (
     Event,
     News,
@@ -99,7 +100,7 @@ def _ensure_aware(value: dt.datetime | None) -> dt.datetime:
 
 
 def build_schedule_reminder_message(
-    lesson: Schedule,
+    lesson: Schedule, *, locale: str | None = None
 ) -> tuple[str, str, str, dict[str, Any]]:
     start_dt = _ensure_aware(getattr(lesson, "start_time", None))
     start_local = start_dt.astimezone()
@@ -115,29 +116,53 @@ def build_schedule_reminder_message(
         "url": "/schedule",
         "lesson_id": getattr(lesson, "id", None),
     }
-    template = render_notification_template("schedule.reminder", payload_input)
-    default_title = (
-        f"Скоро пара: {lesson.subject}"
-        if getattr(lesson, "subject", None)
-        else "Скоро пара"
+    template = render_notification_template(
+        "schedule.reminder", payload_input, locale=locale
     )
+    subject_value = getattr(lesson, "subject", None)
+    if subject_value:
+        default_title = translate(
+            "notifications.schedule.reminder.title_with_subject",
+            locale=locale,
+            subject=subject_value,
+        )
+    else:
+        default_title = translate(
+            "notifications.schedule.reminder.title", locale=locale
+        )
     summary_parts: list[str] = []
     if getattr(lesson, "lesson_type", None):
         summary_parts.append(str(lesson.lesson_type))
     room_value = getattr(lesson, "room", None)
     if room_value:
         room_text = str(room_value)
-        summary_parts.append(
-            room_text if room_text.lower().startswith("ауд") else f"ауд. {room_text}"
-        )
+        normalized = room_text.strip().lower()
+        if normalized.startswith("ауд") or normalized.startswith("aud"):
+            summary_parts.append(room_text)
+        else:
+            summary_parts.append(
+                translate(
+                    "notifications.schedule.room_label",
+                    locale=locale,
+                    room=room_text,
+                )
+            )
     if getattr(lesson, "teacher", None):
         summary_parts.append(str(lesson.teacher))
     when_line = f"{start_local.strftime('%d.%m')} · {start_local.strftime('%H:%M')}"
-    default_lines = [f"Начало: {when_line}"]
+    default_lines = [
+        translate(
+            "notifications.schedule.reminder.start_line",
+            locale=locale,
+            start=when_line,
+        )
+    ]
     if summary_parts:
         default_lines.append(" · ".join(summary_parts))
     else:
-        default_lines.append("Проверьте расписание для подробностей.")
+        default_lines.append(
+            translate("notifications.schedule.reminder.no_details", locale=locale)
+        )
     default_body = "\n".join(default_lines)
     default_tag = f"schedule-reminder:{getattr(lesson, 'id', 'lesson')}:{int(start_dt.timestamp())}"
     default_data: dict[str, Any] = {
@@ -429,6 +454,7 @@ async def generate_schedule_reminders(
         to_notify = [u for u in uids_all if u not in existing]
         if not to_notify:
             continue
+        action_title = translate("notifications.actions.open_schedule", locale=None)
         total_created += await create_notifications_for_users(
             db,
             title=title,
@@ -439,7 +465,7 @@ async def generate_schedule_reminders(
             actions=[
                 {
                     "action": "open-schedule",
-                    "title": "Открыть расписание",
+                    "title": action_title,
                     "url": "/schedule",
                 }
             ],
@@ -450,7 +476,9 @@ async def generate_schedule_reminders(
     return total_created
 
 
-async def notify_about_news(db: AsyncSession, news: News) -> int:
+async def notify_about_news(
+    db: AsyncSession, news: News, *, locale: str | None = None
+) -> int:
     summary = _plain_text(getattr(news, "content", None), limit=220)
     url = f"/news/{news.id}" if getattr(news, "id", None) else "/news"
     template_payload = {
@@ -459,13 +487,18 @@ async def notify_about_news(db: AsyncSession, news: News) -> int:
         "id": getattr(news, "id", None),
         "url": url,
     }
-    template = render_notification_template("news.new", template_payload)
-    default_title = (
-        f"Новая новость: {news.title}"
-        if getattr(news, "title", None)
-        else "Новая новость"
+    template = render_notification_template("news.new", template_payload, locale=locale)
+    if getattr(news, "title", None):
+        default_title = translate(
+            "notifications.news.title_with_headline",
+            locale=locale,
+            headline=news.title,
+        )
+    else:
+        default_title = translate("notifications.news.title", locale=locale)
+    default_body = summary or translate(
+        "notifications.news.no_summary", locale=locale
     )
-    default_body = summary or "Откройте новость, чтобы узнать подробности."
     default_tag = f"news:{news.id}" if getattr(news, "id", None) else "news"
     if template:
         title = str(template.get("title") or default_title)
@@ -504,7 +537,9 @@ async def notify_about_news(db: AsyncSession, news: News) -> int:
     )
 
 
-async def notify_about_event(db: AsyncSession, event: Event) -> int:
+async def notify_about_event(
+    db: AsyncSession, event: Event, *, locale: str | None = None
+) -> int:
     summary = _plain_text(
         getattr(event, "description", None) or getattr(event, "about", None), limit=220
     )
@@ -523,12 +558,17 @@ async def notify_about_event(db: AsyncSession, event: Event) -> int:
         "url": url,
         "id": getattr(event, "id", None),
     }
-    template = render_notification_template("events.new", template_payload)
-    default_title = (
-        f"Новое мероприятие: {event.title}"
-        if getattr(event, "title", None)
-        else "Новое мероприятие"
+    template = render_notification_template(
+        "events.new", template_payload, locale=locale
     )
+    if getattr(event, "title", None):
+        default_title = translate(
+            "notifications.events.title_with_name",
+            locale=locale,
+            title=event.title,
+        )
+    else:
+        default_title = translate("notifications.events.title", locale=locale)
     details = [start_local.strftime("%d.%m · %H:%M")]
     if getattr(event, "location", None):
         details.append(str(event.location))
@@ -541,7 +581,9 @@ async def notify_about_event(db: AsyncSession, event: Event) -> int:
         default_lines.append(summary)
     if details:
         default_lines.append(" · ".join(details))
-    default_body = "\n".join(default_lines) or "Подробнее в карточке события."
+    default_body = "\n".join(default_lines) or translate(
+        "notifications.events.no_details", locale=locale
+    )
     default_tag = f"event:{event.id}" if getattr(event, "id", None) else "event"
     if template:
         title = str(template.get("title") or default_title)

--- a/root/app/services/webpush.py
+++ b/root/app/services/webpush.py
@@ -20,6 +20,7 @@ from app.core.config import settings
 from app.core.database import async_session
 from app.core.rate_limit import RateLimitExceeded, RateLimitInfo, enforce_rate_limit
 from app.models.models import PushSubscription
+from app.localization import translate
 from app.services.notification_templates import render_notification_template
 from app.services.push_schema import ensure_push_subscription_schema_sync
 from app.services.push_topics import normalize_topic, subscription_supports_topic
@@ -368,14 +369,19 @@ async def _check_rate_limit(
 
 
 def build_payload(
-    notification_type: str, data: Mapping[str, Any] | None
+    notification_type: str,
+    data: Mapping[str, Any] | None,
+    *,
+    locale: str | None = None,
 ) -> dict[str, Any]:
     if isinstance(data, Mapping):
         raw_source = {key: deepcopy(value) for key, value in data.items()}
     else:
         raw_source = {}
 
-    template_defaults = render_notification_template(notification_type, raw_source)
+    template_defaults = render_notification_template(
+        notification_type, raw_source, locale=locale
+    )
     if template_defaults:
         source: dict[str, Any] = {
             key: deepcopy(value) for key, value in template_defaults.items()
@@ -409,7 +415,10 @@ def build_payload(
     else:
         source = raw_source
 
-    title = str(source.get("title") or "Уведомление")
+    title = str(
+        source.get("title")
+        or translate("notifications.default_title", locale=locale)
+    )
     payload_data: dict[str, Any] = {}
     if isinstance(source.get("data"), Mapping):
         payload_data.update(
@@ -425,6 +434,8 @@ def build_payload(
         value = source.get(key)
         if value is not None:
             options[key] = str(value)
+    if locale and "lang" not in options:
+        options["lang"] = locale
     actions, action_urls = _prepare_actions(source.get("actions"))
     if actions:
         options["actions"] = actions

--- a/root/app/services/webpush.py
+++ b/root/app/services/webpush.py
@@ -19,8 +19,8 @@ from sqlalchemy.orm import selectinload, sessionmaker
 from app.core.config import settings
 from app.core.database import async_session
 from app.core.rate_limit import RateLimitExceeded, RateLimitInfo, enforce_rate_limit
-from app.models.models import PushSubscription
 from app.localization import translate
+from app.models.models import PushSubscription
 from app.services.notification_templates import render_notification_template
 from app.services.push_schema import ensure_push_subscription_schema_sync
 from app.services.push_topics import normalize_topic, subscription_supports_topic
@@ -416,8 +416,7 @@ def build_payload(
         source = raw_source
 
     title = str(
-        source.get("title")
-        or translate("notifications.default_title", locale=locale)
+        source.get("title") or translate("notifications.default_title", locale=locale)
     )
     payload_data: dict[str, Any] = {}
     if isinstance(source.get("data"), Mapping):

--- a/root/app/utils/email.py
+++ b/root/app/utils/email.py
@@ -3,22 +3,50 @@ import ssl
 from email.message import EmailMessage
 
 from app.core.config import settings
+from app.localization import translate
+from app.localization import resolve_locale
+
+RESET_TOKEN_EXPIRY_MINUTES = 45
 
 
-def _build_html(link: str, full_name: str) -> str:
-    name = f", {full_name}" if full_name else ""
-    return f"""
+def build_reset_email_content(
+    link: str, full_name: str = "", *, locale: str | None = None
+) -> tuple[str, str, str]:
+    resolved_locale = resolve_locale(locale=locale)
+    name_suffix = f", {full_name}" if full_name else ""
+    subject = translate("email.reset.subject", locale=resolved_locale)
+    heading = translate("email.reset.heading", locale=resolved_locale)
+    greeting = translate(
+        "email.reset.greeting", locale=resolved_locale, name=name_suffix
+    )
+    instructions = translate(
+        "email.reset.instructions",
+        locale=resolved_locale,
+        minutes=RESET_TOKEN_EXPIRY_MINUTES,
+    )
+    button = translate("email.reset.button", locale=resolved_locale)
+    ignore = translate("email.reset.ignore", locale=resolved_locale)
+    html = f"""
   <div style="font-family:Inter,Arial,sans-serif">
-    <h2>Сброс пароля</h2>
-    <p>Здравствуйте{name}!</p>
-    <p>Вы запросили сброс пароля в Экосистеме ГУУ. Ссылка действует 45 минут.</p>
-    <p><a href="{link}" style="display:inline-block;padding:10px 16px;background:#1d5fff;color:#fff;border-radius:8px;text-decoration:none">Сбросить пароль</a></p>
-    <p>Если вы не запрашивали сброс, проигнорируйте это письмо.</p>
+    <h2>{heading}</h2>
+    <p>{greeting}</p>
+    <p>{instructions}</p>
+    <p><a href="{link}" style="display:inline-block;padding:10px 16px;background:#1d5fff;color:#fff;border-radius:8px;text-decoration:none">{button}</a></p>
+    <p>{ignore}</p>
   </div>
   """
+    plain = translate(
+        "email.reset.plain",
+        locale=resolved_locale,
+        link=link,
+        minutes=RESET_TOKEN_EXPIRY_MINUTES,
+    )
+    return subject, plain, html
 
 
-def send_reset_email(to_email: str, link: str, full_name: str = "") -> None:
+def send_reset_email(
+    to_email: str, link: str, full_name: str = "", *, locale: str | None = None
+) -> None:
     host = settings.smtp_host
     port = settings.smtp_port
     user = settings.smtp_user
@@ -27,11 +55,14 @@ def send_reset_email(to_email: str, link: str, full_name: str = "") -> None:
     mail_from = settings.mail_from
 
     msg = EmailMessage()
-    msg["Subject"] = "Сброс пароля — Экосистема ГУУ"
+    subject, plain, html = build_reset_email_content(
+        link, full_name, locale=locale
+    )
+    msg["Subject"] = subject
     msg["From"] = mail_from
     msg["To"] = to_email
-    msg.set_content(f"Ссылка для сброса пароля: {link}\nОна действует 45 минут.")
-    msg.add_alternative(_build_html(link, full_name), subtype="html")
+    msg.set_content(plain)
+    msg.add_alternative(html, subtype="html")
 
     context = ssl.create_default_context()
     if starttls:

--- a/root/app/utils/email.py
+++ b/root/app/utils/email.py
@@ -3,8 +3,7 @@ import ssl
 from email.message import EmailMessage
 
 from app.core.config import settings
-from app.localization import translate
-from app.localization import resolve_locale
+from app.localization import resolve_locale, translate
 
 RESET_TOKEN_EXPIRY_MINUTES = 45
 
@@ -55,9 +54,7 @@ def send_reset_email(
     mail_from = settings.mail_from
 
     msg = EmailMessage()
-    subject, plain, html = build_reset_email_content(
-        link, full_name, locale=locale
-    )
+    subject, plain, html = build_reset_email_content(link, full_name, locale=locale)
     msg["Subject"] = subject
     msg["From"] = mail_from
     msg["To"] = to_email

--- a/root/app/utils/files.py
+++ b/root/app/utils/files.py
@@ -117,6 +117,10 @@ def detect_mime_type(data: bytes) -> str | None:
         if normalized:
             return normalized
 
+    # Handle a few lightweight signatures when libmagic is unavailable.
+    if data.startswith(b"%PDF-"):
+        return "application/pdf"
+
     # Fall back to lightweight signature checks for common image formats.
     return _normalize_mime_type(_detect_image_mime(data)) or None
 

--- a/root/tests/test_event_file_upload.py
+++ b/root/tests/test_event_file_upload.py
@@ -57,7 +57,9 @@ async def test_upload_event_file_offloads_io(
     monkeypatch.setattr(settings, "event_file_allowed_extensions", [".txt"])
     monkeypatch.setattr(settings, "event_file_max_size_bytes", 1024)
 
-    result = await events.upload_event_file(event.id, upload, db=db_session, user=admin)
+    result = await events.upload_event_file(
+        event.id, upload, request=None, db=db_session, user=admin
+    )
 
     assert result.event_id == event.id
     assert result.file_url.startswith("/static/event_files/")
@@ -88,7 +90,9 @@ async def test_upload_event_file_rejects_large_payload(
     monkeypatch.setattr(settings, "event_file_max_size_bytes", 8)
 
     with pytest.raises(HTTPException) as excinfo:
-        await events.upload_event_file(event.id, upload, db=db_session, user=admin)
+        await events.upload_event_file(
+            event.id, upload, request=None, db=db_session, user=admin
+        )
 
     assert excinfo.value.status_code == status.HTTP_413_CONTENT_TOO_LARGE
     folder = tmp_path / "event_files"
@@ -114,7 +118,9 @@ async def test_upload_event_file_rejects_forbidden_type(
     monkeypatch.setattr(settings, "event_file_max_size_bytes", 1024)
 
     with pytest.raises(HTTPException) as excinfo:
-        await events.upload_event_file(event.id, upload, db=db_session, user=admin)
+        await events.upload_event_file(
+            event.id, upload, request=None, db=db_session, user=admin
+        )
 
     assert excinfo.value.status_code == status.HTTP_415_UNSUPPORTED_MEDIA_TYPE
     folder = tmp_path / "event_files"
@@ -145,7 +151,9 @@ async def test_upload_event_file_rejects_mismatched_magic_bytes(
     monkeypatch.setattr(settings, "event_file_max_size_bytes", 1024)
 
     with pytest.raises(HTTPException) as excinfo:
-        await events.upload_event_file(event.id, upload, db=db_session, user=admin)
+        await events.upload_event_file(
+            event.id, upload, request=None, db=db_session, user=admin
+        )
 
     assert excinfo.value.status_code == status.HTTP_415_UNSUPPORTED_MEDIA_TYPE
     assert excinfo.value.detail == "content type mismatch"
@@ -172,7 +180,9 @@ async def test_update_event_replaces_image_removes_old_file(
     monkeypatch.setattr(settings, "static_dir_path", tmp_path)
 
     payload = schemas.EventUpdate(image_url="/static/event_images/new.png")
-    result = await events.update_event(event.id, payload, db=db_session, user=admin)
+    result = await events.update_event(
+        event.id, payload, request=None, db=db_session, user=admin
+    )
 
     assert result.image_url == "/static/event_images/new.png"
     assert not old_path.exists()
@@ -198,13 +208,15 @@ async def test_delete_event_file_removes_payload(
     monkeypatch.setattr(settings, "event_file_max_size_bytes", 1024)
 
     event_file = await events.upload_event_file(
-        event.id, upload, db=db_session, user=admin
+        event.id, upload, request=None, db=db_session, user=admin
     )
 
     stored_path = tmp_path / "event_files" / event_file.file_url.rsplit("/", 1)[-1]
     assert stored_path.exists()
 
-    result = await events.delete_event_file(event_file.id, db=db_session, user=admin)
+    result = await events.delete_event_file(
+        event_file.id, request=None, db=db_session, user=admin
+    )
 
     assert result == {"ok": True}
     assert not stored_path.exists()
@@ -237,7 +249,7 @@ async def test_delete_event_removes_all_files(
             headers=Headers({"content-type": "text/plain"}),
         )
         event_file = await events.upload_event_file(
-            event.id, upload, db=db_session, user=admin
+            event.id, upload, request=None, db=db_session, user=admin
         )
         stored_paths.append(
             tmp_path / "event_files" / event_file.file_url.rsplit("/", 1)[-1]
@@ -246,7 +258,9 @@ async def test_delete_event_removes_all_files(
     for path in stored_paths:
         assert path.exists()
 
-    result = await events.delete_event(event.id, db=db_session, user=admin)
+    result = await events.delete_event(
+        event.id, request=None, db=db_session, user=admin
+    )
 
     assert result == {"ok": True}
     for path in stored_paths:

--- a/root/tests/test_localization.py
+++ b/root/tests/test_localization.py
@@ -1,0 +1,32 @@
+from starlette.datastructures import Headers, QueryParams
+
+from app.localization import resolve_locale, translate
+
+
+class _DummyRequest:
+    def __init__(self, query: dict[str, str] | None = None, headers=None) -> None:
+        self.query_params = QueryParams(query or {})
+        self.headers = Headers(headers or {})
+
+
+class _DummyUser:
+    def __init__(self, preferred_locale: str | None = None) -> None:
+        self.preferred_locale = preferred_locale
+
+
+def test_resolve_locale_prefers_query_param_over_header():
+    request = _DummyRequest(query={"lang": "ru"}, headers={"Accept-Language": "en"})
+
+    assert resolve_locale(request=request) == "ru"
+
+
+def test_resolve_locale_uses_user_preference():
+    request = _DummyRequest(headers={"Accept-Language": "en-US"})
+    user = _DummyUser(preferred_locale="ru")
+
+    assert resolve_locale(request=request, user=user) == "ru"
+
+
+def test_translate_falls_back_to_english():
+    # Unknown locale should fall back to English
+    assert translate("notifications.default_title", locale="de") == "Notification"

--- a/root/tests/test_news_image_cleanup.py
+++ b/root/tests/test_news_image_cleanup.py
@@ -30,7 +30,9 @@ async def test_update_news_removes_replaced_image(
         image_url="/static/news_images/new.png",
     )
 
-    updated = await news.update_news(record.id, payload, db=db_session, user=admin)
+    updated = await news.update_news(
+        record.id, payload, request=None, db=db_session, user=admin
+    )
 
     assert updated.image_url == "/static/news_images/new.png"
     assert not old_path.exists()
@@ -54,7 +56,9 @@ async def test_delete_news_removes_image_file(
 
     monkeypatch.setattr(settings, "static_dir_path", tmp_path)
 
-    result = await news.delete_news(record.id, db=db_session, user=admin)
+    result = await news.delete_news(
+        record.id, request=None, db=db_session, user=admin
+    )
 
     assert result == {"ok": True}
     assert await db_session.get(models.News, record.id) is None

--- a/root/tests/test_news_image_cleanup.py
+++ b/root/tests/test_news_image_cleanup.py
@@ -56,9 +56,7 @@ async def test_delete_news_removes_image_file(
 
     monkeypatch.setattr(settings, "static_dir_path", tmp_path)
 
-    result = await news.delete_news(
-        record.id, request=None, db=db_session, user=admin
-    )
+    result = await news.delete_news(record.id, request=None, db=db_session, user=admin)
 
     assert result == {"ok": True}
     assert await db_session.get(models.News, record.id) is None

--- a/root/tests/test_notification_templates.py
+++ b/root/tests/test_notification_templates.py
@@ -12,6 +12,7 @@ def test_build_payload_schedule_change_template():
             "time": "10:00",
             "room": "101",
         },
+        locale="ru",
     )
 
     assert payload["title"] == "Изменение пары: Математика"
@@ -35,6 +36,7 @@ def test_build_payload_news_template_merges_overrides():
             "data": {"foo": "bar"},
             "icon": "/custom-icon.png",
         },
+        locale="ru",
     )
 
     assert payload["title"] == "Новая новость: Ректор выступил"
@@ -60,6 +62,7 @@ def test_build_payload_schedule_reminder_template():
             "time": "09:40",
             "lesson_id": 512,
         },
+        locale="ru",
     )
 
     assert payload["title"] == "Скоро пара: Менеджмент"
@@ -87,6 +90,7 @@ def test_build_payload_events_template():
             "starts_at": "2025-04-10T15:00:00+03:00",
             "id": 77,
         },
+        locale="ru",
     )
 
     assert payload["title"] == "День открытых дверей"
@@ -108,6 +112,7 @@ def test_build_payload_system_message_template():
             "id": "maint",
             "url": "/status",
         },
+        locale="ru",
     )
 
     assert payload["title"] == "Системное сообщение"
@@ -117,3 +122,33 @@ def test_build_payload_system_message_template():
     assert options["requireInteraction"] is True
     assert options["renotify"] is False
     assert payload["data"]["url"] == "/status"
+
+
+def test_build_payload_schedule_change_english_locale():
+    payload = build_payload("schedule.change", None, locale="en")
+
+    assert payload["title"] == "Class change"
+    assert (
+        payload["options"]["body"]
+        == "Check the schedule for the latest information."
+    )
+
+
+def test_build_payload_schedule_reminder_english_locale():
+    payload = build_payload(
+        "schedule.reminder",
+        {
+            "subject": "Management",
+            "lesson_type": "Seminar",
+            "teacher": "John Doe",
+            "room": "203",
+            "starts_at": "2025-03-25T09:40:00+03:00",
+            "date": "25.03",
+            "time": "09:40",
+        },
+        locale="en",
+    )
+
+    assert payload["title"] == "Upcoming class: Management"
+    assert "Starts at:" in payload["options"]["body"]
+    assert payload["data"]["room"] == "room 203"

--- a/root/tests/test_notification_templates.py
+++ b/root/tests/test_notification_templates.py
@@ -129,8 +129,7 @@ def test_build_payload_schedule_change_english_locale():
 
     assert payload["title"] == "Class change"
     assert (
-        payload["options"]["body"]
-        == "Check the schedule for the latest information."
+        payload["options"]["body"] == "Check the schedule for the latest information."
     )
 
 

--- a/root/tests/test_spotify_fallback.py
+++ b/root/tests/test_spotify_fallback.py
@@ -110,6 +110,7 @@ async def test_now_playing_returns_204_when_user_has_no_track(
     user = await user_factory(hashed_password=hashed, is_active=True)
 
     headers = await _login(async_client, user, password)
+    headers["Accept-Language"] = "ru"
 
     response = await async_client.get("/spotify/now-playing", headers=headers)
 
@@ -131,6 +132,7 @@ async def test_now_playing_uses_last_known_track_from_fallback(
     await db_session.refresh(user)
 
     headers = await _login(async_client, user, password)
+    headers["Accept-Language"] = "ru"
 
     response = await async_client.get("/spotify/now-playing", headers=headers)
 
@@ -173,6 +175,7 @@ async def test_now_playing_returns_401_when_refresh_fails(
     monkeypatch.setattr("httpx.AsyncClient.post", fake_post)
 
     headers = await _login(async_client, user, password)
+    headers["Accept-Language"] = "ru"
 
     response = await async_client.get("/spotify/now-playing", headers=headers)
 
@@ -233,6 +236,7 @@ async def test_now_playing_refreshes_when_access_token_missing(
     monkeypatch.setattr("httpx.AsyncClient.get", fake_get)
 
     headers = await _login(async_client, user, password)
+    headers["Accept-Language"] = "ru"
 
     response = await async_client.get("/spotify/now-playing", headers=headers)
 
@@ -275,6 +279,7 @@ async def test_now_playing_disconnects_on_unauthorized_response(
     monkeypatch.setattr("httpx.AsyncClient.get", fake_get)
 
     headers = await _login(async_client, user, password)
+    headers["Accept-Language"] = "ru"
 
     response = await async_client.get("/spotify/now-playing", headers=headers)
 

--- a/root/tests/test_user_profile_update.py
+++ b/root/tests/test_user_profile_update.py
@@ -57,10 +57,12 @@ async def test_update_profile_email_duplicate(async_client, user_factory, db_ses
 
     headers = await _login(async_client, user.email, password)
 
+    headers_ru = {**headers, "Accept-Language": "ru"}
+
     response = await async_client.put(
         "/users/me",
         json={"email": "Existing@Example.com"},
-        headers=headers,
+        headers=headers_ru,
     )
 
     assert response.status_code == 400


### PR DESCRIPTION
## Summary
- introduce a shared localization module with RU/EN translations and helper utilities
- refactor APIs, email/notification services, and Spotify handling to resolve locales and translate user-facing strings
- update file utilities, notification payload formatting, and backend tests to respect locale selection

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ee476f2a848327aa1c2c4baf106995