### PR TITLE
Localize event card and detail messaging

### DIFF
--- a/root/frontend/src/components/EventCard.tsx
+++ b/root/frontend/src/components/EventCard.tsx
@@ -29,6 +29,7 @@ import CloseIcon from "@mui/icons-material/Close"
 import { useAuth } from "../contexts/AuthContext"
 import SmartImage from "@/components/SmartImage"
 import { cardHoverSx } from "@/constants/cardHover"
+import { useTranslation } from "react-i18next"
 
 import dayjs from "dayjs"
 import utc from "dayjs/plugin/utc"
@@ -89,6 +90,7 @@ const EventCardComponent: FC<EventCardProps> = ({
   const { user } = useAuth()
   const navigate = useNavigate()
   const isMobile = useMediaQuery("(max-width: 600px)")
+  const { t } = useTranslation(["events", "common"])
 
   const [registered, setRegistered] = useState(is_registered)
   const [count, setCount] = useState(participant_count)
@@ -263,7 +265,7 @@ const EventCardComponent: FC<EventCardProps> = ({
       setRegistered(true)
       setQr(code)
       setCount((c) => c + 1)
-      setSnack("Вы зарегистрированы на мероприятие")
+      setSnack(t("events:card.messages.registerSuccess"))
       try { localStorage.setItem(qrKey(id, user), code) } catch {}
     } catch (error) {
       const shouldResync =
@@ -274,7 +276,7 @@ const EventCardComponent: FC<EventCardProps> = ({
       if (shouldResync) {
         const restored = await syncRegistrationState()
         if (restored === "registered") {
-          setSnack("Вы зарегистрированы на мероприятие")
+          setSnack(t("events:card.messages.registerSuccess"))
           return
         }
       }
@@ -282,7 +284,7 @@ const EventCardComponent: FC<EventCardProps> = ({
       const detail =
         (isAxiosError(error) && typeof error.response?.data?.detail === "string"
           ? error.response?.data?.detail
-          : null) || "Не удалось зарегистрироваться"
+          : null) || t("events:card.messages.registerFailure")
       setSnack(detail)
     } finally {
       setLoading(false)
@@ -297,7 +299,7 @@ const EventCardComponent: FC<EventCardProps> = ({
       setRegistered(false)
       setQr(undefined)
       setCount((c) => Math.max(0, c - 1))
-      setSnack("Регистрация отменена")
+      setSnack(t("events:card.messages.unregisterSuccess"))
       try { localStorage.removeItem(qrKey(id, user)) } catch {}
     } catch (error) {
       const shouldResync =
@@ -308,7 +310,7 @@ const EventCardComponent: FC<EventCardProps> = ({
       if (shouldResync) {
         const restored = await syncRegistrationState()
         if (restored === "unregistered") {
-          setSnack("Регистрация отменена")
+          setSnack(t("events:card.messages.unregisterSuccess"))
           return
         }
       }
@@ -316,7 +318,7 @@ const EventCardComponent: FC<EventCardProps> = ({
       const detail =
         (isAxiosError(error) && typeof error.response?.data?.detail === "string"
           ? error.response?.data?.detail
-          : null) || "Не удалось отменить регистрацию"
+          : null) || t("events:card.messages.unregisterFailure")
       setSnack(detail)
     } finally {
       setLoading(false)
@@ -328,10 +330,10 @@ const EventCardComponent: FC<EventCardProps> = ({
     try {
       await api.delete(`/events/${id}`)
       try { localStorage.removeItem(qrKey(id, user)) } catch {}
-      setSnack("Мероприятие удалено")
+      setSnack(t("events:card.messages.deleteSuccess"))
       onChange && onChange()
     } catch {
-      setSnack("Ошибка удаления")
+      setSnack(t("events:card.messages.deleteFailure"))
     } finally {
       setLoading(false)
       setConfirmDeleteOpen(false)
@@ -362,9 +364,9 @@ const EventCardComponent: FC<EventCardProps> = ({
       setEditData((prev) => ({ ...prev, image_url: imgUrl }))
       closeEditDialog()
       onChange && onChange()
-      setSnack("Сохранено")
+      setSnack(t("events:card.messages.saveSuccess"))
     } catch {
-      setSnack("Не удалось сохранить")
+      setSnack(t("events:card.messages.saveFailure"))
     } finally {
       setLoading(false)
     }
@@ -435,7 +437,7 @@ const EventCardComponent: FC<EventCardProps> = ({
       {user && (user.role === "admin" || user.role === "teacher") && (
         <>
           <IconButton
-            aria-label="Действия"
+            aria-label={t("events:card.aria.actions")}
             aria-controls={menuAnchor ? menuId : undefined}
             aria-haspopup="true"
             aria-expanded={Boolean(menuAnchor) ? "true" : undefined}
@@ -475,7 +477,7 @@ const EventCardComponent: FC<EventCardProps> = ({
               }}
             >
               <EditIcon fontSize="small" sx={{ mr: 1 }} />
-              Редактировать
+              {t("common:buttons.edit")}
             </MenuItem>
             <MenuItem
               onClick={(e) => {
@@ -485,7 +487,7 @@ const EventCardComponent: FC<EventCardProps> = ({
               }}
             >
               <DeleteIcon fontSize="small" sx={{ mr: 1 }} color="error" />
-              <span style={{ color: "#d32f2f" }}>Удалить</span>
+              <span style={{ color: "#d32f2f" }}>{t("common:buttons.delete")}</span>
             </MenuItem>
           </Menu>
         </>
@@ -526,7 +528,7 @@ const EventCardComponent: FC<EventCardProps> = ({
         >
           <SmartImage
             srcRaw={cardImageUrl}
-            alt="Изображение мероприятия"
+            alt={t("events:alt.image")}
             sizes="(min-width: 1200px) 560px, (min-width: 900px) 480px, 100vw"
             style={{
               width: "100%",
@@ -552,7 +554,7 @@ const EventCardComponent: FC<EventCardProps> = ({
 
       {speaker && (
         <Typography color="secondary" fontSize={15} fontWeight={600} sx={{ mb: 1 }}>
-          Спикер: {speaker}
+          {t("events:form.speaker")}: {speaker}
         </Typography>
       )}
 
@@ -565,7 +567,7 @@ const EventCardComponent: FC<EventCardProps> = ({
 
       {eventEnded && (
         <Typography color="error.main" fontWeight={700} sx={{ mb: 1 }}>
-          Мероприятие завершено
+          {t("events:card.statuses.ended")}
         </Typography>
       )}
 
@@ -591,7 +593,7 @@ const EventCardComponent: FC<EventCardProps> = ({
 
       <Box display="flex" gap={1} alignItems="center" sx={{ mb: 2 }}>
         <PeopleAltIcon sx={{ fontSize: 19, color: "var(--nav-link)" }} />
-        <Typography fontSize={15}>Участников: {count}</Typography>
+        <Typography fontSize={15}>{t("events:card.participants", { count })}</Typography>
       </Box>
 
       {is_active && !eventEnded && !registered && user?.role !== "admin" && user?.role !== "teacher" && (
@@ -602,7 +604,7 @@ const EventCardComponent: FC<EventCardProps> = ({
           onClick={(e) => handleRegister(e)}
           disabled={loading}
         >
-          Зарегистрироваться
+          {t("events:card.actions.register")}
         </Button>
       )}
 
@@ -615,12 +617,12 @@ const EventCardComponent: FC<EventCardProps> = ({
             onClick={(e) => handleUnregister(e)}
             disabled={loading}
           >
-            Отменить регистрацию
+            {t("events:card.actions.unregister")}
           </Button>
 
           {qr && (
             <>
-              <Tooltip title="Открыть QR" arrow>
+              <Tooltip title={t("events:card.actions.openQr")} arrow>
                 <SmartImage
                   srcRaw={`https://api.qrserver.com/v1/create-qr-code/?data=${encodeURIComponent(qr)}&size=600x600`}
                   alt="QR"
@@ -697,7 +699,7 @@ const EventCardComponent: FC<EventCardProps> = ({
                     />
                   </Box>
                   <Button sx={{ mt: 2 }} variant="outlined" onClick={() => setQrOpen(false)}>
-                    Закрыть
+                    {t("events:card.actions.closeQr")}
                   </Button>
                 </Box>
               </Dialog>
@@ -712,18 +714,18 @@ const EventCardComponent: FC<EventCardProps> = ({
         PaperProps={{ sx: { minWidth: 340, bgcolor: "var(--card-bg)", color: "var(--page-text)" } }}
       >
         <DialogTitle sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-          <EditIcon fontSize="small" /> Редактировать мероприятие
+          <EditIcon fontSize="small" /> {t("events:card.dialogs.edit.title")}
         </DialogTitle>
         <DialogContent>
           <Stack spacing={2} mt={1}>
             <TextField
-              label="Название"
+              label={t("events:form.title")}
               value={editData.title}
               onChange={(e) => setEditData({ ...editData, title: e.target.value })}
               fullWidth
             />
             <TextField
-              label="Описание"
+              label={t("events:form.description")}
               value={editData.description}
               onChange={(e) => setEditData({ ...editData, description: e.target.value })}
               multiline
@@ -731,19 +733,19 @@ const EventCardComponent: FC<EventCardProps> = ({
               fullWidth
             />
             <TextField
-              label="Тип"
+              label={t("events:form.type")}
               value={editData.event_type}
               onChange={(e) => setEditData({ ...editData, event_type: e.target.value })}
               fullWidth
             />
             <TextField
-              label="Место"
+              label={t("events:form.location")}
               value={editData.location}
               onChange={(e) => setEditData({ ...editData, location: e.target.value })}
               fullWidth
             />
             <TextField
-              label="Начало"
+              label={t("events:form.start")}
               type="datetime-local"
               value={editData.starts_at.slice(0, 16)}
               onChange={(e) => setEditData({ ...editData, starts_at: e.target.value })}
@@ -751,17 +753,17 @@ const EventCardComponent: FC<EventCardProps> = ({
               fullWidth
             />
             <TextField
-              label="Окончание"
+              label={t("events:form.end")}
               type="datetime-local"
               value={editData.ends_at.slice(0, 16)}
               onChange={(e) => setEditData({ ...editData, ends_at: e.target.value })}
               InputLabelProps={{ shrink: true }}
               error={dateError}
-              helperText={dateError ? "Окончание не может быть раньше начала" : " "}
+              helperText={dateError ? t("events:form.errors.endsBeforeStarts") : " "}
               fullWidth
             />
             <TextField
-              label="Спикер"
+              label={t("events:form.speaker")}
               value={editData.speaker}
               onChange={(e) => setEditData({ ...editData, speaker: e.target.value })}
               fullWidth
@@ -774,7 +776,7 @@ const EventCardComponent: FC<EventCardProps> = ({
                 disabled={imageLoading}
                 onClick={(e) => e.stopPropagation()}
               >
-                {imageLoading ? "Загрузка..." : "Изменить фото"}
+                {imageLoading ? t("common:statuses.uploading") : t("common:buttons.changePhoto")}
                 <input
                   type="file"
                   accept="image/*"
@@ -791,7 +793,7 @@ const EventCardComponent: FC<EventCardProps> = ({
                 <Box mt={1}>
                   <SmartImage
                     srcRaw={cardImageUrl}
-                    alt="Предпросмотр изображения"
+                    alt={t("events:alt.preview")}
                     style={{
                       width: 220,
                       maxHeight: 140,
@@ -808,29 +810,29 @@ const EventCardComponent: FC<EventCardProps> = ({
         </DialogContent>
         <DialogActions sx={{ px: 3, pb: 2 }}>
           <Button variant="outlined" color="secondary" onClick={closeEditDialog} startIcon={<CloseIcon />}>
-            Отмена
+            {t("common:buttons.cancel")}
           </Button>
           <Button
             variant="contained"
             onClick={handleEdit}
             disabled={loading || imageLoading || dateError}
           >
-            Сохранить
+            {t("common:buttons.save")}
           </Button>
         </DialogActions>
       </Dialog>
 
       <Dialog open={confirmDeleteOpen} onClose={() => setConfirmDeleteOpen(false)}>
-        <DialogTitle>Удалить мероприятие?</DialogTitle>
+        <DialogTitle>{t("events:card.dialogs.delete.title")}</DialogTitle>
         <DialogContent>
-          <Typography>Действие необратимо. Подтвердите удаление.</Typography>
+          <Typography>{t("events:card.dialogs.delete.description")}</Typography>
         </DialogContent>
         <DialogActions>
           <Button variant="outlined" color="secondary" onClick={() => setConfirmDeleteOpen(false)}>
-            Отмена
+            {t("common:buttons.cancel")}
           </Button>
           <Button variant="contained" color="error" onClick={handleDelete} disabled={loading}>
-            <DeleteIcon sx={{ mr: 1 }} /> Удалить
+            <DeleteIcon sx={{ mr: 1 }} /> {t("common:buttons.delete")}
           </Button>
         </DialogActions>
       </Dialog>

--- a/root/frontend/src/components/EventDetail.tsx
+++ b/root/frontend/src/components/EventDetail.tsx
@@ -17,6 +17,7 @@ import Layout from '../components/Layout'
 import { resolveMediaUrl } from '@/utils/media'
 import SmartImage from '@/components/SmartImage'
 import type { Event } from '@/types/Event'
+import { useTranslation } from 'react-i18next'
 import {
   applyOptimisticFileAction,
   isUploadErrorState,
@@ -57,6 +58,7 @@ const EventDetail = () => {
   const navigate = useNavigate()
   const { user } = useAuth()
   const isMobile = useMediaQuery('(max-width: 900px)')
+  const { t } = useTranslation(['events', 'common'])
 
   const [event, setEvent] = useState<Event | null>(null)
   const [loading, setLoading] = useState(true)
@@ -75,11 +77,11 @@ const EventDetail = () => {
 
     const file = input.get('file')
     if (!(file instanceof File) || file.size === 0) {
-      return { status: 'error', error: 'Выберите файл' }
+      return { status: 'error', error: t('events:detail.upload.errors.noFile') }
     }
 
     if (!event) {
-      return { status: 'error', error: 'Мероприятие не найдено' }
+      return { status: 'error', error: t('events:detail.messages.notFound') }
     }
 
     const optimisticId = `pending-${Date.now()}`
@@ -101,15 +103,15 @@ const EventDetail = () => {
         headers: { 'Content-Type': 'multipart/form-data' }
       })
       mutateFiles({ type: 'remove', id: optimisticId })
-      setSnack('Файл добавлен')
+      setSnack(t('events:detail.messages.fileAdded'))
       setSelectedFile(null)
       if (fileInputRef.current) fileInputRef.current.value = ''
       await refreshEvent().catch(() => {})
       return { status: 'success' }
     } catch (err) {
       mutateFiles({ type: 'remove', id: optimisticId })
-      setSnack('Ошибка добавления файла')
-      return { status: 'error', error: 'Не удалось добавить файл' }
+      setSnack(t('events:detail.messages.fileAddFailed'))
+      return { status: 'error', error: t('events:detail.upload.errors.failed') }
     }
   }, { status: 'idle' })
 
@@ -152,7 +154,7 @@ const EventDetail = () => {
       return data
     } catch (err) {
       if (!isCanceledRequestError(err) && !signal?.aborted) {
-        setSnack('Ошибка загрузки')
+        setSnack(t('events:detail.messages.loadFailed'))
       }
       throw err
     } finally {
@@ -182,9 +184,9 @@ const EventDetail = () => {
     mutateFiles({ type: 'remove', id: fileId })
     try {
       await api.delete(`/events/file/${fileId}`)
-      setSnack('Файл удалён')
+      setSnack(t('events:detail.messages.fileDeleted'))
     } catch {
-      setSnack('Ошибка удаления файла')
+      setSnack(t('events:detail.messages.fileDeleteFailed'))
     } finally {
       await refreshEvent().catch(() => {})
     }
@@ -201,7 +203,7 @@ const EventDetail = () => {
 
   const handleSaveAbout = async () => {
     if (!event) {
-      setSnack('Ошибка сохранения описания')
+      setSnack(t('events:detail.messages.aboutUpdateFailed'))
       return
     }
 
@@ -209,11 +211,11 @@ const EventDetail = () => {
     try {
       await api.patch(`/events/${event.id}`, { about: aboutDraft.trim() })
       setEditingAbout(false)
-      setSnack('Описание обновлено')
+      setSnack(t('events:detail.messages.aboutUpdated'))
       await refreshEvent().catch(() => {})
       setTimeout(() => aboutSectionRef.current?.focus?.(), 0)
     } catch {
-      setSnack('Ошибка сохранения описания')
+      setSnack(t('events:detail.messages.aboutUpdateFailed'))
     } finally {
       setSavingAbout(false)
     }
@@ -244,7 +246,7 @@ const EventDetail = () => {
     return (
       <Layout>
         <Box minHeight="80vh" display="flex" alignItems="center" justifyContent="center">
-          <Typography>Мероприятие не найдено</Typography>
+          <Typography>{t('events:detail.messages.notFound')}</Typography>
         </Box>
       </Layout>
     )
@@ -281,7 +283,7 @@ const EventDetail = () => {
         zIndex: 99
       }}
     >
-      Назад
+      {t('common:buttons.back')}
     </Button>
   )
 
@@ -311,17 +313,23 @@ const EventDetail = () => {
               )}
               <Chip
                 icon={<PeopleAltIcon sx={{ color: '#1976d2' }} />}
-                label={`Участников: ${event.participant_count || 0}`}
+                label={t('events:card.participants', { count: event.participant_count || 0 })}
                 sx={{ fontWeight: 500, fontSize: 14 }}
               />
             </Stack>
             <Typography variant="body1" fontWeight={600}>{event.description}</Typography>
             <Box>
-              <Typography variant="subtitle1" fontWeight={600}>Место: <b>{event.location}</b></Typography>
-              <Typography variant="subtitle1">
-                Дата: <b>{formatDateSafe(event.starts_at)} — {formatDateSafe(event.ends_at)}</b>
+              <Typography variant="subtitle1" fontWeight={600}>
+                {t('events:detail.fields.location')}: <b>{event.location}</b>
               </Typography>
-              {event.speaker && <Typography variant="subtitle1">Спикер: <b>{event.speaker}</b></Typography>}
+              <Typography variant="subtitle1">
+                {t('events:detail.fields.date')}: <b>{formatDateSafe(event.starts_at)} — {formatDateSafe(event.ends_at)}</b>
+              </Typography>
+              {event.speaker && (
+                <Typography variant="subtitle1">
+                  {t('events:detail.fields.speaker')}: <b>{event.speaker}</b>
+                </Typography>
+              )}
             </Box>
             <Box
               sx={{
@@ -337,7 +345,7 @@ const EventDetail = () => {
             >
               <SmartImage
                 srcRaw={imageUrl}
-                alt="Изображение мероприятия"
+                alt={t('events:alt.image')}
                 onLoad={handleHeroLoad}
                 style={{
                   position: 'absolute',
@@ -358,10 +366,10 @@ const EventDetail = () => {
                   variant="h6"
                   fontWeight={700}
                 >
-                  Описание мероприятия
+                  {t('events:detail.sections.about.title')}
                 </Typography>
                 {(user?.role === 'admin' || user?.role === 'teacher') && !editingAbout && (
-                  <IconButton aria-label="Редактировать описание" size="small" onClick={handleEditAbout}>
+                  <IconButton aria-label={t('events:detail.sections.about.editAria')} size="small" onClick={handleEditAbout}>
                     <EditIcon fontSize="small" />
                   </IconButton>
                 )}
@@ -369,7 +377,7 @@ const EventDetail = () => {
               {editingAbout ? (
                 <Stack spacing={1}>
                   <TextField
-                    label="Описание мероприятия"
+                    label={t('events:detail.sections.about.fieldLabel')}
                     multiline
                     minRows={3}
                     value={aboutDraft}
@@ -385,10 +393,10 @@ const EventDetail = () => {
                       onClick={handleSaveAbout}
                       disabled={savingAbout || aboutDraft.trim() === (event.about || '')}
                     >
-                      {savingAbout ? 'Сохраняю...' : 'Сохранить'}
+                      {savingAbout ? t('events:detail.sections.about.savePending') : t('common:buttons.save')}
                     </Button>
                     <Button variant="outlined" size="small" startIcon={<CloseIcon />} onClick={handleCancelAbout} disabled={savingAbout}>
-                      Отмена
+                      {t('common:buttons.cancel')}
                     </Button>
                   </Stack>
                 </Stack>
@@ -398,7 +406,7 @@ const EventDetail = () => {
                   fontSize={16}
                   sx={{ whiteSpace: 'pre-line', color: event.about ? 'inherit' : 'text.disabled' }}
                 >
-                  {event.about || 'Описание мероприятия не заполнено.'}
+                  {event.about || t('events:detail.sections.about.empty')}
                 </Typography>
               )}
             </Box>
@@ -408,7 +416,7 @@ const EventDetail = () => {
                 <form action={uploadAction}>
                   <Stack direction="row" spacing={1} alignItems="center">
                     <Button variant="contained" component="label" disabled={uploadPending}>
-                      Файл
+                      {t('events:detail.sections.files.pickFile')}
                       <input
                         type="file"
                         name="file"
@@ -420,7 +428,7 @@ const EventDetail = () => {
                       />
                     </Button>
                     <Button variant="outlined" type="submit" disabled={!selectedFile || uploadPending}>
-                      {uploadPending ? 'Добавление...' : 'Добавить'}
+                      {uploadPending ? t('events:detail.upload.submit.pending') : t('events:detail.upload.submit.label')}
                     </Button>
                     {selectedFile && (
                       <Typography
@@ -449,7 +457,7 @@ const EventDetail = () => {
 
             {optimisticFiles.length > 0 ? (
               <Box>
-                <Typography variant="subtitle1" fontWeight={600}>Файлы:</Typography>
+                <Typography variant="subtitle1" fontWeight={600}>{t('events:detail.sections.files.title')}</Typography>
                 <Stack spacing={1}>
                   {optimisticFiles.map(f => {
                     const isPendingFile = f.pending === true || typeof f.id !== 'number'
@@ -459,7 +467,7 @@ const EventDetail = () => {
                       <Box key={f.id} display="flex" alignItems="center">
                         {isPendingFile ? (
                           <Typography color="text.secondary" sx={{ flex: 1 }}>
-                            {f.description || 'Добавление файла...'}
+                            {f.description || t('events:detail.sections.files.pending')}
                           </Typography>
                         ) : (
                           <a
@@ -468,7 +476,7 @@ const EventDetail = () => {
                             rel="noopener noreferrer"
                             download
                             title={fileLabel}
-                            aria-label={`Скачать файл ${fileLabel}`}
+                            aria-label={t('events:detail.sections.files.downloadAria', { label: fileLabel })}
                             style={{ color: '#1976d2', fontWeight: 500, textDecoration: 'underline', flex: 1 }}
                           >
                             {fileLabel}
@@ -476,7 +484,7 @@ const EventDetail = () => {
                         )}
                         {(user?.role === 'admin' || user?.role === 'teacher') && (
                           <IconButton
-                            aria-label="Удалить файл"
+                            aria-label={t('events:detail.sections.files.deleteAria')}
                             color="error"
                             disabled={isPendingFile}
                             onClick={async () => {
@@ -496,7 +504,7 @@ const EventDetail = () => {
                 </Stack>
               </Box>
             ) : (
-              <Typography variant="body2" color="text.secondary">Файлов пока нет</Typography>
+              <Typography variant="body2" color="text.secondary">{t('events:detail.sections.files.empty')}</Typography>
             )}
           </Stack>
 
@@ -541,7 +549,7 @@ const EventDetail = () => {
               >
                 <SmartImage
                   srcRaw={imageUrl}
-                  alt="Изображение мероприятия"
+                  alt={t('events:alt.image')}
                   onLoad={handleHeroLoad}
                   style={{
                     position: 'absolute',
@@ -563,10 +571,10 @@ const EventDetail = () => {
                 variant="h5"
                 fontWeight={700}
               >
-                Описание мероприятия
+                {t('events:detail.sections.about.title')}
               </Typography>
               {(user?.role === 'admin' || user?.role === 'teacher') && !editingAbout && (
-                <IconButton aria-label="Редактировать описание" size="small" onClick={handleEditAbout}>
+                <IconButton aria-label={t('events:detail.sections.about.editAria')} size="small" onClick={handleEditAbout}>
                   <EditIcon fontSize="small" />
                 </IconButton>
               )}
@@ -574,7 +582,7 @@ const EventDetail = () => {
             {editingAbout ? (
               <Stack spacing={1}>
                 <TextField
-                  label="Описание мероприятия"
+                  label={t('events:detail.sections.about.fieldLabel')}
                   multiline
                   minRows={3}
                   value={aboutDraft}
@@ -590,10 +598,10 @@ const EventDetail = () => {
                     onClick={handleSaveAbout}
                     disabled={savingAbout || aboutDraft.trim() === (event.about || '')}
                   >
-                    {savingAbout ? 'Сохраняю...' : 'Сохранить'}
+                    {savingAbout ? t('events:detail.sections.about.savePending') : t('common:buttons.save')}
                   </Button>
                   <Button variant="outlined" size="small" startIcon={<CloseIcon />} onClick={handleCancelAbout} disabled={savingAbout}>
-                    Отмена
+                    {t('common:buttons.cancel')}
                   </Button>
                 </Stack>
               </Stack>
@@ -603,7 +611,7 @@ const EventDetail = () => {
                 fontSize={18}
                 sx={{ whiteSpace: 'pre-line', color: event.about ? 'inherit' : 'text.disabled' }}
               >
-                {event.about || 'Описание мероприятия не заполнено.'}
+                {event.about || t('events:detail.sections.about.empty')}
               </Typography>
             )}
           </Stack>
@@ -616,7 +624,7 @@ const EventDetail = () => {
               )}
               <Chip
                 icon={<PeopleAltIcon sx={{ color: '#1976d2' }} />}
-                label={`Участников: ${event.participant_count || 0}`}
+                label={t('events:card.participants', { count: event.participant_count || 0 })}
                 sx={{ fontWeight: 500, fontSize: 16 }}
               />
             </Stack>
@@ -625,18 +633,24 @@ const EventDetail = () => {
               {event.description}
             </Typography>
             <Divider />
-            <Typography variant="subtitle1" fontWeight={600}>Место: <b>{event.location}</b></Typography>
-            <Typography variant="subtitle1">
-              Дата: <b>{formatDateSafe(event.starts_at)} — {formatDateSafe(event.ends_at)}</b>
+            <Typography variant="subtitle1" fontWeight={600}>
+              {t('events:detail.fields.location')}: <b>{event.location}</b>
             </Typography>
-            {event.speaker && <Typography variant="subtitle1">Спикер: <b>{event.speaker}</b></Typography>}
+            <Typography variant="subtitle1">
+              {t('events:detail.fields.date')}: <b>{formatDateSafe(event.starts_at)} — {formatDateSafe(event.ends_at)}</b>
+            </Typography>
+            {event.speaker && (
+              <Typography variant="subtitle1">
+                {t('events:detail.fields.speaker')}: <b>{event.speaker}</b>
+              </Typography>
+            )}
 
             {user && (user.role === 'admin' || user.role === 'teacher') && (
               <Box mt={2}>
                 <form action={uploadAction}>
                   <Stack direction="row" spacing={2} alignItems="center">
                     <Button variant="contained" component="label" disabled={uploadPending}>
-                      Файл
+                      {t('events:detail.sections.files.pickFile')}
                       <input
                         type="file"
                         name="file"
@@ -648,7 +662,7 @@ const EventDetail = () => {
                       />
                     </Button>
                     <Button variant="outlined" type="submit" disabled={!selectedFile || uploadPending}>
-                      {uploadPending ? 'Добавление...' : 'Добавить'}
+                      {uploadPending ? t('events:detail.upload.submit.pending') : t('events:detail.upload.submit.label')}
                     </Button>
                     {selectedFile && (
                       <Typography
@@ -678,7 +692,7 @@ const EventDetail = () => {
             {optimisticFiles.length > 0 ? (
               <Box>
                 <Divider sx={{ my: 1 }} />
-                <Typography variant="subtitle1" fontWeight={600}>Файлы:</Typography>
+                <Typography variant="subtitle1" fontWeight={600}>{t('events:detail.sections.files.title')}</Typography>
                 <Stack spacing={1}>
                   {optimisticFiles.map(f => {
                     const isPendingFile = f.pending === true || typeof f.id !== 'number'
@@ -688,7 +702,7 @@ const EventDetail = () => {
                       <Box key={f.id} display="flex" alignItems="center">
                         {isPendingFile ? (
                           <Typography color="text.secondary" sx={{ flex: 1 }}>
-                            {f.description || 'Добавление файла...'}
+                            {f.description || t('events:detail.sections.files.pending')}
                           </Typography>
                         ) : (
                           <a
@@ -697,7 +711,7 @@ const EventDetail = () => {
                             rel="noopener noreferrer"
                             download
                             title={fileLabel}
-                            aria-label={`Скачать файл ${fileLabel}`}
+                            aria-label={t('events:detail.sections.files.downloadAria', { label: fileLabel })}
                             style={{ color: '#1976d2', fontWeight: 500, textDecoration: 'underline', flex: 1 }}
                           >
                             {fileLabel}
@@ -705,7 +719,7 @@ const EventDetail = () => {
                         )}
                         {(user?.role === 'admin' || user?.role === 'teacher') && (
                           <IconButton
-                            aria-label="Удалить файл"
+                            aria-label={t('events:detail.sections.files.deleteAria')}
                             color="error"
                             disabled={isPendingFile}
                             onClick={async () => {
@@ -725,7 +739,7 @@ const EventDetail = () => {
                 </Stack>
               </Box>
             ) : (
-              <Typography variant="body2" color="text.secondary">Файлов пока нет</Typography>
+              <Typography variant="body2" color="text.secondary">{t('events:detail.sections.files.empty')}</Typography>
             )}
           </Stack>
         </Stack>

--- a/root/frontend/src/i18n/locales/en/events.json
+++ b/root/frontend/src/i18n/locales/en/events.json
@@ -42,5 +42,83 @@
   "alt": {
     "preview": "Preview of the event image",
     "image": "Event image"
+  },
+  "card": {
+    "aria": {
+      "actions": "Event actions"
+    },
+    "actions": {
+      "register": "Register",
+      "unregister": "Cancel registration",
+      "openQr": "Open QR code",
+      "closeQr": "Close"
+    },
+    "statuses": {
+      "ended": "Event has ended"
+    },
+    "participants": "Participants: {{count}}",
+    "messages": {
+      "registerSuccess": "You are registered for the event",
+      "registerFailure": "Couldn't register for the event",
+      "unregisterSuccess": "Registration cancelled",
+      "unregisterFailure": "Couldn't cancel registration",
+      "deleteSuccess": "Event deleted",
+      "deleteFailure": "Couldn't delete the event",
+      "saveSuccess": "Changes saved",
+      "saveFailure": "Couldn't save changes"
+    },
+    "dialogs": {
+      "edit": {
+        "title": "Edit event"
+      },
+      "delete": {
+        "title": "Delete event?",
+        "description": "This action cannot be undone. Confirm deletion."
+      }
+    }
+  },
+  "detail": {
+    "messages": {
+      "loadFailed": "Couldn't load event",
+      "notFound": "Event not found",
+      "fileAdded": "File added",
+      "fileAddFailed": "Couldn't add file",
+      "fileDeleted": "File deleted",
+      "fileDeleteFailed": "Couldn't delete file",
+      "aboutUpdated": "Description updated",
+      "aboutUpdateFailed": "Couldn't update description"
+    },
+    "upload": {
+      "errors": {
+        "noFile": "Select a file",
+        "failed": "Couldn't add file"
+      },
+      "submit": {
+        "label": "Add",
+        "pending": "Adding..."
+      }
+    },
+    "fields": {
+      "location": "Location",
+      "date": "Date",
+      "speaker": "Speaker"
+    },
+    "sections": {
+      "about": {
+        "title": "About the event",
+        "fieldLabel": "Event description",
+        "editAria": "Edit description",
+        "savePending": "Saving...",
+        "empty": "The event description is empty."
+      },
+      "files": {
+        "title": "Files",
+        "pickFile": "File",
+        "empty": "No files yet",
+        "pending": "Adding file...",
+        "downloadAria": "Download file {{label}}",
+        "deleteAria": "Delete file"
+      }
+    }
   }
 }

--- a/root/frontend/src/i18n/locales/ru/events.json
+++ b/root/frontend/src/i18n/locales/ru/events.json
@@ -42,5 +42,83 @@
   "alt": {
     "preview": "Предпросмотр изображения события",
     "image": "Изображение события"
+  },
+  "card": {
+    "aria": {
+      "actions": "Действия с мероприятием"
+    },
+    "actions": {
+      "register": "Зарегистрироваться",
+      "unregister": "Отменить регистрацию",
+      "openQr": "Открыть QR",
+      "closeQr": "Закрыть"
+    },
+    "statuses": {
+      "ended": "Мероприятие завершено"
+    },
+    "participants": "Участников: {{count}}",
+    "messages": {
+      "registerSuccess": "Вы зарегистрированы на мероприятие",
+      "registerFailure": "Не удалось зарегистрироваться",
+      "unregisterSuccess": "Регистрация отменена",
+      "unregisterFailure": "Не удалось отменить регистрацию",
+      "deleteSuccess": "Мероприятие удалено",
+      "deleteFailure": "Не удалось удалить мероприятие",
+      "saveSuccess": "Изменения сохранены",
+      "saveFailure": "Не удалось сохранить изменения"
+    },
+    "dialogs": {
+      "edit": {
+        "title": "Редактировать мероприятие"
+      },
+      "delete": {
+        "title": "Удалить мероприятие?",
+        "description": "Действие необратимо. Подтвердите удаление."
+      }
+    }
+  },
+  "detail": {
+    "messages": {
+      "loadFailed": "Ошибка загрузки",
+      "notFound": "Мероприятие не найдено",
+      "fileAdded": "Файл добавлен",
+      "fileAddFailed": "Ошибка добавления файла",
+      "fileDeleted": "Файл удалён",
+      "fileDeleteFailed": "Ошибка удаления файла",
+      "aboutUpdated": "Описание обновлено",
+      "aboutUpdateFailed": "Ошибка сохранения описания"
+    },
+    "upload": {
+      "errors": {
+        "noFile": "Выберите файл",
+        "failed": "Не удалось добавить файл"
+      },
+      "submit": {
+        "label": "Добавить",
+        "pending": "Добавление..."
+      }
+    },
+    "fields": {
+      "location": "Место",
+      "date": "Дата",
+      "speaker": "Спикер"
+    },
+    "sections": {
+      "about": {
+        "title": "Описание мероприятия",
+        "fieldLabel": "Описание мероприятия",
+        "editAria": "Редактировать описание",
+        "savePending": "Сохраняю...",
+        "empty": "Описание мероприятия не заполнено."
+      },
+      "files": {
+        "title": "Файлы",
+        "pickFile": "Файл",
+        "empty": "Файлов пока нет",
+        "pending": "Добавление файла...",
+        "downloadAria": "Скачать файл {{label}}",
+        "deleteAria": "Удалить файл"
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- replace hard-coded event card snackbars, menus, and dialog content with translation keys
- internationalize event detail errors, buttons, and empty states and sync locale files with the new keys

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68eed947fe1883278be1d6a5956dc50d