### PR TITLE
Localize map and admin user interface strings

### DIFF
--- a/root/frontend/src/i18n/config.ts
+++ b/root/frontend/src/i18n/config.ts
@@ -25,6 +25,8 @@ import profileEn from "./locales/en/profile.json" assert { type: "json" }
 import profileRu from "./locales/ru/profile.json" assert { type: "json" }
 import notificationsEn from "./locales/en/notifications.json" assert { type: "json" }
 import notificationsRu from "./locales/ru/notifications.json" assert { type: "json" }
+import adminEn from "./locales/en/admin.json" assert { type: "json" }
+import adminRu from "./locales/ru/admin.json" assert { type: "json" }
 
 export const defaultNS = "common"
 
@@ -42,6 +44,7 @@ export const resources = {
     events: eventsEn,
     profile: profileEn,
     notifications: notificationsEn,
+    admin: adminEn,
   },
   ru: {
     common: commonRu,
@@ -56,6 +59,7 @@ export const resources = {
     events: eventsRu,
     profile: profileRu,
     notifications: notificationsRu,
+    admin: adminRu,
   },
 } as const
 

--- a/root/frontend/src/i18n/locales/en/admin.json
+++ b/root/frontend/src/i18n/locales/en/admin.json
@@ -1,0 +1,25 @@
+{
+  "users": {
+    "title": "Users",
+    "confirmDelete": "Delete this user?",
+    "filters": {
+      "fullName": "Full name",
+      "group": "Group",
+      "role": "Role",
+      "all": "All"
+    },
+    "roles": {
+      "student": "Student",
+      "teacher": "Teacher",
+      "admin": "Admin"
+    },
+    "table": {
+      "avatar": "Avatar",
+      "fullName": "Full name",
+      "email": "Email",
+      "role": "Role",
+      "group": "Group",
+      "actions": "Actions"
+    }
+  }
+}

--- a/root/frontend/src/i18n/locales/en/system.json
+++ b/root/frontend/src/i18n/locales/en/system.json
@@ -14,6 +14,26 @@
     "empty": "Nothing yet",
     "markRead": "Mark as read"
   },
+  "map": {
+    "title": "Campus map",
+    "openInYandex": "Open in Yandex Maps",
+    "reset": "Reset",
+    "iframeTitle": "GUU campus map",
+    "loadError": "Could not load the map",
+    "layer": {
+      "map": "Map",
+      "hybrid": "Satellite"
+    },
+    "layerAria": {
+      "map": "Map view",
+      "hybrid": "Satellite view"
+    },
+    "traffic": {
+      "label": "Traffic",
+      "show": "Show traffic",
+      "hide": "Hide traffic"
+    }
+  },
   "installPrompt": {
     "installTitle": "Install “{{appName}}”",
     "title": "{{appName}}",

--- a/root/frontend/src/i18n/locales/ru/admin.json
+++ b/root/frontend/src/i18n/locales/ru/admin.json
@@ -1,0 +1,25 @@
+{
+  "users": {
+    "title": "Пользователи",
+    "confirmDelete": "Удалить пользователя?",
+    "filters": {
+      "fullName": "ФИО",
+      "group": "Группа",
+      "role": "Роль",
+      "all": "Все"
+    },
+    "roles": {
+      "student": "Студент",
+      "teacher": "Преподаватель",
+      "admin": "Администратор"
+    },
+    "table": {
+      "avatar": "Аватар",
+      "fullName": "ФИО",
+      "email": "Email",
+      "role": "Роль",
+      "group": "Группа",
+      "actions": "Действия"
+    }
+  }
+}

--- a/root/frontend/src/i18n/locales/ru/system.json
+++ b/root/frontend/src/i18n/locales/ru/system.json
@@ -14,6 +14,26 @@
     "empty": "Пока пусто",
     "markRead": "Прочитано"
   },
+  "map": {
+    "title": "Карта кампуса",
+    "openInYandex": "Открыть в Яндекс Картах",
+    "reset": "Сбросить",
+    "iframeTitle": "Карта кампуса ГУУ",
+    "loadError": "Не удалось загрузить карту",
+    "layer": {
+      "map": "Карта",
+      "hybrid": "Спутник"
+    },
+    "layerAria": {
+      "map": "Режим карты",
+      "hybrid": "Режим спутника"
+    },
+    "traffic": {
+      "label": "Пробки",
+      "show": "Показать пробки",
+      "hide": "Скрыть пробки"
+    }
+  },
   "installPrompt": {
     "installTitle": "Установить «{{appName}}»",
     "title": "{{appName}}",

--- a/root/frontend/src/pages/AdminUsers.tsx
+++ b/root/frontend/src/pages/AdminUsers.tsx
@@ -9,6 +9,7 @@ import {
 import DeleteIcon from "@mui/icons-material/Delete"
 import { useAuth } from "../contexts/AuthContext"
 import useMediaQuery from "@mui/material/useMediaQuery"
+import { useTranslation } from "react-i18next"
 
 const backendBaseUrl = "http://localhost:8000"
 
@@ -43,6 +44,13 @@ export default function AdminUsers() {
   const [filters, setFilters] = useState<UserFilters>({ full_name: "", group_id: "", role: "" })
   const { user: userContext } = useAuth()
   const isMobile = useMediaQuery("(max-width:1200px)")
+  const { t } = useTranslation("admin")
+
+  const roleOptions: Record<UserRole, string> = {
+    student: t("users.roles.student"),
+    teacher: t("users.roles.teacher"),
+    admin: t("users.roles.admin")
+  }
 
   const fetchUsers = useCallback(async () => {
     const params: Record<string, string> = {}
@@ -73,7 +81,7 @@ export default function AdminUsers() {
   }
 
   const handleDelete = async (userId: number) => {
-    if (!window.confirm("Удалить пользователя?")) return
+    if (!window.confirm(t("users.confirmDelete"))) return
     await api.delete(`/users/${userId}`)
     void fetchUsers()
   }
@@ -127,19 +135,19 @@ export default function AdminUsers() {
               textOverflow: "ellipsis"
             }}
           >
-            Пользователи
+            {t("users.title")}
           </Typography>
           <Box mb={2} display="flex" gap={2} flexWrap="wrap">
             <TextField
-              label="ФИО"
+              label={t("users.filters.fullName")}
               value={filters.full_name}
               onChange={e => handleFilterChange("full_name")(e.target.value)}
               sx={{ minWidth: 220 }}
             />
             <FormControl sx={{ minWidth: 150 }}>
-              <InputLabel>Группа</InputLabel>
+              <InputLabel>{t("users.filters.group")}</InputLabel>
               <Select value={filters.group_id} onChange={handleGroupFilterChange}>
-                <MenuItem value="">Все</MenuItem>
+                <MenuItem value="">{t("users.filters.all")}</MenuItem>
                 {groups.map(g => (
                   <MenuItem value={String(g.id)} key={g.id}>
                     {g.name}
@@ -148,12 +156,12 @@ export default function AdminUsers() {
               </Select>
             </FormControl>
             <FormControl sx={{ minWidth: 150 }}>
-              <InputLabel>Роль</InputLabel>
+              <InputLabel>{t("users.filters.role")}</InputLabel>
               <Select value={filters.role} onChange={handleRoleChange}>
-                <MenuItem value="">Все</MenuItem>
-                <MenuItem value="student">Студент</MenuItem>
-                <MenuItem value="teacher">Преподаватель</MenuItem>
-                <MenuItem value="admin">Админ</MenuItem>
+                <MenuItem value="">{t("users.filters.all")}</MenuItem>
+                <MenuItem value="student">{roleOptions.student}</MenuItem>
+                <MenuItem value="teacher">{roleOptions.teacher}</MenuItem>
+                <MenuItem value="admin">{roleOptions.admin}</MenuItem>
               </Select>
             </FormControl>
           </Box>
@@ -183,7 +191,7 @@ export default function AdminUsers() {
                     </Typography>
                     <Stack direction="row" spacing={1} alignItems="center" mt={0.4}>
                       <Typography fontSize={14} sx={{ bgcolor: "#e3f1fd", color: "#1565c0", borderRadius: 1, px: 1.2, py: 0.2 }}>
-                        {user.role}
+                        {roleOptions[user.role]}
                       </Typography>
                       {user.role !== "teacher" && user.role !== "admin" && (
                         <FormControl size="small" sx={{ minWidth: 60 }}>
@@ -228,12 +236,12 @@ export default function AdminUsers() {
               <Table stickyHeader sx={{ minWidth: 700, width: "100%" }}>
                 <TableHead>
                   <TableRow>
-                    <TableCell align="center" sx={{ fontWeight: 700 }}>Аватар</TableCell>
-                    <TableCell align="center" sx={{ fontWeight: 700 }}>ФИО</TableCell>
-                    <TableCell align="center" sx={{ fontWeight: 700 }}>Email</TableCell>
-                    <TableCell align="center" sx={{ fontWeight: 700 }}>Роль</TableCell>
-                    <TableCell align="center" sx={{ fontWeight: 700 }}>Группа</TableCell>
-                    <TableCell align="center" sx={{ fontWeight: 700 }}>Действия</TableCell>
+                    <TableCell align="center" sx={{ fontWeight: 700 }}>{t("users.table.avatar")}</TableCell>
+                    <TableCell align="center" sx={{ fontWeight: 700 }}>{t("users.table.fullName")}</TableCell>
+                    <TableCell align="center" sx={{ fontWeight: 700 }}>{t("users.table.email")}</TableCell>
+                    <TableCell align="center" sx={{ fontWeight: 700 }}>{t("users.table.role")}</TableCell>
+                    <TableCell align="center" sx={{ fontWeight: 700 }}>{t("users.table.group")}</TableCell>
+                    <TableCell align="center" sx={{ fontWeight: 700 }}>{t("users.table.actions")}</TableCell>
                   </TableRow>
                 </TableHead>
                 <TableBody>
@@ -244,7 +252,7 @@ export default function AdminUsers() {
                       </TableCell>
                       <TableCell align="center">{user.full_name}</TableCell>
                       <TableCell align="center">{user.email}</TableCell>
-                      <TableCell align="center">{user.role}</TableCell>
+                      <TableCell align="center">{roleOptions[user.role]}</TableCell>
                       <TableCell align="center">
                         {user.role !== "teacher" && user.role !== "admin" ? (
                           <Select

--- a/root/frontend/src/pages/MapContent.tsx
+++ b/root/frontend/src/pages/MapContent.tsx
@@ -19,6 +19,7 @@ import SatelliteAltIcon from "@mui/icons-material/SatelliteAlt"
 import TrafficIcon from "@mui/icons-material/Traffic"
 import RestartAltIcon from "@mui/icons-material/RestartAlt"
 import "../assets/themes.css"
+import { useTranslation } from "react-i18next"
 
 type LayerMode = "map" | "hybrid"
 
@@ -30,6 +31,7 @@ const LOAD_TIMEOUT_MS = 12000
 export default function MapContent() {
   const theme = useTheme()
   const isMobile = useMediaQuery("(max-width:900px)")
+  const { t } = useTranslation("system")
   const [layer, setLayer] = useState<LayerMode>("map")
   const [traffic, setTraffic] = useState(false)
   const [iframeLoaded, setIframeLoaded] = useState(false)
@@ -160,13 +162,13 @@ export default function MapContent() {
                   fontWeight={800}
                   sx={{ letterSpacing: 0.2, fontSize: "clamp(1.1rem, 3.6vw, 2.4rem)" }}
                 >
-                  Карта кампуса
+                  {t("map.title")}
                 </Typography>
               </Stack>
               <Stack direction="row" spacing={1}>
-                <Tooltip title="Открыть в Яндекс-Картах" {...tooltipCfg}>
+                <Tooltip title={t("map.openInYandex") ?? undefined} {...tooltipCfg}>
                   <IconButton
-                    aria-label="Открыть в Яндекс-Картах"
+                    aria-label={t("map.openInYandex")}
                     className="glass glass--btn map-btn map-btn--open"
                     onClick={openInYandex}
                     sx={{ touchAction: "manipulation" }}
@@ -174,9 +176,9 @@ export default function MapContent() {
                     <OpenInNewIcon />
                   </IconButton>
                 </Tooltip>
-                <Tooltip title="Сбросить" {...tooltipCfg}>
+                <Tooltip title={t("map.reset") ?? undefined} {...tooltipCfg}>
                   <IconButton
-                    aria-label="Сбросить"
+                    aria-label={t("map.reset")}
                     className="glass glass--btn map-btn map-btn--reset"
                     onClick={reset}
                     sx={{ touchAction: "manipulation" }}
@@ -191,7 +193,7 @@ export default function MapContent() {
           <iframe
             key={`${frameKey}`}
             src={mapSrc}
-            title="Карта кампуса ГУУ"
+            title={t("map.iframeTitle")}
             width="100%"
             height="100%"
             style={{ border: 0, position: "absolute", inset: 0, display: "block" }}
@@ -227,7 +229,7 @@ export default function MapContent() {
                 }} />
               ) : (
                 <Stack spacing={2} alignItems="center">
-                  <Typography>Не удалось загрузить карту</Typography>
+                  <Typography>{t("map.loadError")}</Typography>
                   <IconButton color="primary" onClick={() => { setLoadError(false); setIframeLoaded(false); setFrameKey(k => k + 1) }}>
                     <RestartAltIcon />
                   </IconButton>
@@ -271,28 +273,28 @@ export default function MapContent() {
                     "& .MuiToggleButton-root.Mui-selected .MuiSvgIcon-root": { color: "inherit" }
                   }}
                 >
-                  <ToggleButton value="map" disableRipple aria-label="Схема">
+                  <ToggleButton value="map" disableRipple aria-label={t("map.layerAria.map")}>
                     <MapIcon fontSize="small" sx={{ color: "inherit" }} />
                     {!isMobile && (
                       <Box component="span" ml={1} sx={{ color: "inherit" }}>
-                        Карта
+                        {t("map.layer.map")}
                       </Box>
                     )}
                   </ToggleButton>
-                  <ToggleButton value="hybrid" disableRipple aria-label="Спутник">
+                  <ToggleButton value="hybrid" disableRipple aria-label={t("map.layerAria.hybrid")}>
                     <SatelliteAltIcon fontSize="small" sx={{ color: "inherit" }} />
                     {!isMobile && (
                       <Box component="span" ml={1} sx={{ color: "inherit" }}>
-                        Спутник
+                        {t("map.layer.hybrid")}
                       </Box>
                     )}
                   </ToggleButton>
                 </ToggleButtonGroup>
               </Box>
-              <Tooltip title={traffic ? "Скрыть пробки" : "Показать пробки"} {...tooltipCfg}>
+              <Tooltip title={(traffic ? t("map.traffic.hide") : t("map.traffic.show")) ?? undefined} {...tooltipCfg}>
                 <IconButton
                   aria-pressed={traffic}
-                  aria-label="Пробки"
+                  aria-label={t("map.traffic.label")}
                   onClick={() => setTraffic(v => !v)}
                   className="glass glass--btn"
                   sx={{


### PR DESCRIPTION
## Summary
- move map page headings, tooltips, and accessibility labels into the system translation namespace
- translate admin user management labels and role names through a new admin namespace
- register new English and Russian locale resources for the admin panel strings

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68eedfdd3ef88327836fb80441261afd