### PR TITLE
Localize push notification fallbacks and reminders

### DIFF
--- a/root/frontend/src/components/LivePushToasts.tsx
+++ b/root/frontend/src/components/LivePushToasts.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState, type SyntheticEvent } from "react"
 import { Alert, Button, Snackbar, Stack, Typography } from "@mui/material"
 import type { SnackbarCloseReason } from "@mui/material/Snackbar"
+import { useTranslation } from "react-i18next"
 
 type SnackbarSeverity = "success" | "info" | "warning" | "error"
 
@@ -42,6 +43,7 @@ const buildToastId = (toast: ToastPayload) => {
 }
 
 export default function LivePushToasts() {
+  const { t } = useTranslation("notifications")
   const [queue, setQueue] = useState<ActiveToast[]>([])
   const [current, setCurrent] = useState<ActiveToast | null>(null)
   const [open, setOpen] = useState(false)
@@ -100,8 +102,8 @@ export default function LivePushToasts() {
   }, [current])
 
   const severity = resolveSeverity(current)
-  const title = current?.title?.trim()
-  const body = current?.body?.trim()
+  const title = current?.title?.trim() || t("defaultTitle")
+  const body = current?.body?.trim() || t("defaultBody")
 
   return (
     <Snackbar
@@ -119,7 +121,7 @@ export default function LivePushToasts() {
         action={
           current?.url ? (
             <Button color="inherit" size="small" onClick={handleAction}>
-              Открыть
+              {t("toast.open")}
             </Button>
           ) : null
         }

--- a/root/frontend/src/contexts/AuthContext.tsx
+++ b/root/frontend/src/contexts/AuthContext.tsx
@@ -12,6 +12,7 @@ import {
 } from "react"
 import { useQueryClient } from "@tanstack/react-query"
 import { isAxiosError } from "axios"
+import { useTranslation } from "react-i18next"
 import {
   hasPushConsent,
   softSyncPushSubscription,
@@ -239,6 +240,7 @@ const initializeCachedUser = (): UserState => {
 
 export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const queryClient = useQueryClient()
+  const { t } = useTranslation("auth")
   const [userState, setUserState] = useState<UserState>(initializeCachedUser)
   const cachedUserRef = useRef<UserState>(userState)
   const [initializing, setInitializing] = useState<boolean>(true)
@@ -416,7 +418,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
           const message =
             typeof error.response?.data?.detail === "string"
               ? error.response.data.detail
-              : "Не удалось войти"
+              : t("login.error")
           throw new Error(message)
         }
 
@@ -424,7 +426,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
           throw error
         }
 
-        throw new Error("Не удалось войти")
+        throw new Error(t("login.error"))
       } finally {
         if (activeRequestRef.current === controller) {
           activeRequestRef.current = null
@@ -435,7 +437,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         }
       }
     },
-    [handleUnauthorized, setUser]
+    [handleUnauthorized, setUser, t]
   )
 
   const logout = useCallback(async () => {

--- a/root/frontend/src/hooks/useClassReminders.ts
+++ b/root/frontend/src/hooks/useClassReminders.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useCallback } from "react"
+import { useTranslation } from "react-i18next"
 
 export type RemindItem = {
   id: string | number
@@ -24,6 +25,7 @@ function openUrl(u: string) {
 }
 
 export function useClassReminders(items: RemindItem[] | undefined, opts?: { defaultMinutesBefore?: number }) {
+  const { t } = useTranslation("notifications")
   const timers = useRef<Timer[]>([])
   const defMins = Math.max(0, opts?.defaultMinutesBefore ?? 10)
 
@@ -54,7 +56,7 @@ export function useClassReminders(items: RemindItem[] | undefined, opts?: { defa
         if (!("Notification" in window) || Notification.permission !== "granted") return
         const data = { url: ev.url || "/", id: ev.id, type: "reminder" }
         const title = ev.title
-        const body = `Через ${mins} мин.`
+        const body = t("reminders.startsSoon", { minutes: mins })
         const tag = ev.tag || `reminder:${ev.id}`
         try {
           const reg = await navigator.serviceWorker?.getRegistration()
@@ -80,7 +82,7 @@ export function useClassReminders(items: RemindItem[] | undefined, opts?: { defa
     })
 
     return clearAll
-  }, [items, defMins, clearAll])
+  }, [items, defMins, clearAll, t])
 
   return { requestPermission, clear: clearAll }
 }

--- a/root/frontend/src/i18n/locales/en/notifications.json
+++ b/root/frontend/src/i18n/locales/en/notifications.json
@@ -1,4 +1,12 @@
 {
+  "defaultTitle": "University Ecosystem",
+  "defaultBody": "You have a new notification.",
+  "toast": {
+    "open": "Open"
+  },
+  "reminders": {
+    "startsSoon": "In {{minutes}} min."
+  },
   "topics": {
     "schedule": "Schedule",
     "news": "News",

--- a/root/frontend/src/i18n/locales/ru/notifications.json
+++ b/root/frontend/src/i18n/locales/ru/notifications.json
@@ -1,4 +1,12 @@
 {
+  "defaultTitle": "Экосистема ГУУ",
+  "defaultBody": "У вас новое уведомление.",
+  "toast": {
+    "open": "Открыть"
+  },
+  "reminders": {
+    "startsSoon": "Через {{minutes}} мин."
+  },
   "topics": {
     "schedule": "Расписание",
     "news": "Новости",

--- a/root/frontend/src/push/__tests__/notification-helpers.test.ts
+++ b/root/frontend/src/push/__tests__/notification-helpers.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from "vitest"
 import {
   DEFAULT_ICON,
-  DEFAULT_TITLE,
   buildNotificationDetails,
+  getDefaultNotificationBody,
+  getDefaultNotificationTitle,
   parsePushEventData,
 } from "../notification-helpers"
 
@@ -35,9 +36,10 @@ describe("parsePushEventData", () => {
 describe("buildNotificationDetails", () => {
   it("applies defaults for title and icon", () => {
     const result = buildNotificationDetails({})
-    expect(result.title).toBe(DEFAULT_TITLE)
+    expect(result.title).toBe(getDefaultNotificationTitle())
     expect(result.options.icon).toBe(DEFAULT_ICON)
     expect(result.options.badge).toBe(DEFAULT_ICON)
+    expect(result.options.body).toBe(getDefaultNotificationBody())
     expect(result.data.url).toBe("/")
   })
 

--- a/root/frontend/src/push/notification-helpers.ts
+++ b/root/frontend/src/push/notification-helpers.ts
@@ -1,3 +1,5 @@
+import i18n from "@/i18n/config"
+
 export type NotificationData = {
   url?: string
   actionUrls?: Record<string, string>
@@ -37,8 +39,14 @@ export type PushPayload = {
   actions?: NotificationActionPayload[]
 }
 
-export const DEFAULT_TITLE = "Экосистема ГУУ"
 export const DEFAULT_ICON = "/maskable-icon-192.png"
+
+const translateNotification = (key: string, options?: Record<string, unknown>) =>
+  i18n.t(`notifications:${key}`, options)
+
+export const getDefaultNotificationTitle = () => translateNotification("defaultTitle")
+
+export const getDefaultNotificationBody = () => translateNotification("defaultBody")
 
 export type ExtendedNotificationOptions = NotificationOptions & {
   renotify?: boolean
@@ -82,15 +90,19 @@ export function buildNotificationDetails(payload: PushPayload): {
       ? (payload.data as Record<string, unknown>)
       : undefined
 
-  const title = payload.title || DEFAULT_TITLE
+  const rawTitle = typeof payload.title === "string" ? payload.title.trim() : ""
+  const title = rawTitle || getDefaultNotificationTitle()
 
   const data: NotificationData = {
     url: payload.url || "/",
     ...(rawData ?? {}),
   }
 
+  const rawBody = typeof payload.body === "string" ? payload.body.trim() : ""
+  const body = rawBody || getDefaultNotificationBody()
+
   const options: ExtendedNotificationOptions = {
-    body: payload.body,
+    body,
     icon: payload.icon || DEFAULT_ICON,
     badge: payload.badge || payload.icon || DEFAULT_ICON,
     tag: payload.tag,

--- a/root/frontend/src/sw.ts
+++ b/root/frontend/src/sw.ts
@@ -490,7 +490,7 @@ self.addEventListener("push", (event) => {
           type: "PUSH_NOTIFICATION",
           toast: {
             title,
-            body: payload.body,
+            body: options.body,
             url: typeof data.url === "string" ? data.url : undefined,
             icon: options.icon,
             tag: options.tag,


### PR DESCRIPTION
## Summary
- load notification defaults from the i18n dictionaries and trim incoming payloads before applying fallbacks
- localize in-app toast labels, reminder texts, and auth login fallback errors through the notifications/auth namespaces
- add the required translation keys for en/ru and update notification helper tests to cover the new behavior

## Testing
- npm --prefix root/frontend run test

------
https://chatgpt.com/codex/tasks/task_e_68ef00cc4e448327a8422123b1108263