### PR TITLE
feat: localize backend messaging

### DIFF
--- a/root/app/auth/auth.py
+++ b/root/app/auth/auth.py
@@ -1,6 +1,6 @@
 from datetime import UTC, datetime, timedelta
 
-from fastapi import APIRouter, Depends, HTTPException, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from fastapi.security import OAuth2PasswordRequestForm
 from pydantic import BaseModel, EmailStr
 from sqlalchemy import select
@@ -13,6 +13,7 @@ from app.auth.security import (
 )
 from app.core.config import settings
 from app.core.database import get_db
+from app.localization import resolve_locale, translate
 from app.models.models import User
 from app.schemas.schemas import Token, UserCreate
 from app.utils.ratelimit import sensitive_route_limit
@@ -67,32 +68,38 @@ def _clear_access_token_cookie(response: Response) -> None:
 )
 async def login(
     response: Response,
+    request: Request,
     form_data: OAuth2PasswordRequestForm = Depends(OAuth2PasswordRequestForm),
     db: AsyncSession = Depends(get_db),
 ):
+    locale = resolve_locale(request=request)
     email = form_data.username.strip().lower()
     res = await db.execute(select(User).where(User.email == email))
     user = res.scalars().first()
     if not user:
+        message = translate("errors.auth.credentials_invalid", locale=locale)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Неверный email или пароль",
+            detail=message,
             headers={"WWW-Authenticate": "Bearer"},
         )
 
+    locale = resolve_locale(request=request, user=user)
     verified, new_hash = verify_and_update_password(
         form_data.password, user.hashed_password
     )
     if not verified:
+        message = translate("errors.auth.credentials_invalid", locale=locale)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Неверный email или пароль",
+            detail=message,
             headers={"WWW-Authenticate": "Bearer"},
         )
     if not user.is_active:
+        message = translate("errors.auth.user_deactivated", locale=locale)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Пользователь деактивирован",
+            detail=message,
             headers={"WWW-Authenticate": "Bearer"},
         )
     user_id = user.id
@@ -113,31 +120,37 @@ async def login(
 async def login_json(
     payload: LoginIn,
     response: Response,
+    request: Request,
     db: AsyncSession = Depends(get_db),
 ):
+    locale = resolve_locale(request=request)
     email = payload.email.strip().lower()
     res = await db.execute(select(User).where(User.email == email))
     user = res.scalars().first()
     if not user:
+        message = translate("errors.auth.credentials_invalid", locale=locale)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Неверный email или пароль",
+            detail=message,
             headers={"WWW-Authenticate": "Bearer"},
         )
 
+    locale = resolve_locale(request=request, user=user)
     verified, new_hash = verify_and_update_password(
         payload.password, user.hashed_password
     )
     if not verified:
+        message = translate("errors.auth.credentials_invalid", locale=locale)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Неверный email или пароль",
+            detail=message,
             headers={"WWW-Authenticate": "Bearer"},
         )
     if not user.is_active:
+        message = translate("errors.auth.user_deactivated", locale=locale)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Пользователь деактивирован",
+            detail=message,
             headers={"WWW-Authenticate": "Bearer"},
         )
     user_id = user.id
@@ -151,13 +164,19 @@ async def login_json(
 
 
 @router.post("/register")
-async def register(user: UserCreate, db: AsyncSession = Depends(get_db)):
+async def register(
+    user: UserCreate,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+):
     email = user.email.strip().lower()
     res = await db.execute(select(User).where(User.email == email))
     if res.scalars().first():
+        locale = resolve_locale(request=request)
+        message = translate("errors.users.email_in_use", locale=locale)
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Пользователь с таким email уже существует",
+            detail=message,
         )
     try:
         hashed_password = get_password_hash(user.password)

--- a/root/app/crud/__init__.py
+++ b/root/app/crud/__init__.py
@@ -7,6 +7,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth.security import get_password_hash
+from app.localization import translate
 from app.models import models
 from app.models.enums import UserRole
 from app.schemas import schemas
@@ -23,8 +24,8 @@ def _ensure_utc(value: datetime) -> datetime:
     return value.astimezone(UTC) if value.tzinfo else value.replace(tzinfo=UTC)
 
 
-_EVENT_TIME_ORDER_ERROR = "Время окончания должно быть позже времени начала мероприятия"
-_EVENT_TIME_PAIR_ERROR = "Укажите время начала и окончания мероприятия одновременно"
+_EVENT_TIME_ORDER_KEY = "validation.events.end_after_start"
+_EVENT_TIME_PAIR_KEY = "validation.events.times_required"
 
 
 async def create_user(db: AsyncSession, user_in: schemas.UserCreate):
@@ -44,7 +45,7 @@ async def create_user(db: AsyncSession, user_in: schemas.UserCreate):
         )
         code = (await db.execute(code_q)).scalar_one_or_none()
         if not code:
-            raise ValueError("Неверный или уже использованный invite code")
+            raise ValueError(translate("errors.users.invalid_invite"))
 
     exists = await db.execute(
         select(models.User).where(
@@ -52,7 +53,7 @@ async def create_user(db: AsyncSession, user_in: schemas.UserCreate):
         )
     )
     if exists.scalar_one_or_none():
-        raise ValueError("Пользователь с таким email уже существует")
+        raise ValueError(translate("errors.users.email_in_use"))
 
     hashed_password = get_password_hash(user_in.password)
     db_user = models.User(
@@ -81,7 +82,7 @@ async def create_user(db: AsyncSession, user_in: schemas.UserCreate):
         await db.commit()
     except IntegrityError:
         await db.rollback()
-        raise ValueError("Ошибка создания пользователя")
+        raise ValueError(translate("errors.users.create_failed"))
 
     await db.refresh(db_user)
 
@@ -231,7 +232,7 @@ async def create_event(db: AsyncSession, event: schemas.EventCreate, user_id: in
     starts_at = _ensure_utc(event.starts_at)
     ends_at = _ensure_utc(event.ends_at)
     if ends_at <= starts_at:
-        raise ValueError(_EVENT_TIME_ORDER_ERROR)
+        raise ValueError(translate(_EVENT_TIME_ORDER_KEY))
     record = models.Event(
         title=event.title,
         description=event.description,
@@ -250,7 +251,7 @@ async def create_event(db: AsyncSession, event: schemas.EventCreate, user_id: in
     except IntegrityError as exc:
         await db.rollback()
         if "ck_event_time_order" in str(exc.orig):
-            raise ValueError(_EVENT_TIME_ORDER_ERROR) from None
+            raise ValueError(translate(_EVENT_TIME_ORDER_KEY)) from None
         raise
     await db.refresh(record)
     return record
@@ -269,14 +270,14 @@ async def update_event(
     starts_set = "starts_at" in updates
     ends_set = "ends_at" in updates
     if starts_set ^ ends_set:
-        raise ValueError(_EVENT_TIME_PAIR_ERROR)
+        raise ValueError(translate(_EVENT_TIME_PAIR_KEY))
     if starts_set or ends_set:
         starts_at = updates.get("starts_at", record.starts_at)
         ends_at = updates.get("ends_at", record.ends_at)
         if starts_at is None or ends_at is None:
-            raise ValueError(_EVENT_TIME_PAIR_ERROR)
+            raise ValueError(translate(_EVENT_TIME_PAIR_KEY))
         if ends_at <= starts_at:
-            raise ValueError(_EVENT_TIME_ORDER_ERROR)
+            raise ValueError(translate(_EVENT_TIME_ORDER_KEY))
     for field, value in updates.items():
         setattr(record, field, value)
     db.add(record)
@@ -285,7 +286,7 @@ async def update_event(
     except IntegrityError as exc:
         await db.rollback()
         if "ck_event_time_order" in str(exc.orig):
-            raise ValueError(_EVENT_TIME_ORDER_ERROR) from None
+            raise ValueError(translate(_EVENT_TIME_ORDER_KEY)) from None
         raise
     await db.refresh(record)
     return record
@@ -424,7 +425,11 @@ async def create_schedule(db: AsyncSession, data: schemas.ScheduleCreate):
         start_time=start_time,
         end_time=end_time,
         parity=getattr(data, "parity", "both"),
-        lesson_type=getattr(data, "lesson_type", "Лекция"),
+        lesson_type=getattr(
+            data,
+            "lesson_type",
+            translate("schedule.lesson.default_type", locale="ru"),
+        ),
     )
     db.add(record)
     await db.commit()
@@ -462,7 +467,7 @@ async def admin_update_user(
 ) -> models.User:
     user = await db.get(models.User, user_id)
     if not user:
-        raise ValueError("Пользователь не найден")
+        raise ValueError(translate("errors.users.not_found"))
     for field, value in data.model_dump(exclude_unset=True).items():
         setattr(user, field, value)
     await db.commit()
@@ -473,6 +478,6 @@ async def admin_update_user(
 async def delete_user(db: AsyncSession, user_id: int):
     user = await db.get(models.User, user_id)
     if not user:
-        raise ValueError("Пользователь не найден")
+        raise ValueError(translate("errors.users.not_found"))
     await db.delete(user)
     await db.commit()

--- a/root/app/localization.py
+++ b/root/app/localization.py
@@ -117,6 +117,10 @@ _TRANSLATIONS: Mapping[str, Mapping[str, str]] = {
         "ru": "Не удалось подтвердить учётные данные",
         "en": "Could not validate credentials",
     },
+    "errors.auth.user_deactivated": {
+        "ru": "Пользователь деактивирован",
+        "en": "User account is deactivated",
+    },
     "errors.forbidden": {
         "ru": "Доступ запрещён",
         "en": "Access denied",
@@ -145,9 +149,45 @@ _TRANSLATIONS: Mapping[str, Mapping[str, str]] = {
         "ru": "Уведомление не найдено",
         "en": "Notification not found",
     },
+    "errors.push.not_configured": {
+        "ru": "Web push не настроен",
+        "en": "Web push is not configured",
+    },
+    "errors.push.subscription_exists": {
+        "ru": "Точка подписки уже зарегистрирована",
+        "en": "Subscription endpoint already registered",
+    },
+    "errors.push.subscription_not_found": {
+        "ru": "Подписка не найдена",
+        "en": "Subscription not found",
+    },
+    "errors.push.subscription_validation_failed": {
+        "ru": "Не удалось проверить данные подписки",
+        "en": "Subscription payload validation failed",
+    },
+    "errors.rate_limit.generic": {
+        "ru": "Слишком много запросов",
+        "en": "Too many requests",
+    },
+    "errors.rate_limit.push_subscribe": {
+        "ru": "Слишком много запросов подписки. Попробуйте позже.",
+        "en": "Too many subscription attempts. Please try again later.",
+    },
+    "errors.rate_limit.push_unsubscribe": {
+        "ru": "Слишком много попыток отключить уведомления.",
+        "en": "Too many unsubscribe attempts.",
+    },
+    "errors.rate_limit.push_test": {
+        "ru": "Слишком много тестовых уведомлений",
+        "en": "Too many test notifications",
+    },
     "errors.schedule.not_found": {
         "ru": "Запись расписания не найдена",
         "en": "Schedule entry not found",
+    },
+    "errors.schedule.group_not_found": {
+        "ru": "Группа не найдена",
+        "en": "Group not found",
     },
     "errors.spotify.reconnect_required": {
         "ru": "Требуется переподключить Spotify",
@@ -185,6 +225,10 @@ _TRANSLATIONS: Mapping[str, Mapping[str, str]] = {
         "ru": "Указанный email уже используется",
         "en": "The specified email is already in use",
     },
+    "errors.users.create_failed": {
+        "ru": "Ошибка создания пользователя",
+        "en": "Failed to create user",
+    },
     "errors.users.invite_required": {
         "ru": "Необходим уникальный код для регистрации преподавателя/админа",
         "en": "A unique invite code is required to register a teacher or admin",
@@ -196,6 +240,94 @@ _TRANSLATIONS: Mapping[str, Mapping[str, str]] = {
     "errors.users.cannot_delete_self": {
         "ru": "Нельзя удалить самого себя",
         "en": "You cannot delete yourself",
+    },
+    "errors.users.not_found": {
+        "ru": "Пользователь не найден",
+        "en": "User not found",
+    },
+    "notifications.push.test.title_default": {
+        "ru": "Тестовое веб-push уведомление",
+        "en": "Test web push notification",
+    },
+    "notifications.push.test.body_default": {
+        "ru": "Проверка доставки уведомлений",
+        "en": "Delivery check",
+    },
+    "notifications.push.test.no_subscriptions": {
+        "ru": "Активные подписки не найдены",
+        "en": "No subscriptions found",
+    },
+    "notifications.push.test_failure": {
+        "ru": "Не удалось отправить тестовое уведомление",
+        "en": "Failed to send the test notification",
+    },
+    "notifications.push.broadcast_failure": {
+        "ru": "Не удалось отправить уведомления",
+        "en": "Failed to deliver notifications",
+    },
+    "notifications.push.disable_user.description": {
+        "ru": "ID пользователя, для которого нужно отключить push",
+        "en": "User ID for which push notifications should be disabled",
+    },
+    "notifications.push.validation.endpoint_required": {
+        "ru": "Endpoint обязателен",
+        "en": "Endpoint is required",
+    },
+    "notifications.push.validation.keys_auth_required": {
+        "ru": "keys.auth не может быть пустым",
+        "en": "keys.auth must not be empty",
+    },
+    "notifications.push.validation.keys_p256dh_required": {
+        "ru": "keys.p256dh не может быть пустым",
+        "en": "keys.p256dh must not be empty",
+    },
+    "schedule.ics.calendar_name": {
+        "ru": "Расписание {group}",
+        "en": "Schedule for {group}",
+    },
+    "schedule.ics.calendar_name_generic": {
+        "ru": "Расписание",
+        "en": "Schedule",
+    },
+    "schedule.ics.lesson_default_subject": {
+        "ru": "Занятие",
+        "en": "Lesson",
+    },
+    "schedule.ics.description.teacher": {
+        "ru": "Преподаватель: {teacher}",
+        "en": "Teacher: {teacher}",
+    },
+    "schedule.ics.description.room": {
+        "ru": "Аудитория: {room}",
+        "en": "Room: {room}",
+    },
+    "schedule.ics.description.parity_odd": {
+        "ru": "Нечётные недели",
+        "en": "Odd weeks",
+    },
+    "schedule.ics.description.parity_even": {
+        "ru": "Чётные недели",
+        "en": "Even weeks",
+    },
+    "schedule.lesson.default_type": {
+        "ru": "Лекция",
+        "en": "Lecture",
+    },
+    "schedule.query.group_id_description": {
+        "ru": "Идентификатор группы",
+        "en": "Group identifier",
+    },
+    "validation.dnd.times_required": {
+        "ru": 'Укажите время начала и окончания режима "Не беспокоить"',
+        "en": 'Provide both start and end times for "Do Not Disturb" mode',
+    },
+    "validation.events.end_after_start": {
+        "ru": "Время окончания должно быть позже времени начала мероприятия",
+        "en": "The end time must be later than the start time",
+    },
+    "validation.events.times_required": {
+        "ru": "Укажите время начала и окончания мероприятия одновременно",
+        "en": "Provide both start and end times for the event",
     },
 }
 

--- a/root/app/routers/notifications.py
+++ b/root/app/routers/notifications.py
@@ -18,6 +18,7 @@ from app.api.deps import get_current_user
 from app.core.config import settings
 from app.core.database import get_db
 from app.core.rate_limit import RateLimitExceeded, RateLimitInfo, enforce_rate_limit
+from app.localization import resolve_locale, translate
 from app.models.models import PushSubscription, User
 from app.services.notifications import prepare_push_payload_for_user
 from app.services.push_schema import ensure_push_subscription_schema
@@ -179,7 +180,9 @@ class PushSubscriptionDelete(BaseModel):
 
 class DisableUserPushRequest(BaseModel):
     user_id: int = Field(
-        ..., ge=1, description="ID пользователя, для которого нужно отключить push"
+        ...,
+        ge=1,
+        description=translate("notifications.push.disable_user.description"),
     )
 
 
@@ -196,11 +199,11 @@ class PushTestRequest(NotifyBody):
         default=None, description="Target user id for testing", ge=1
     )
     title: str = Field(
-        default="Тестовое веб-push уведомление",
+        default=translate("notifications.push.test.title_default"),
         description="Notification title",
     )
     body: str | None = Field(
-        default="Проверка доставки уведомлений",
+        default=translate("notifications.push.test.body_default"),
         description="Notification body",
     )
     url: str | None = Field(
@@ -234,25 +237,51 @@ def _aggregate_results(
 
 async def _validate_subscription_payload(
     data: PushSubscriptionIn,
+    *,
+    locale: str | None,
 ) -> tuple[str, str, str]:
     endpoint = data.endpoint.strip()
     p256dh = data.keys.p256dh.strip()
     auth = data.keys.auth.strip()
     errors = []
     if not endpoint:
-        errors.append({"field": "endpoint", "message": "Endpoint is required"})
+        errors.append(
+            {
+                "field": "endpoint",
+                "message": translate(
+                    "notifications.push.validation.endpoint_required",
+                    locale=locale,
+                ),
+            }
+        )
     if not p256dh:
         errors.append(
-            {"field": "keys.p256dh", "message": "keys.p256dh must not be empty"}
+            {
+                "field": "keys.p256dh",
+                "message": translate(
+                    "notifications.push.validation.keys_p256dh_required",
+                    locale=locale,
+                ),
+            }
         )
     if not auth:
-        errors.append({"field": "keys.auth", "message": "keys.auth must not be empty"})
+        errors.append(
+            {
+                "field": "keys.auth",
+                "message": translate(
+                    "notifications.push.validation.keys_auth_required",
+                    locale=locale,
+                ),
+            }
+        )
     if errors:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail={
                 "error": "invalid_subscription",
-                "message": "Subscription payload validation failed",
+                "message": translate(
+                    "errors.push.subscription_validation_failed", locale=locale
+                ),
                 "fields": errors,
             },
         )
@@ -272,8 +301,11 @@ async def subscribe(
     db: Annotated[AsyncSession, Depends(get_db)],
     user: Annotated[User, Depends(get_current_user)],
 ) -> PushSubscriptionOut:
+    locale = resolve_locale(request=request, user=user)
     await ensure_push_subscription_schema(db)
-    endpoint, p256dh, auth = await _validate_subscription_payload(payload)
+    endpoint, p256dh, auth = await _validate_subscription_payload(
+        payload, locale=locale
+    )
 
     client_host = request.client.host if request.client else None
     try:
@@ -298,7 +330,7 @@ async def subscribe(
             status_code=status.HTTP_429_TOO_MANY_REQUESTS,
             detail={
                 "error": "rate_limited",
-                "message": "Слишком много запросов подписки. Попробуйте позже.",
+                "message": translate("errors.rate_limit.push_subscribe", locale=locale),
                 "retry_after": info.retry_after,
             },
         ) from None
@@ -326,7 +358,9 @@ async def subscribe(
                     status_code=status.HTTP_409_CONFLICT,
                     detail={
                         "error": "duplicate_endpoint",
-                        "message": "Subscription endpoint already registered",
+                        "message": translate(
+                            "errors.push.subscription_exists", locale=locale
+                        ),
                     },
                 )
             existing.p256dh = p256dh
@@ -361,7 +395,9 @@ async def subscribe(
             status_code=status.HTTP_409_CONFLICT,
             detail={
                 "error": "duplicate_endpoint",
-                "message": "Subscription endpoint already exists",
+                "message": translate(
+                    "errors.push.subscription_exists", locale=locale
+                ),
             },
         )
 
@@ -371,9 +407,11 @@ async def subscribe(
 @router.patch("/subscribe/topics", response_model=PushSubscriptionOut)
 async def update_subscription_topics(
     payload: PushSubscriptionTopicsUpdate,
+    request: Request,
     db: Annotated[AsyncSession, Depends(get_db)],
     user: Annotated[User, Depends(get_current_user)],
 ) -> PushSubscriptionOut:
+    locale = resolve_locale(request=request, user=user)
     await ensure_push_subscription_schema(db)
     endpoint = payload.endpoint.strip()
     if not endpoint:
@@ -381,7 +419,9 @@ async def update_subscription_topics(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail={
                 "error": "invalid_subscription",
-                "message": "Endpoint is required",
+                "message": translate(
+                    "notifications.push.validation.endpoint_required", locale=locale
+                ),
             },
         )
 
@@ -398,7 +438,9 @@ async def update_subscription_topics(
             status_code=status.HTTP_404_NOT_FOUND,
             detail={
                 "error": "subscription_not_found",
-                "message": "Subscription not found",
+                "message": translate(
+                    "errors.push.subscription_not_found", locale=locale
+                ),
             },
         )
 
@@ -416,6 +458,7 @@ async def unsubscribe(
     db: Annotated[AsyncSession, Depends(get_db)],
     user: Annotated[User, Depends(get_current_user)],
 ) -> dict[str, bool]:
+    locale = resolve_locale(request=request, user=user)
     await ensure_push_subscription_schema(db)
     endpoint = payload.endpoint.strip()
     if not endpoint:
@@ -423,7 +466,9 @@ async def unsubscribe(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail={
                 "error": "invalid_subscription",
-                "message": "Endpoint is required",
+                "message": translate(
+                    "notifications.push.validation.endpoint_required", locale=locale
+                ),
             },
         )
 
@@ -450,7 +495,9 @@ async def unsubscribe(
             status_code=status.HTTP_429_TOO_MANY_REQUESTS,
             detail={
                 "error": "rate_limited",
-                "message": "Слишком много попыток отключить уведомления.",
+                "message": translate(
+                    "errors.rate_limit.push_unsubscribe", locale=locale
+                ),
                 "retry_after": info.retry_after,
             },
         ) from None
@@ -478,17 +525,21 @@ async def send_test(
     user: Annotated[User, Depends(get_current_user)],
     payload: PushTestRequest | None = None,
 ) -> SendTestResponse:
+    locale = resolve_locale(request=request, user=user)
     await ensure_push_subscription_schema(db)
     if user.role != "admin":
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail={"error": "forbidden", "message": "Admin access required"},
+            detail={
+                "error": "forbidden",
+                "message": translate("errors.forbidden", locale=locale),
+            },
         )
 
     if not settings.VAPID_PRIVATE_KEY or not settings.VAPID_PUBLIC_KEY:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="Web push is not configured",
+            detail=translate("errors.push.not_configured", locale=locale),
         )
 
     client_host = request.client.host if request and request.client else None
@@ -514,7 +565,7 @@ async def send_test(
             status_code=status.HTTP_429_TOO_MANY_REQUESTS,
             detail={
                 "error": "rate_limited",
-                "message": "Too many test notifications",
+                "message": translate("errors.rate_limit.push_test", locale=locale),
                 "retry_after": info.retry_after,
             },
         )
@@ -524,7 +575,10 @@ async def send_test(
     if not target:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail={"error": "user_not_found", "message": "Target user not found"},
+            detail={
+                "error": "user_not_found",
+                "message": translate("errors.users.not_found", locale=locale),
+            },
         )
 
     subscriptions = (
@@ -540,16 +594,27 @@ async def send_test(
     )
     if not subscriptions:
         return SendTestResponse(
-            total=0, sent=0, removed=0, failed=0, detail="No subscriptions found"
+            total=0,
+            sent=0,
+            removed=0,
+            failed=0,
+            detail=translate(
+                "notifications.push.test.no_subscriptions", locale=locale
+            ),
         )
 
     normalized_topic = normalize_topic(payload.topic if payload else None) or "system"
     base_url = payload.url if payload and payload.url else settings.app_base_url or "/"
     body = payload.body if payload else None
-    title = payload.title if payload else "Тестовое веб-push уведомление"
+    title = (
+        payload.title
+        if payload and payload.title
+        else translate("notifications.push.test.title_default", locale=locale)
+    )
     message = {
         "title": title,
-        "body": body or "Проверка доставки уведомлений",
+        "body": body
+        or translate("notifications.push.test.body_default", locale=locale),
         "url": base_url,
     }
     if normalized_topic:
@@ -573,7 +638,8 @@ async def send_test(
         result = await _deliver_to_subscription(sub, prepared)
         results.append(result)
     summary = _aggregate_results(
-        results, failure_detail="Не удалось отправить тестовое уведомление"
+        results,
+        failure_detail=translate("notifications.push.test_failure", locale=locale),
     )
     logger.info(
         "push.test.summary",
@@ -591,17 +657,29 @@ async def send_test(
 @router.post("/admin/disable-user")
 async def disable_user_push(
     payload: DisableUserPushRequest,
+    request: Request,
     db: Annotated[AsyncSession, Depends(get_db)],
     user: Annotated[User, Depends(get_current_user)],
 ) -> dict[str, int | bool]:
+    locale = resolve_locale(request=request, user=user)
     await ensure_push_subscription_schema(db)
     if user.role != "admin":
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="forbidden")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "error": "forbidden",
+                "message": translate("errors.forbidden", locale=locale),
+            },
+        )
 
     target = await db.get(User, payload.user_id)
     if not target:
         raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="user_not_found"
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={
+                "error": "user_not_found",
+                "message": translate("errors.users.not_found", locale=locale),
+            },
         )
 
     existing = (
@@ -634,12 +712,20 @@ async def disable_user_push(
 @router.post("/broadcast", response_model=SendTestResponse)
 async def broadcast(
     data: NotifyBody,
+    request: Request,
     db: Annotated[AsyncSession, Depends(get_db)],
     user: Annotated[User, Depends(get_current_user)],
 ) -> SendTestResponse:
+    locale = resolve_locale(request=request, user=user)
     await ensure_push_subscription_schema(db)
     if user.role != "admin":
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="forbidden")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "error": "forbidden",
+                "message": translate("errors.forbidden", locale=locale),
+            },
+        )
 
     subscriptions = (
         (
@@ -669,7 +755,8 @@ async def broadcast(
         results.append(await _deliver_to_subscription(subscription, prepared))
 
     summary = _aggregate_results(
-        results, failure_detail="Не удалось отправить уведомления"
+        results,
+        failure_detail=translate("notifications.push.broadcast_failure", locale=locale),
     )
     logger.info(
         "push.broadcast.summary",

--- a/root/app/routers/notifications.py
+++ b/root/app/routers/notifications.py
@@ -395,9 +395,7 @@ async def subscribe(
             status_code=status.HTTP_409_CONFLICT,
             detail={
                 "error": "duplicate_endpoint",
-                "message": translate(
-                    "errors.push.subscription_exists", locale=locale
-                ),
+                "message": translate("errors.push.subscription_exists", locale=locale),
             },
         )
 
@@ -598,9 +596,7 @@ async def send_test(
             sent=0,
             removed=0,
             failed=0,
-            detail=translate(
-                "notifications.push.test.no_subscriptions", locale=locale
-            ),
+            detail=translate("notifications.push.test.no_subscriptions", locale=locale),
         )
 
     normalized_topic = normalize_topic(payload.topic if payload else None) or "system"

--- a/root/app/routers/schedule.py
+++ b/root/app/routers/schedule.py
@@ -10,8 +10,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import crud
 from app.core.database import get_db
-from app.models import models
 from app.localization import resolve_locale, translate
+from app.models import models
 from app.services.ical import generate_schedule_ics
 
 router = APIRouter(prefix="/schedule", tags=["schedule"])

--- a/root/app/routers/schedule.py
+++ b/root/app/routers/schedule.py
@@ -5,12 +5,13 @@ from __future__ import annotations
 import re
 from typing import Sequence
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Response
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import crud
 from app.core.database import get_db
 from app.models import models
+from app.localization import resolve_locale, translate
 from app.services.ical import generate_schedule_ics
 
 router = APIRouter(prefix="/schedule", tags=["schedule"])
@@ -25,21 +26,28 @@ def _build_filename(group: models.Group) -> str:
 
 @router.get("/ics", response_class=Response)
 async def download_schedule_ics(
-    group: int = Query(..., description="Идентификатор группы"),
+    request: Request,
+    group: int = Query(
+        ..., description=translate("schedule.query.group_id_description")
+    ),
     db: AsyncSession = Depends(get_db),
 ) -> Response:
+    locale = resolve_locale(request=request)
     group_obj = await db.get(models.Group, group)
     if not group_obj:
-        raise HTTPException(status_code=404, detail="Группа не найдена")
+        message = translate("errors.schedule.group_not_found", locale=locale)
+        raise HTTPException(status_code=404, detail=message)
 
     lessons: Sequence[models.Schedule] = await crud.get_schedule_by_group(db, group)
-    ics_body = generate_schedule_ics(group_obj, lessons)
+    ics_body = generate_schedule_ics(group_obj, lessons, locale=locale)
     filename = _build_filename(group_obj)
 
     headers = {
         "Content-Disposition": f'attachment; filename="{filename}"',
         "Cache-Control": "no-cache",
     }
+    if locale:
+        headers["Content-Language"] = locale
     return Response(
         content=ics_body, media_type="text/calendar; charset=utf-8", headers=headers
     )

--- a/root/app/schemas/schemas.py
+++ b/root/app/schemas/schemas.py
@@ -3,8 +3,8 @@ from typing import Any, List, Optional
 
 from pydantic import BaseModel, ConfigDict, EmailStr, Field, model_validator
 
-from app.models.enums import UserRole
 from app.localization import translate
+from app.models.enums import UserRole
 
 
 class OrmModel(BaseModel):
@@ -124,9 +124,7 @@ class ScheduleBase(BaseModel):
     start_time: datetime
     end_time: datetime
     parity: Optional[str] = "both"
-    lesson_type: Optional[str] = translate(
-        "schedule.lesson.default_type", locale="ru"
-    )
+    lesson_type: Optional[str] = translate("schedule.lesson.default_type", locale="ru")
 
 
 class ScheduleCreate(ScheduleBase):

--- a/root/app/schemas/schemas.py
+++ b/root/app/schemas/schemas.py
@@ -4,6 +4,7 @@ from typing import Any, List, Optional
 from pydantic import BaseModel, ConfigDict, EmailStr, Field, model_validator
 
 from app.models.enums import UserRole
+from app.localization import translate
 
 
 class OrmModel(BaseModel):
@@ -96,7 +97,7 @@ class UserProfileUpdate(BaseModel):
         start = payload.get("dnd_start")
         end = payload.get("dnd_end")
         if enabled and (start is None or end is None):
-            raise ValueError('Укажите время начала и окончания режима "Не беспокоить"')
+            raise ValueError(translate("validation.dnd.times_required"))
 
         return raw
 
@@ -123,7 +124,9 @@ class ScheduleBase(BaseModel):
     start_time: datetime
     end_time: datetime
     parity: Optional[str] = "both"
-    lesson_type: Optional[str] = "Лекция"
+    lesson_type: Optional[str] = translate(
+        "schedule.lesson.default_type", locale="ru"
+    )
 
 
 class ScheduleCreate(ScheduleBase):
@@ -178,9 +181,7 @@ class EventCreate(BaseModel):
     @model_validator(mode="after")
     def _validate_time_order(self):  # type: ignore[override]
         if self.ends_at <= self.starts_at:
-            raise ValueError(
-                "Время окончания должно быть позже времени начала мероприятия"
-            )
+            raise ValueError(translate("validation.events.end_after_start"))
         return self
 
 
@@ -202,18 +203,12 @@ class EventUpdate(BaseModel):
         starts_set = "starts_at" in provided
         ends_set = "ends_at" in provided
         if starts_set ^ ends_set:
-            raise ValueError(
-                "Укажите время начала и окончания мероприятия одновременно"
-            )
+            raise ValueError(translate("validation.events.times_required"))
         if starts_set or ends_set:
             if self.starts_at is None or self.ends_at is None:
-                raise ValueError(
-                    "Укажите время начала и окончания мероприятия одновременно"
-                )
+                raise ValueError(translate("validation.events.times_required"))
             if self.ends_at <= self.starts_at:
-                raise ValueError(
-                    "Время окончания должно быть позже времени начала мероприятия"
-                )
+                raise ValueError(translate("validation.events.end_after_start"))
         return self
 
 

--- a/root/app/services/ical.py
+++ b/root/app/services/ical.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import date, datetime, time, timedelta, timezone
 from typing import Iterable, Sequence
 
+from app.localization import translate
 from app.models import models
 
 _WEEKDAY_ALIASES: dict[str, int] = {
@@ -92,6 +93,7 @@ def generate_schedule_ics(
     lessons: Sequence[models.Schedule],
     *,
     weeks: int = 16,
+    locale: str | None = None,
 ) -> str:
     """Generate an iCalendar representation for the provided schedule."""
 
@@ -101,8 +103,11 @@ def generate_schedule_ics(
     current_week_number = today.isocalendar()[1]
     current_week_parity = "odd" if current_week_number % 2 else "even"
 
+    group_name = getattr(group, "name", None)
     calendar_name = (
-        f"Расписание {group.name}" if getattr(group, "name", None) else "Расписание"
+        translate("schedule.ics.calendar_name", locale=locale, group=group_name)
+        if group_name
+        else translate("schedule.ics.calendar_name_generic", locale=locale)
     )
 
     lines: list[str] = [
@@ -124,7 +129,10 @@ def generate_schedule_ics(
             continue
 
         parity = getattr(lesson, "parity", "both") or "both"
-        subject = getattr(lesson, "subject", "Занятие") or "Занятие"
+        subject = (
+            getattr(lesson, "subject", None)
+            or translate("schedule.ics.lesson_default_subject", locale=locale)
+        )
         lesson_type = getattr(lesson, "lesson_type", None)
         summary = subject if not lesson_type else f"{subject} ({lesson_type})"
         teacher = getattr(lesson, "teacher", None)
@@ -142,13 +150,28 @@ def generate_schedule_ics(
             uid = f"lesson-{getattr(lesson, 'id', 'x')}-{lesson_date.strftime('%Y%m%d')}@university-ecosystem"
             description_parts = []
             if teacher:
-                description_parts.append(f"Преподаватель: {teacher}")
-            if room:
-                description_parts.append(f"Аудитория: {room}")
-            if parity and parity.lower() in {"odd", "even"}:
                 description_parts.append(
-                    "Нечётные недели" if parity.lower() == "odd" else "Чётные недели"
+                    translate(
+                        "schedule.ics.description.teacher",
+                        locale=locale,
+                        teacher=teacher,
+                    )
                 )
+            if room:
+                description_parts.append(
+                    translate(
+                        "schedule.ics.description.room",
+                        locale=locale,
+                        room=room,
+                    )
+                )
+            if parity and parity.lower() in {"odd", "even"}:
+                parity_key = (
+                    "schedule.ics.description.parity_odd"
+                    if parity.lower() == "odd"
+                    else "schedule.ics.description.parity_even"
+                )
+                description_parts.append(translate(parity_key, locale=locale))
             description = "\\n".join(description_parts) if description_parts else ""
 
             lines.extend(

--- a/root/app/services/ical.py
+++ b/root/app/services/ical.py
@@ -129,9 +129,8 @@ def generate_schedule_ics(
             continue
 
         parity = getattr(lesson, "parity", "both") or "both"
-        subject = (
-            getattr(lesson, "subject", None)
-            or translate("schedule.ics.lesson_default_subject", locale=locale)
+        subject = getattr(lesson, "subject", None) or translate(
+            "schedule.ics.lesson_default_subject", locale=locale
         )
         lesson_type = getattr(lesson, "lesson_type", None)
         summary = subject if not lesson_type else f"{subject} ({lesson_type})"

--- a/root/app/services/webpush.py
+++ b/root/app/services/webpush.py
@@ -19,7 +19,7 @@ from sqlalchemy.orm import selectinload, sessionmaker
 from app.core.config import settings
 from app.core.database import async_session
 from app.core.rate_limit import RateLimitExceeded, RateLimitInfo, enforce_rate_limit
-from app.localization import translate
+from app.localization import resolve_locale, translate
 from app.models.models import PushSubscription
 from app.services.notification_templates import render_notification_template
 from app.services.push_schema import ensure_push_subscription_schema_sync
@@ -163,6 +163,8 @@ def _prepare_actions(raw_actions: Any) -> tuple[list[dict[str, str]], dict[str, 
 
 def _normalize_payload(
     raw: Mapping[str, Any] | None,
+    *,
+    locale: str | None = None,
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     if not isinstance(raw, Mapping):
         raw = {}
@@ -275,7 +277,12 @@ def _normalize_payload(
     topic = meta.get("topic")
     if topic and isinstance(topic, str):
         payload_data.setdefault("topic", topic)
-    title = str(raw.get("title") or "Уведомление")
+    title_value = raw.get("title")
+    title = (
+        str(title_value)
+        if title_value not in (None, "")
+        else translate("notifications.default_title", locale=locale)
+    )
     payload = {
         "title": title,
         "options": payload_options,
@@ -304,10 +311,16 @@ def _resolve_ttl(meta: Mapping[str, Any]) -> int:
 
 
 def _compose_payload(
-    payload: Mapping[str, Any], meta: Mapping[str, Any] | None
+    payload: Mapping[str, Any],
+    meta: Mapping[str, Any] | None,
+    *,
+    locale: str | None = None,
 ) -> dict[str, Any]:
     result = {
-        "title": str(payload.get("title") or "Уведомление"),
+        "title": str(
+            payload.get("title")
+            or translate("notifications.default_title", locale=locale)
+        ),
         "options": deepcopy(payload.get("options", {})),
         "data": deepcopy(payload.get("data", {})),
     }
@@ -337,7 +350,8 @@ def _prepare_delivery_payload(
     topic: str | None,
     user: Any | None,
 ) -> dict[str, Any]:
-    normalized, meta = _normalize_payload(payload)
+    resolved_locale = resolve_locale(user=user)
+    normalized, meta = _normalize_payload(payload, locale=resolved_locale)
     normalized_topic = normalize_topic(topic) or normalize_topic(meta.get("topic"))
     if normalized_topic:
         meta["topic"] = normalized_topic
@@ -345,7 +359,7 @@ def _prepare_delivery_payload(
         normalized["data"].setdefault("topic", normalized_topic)
     if user and _is_user_in_quiet_hours(user):
         _apply_quiet_mode(normalized)
-    return _compose_payload(normalized, meta)
+    return _compose_payload(normalized, meta, locale=resolved_locale)
 
 
 async def _check_rate_limit(
@@ -474,7 +488,9 @@ def build_payload(
 
 
 def send_web_push(sub: PushSubscription, data: dict) -> WebPushResult:
-    normalized_payload, meta = _normalize_payload(data)
+    user = getattr(sub, "user", None)
+    locale = resolve_locale(user=user)
+    normalized_payload, meta = _normalize_payload(data, locale=locale)
     ttl = _resolve_ttl(meta)
     headers = {"TTL": str(ttl)}
     urgency = meta.get("urgency")

--- a/root/app/utils/ratelimit.py
+++ b/root/app/utils/ratelimit.py
@@ -36,9 +36,7 @@ class MemoryLimiter:
     def __init__(self) -> None:
         self.bucket: dict[str, list[float]] = {}
 
-    def check(
-        self, key: str, limit: int, window_sec: int, *, message: str
-    ) -> None:
+    def check(self, key: str, limit: int, window_sec: int, *, message: str) -> None:
         if limit <= 0 or window_sec <= 0:
             return
         now = time.time()
@@ -87,8 +85,6 @@ def sensitive_route_limit(
         key = f"{key_prefix}:{ip}:{request.url.path}"
         locale = resolve_locale(request=request)
         message = translate("errors.rate_limit.generic", locale=locale)
-        limiter.check(
-            key, resolved_limit, resolved_window, message=message
-        )
+        limiter.check(key, resolved_limit, resolved_window, message=message)
 
     return dependency

--- a/root/app/utils/ratelimit.py
+++ b/root/app/utils/ratelimit.py
@@ -7,6 +7,7 @@ from fastapi import HTTPException, Request, status
 
 from app.core.config import settings
 from app.core.rate_limit import parse_rate_limit
+from app.localization import resolve_locale, translate
 
 DEFAULT_LIMIT = 5
 DEFAULT_WINDOW_SECONDS = 60
@@ -35,7 +36,9 @@ class MemoryLimiter:
     def __init__(self) -> None:
         self.bucket: dict[str, list[float]] = {}
 
-    def check(self, key: str, limit: int, window_sec: int) -> None:
+    def check(
+        self, key: str, limit: int, window_sec: int, *, message: str
+    ) -> None:
         if limit <= 0 or window_sec <= 0:
             return
         now = time.time()
@@ -46,7 +49,7 @@ class MemoryLimiter:
         if len(arr) >= limit:
             raise HTTPException(
                 status_code=status.HTTP_429_TOO_MANY_REQUESTS,
-                detail="Слишком много запросов",
+                detail=message,
             )
         arr.append(now)
         self.bucket[key] = arr
@@ -82,6 +85,10 @@ def sensitive_route_limit(
             return
         ip = request.client.host if request.client else "unknown"
         key = f"{key_prefix}:{ip}:{request.url.path}"
-        limiter.check(key, resolved_limit, resolved_window)
+        locale = resolve_locale(request=request)
+        message = translate("errors.rate_limit.generic", locale=locale)
+        limiter.check(
+            key, resolved_limit, resolved_window, message=message
+        )
 
     return dependency

--- a/root/tests/test_event_time_constraints.py
+++ b/root/tests/test_event_time_constraints.py
@@ -4,6 +4,7 @@ import pytest
 from sqlalchemy.exc import IntegrityError
 
 from app import crud
+from app.localization import translate
 from app.models import models
 from app.schemas import schemas
 
@@ -24,7 +25,10 @@ async def test_create_event_guard(db_session, user_factory):
         image_url=None,
         about=None,
     )
-    with pytest.raises(ValueError, match="Время окончания"):
+    with pytest.raises(
+        ValueError,
+        match=translate("validation.events.end_after_start"),
+    ):
         await crud.create_event(db_session, payload, user_id=user.id)
 
 
@@ -43,7 +47,10 @@ async def test_update_event_guard(db_session, user_factory):
         ends_at=starts,
         fields_set={"starts_at", "ends_at"},
     )
-    with pytest.raises(ValueError, match="Время окончания"):
+    with pytest.raises(
+        ValueError,
+        match=translate("validation.events.end_after_start"),
+    ):
         await crud.update_event(db_session, record, invalid_update)
 
 

--- a/root/tests/test_push_api.py
+++ b/root/tests/test_push_api.py
@@ -1,9 +1,7 @@
 import pytest
-from fastapi import HTTPException
+from fastapi import HTTPException, Request
 from sqlalchemy import select
 from starlette.requests import Request
-
-from fastapi import Request
 
 from app.localization import translate
 from app.models.models import PushSubscription

--- a/root/tests/test_push_api.py
+++ b/root/tests/test_push_api.py
@@ -3,6 +3,9 @@ from fastapi import HTTPException
 from sqlalchemy import select
 from starlette.requests import Request
 
+from fastapi import Request
+
+from app.localization import translate
 from app.models.models import PushSubscription
 from app.routers.notifications import (
     DisableUserPushRequest,
@@ -12,6 +15,20 @@ from app.routers.notifications import (
     send_test,
 )
 from app.services.webpush import WebPushResult
+
+
+def _make_request(path: str) -> Request:
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": path,
+        "headers": [],
+        "query_string": b"",
+        "client": ("testclient", 12345),
+        "server": ("testserver", 80),
+        "scheme": "http",
+    }
+    return Request(scope)
 
 
 @pytest.mark.anyio
@@ -67,7 +84,7 @@ async def test_push_test_returns_aggregated_stats(
         "app.routers.notifications._deliver_to_subscription", _fake_deliver
     )
 
-    request = Request({"type": "http"})
+    request = _make_request("/push/test")
     response = await send_test(request=request, db=db_session, user=user, payload=None)
     assert response.model_dump() == {
         "total": 3,
@@ -113,13 +130,18 @@ async def test_push_broadcast_reports_failures(
     )
 
     payload = NotifyBody(title="System", body="Maintenance", url="/")
-    response = await broadcast(data=payload, db=db_session, user=admin)
+    response = await broadcast(
+        data=payload,
+        request=_make_request("/push/broadcast"),
+        db=db_session,
+        user=admin,
+    )
     assert response.model_dump() == {
         "total": 2,
         "sent": 0,
         "removed": 0,
         "failed": 2,
-        "detail": "Не удалось отправить уведомления",
+        "detail": translate("notifications.push.broadcast_failure"),
     }
 
 
@@ -152,7 +174,12 @@ async def test_admin_disable_user_push_removes_subscriptions(
     await db_session.commit()
 
     payload = DisableUserPushRequest(user_id=target.id)
-    response = await disable_user_push(payload=payload, db=db_session, user=admin)
+    response = await disable_user_push(
+        payload=payload,
+        request=_make_request("/push/admin/disable-user"),
+        db=db_session,
+        user=admin,
+    )
 
     assert response == {"ok": True, "removed": 2}
     remaining = (
@@ -185,7 +212,12 @@ async def test_admin_disable_user_push_requires_admin(db_session, user_factory) 
     target = await user_factory()
     payload = DisableUserPushRequest(user_id=target.id)
     with pytest.raises(HTTPException) as exc:
-        await disable_user_push(payload=payload, db=db_session, user=requester)
+        await disable_user_push(
+            payload=payload,
+            request=_make_request("/push/admin/disable-user"),
+            db=db_session,
+            user=requester,
+        )
     assert exc.value.status_code == 403
 
 
@@ -194,5 +226,10 @@ async def test_admin_disable_user_push_missing_user(db_session, user_factory) ->
     admin = await user_factory(role="admin")
     payload = DisableUserPushRequest(user_id=9999)
     with pytest.raises(HTTPException) as exc:
-        await disable_user_push(payload=payload, db=db_session, user=admin)
+        await disable_user_push(
+            payload=payload,
+            request=_make_request("/push/admin/disable-user"),
+            db=db_session,
+            user=admin,
+        )
     assert exc.value.status_code == 404

--- a/root/tests/test_rate_limit.py
+++ b/root/tests/test_rate_limit.py
@@ -2,6 +2,7 @@ import pytest
 from fastapi import status
 
 from app.auth.security import get_password_hash
+from app.localization import translate
 
 
 @pytest.mark.anyio
@@ -12,7 +13,8 @@ async def test_rate_limit_per_ip(async_client):
         assert response.headers.get("X-RateLimit-Limit") == "5"
     response = await async_client.get("/healthz")
     assert response.status_code == 429
-    assert response.json()["detail"] == "Too many requests"
+    expected = translate("errors.rate_limit.generic")
+    assert response.json()["detail"] == expected
     assert response.headers.get("Retry-After") is not None
 
 

--- a/root/tests/test_schedule_ics.py
+++ b/root/tests/test_schedule_ics.py
@@ -64,9 +64,7 @@ async def test_schedule_ics_endpoint(async_client, db_session) -> None:
     assert "schedule-" in disposition.lower()
     assert response.headers.get("content-language") == "en"
     assert "Алгебра" in response.text
-    expected_en = translate(
-        "schedule.ics.description.room", locale="en", room="А-101"
-    )
+    expected_en = translate("schedule.ics.description.room", locale="en", room="А-101")
     assert expected_en in response.text
 
     response_ru = await async_client.get(

--- a/root/tests/test_schedule_ics.py
+++ b/root/tests/test_schedule_ics.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 import pytest
 
+from app.localization import translate
 from app.models import models
 from app.services.ical import generate_schedule_ics
 
@@ -21,13 +22,17 @@ def test_generate_schedule_ics_includes_lessons() -> None:
         lesson_type="Лекция",
     )
 
-    ics = generate_schedule_ics(group, [lesson], weeks=1)
+    ics = generate_schedule_ics(group, [lesson], weeks=1, locale="en")
 
     assert "BEGIN:VCALENDAR" in ics
     assert "END:VCALENDAR" in ics
     assert "SUMMARY:Алгебра (Лекция)" in ics
     assert "DTSTART:" in ics
     assert "DTEND:" in ics
+    expected_teacher = translate(
+        "schedule.ics.description.teacher", locale="en", teacher="Проф. Смирнов"
+    )
+    assert expected_teacher in ics
 
 
 @pytest.mark.anyio
@@ -57,4 +62,19 @@ async def test_schedule_ics_endpoint(async_client, db_session) -> None:
     assert response.headers.get("content-type", "").startswith("text/calendar")
     disposition = response.headers.get("content-disposition", "")
     assert "schedule-" in disposition.lower()
+    assert response.headers.get("content-language") == "en"
     assert "Алгебра" in response.text
+    expected_en = translate(
+        "schedule.ics.description.room", locale="en", room="А-101"
+    )
+    assert expected_en in response.text
+
+    response_ru = await async_client.get(
+        f"/schedule/ics?group={group.id}", headers={"Accept-Language": "ru"}
+    )
+    assert response_ru.status_code == 200
+    assert response_ru.headers.get("content-language") == "ru"
+    expected_ru = translate(
+        "schedule.ics.description.teacher", locale="ru", teacher="Проф. Смирнов"
+    )
+    assert expected_ru in response_ru.text


### PR DESCRIPTION
## Summary
- expand the localization catalog with strings for rate limits, schedule exports, authentication, push notifications, and validation errors
- resolve client locale in authentication, schedule, notification, and rate-limit handlers so responses use translated messages
- update ICS generation, push workflows, and associated tests to validate localized output

## Testing
- pytest -q --disable-warnings

------
https://chatgpt.com/codex/tasks/task_e_68ef07914d1c8327a40387bede3eb0ab