### PR TITLE
feat: localize static shell metadata and offline assets

### DIFF
--- a/root/frontend/index.html
+++ b/root/frontend/index.html
@@ -1,10 +1,35 @@
 <!doctype html>
 <html lang="ru">
   <head>
+    <script type="module">
+      import { applyDocumentLanguage, applyMetaTranslations, getPreferredLanguage } from "/static-shell-i18n.js";
+
+      const language = window.__UE_SELECTED_LANG__ || getPreferredLanguage(window);
+      window.__UE_SELECTED_LANG__ = language;
+      applyDocumentLanguage(document, language);
+      applyMetaTranslations(document, language);
+    </script>
     <script>
       (function () {
+        var lang = "ru";
+        try {
+          var storedLang = localStorage.getItem("ue:language");
+          if (storedLang === "en" || storedLang === "ru") {
+            lang = storedLang;
+          } else {
+            var browser = (navigator.language || "").toLowerCase();
+            if (browser.indexOf("en") === 0) {
+              lang = "en";
+            }
+          }
+        } catch (error) {}
+        document.documentElement.setAttribute("lang", lang);
+        window.__UE_SELECTED_LANG__ = lang;
+
         var s = null;
-        try { s = localStorage.getItem("theme"); } catch (e) {}
+        try {
+          s = localStorage.getItem("theme");
+        } catch (e) {}
         var m = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
         var dark = s ? s === "dark" : m;
         var bg = dark ? "#0b0d11" : "#f4f8fd";

--- a/root/frontend/index.html
+++ b/root/frontend/index.html
@@ -1,13 +1,19 @@
 <!doctype html>
 <html lang="ru">
   <head>
-    <script type="module">
-      import { applyDocumentLanguage, applyMetaTranslations, getPreferredLanguage } from "/static-shell-i18n.js";
-
-      const language = window.__UE_SELECTED_LANG__ || getPreferredLanguage(window);
-      window.__UE_SELECTED_LANG__ = language;
-      applyDocumentLanguage(document, language);
-      applyMetaTranslations(document, language);
+    <script>
+      (function () {
+        import("/static-shell-i18n.js")
+          .then(({ applyDocumentLanguage, applyMetaTranslations, getPreferredLanguage }) => {
+            const language = window.__UE_SELECTED_LANG__ || getPreferredLanguage(window);
+            window.__UE_SELECTED_LANG__ = language;
+            applyDocumentLanguage(document, language);
+            applyMetaTranslations(document, language);
+          })
+          .catch((error) => {
+            console.error("Failed to load static shell translations", error);
+          });
+      })();
     </script>
     <script>
       (function () {

--- a/root/frontend/package-lock.json
+++ b/root/frontend/package-lock.json
@@ -39,6 +39,7 @@
         "@testing-library/react": "^16.2.0",
         "@testing-library/user-event": "^14.5.2",
         "@types/jest-axe": "^3.5.9",
+        "@types/jsdom": "^21.1.7",
         "@types/node": "^22.14.1",
         "@types/qrcode": "^1.5.5",
         "@types/qrcode.react": "^1.0.5",
@@ -4458,6 +4459,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/jsdom": {
+      "version": "21.1.7",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz",
+      "integrity": "sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -4566,6 +4579,13 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
       "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
       "license": "MIT"
     },

--- a/root/frontend/package.json
+++ b/root/frontend/package.json
@@ -58,6 +58,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.2.0",
     "@testing-library/user-event": "^14.5.2",
+    "@types/jsdom": "^21.1.7",
     "@types/jest-axe": "^3.5.9",
     "@types/node": "^22.14.1",
     "@types/qrcode": "^1.5.5",

--- a/root/frontend/public/manifest.en.webmanifest
+++ b/root/frontend/public/manifest.en.webmanifest
@@ -1,0 +1,81 @@
+{
+  "id": "/?source=pwa",
+  "name": "GUU Ecosystem — digital campus",
+  "short_name": "GUU Ecosystem",
+  "description": "Class schedule, university news, and the campus map stay available even when you're offline.",
+  "lang": "en",
+  "dir": "ltr",
+  "display": "standalone",
+  "display_override": ["standalone", "browser"],
+  "start_url": "/?source=pwa",
+  "scope": "/",
+  "orientation": "portrait-primary",
+  "theme_color": "#0b63f4",
+  "background_color": "#f4f8fd",
+  "launch_handler": {
+    "client_mode": "navigate-existing"
+  },
+  "categories": ["education", "productivity"],
+  "shortcuts": [
+    {
+      "name": "Schedule",
+      "description": "Jump straight to your class schedule",
+      "url": "/schedule",
+      "icons": [
+        {
+          "src": "/maskable-icon-192.png",
+          "sizes": "192x192",
+          "type": "image/png"
+        }
+      ]
+    },
+    {
+      "name": "News",
+      "description": "Latest campus updates",
+      "url": "/news",
+      "icons": [
+        {
+          "src": "/maskable-icon-192.png",
+          "sizes": "192x192",
+          "type": "image/png"
+        }
+      ]
+    },
+    {
+      "name": "Campus map",
+      "description": "Routes and buildings on the GUU map",
+      "url": "/map",
+      "icons": [
+        {
+          "src": "/maskable-icon-192.png",
+          "sizes": "192x192",
+          "type": "image/png"
+        }
+      ]
+    }
+  ],
+  "icons": [
+    {
+      "src": "/guu_logo.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/maskable-icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "maskable any"
+    },
+    {
+      "src": "/guu_logo.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    },
+    {
+      "src": "/maskable-icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "maskable any"
+    }
+  ]
+}

--- a/root/frontend/public/offline.html
+++ b/root/frontend/public/offline.html
@@ -92,17 +92,26 @@
   </head>
   <body>
     <main>
-      <h1>Нет подключения к сети</h1>
-      <p>
+      <h1 data-i18n="offline.title">Нет подключения к сети</h1>
+      <p data-i18n="offline.description">
         Экосистема ГУУ продолжит синхронизировать расписание, новости и карту кампуса,
         как только появится интернет.
       </p>
       <ul>
-        <li>Расписание и новости, просмотренные ранее, останутся доступными офлайн.</li>
-        <li>Интерактивная карта загрузится автоматически после восстановления связи.</li>
+        <li data-i18n="offline.hints.0">Расписание и новости, просмотренные ранее, останутся доступными офлайн.</li>
+        <li data-i18n="offline.hints.1">Интерактивная карта загрузится автоматически после восстановления связи.</li>
       </ul>
-      <button type="button" onclick="window.location.reload()">Повторить попытку</button>
-      <small>Проверьте подключение или попробуйте открыть приложение позднее.</small>
+      <button type="button" onclick="window.location.reload()" data-i18n="offline.retry">
+        Повторить попытку
+      </button>
+      <small data-i18n="offline.footer">Проверьте подключение или попробуйте открыть приложение позднее.</small>
     </main>
+    <script type="module">
+      import { applyDocumentLanguage, applyOfflineTranslations, getPreferredLanguage } from "./static-shell-i18n.js";
+
+      const language = getPreferredLanguage(window);
+      applyDocumentLanguage(document, language);
+      applyOfflineTranslations(document, language);
+    </script>
   </body>
 </html>

--- a/root/frontend/public/offline.html
+++ b/root/frontend/public/offline.html
@@ -106,12 +106,18 @@
       </button>
       <small data-i18n="offline.footer">Проверьте подключение или попробуйте открыть приложение позднее.</small>
     </main>
-    <script type="module">
-      import { applyDocumentLanguage, applyOfflineTranslations, getPreferredLanguage } from "./static-shell-i18n.js";
-
-      const language = getPreferredLanguage(window);
-      applyDocumentLanguage(document, language);
-      applyOfflineTranslations(document, language);
+    <script>
+      (function () {
+        import("./static-shell-i18n.js")
+          .then(({ applyDocumentLanguage, applyOfflineTranslations, getPreferredLanguage }) => {
+            const language = getPreferredLanguage(window);
+            applyDocumentLanguage(document, language);
+            applyOfflineTranslations(document, language);
+          })
+          .catch((error) => {
+            console.error("Failed to load offline translations", error);
+          });
+      })();
     </script>
   </body>
 </html>

--- a/root/frontend/public/static-shell-i18n.d.ts
+++ b/root/frontend/public/static-shell-i18n.d.ts
@@ -1,0 +1,58 @@
+export type SupportedLanguage = "ru" | "en";
+
+export interface MetaStrings {
+  title: string;
+  description: string;
+  ogTitle?: string;
+  ogDescription?: string;
+  twitterTitle?: string;
+  twitterDescription?: string;
+  ogLocale?: string;
+}
+
+export interface OfflineStrings {
+  pageTitle: string;
+  title: string;
+  description: string;
+  hints?: string[];
+  retry: string;
+  footer: string;
+}
+
+export interface ManifestShortcutStrings {
+  name: string;
+  description?: string;
+}
+
+export interface ManifestStrings {
+  name: string;
+  short_name: string;
+  description: string;
+  shortcuts?: ManifestShortcutStrings[];
+}
+
+export interface TranslationBundle {
+  meta?: MetaStrings;
+  offline?: OfflineStrings;
+  manifest: ManifestStrings;
+}
+
+export const storageKey: string;
+export const fallbackLanguage: SupportedLanguage;
+export const supportedLanguages: SupportedLanguage[];
+export const translations: Record<SupportedLanguage, TranslationBundle>;
+
+export function detectLanguage(options?: {
+  storedLanguage?: string | null;
+  navigatorLanguage?: string;
+}): SupportedLanguage;
+
+export function getPreferredLanguage(win?: Window): SupportedLanguage;
+
+export function getStrings(language: string | undefined): TranslationBundle;
+export function getManifestStrings(language: string | undefined): ManifestStrings;
+export function getManifestPath(language: string | undefined): string;
+
+export function applyDocumentLanguage(doc: Document | undefined, language: string | undefined): void;
+export function applyMetaTranslations(doc: Document | undefined, language: string | undefined): void;
+export function applyOfflineTranslations(doc: Document | undefined, language: string | undefined): void;

--- a/root/frontend/public/static-shell-i18n.js
+++ b/root/frontend/public/static-shell-i18n.js
@@ -1,0 +1,198 @@
+const storageKey = "ue:language";
+const fallbackLanguage = "ru";
+const supportedLanguages = ["ru", "en"];
+
+const translations = {
+  ru: {
+    meta: {
+      title: "Экосистема ГУУ",
+      description: "Экосистема ГУУ — профиль, расписание, новости и события.",
+      ogTitle: "Экосистема ГУУ",
+      ogDescription: "Личный кабинет: профиль, расписание, новости и события.",
+      twitterTitle: "Экосистема ГУУ",
+      twitterDescription: "Личный кабинет: профиль, расписание, новости и события.",
+      ogLocale: "ru_RU",
+    },
+    offline: {
+      pageTitle: "Экосистема ГУУ — офлайн режим",
+      title: "Нет подключения к сети",
+      description:
+        "Экосистема ГУУ продолжит синхронизировать расписание, новости и карту кампуса, как только появится интернет.",
+      hints: [
+        "Расписание и новости, просмотренные ранее, останутся доступными офлайн.",
+        "Интерактивная карта загрузится автоматически после восстановления связи.",
+      ],
+      retry: "Повторить попытку",
+      footer: "Проверьте подключение или попробуйте открыть приложение позднее.",
+    },
+    manifest: {
+      name: "Экосистема ГУУ — цифровой кампус",
+      short_name: "Экосистема ГУУ",
+      description:
+        "Расписание пар, новости университета и интерактивная карта кампуса — всё доступно даже офлайн.",
+      shortcuts: [
+        { name: "Расписание", description: "Быстрый переход к расписанию занятий" },
+        { name: "Новости", description: "Свежие новости кампуса" },
+        { name: "Карта кампуса", description: "Маршруты и корпуса на карте ГУУ" },
+      ],
+    },
+  },
+  en: {
+    meta: {
+      title: "GUU Ecosystem",
+      description: "GUU Ecosystem — profile, schedule, news, and events.",
+      ogTitle: "GUU Ecosystem",
+      ogDescription: "Dashboard: profile, schedule, news, and events.",
+      twitterTitle: "GUU Ecosystem",
+      twitterDescription: "Dashboard: profile, schedule, news, and events.",
+      ogLocale: "en_US",
+    },
+    offline: {
+      pageTitle: "GUU Ecosystem — offline mode",
+      title: "No network connection",
+      description:
+        "GUU Ecosystem will continue syncing your schedule, news, and campus map once you're back online.",
+      hints: [
+        "Previously viewed schedule and news stay available offline.",
+        "The interactive campus map loads automatically when the connection is restored.",
+      ],
+      retry: "Try again",
+      footer: "Check your connection or open the app again later.",
+    },
+    manifest: {
+      name: "GUU Ecosystem — digital campus",
+      short_name: "GUU Ecosystem",
+      description:
+        "Class schedule, university news, and the campus map stay available even when you're offline.",
+      shortcuts: [
+        { name: "Schedule", description: "Jump straight to your class schedule" },
+        { name: "News", description: "Latest campus updates" },
+        { name: "Campus map", description: "Routes and buildings on the GUU map" },
+      ],
+    },
+  },
+};
+
+function normalizeLanguage(language) {
+  if (language === "en" || language === "ru") {
+    return language;
+  }
+  if (typeof language === "string") {
+    const lower = language.toLowerCase();
+    if (lower.startsWith("en")) {
+      return "en";
+    }
+    if (lower.startsWith("ru")) {
+      return "ru";
+    }
+  }
+  return fallbackLanguage;
+}
+
+export function detectLanguage(options = {}) {
+  const { storedLanguage, navigatorLanguage } = options;
+  if (storedLanguage && supportedLanguages.includes(storedLanguage)) {
+    return storedLanguage;
+  }
+  return normalizeLanguage(navigatorLanguage);
+}
+
+export function getPreferredLanguage(win = typeof window !== "undefined" ? window : undefined) {
+  let stored;
+  if (win && win.localStorage) {
+    try {
+      stored = win.localStorage.getItem(storageKey);
+    } catch (error) {
+      // Ignore storage access errors (e.g. privacy mode)
+    }
+  }
+  const navigatorLanguage = win && win.navigator ? win.navigator.language : undefined;
+  return detectLanguage({ storedLanguage: stored, navigatorLanguage });
+}
+
+function getLanguageBundle(language) {
+  const normalized = normalizeLanguage(language);
+  return translations[normalized] ?? translations[fallbackLanguage];
+}
+
+export function getStrings(language) {
+  return getLanguageBundle(language);
+}
+
+export function getManifestStrings(language) {
+  const bundle = getLanguageBundle(language);
+  return bundle.manifest;
+}
+
+export function getManifestPath(language) {
+  return normalizeLanguage(language) === "en" ? "/manifest.en.webmanifest" : "/manifest.webmanifest";
+}
+
+export function applyDocumentLanguage(doc, language) {
+  if (!doc || !doc.documentElement) return;
+  const normalized = normalizeLanguage(language);
+  doc.documentElement.setAttribute("lang", normalized);
+}
+
+function setMetaContent(doc, selector, attribute, value) {
+  if (!value) return;
+  const element = doc.querySelector(selector);
+  if (element) {
+    element.setAttribute(attribute, value);
+  }
+}
+
+export function applyMetaTranslations(doc, language) {
+  if (!doc) return;
+  const bundle = getLanguageBundle(language);
+  const meta = bundle.meta;
+  if (!meta) return;
+
+  doc.title = meta.title;
+  setMetaContent(doc, 'meta[name="description"]', "content", meta.description);
+  setMetaContent(doc, 'meta[property="og:title"]', "content", meta.ogTitle || meta.title);
+  setMetaContent(doc, 'meta[property="og:description"]', "content", meta.ogDescription || meta.description);
+  setMetaContent(doc, 'meta[property="og:locale"]', "content", meta.ogLocale);
+  setMetaContent(doc, 'meta[name="twitter:title"]', "content", meta.twitterTitle || meta.title);
+  setMetaContent(
+    doc,
+    'meta[name="twitter:description"]',
+    "content",
+    meta.twitterDescription || meta.description,
+  );
+
+  const manifest = doc.querySelector('link[rel="manifest"]');
+  if (manifest) {
+    manifest.setAttribute("href", getManifestPath(language));
+    if (!manifest.hasAttribute("crossorigin")) {
+      manifest.setAttribute("crossorigin", "use-credentials");
+    }
+  }
+}
+
+function setTextContent(doc, key, value) {
+  if (!value) return;
+  const target = doc.querySelector(`[data-i18n="${key}"]`);
+  if (target) {
+    target.textContent = value;
+  }
+}
+
+export function applyOfflineTranslations(doc, language) {
+  if (!doc) return;
+  const bundle = getLanguageBundle(language);
+  const offline = bundle.offline;
+  if (!offline) return;
+
+  doc.title = offline.pageTitle;
+  setTextContent(doc, "offline.title", offline.title);
+  setTextContent(doc, "offline.description", offline.description);
+  const hints = Array.isArray(offline.hints) ? offline.hints : [];
+  hints.forEach((hint, index) => {
+    setTextContent(doc, `offline.hints.${index}`, hint);
+  });
+  setTextContent(doc, "offline.retry", offline.retry);
+  setTextContent(doc, "offline.footer", offline.footer);
+}
+
+export { storageKey, fallbackLanguage, supportedLanguages, translations };

--- a/root/frontend/src/tests/staticShellI18n.test.ts
+++ b/root/frontend/src/tests/staticShellI18n.test.ts
@@ -12,6 +12,7 @@ import {
   getManifestStrings,
   getStrings,
 } from "../../public/static-shell-i18n.js";
+import type { ManifestShortcutStrings } from "../../public/static-shell-i18n.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -97,7 +98,10 @@ describe("static shell i18n integration", () => {
     expect(manifest.short_name).toBe(manifestStrings?.short_name);
     expect(manifest.description).toBe(manifestStrings?.description);
     expect(
-      manifest.shortcuts?.map((shortcut) => ({ name: shortcut.name, description: shortcut.description })),
+      manifest.shortcuts?.map((shortcut: ManifestShortcutStrings) => ({
+        name: shortcut.name,
+        description: shortcut.description,
+      })),
     ).toEqual(manifestStrings?.shortcuts);
   });
 });

--- a/root/frontend/src/tests/staticShellI18n.test.ts
+++ b/root/frontend/src/tests/staticShellI18n.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import { JSDOM } from "jsdom";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  applyDocumentLanguage,
+  applyMetaTranslations,
+  applyOfflineTranslations,
+  getManifestPath,
+  getManifestStrings,
+  getStrings,
+} from "../../public/static-shell-i18n.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const publicDir = path.resolve(__dirname, "../../public");
+
+describe("static shell i18n integration", () => {
+  it("applies english meta tags", () => {
+    const dom = new JSDOM(`<!doctype html><html lang="ru"><head>
+      <meta name="description" content="" />
+      <meta property="og:title" content="" />
+      <meta property="og:description" content="" />
+      <meta property="og:locale" content="ru_RU" />
+      <meta name="twitter:title" content="" />
+      <meta name="twitter:description" content="" />
+      <link rel="manifest" href="/manifest.webmanifest" crossorigin="use-credentials" />
+      <title></title>
+    </head><body></body></html>`);
+
+    const { document } = dom.window;
+    applyDocumentLanguage(document, "en");
+    applyMetaTranslations(document, "en");
+
+    const metaStrings = getStrings("en").meta;
+    expect(document.documentElement.lang).toBe("en");
+    expect(document.title).toBe(metaStrings?.title);
+    expect(document.querySelector('meta[name="description"]')?.getAttribute("content")).toBe(
+      metaStrings?.description,
+    );
+    expect(document.querySelector('meta[property="og:locale"]')?.getAttribute("content")).toBe(
+      metaStrings?.ogLocale,
+    );
+    expect(document.querySelector('meta[property="og:description"]')?.getAttribute("content")).toBe(
+      metaStrings?.ogDescription,
+    );
+    expect(document.querySelector('meta[name="twitter:title"]')?.getAttribute("content")).toBe(
+      metaStrings?.twitterTitle,
+    );
+    expect(document.querySelector('meta[name="twitter:description"]')?.getAttribute("content")).toBe(
+      metaStrings?.twitterDescription,
+    );
+    expect(document.querySelector('link[rel="manifest"]')?.getAttribute("href")).toBe(getManifestPath("en"));
+  });
+
+  it("populates the offline fallback in english", () => {
+    const dom = new JSDOM(`<!doctype html><html lang="ru"><head><title></title></head><body>
+      <main>
+        <h1 data-i18n="offline.title"></h1>
+        <p data-i18n="offline.description"></p>
+        <ul>
+          <li data-i18n="offline.hints.0"></li>
+          <li data-i18n="offline.hints.1"></li>
+        </ul>
+        <button data-i18n="offline.retry"></button>
+        <small data-i18n="offline.footer"></small>
+      </main>
+    </body></html>`);
+
+    const { document } = dom.window;
+    applyDocumentLanguage(document, "en");
+    applyOfflineTranslations(document, "en");
+
+    const offlineStrings = getStrings("en").offline;
+    expect(document.documentElement.lang).toBe("en");
+    expect(document.title).toBe(offlineStrings?.pageTitle);
+    expect(document.querySelector('[data-i18n="offline.title"]')?.textContent).toBe(offlineStrings?.title);
+    expect(document.querySelector('[data-i18n="offline.description"]')?.textContent).toBe(
+      offlineStrings?.description,
+    );
+    expect(document.querySelector('[data-i18n="offline.hints.0"]')?.textContent).toBe(offlineStrings?.hints?.[0]);
+    expect(document.querySelector('[data-i18n="offline.hints.1"]')?.textContent).toBe(offlineStrings?.hints?.[1]);
+    expect(document.querySelector('[data-i18n="offline.retry"]')?.textContent).toBe(offlineStrings?.retry);
+    expect(document.querySelector('[data-i18n="offline.footer"]')?.textContent).toBe(offlineStrings?.footer);
+  });
+
+  it("ships an english manifest variant", async () => {
+    const manifestPath = path.join(publicDir, "manifest.en.webmanifest");
+    const content = await fs.readFile(manifestPath, "utf-8");
+    const manifest = JSON.parse(content);
+    const manifestStrings = getManifestStrings("en");
+
+    expect(manifest.lang).toBe("en");
+    expect(manifest.name).toBe(manifestStrings?.name);
+    expect(manifest.short_name).toBe(manifestStrings?.short_name);
+    expect(manifest.description).toBe(manifestStrings?.description);
+    expect(
+      manifest.shortcuts?.map((shortcut) => ({ name: shortcut.name, description: shortcut.description })),
+    ).toEqual(manifestStrings?.shortcuts);
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared static-shell i18n helper to drive localized `<html>` lang, meta tags, and manifest selection
- convert the offline fallback to the helper so it renders Russian and English strings
- add an English manifest variant and automated tests that assert English metadata, offline copy, and manifest contents

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ef812852908327857fdca316443478