### PR TITLE
Localize password policy validation

### DIFF
--- a/root/app/api/users.py
+++ b/root/app/api/users.py
@@ -193,7 +193,7 @@ async def reset_password(
             detail=translate("errors.password.invalid_link", locale=locale),
         )
     try:
-        user.hashed_password = get_password_hash(payload.password)
+        user.hashed_password = get_password_hash(payload.password, locale=locale)
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
     rec.used = True

--- a/root/app/auth/auth.py
+++ b/root/app/auth/auth.py
@@ -169,17 +169,17 @@ async def register(
     request: Request,
     db: AsyncSession = Depends(get_db),
 ):
+    locale = resolve_locale(request=request)
     email = user.email.strip().lower()
     res = await db.execute(select(User).where(User.email == email))
     if res.scalars().first():
-        locale = resolve_locale(request=request)
         message = translate("errors.users.email_in_use", locale=locale)
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=message,
         )
     try:
-        hashed_password = get_password_hash(user.password)
+        hashed_password = get_password_hash(user.password, locale=locale)
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
     new_user = User(

--- a/root/app/auth/security.py
+++ b/root/app/auth/security.py
@@ -6,6 +6,7 @@ from passlib.context import CryptContext
 from passlib.hash import bcrypt as passlib_bcrypt
 
 from app.core.config import settings
+from app.localization import translate
 
 PASSWORD_MIN_LENGTH = 8
 PASSWORD_MAX_LENGTH = 200
@@ -60,10 +61,14 @@ pwd_context = CryptContext(
 )
 
 
-def _validate_password_policy(password: str) -> None:
+def _validate_password_policy(
+    password: str, *, locale: str | None = None
+) -> None:
     length = len(password)
     if length < PASSWORD_MIN_LENGTH or length > PASSWORD_MAX_LENGTH:
-        raise ValueError("Пароль должен содержать от 8 до 200 символов.")
+        raise ValueError(
+            translate("errors.auth.password_policy", locale=locale)
+        )
 
 
 def _truncate_for_bcrypt(password: str) -> str:
@@ -90,8 +95,8 @@ def verify_and_update_password(
     return verified, new_hash
 
 
-def get_password_hash(password: str) -> str:
-    _validate_password_policy(password)
+def get_password_hash(password: str, *, locale: str | None = None) -> str:
+    _validate_password_policy(password, locale=locale)
     return pwd_context.hash(password)
 
 

--- a/root/app/auth/security.py
+++ b/root/app/auth/security.py
@@ -61,14 +61,10 @@ pwd_context = CryptContext(
 )
 
 
-def _validate_password_policy(
-    password: str, *, locale: str | None = None
-) -> None:
+def _validate_password_policy(password: str, *, locale: str | None = None) -> None:
     length = len(password)
     if length < PASSWORD_MIN_LENGTH or length > PASSWORD_MAX_LENGTH:
-        raise ValueError(
-            translate("errors.auth.password_policy", locale=locale)
-        )
+        raise ValueError(translate("errors.auth.password_policy", locale=locale))
 
 
 def _truncate_for_bcrypt(password: str) -> str:

--- a/root/app/localization.py
+++ b/root/app/localization.py
@@ -121,6 +121,10 @@ _TRANSLATIONS: Mapping[str, Mapping[str, str]] = {
         "ru": "Пользователь деактивирован",
         "en": "User account is deactivated",
     },
+    "errors.auth.password_policy": {
+        "ru": "Пароль должен содержать от 8 до 200 символов.",
+        "en": "Password must be between 8 and 200 characters long.",
+    },
     "errors.forbidden": {
         "ru": "Доступ запрещён",
         "en": "Access denied",

--- a/root/tests/test_auth_security.py
+++ b/root/tests/test_auth_security.py
@@ -31,10 +31,7 @@ def test_get_password_hash_enforces_length_bounds():
     with pytest.raises(ValueError) as exc_en:
         get_password_hash("x" * 201, locale="en")
 
-    assert (
-        str(exc_en.value)
-        == "Password must be between 8 and 200 characters long."
-    )
+    assert str(exc_en.value) == "Password must be between 8 and 200 characters long."
 
 
 def test_password_policy_allows_limits():

--- a/root/tests/test_auth_security.py
+++ b/root/tests/test_auth_security.py
@@ -23,11 +23,18 @@ def test_get_password_hash_uses_argon2id_by_default():
 
 
 def test_get_password_hash_enforces_length_bounds():
-    with pytest.raises(ValueError):
-        get_password_hash("short")
+    with pytest.raises(ValueError) as exc_ru:
+        get_password_hash("short", locale="ru")
 
-    with pytest.raises(ValueError):
-        get_password_hash("x" * 201)
+    assert str(exc_ru.value) == "Пароль должен содержать от 8 до 200 символов."
+
+    with pytest.raises(ValueError) as exc_en:
+        get_password_hash("x" * 201, locale="en")
+
+    assert (
+        str(exc_en.value)
+        == "Password must be between 8 and 200 characters long."
+    )
 
 
 def test_password_policy_allows_limits():


### PR DESCRIPTION
## Summary
- translate password policy validation errors through the localization module
- resolve and pass the current locale in registration and password reset handlers
- assert localized password policy messages in the auth security tests

## Testing
- pytest root/tests/test_auth_security.py

------
https://chatgpt.com/codex/tasks/task_e_68efa30f6ab083279c38dc4efec36e87