### PR TITLE
Localize ICS exports for English

### DIFF
--- a/root/app/localization.py
+++ b/root/app/localization.py
@@ -293,9 +293,17 @@ _TRANSLATIONS: Mapping[str, Mapping[str, str]] = {
         "ru": "Расписание",
         "en": "Schedule",
     },
+    "schedule.ics.prodid": {
+        "ru": "-//University Ecosystem//Schedule//RU",
+        "en": "-//University Ecosystem//Schedule//EN",
+    },
     "schedule.ics.lesson_default_subject": {
         "ru": "Занятие",
         "en": "Lesson",
+    },
+    "schedule.ics.description.lesson_type": {
+        "ru": "Тип занятия: {lesson_type}",
+        "en": "Lesson type: {lesson_type}",
     },
     "schedule.ics.description.teacher": {
         "ru": "Преподаватель: {teacher}",
@@ -312,6 +320,26 @@ _TRANSLATIONS: Mapping[str, Mapping[str, str]] = {
     "schedule.ics.description.parity_even": {
         "ru": "Чётные недели",
         "en": "Even weeks",
+    },
+    "schedule.lesson.type.lecture": {
+        "ru": "Лекция",
+        "en": "Lecture",
+    },
+    "schedule.lesson.type.practice": {
+        "ru": "Практическое занятие",
+        "en": "Practical class",
+    },
+    "schedule.lesson.type.lab": {
+        "ru": "Лабораторная работа",
+        "en": "Lab work",
+    },
+    "schedule.lesson.type.seminar": {
+        "ru": "Семинар",
+        "en": "Seminar",
+    },
+    "schedule.lesson.type.consultation": {
+        "ru": "Консультация",
+        "en": "Consultation",
     },
     "schedule.lesson.default_type": {
         "ru": "Лекция",
@@ -460,4 +488,60 @@ def translate(
     return text
 
 
-__all__ = ["SUPPORTED_LOCALES", "DEFAULT_LOCALE", "resolve_locale", "translate"]
+_LESSON_TYPE_TRANSLATIONS: Mapping[str, str] = {
+    "lecture": "schedule.lesson.type.lecture",
+    "practice": "schedule.lesson.type.practice",
+    "lab": "schedule.lesson.type.lab",
+    "seminar": "schedule.lesson.type.seminar",
+    "consultation": "schedule.lesson.type.consultation",
+}
+
+_LESSON_TYPE_ALIASES: Mapping[str, str] = {
+    "лекция": "lecture",
+    "лк": "lecture",
+    "лекцияонлайн": "lecture",
+    "lecture": "lecture",
+    "пз": "practice",
+    "практика": "practice",
+    "практическоезанятие": "practice",
+    "семинар": "seminar",
+    "семинарское": "seminar",
+    "семинарскоезанятие": "seminar",
+    "лз": "lab",
+    "лр": "lab",
+    "лаб": "lab",
+    "лабораторная": "lab",
+    "лабораторнаяработа": "lab",
+    "консультация": "consultation",
+    "consultation": "consultation",
+}
+
+
+def translate_lesson_type(
+    lesson_type: str | None, *, locale: str | None = None
+) -> str | None:
+    if lesson_type is None:
+        return None
+
+    raw_value = str(lesson_type).strip()
+    if not raw_value:
+        return raw_value
+
+    normalized = "".join(ch for ch in raw_value.lower() if ch.isalnum())
+    canonical = _LESSON_TYPE_ALIASES.get(normalized)
+    if canonical is None and normalized in _LESSON_TYPE_TRANSLATIONS:
+        canonical = normalized
+    if canonical:
+        translation_key = _LESSON_TYPE_TRANSLATIONS[canonical]
+        return translate(translation_key, locale=locale)
+
+    return raw_value
+
+
+__all__ = [
+    "SUPPORTED_LOCALES",
+    "DEFAULT_LOCALE",
+    "resolve_locale",
+    "translate",
+    "translate_lesson_type",
+]

--- a/root/app/services/ical.py
+++ b/root/app/services/ical.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import date, datetime, time, timedelta, timezone
 from typing import Iterable, Sequence
 
-from app.localization import translate
+from app.localization import translate, translate_lesson_type
 from app.models import models
 
 _WEEKDAY_ALIASES: dict[str, int] = {
@@ -110,9 +110,11 @@ def generate_schedule_ics(
         else translate("schedule.ics.calendar_name_generic", locale=locale)
     )
 
+    prodid = translate("schedule.ics.prodid", locale=locale)
+
     lines: list[str] = [
         "BEGIN:VCALENDAR",
-        "PRODID:-//University Ecosystem//Schedule//RU",
+        f"PRODID:{_escape(prodid)}",
         "VERSION:2.0",
         "CALSCALE:GREGORIAN",
         f"NAME:{_escape(calendar_name)}",
@@ -133,7 +135,12 @@ def generate_schedule_ics(
             "schedule.ics.lesson_default_subject", locale=locale
         )
         lesson_type = getattr(lesson, "lesson_type", None)
-        summary = subject if not lesson_type else f"{subject} ({lesson_type})"
+        lesson_type_display = translate_lesson_type(lesson_type, locale=locale)
+        summary = (
+            subject
+            if not lesson_type_display
+            else f"{subject} ({lesson_type_display})"
+        )
         teacher = getattr(lesson, "teacher", None)
         room = getattr(lesson, "room", None)
 
@@ -148,6 +155,14 @@ def generate_schedule_ics(
             end_dt = datetime.combine(lesson_date, end_time)
             uid = f"lesson-{getattr(lesson, 'id', 'x')}-{lesson_date.strftime('%Y%m%d')}@university-ecosystem"
             description_parts = []
+            if lesson_type_display:
+                description_parts.append(
+                    translate(
+                        "schedule.ics.description.lesson_type",
+                        locale=locale,
+                        lesson_type=lesson_type_display,
+                    )
+                )
             if teacher:
                 description_parts.append(
                     translate(

--- a/root/app/services/ical.py
+++ b/root/app/services/ical.py
@@ -137,9 +137,7 @@ def generate_schedule_ics(
         lesson_type = getattr(lesson, "lesson_type", None)
         lesson_type_display = translate_lesson_type(lesson_type, locale=locale)
         summary = (
-            subject
-            if not lesson_type_display
-            else f"{subject} ({lesson_type_display})"
+            subject if not lesson_type_display else f"{subject} ({lesson_type_display})"
         )
         teacher = getattr(lesson, "teacher", None)
         room = getattr(lesson, "room", None)

--- a/root/tests/test_schedule_ics.py
+++ b/root/tests/test_schedule_ics.py
@@ -2,7 +2,7 @@ from datetime import datetime
 
 import pytest
 
-from app.localization import translate
+from app.localization import translate, translate_lesson_type
 from app.models import models
 from app.services.ical import generate_schedule_ics
 
@@ -26,9 +26,16 @@ def test_generate_schedule_ics_includes_lessons() -> None:
 
     assert "BEGIN:VCALENDAR" in ics
     assert "END:VCALENDAR" in ics
-    assert "SUMMARY:Алгебра (Лекция)" in ics
+    expected_type = translate_lesson_type("Лекция", locale="en") or "Лекция"
+    assert f"SUMMARY:Алгебра ({expected_type})" in ics
     assert "DTSTART:" in ics
     assert "DTEND:" in ics
+    expected_type_line = translate(
+        "schedule.ics.description.lesson_type",
+        locale="en",
+        lesson_type=expected_type,
+    )
+    assert expected_type_line in ics
     expected_teacher = translate(
         "schedule.ics.description.teacher", locale="en", teacher="Проф. Смирнов"
     )
@@ -76,3 +83,37 @@ async def test_schedule_ics_endpoint(async_client, db_session) -> None:
         "schedule.ics.description.teacher", locale="ru", teacher="Проф. Смирнов"
     )
     assert expected_ru in response_ru.text
+
+
+def _contains_cyrillic(text: str) -> bool:
+    return any("а" <= ch <= "я" or "А" <= ch <= "Я" for ch in text)
+
+
+def test_generate_schedule_ics_english_avoids_cyrillic_labels() -> None:
+    group = models.Group(id=2, name="IU-22", course=1, faculty="IT")
+    lesson = models.Schedule(
+        id=42,
+        group_id=group.id,
+        subject="Mathematics",
+        teacher="Dr. Smith",
+        room="B-202",
+        weekday="Tuesday",
+        start_time=datetime(2024, 1, 2, 11, 0),
+        end_time=datetime(2024, 1, 2, 12, 30),
+        parity="both",
+        lesson_type="ПЗ",
+    )
+
+    ics = generate_schedule_ics(group, [lesson], weeks=1, locale="en")
+
+    lines = ics.split("\r\n")
+    prodid_line = next(line for line in lines if line.startswith("PRODID:"))
+    assert "//RU" not in prodid_line
+
+    summary_line = next(line for line in lines if line.startswith("SUMMARY:"))
+    assert not _contains_cyrillic(summary_line)
+
+    description_line = next(
+        line for line in lines if line.startswith("DESCRIPTION:")
+    )
+    assert not _contains_cyrillic(description_line)

--- a/root/tests/test_schedule_ics.py
+++ b/root/tests/test_schedule_ics.py
@@ -113,7 +113,5 @@ def test_generate_schedule_ics_english_avoids_cyrillic_labels() -> None:
     summary_line = next(line for line in lines if line.startswith("SUMMARY:"))
     assert not _contains_cyrillic(summary_line)
 
-    description_line = next(
-        line for line in lines if line.startswith("DESCRIPTION:")
-    )
+    description_line = next(line for line in lines if line.startswith("DESCRIPTION:"))
     assert not _contains_cyrillic(description_line)


### PR DESCRIPTION
## Summary
- localize the iCalendar PRODID and lesson type metadata using translations
- add translation keys and helper to map known lesson types across locales
- expand ICS schedule tests with English scenarios ensuring no Cyrillic labels

## Testing
- pytest root/tests/test_schedule_ics.py

------
https://chatgpt.com/codex/tasks/task_e_68efa64baa4c83279965fc17f3d06545