### PR TITLE
Use translation-backed schedule metadata

### DIFF
--- a/root/frontend/src/i18n/locales/en/schedule.json
+++ b/root/frontend/src/i18n/locales/en/schedule.json
@@ -17,32 +17,50 @@
     ],
     "items": {
       "mon": {
-        "backend": "Понедельник",
+        "backend": [
+          "Понедельник",
+          "Monday"
+        ],
         "long": "Monday",
         "short": "Mon"
       },
       "tue": {
-        "backend": "Вторник",
+        "backend": [
+          "Вторник",
+          "Tuesday"
+        ],
         "long": "Tuesday",
         "short": "Tue"
       },
       "wed": {
-        "backend": "Среда",
+        "backend": [
+          "Среда",
+          "Wednesday"
+        ],
         "long": "Wednesday",
         "short": "Wed"
       },
       "thu": {
-        "backend": "Четверг",
+        "backend": [
+          "Четверг",
+          "Thursday"
+        ],
         "long": "Thursday",
         "short": "Thu"
       },
       "fri": {
-        "backend": "Пятница",
+        "backend": [
+          "Пятница",
+          "Friday"
+        ],
         "long": "Friday",
         "short": "Fri"
       },
       "sat": {
-        "backend": "Суббота",
+        "backend": [
+          "Суббота",
+          "Saturday"
+        ],
         "long": "Saturday",
         "short": "Sat"
       }
@@ -68,7 +86,9 @@
         "backend": [
           "ПЗ",
           "Практика",
-          "Practical class"
+          "Practical class",
+          "Practice",
+          "Seminar"
         ],
         "label": "Seminar",
         "color": "var(--badge-prac)"
@@ -77,7 +97,8 @@
         "backend": [
           "ЛЗ",
           "Лабораторная",
-          "Lab work"
+          "Lab work",
+          "Lab"
         ],
         "label": "Lab",
         "color": "var(--badge-lab)"
@@ -85,7 +106,8 @@
       "project": {
         "backend": [
           "Проектная деятельность",
-          "Project work"
+          "Project work",
+          "Project"
         ],
         "label": "Project work",
         "color": "#607d8b"

--- a/root/frontend/src/i18n/locales/ru/schedule.json
+++ b/root/frontend/src/i18n/locales/ru/schedule.json
@@ -17,32 +17,50 @@
     ],
     "items": {
       "mon": {
-        "backend": "Понедельник",
+        "backend": [
+          "Понедельник",
+          "Monday"
+        ],
         "long": "Понедельник",
         "short": "Пн"
       },
       "tue": {
-        "backend": "Вторник",
+        "backend": [
+          "Вторник",
+          "Tuesday"
+        ],
         "long": "Вторник",
         "short": "Вт"
       },
       "wed": {
-        "backend": "Среда",
+        "backend": [
+          "Среда",
+          "Wednesday"
+        ],
         "long": "Среда",
         "short": "Ср"
       },
       "thu": {
-        "backend": "Четверг",
+        "backend": [
+          "Четверг",
+          "Thursday"
+        ],
         "long": "Четверг",
         "short": "Чт"
       },
       "fri": {
-        "backend": "Пятница",
+        "backend": [
+          "Пятница",
+          "Friday"
+        ],
         "long": "Пятница",
         "short": "Пт"
       },
       "sat": {
-        "backend": "Суббота",
+        "backend": [
+          "Суббота",
+          "Saturday"
+        ],
         "long": "Суббота",
         "short": "Сб"
       }
@@ -68,7 +86,9 @@
         "backend": [
           "ПЗ",
           "Практика",
-          "Practical class"
+          "Practical class",
+          "Practice",
+          "Seminar"
         ],
         "label": "Практика",
         "color": "var(--badge-prac)"
@@ -77,7 +97,8 @@
         "backend": [
           "ЛЗ",
           "Лабораторная",
-          "Lab work"
+          "Lab work",
+          "Lab"
         ],
         "label": "Лабораторная",
         "color": "var(--badge-lab)"
@@ -85,7 +106,8 @@
       "project": {
         "backend": [
           "Проектная деятельность",
-          "Project work"
+          "Project work",
+          "Project"
         ],
         "label": "Проектная работа",
         "color": "#607d8b"

--- a/root/frontend/src/pages/Schedule.tsx
+++ b/root/frontend/src/pages/Schedule.tsx
@@ -126,32 +126,27 @@ type LessonTypeConfig = {
 
 type WeekdayConfig = {
   id: string
-  backend: string
+  backend: string[]
   long: string
   short: string
 }
 
 const defaultLessonTypeColor = "#888"
 
-const fallbackLessonTypes: LessonTypeConfig[] = [
-  { id: "lecture", backend: ["Лекция"], label: "Lecture", color: "var(--badge-lec)" },
-  { id: "practice", backend: ["ПЗ"], label: "Practical class", color: "var(--badge-prac)" },
-  { id: "lab", backend: ["ЛЗ"], label: "Lab work", color: "var(--badge-lab)" },
-  {
-    id: "project",
-    backend: ["Проектная деятельность"],
-    label: "Project work",
-    color: "#607d8b"
-  }
-]
+const minimalLessonTypeFallback: LessonTypeConfig = {
+  id: "lesson",
+  backend: ["lesson"],
+  label: "Lesson",
+  color: defaultLessonTypeColor
+}
 
-const fallbackWeekdays: WeekdayConfig[] = [
-  { id: "mon", backend: "Понедельник", long: "Monday", short: "Mon" },
-  { id: "tue", backend: "Вторник", long: "Tuesday", short: "Tue" },
-  { id: "wed", backend: "Среда", long: "Wednesday", short: "Wed" },
-  { id: "thu", backend: "Четверг", long: "Thursday", short: "Thu" },
-  { id: "fri", backend: "Пятница", long: "Friday", short: "Fri" },
-  { id: "sat", backend: "Суббота", long: "Saturday", short: "Sat" }
+const minimalWeekdayFallback: WeekdayConfig[] = [
+  { id: "mon", backend: ["Monday"], long: "Monday", short: "Mon" },
+  { id: "tue", backend: ["Tuesday"], long: "Tuesday", short: "Tue" },
+  { id: "wed", backend: ["Wednesday"], long: "Wednesday", short: "Wed" },
+  { id: "thu", backend: ["Thursday"], long: "Thursday", short: "Thu" },
+  { id: "fri", backend: ["Friday"], long: "Friday", short: "Fri" },
+  { id: "sat", backend: ["Saturday"], long: "Saturday", short: "Sat" }
 ]
 
 const groupsPlaceholder = (previous?: ScheduleGroup[]) => {
@@ -227,24 +222,27 @@ export default function Schedule() {
     const items = rawItems && typeof rawItems === "object" && !Array.isArray(rawItems)
       ? (rawItems as Record<string, unknown>)
       : {}
-    const fallbackById = new Map(fallbackWeekdays.map(item => [item.id, item]))
+    const fallbackById = new Map(minimalWeekdayFallback.map(item => [item.id, item]))
     const baseOrder = Array.isArray(rawOrder) && rawOrder.length > 0
       ? rawOrder.filter((id): id is string => typeof id === "string" && id.length > 0)
-      : fallbackWeekdays.map(item => item.id)
+      : (Object.keys(items) as string[])
     const configs: WeekdayConfig[] = []
     const seen = new Set<string>()
     const toConfig = (id: string, value?: unknown): WeekdayConfig => {
       const fallback = fallbackById.get(id) ?? {
         id,
-        backend: id,
+        backend: [id],
         long: id,
         short: id.slice(0, 3)
       }
       const entry = value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : undefined
-      const backend =
-        typeof entry?.backend === "string" && entry.backend.length > 0
-          ? entry.backend
-          : fallback.backend
+      let backend: string[] = []
+      if (Array.isArray(entry?.backend)) {
+        backend = entry.backend.filter((item): item is string => typeof item === "string" && item.length > 0)
+      } else if (typeof entry?.backend === "string" && entry.backend.length > 0) {
+        backend = [entry.backend]
+      }
+      if (backend.length === 0) backend = [...fallback.backend]
       const long =
         typeof entry?.long === "string" && entry.long.length > 0
           ? entry.long
@@ -263,34 +261,61 @@ export default function Schedule() {
       if (seen.has(id)) continue
       configs.push(toConfig(id, value))
     }
-    return configs.length > 0 ? configs : fallbackWeekdays
+    if (configs.length === 0) return [...minimalWeekdayFallback]
+    return configs
   }, [t])
-  const weekdayBackend = useMemo(() => weekdayConfigs.map(config => config.backend), [weekdayConfigs])
+  const weekdayBackend = useMemo(() => weekdayConfigs.map(config => config.backend[0] ?? config.id), [weekdayConfigs])
   const weekdayLabels = useMemo(() => weekdayConfigs.map(config => config.long), [weekdayConfigs])
   const weekdayShort = useMemo(() => weekdayConfigs.map(config => config.short), [weekdayConfigs])
   const weekdayLabelMap = useMemo(() => {
     const map = new Map<string, string>()
     for (const config of weekdayConfigs) {
-      map.set(config.backend, config.long)
       map.set(config.id, config.long)
+      for (const backend of config.backend) {
+        map.set(backend, config.long)
+      }
     }
     return map
   }, [weekdayConfigs])
   const getDayLabel = useCallback((value: string) => weekdayLabelMap.get(value) ?? value, [weekdayLabelMap])
+  const weekdayCanonicalMap = useMemo(() => {
+    const map = new Map<string, string>()
+    for (const config of weekdayConfigs) {
+      const primary = config.backend[0] ?? config.id
+      map.set(config.id, primary)
+      for (const backend of config.backend) {
+        map.set(backend, primary)
+      }
+    }
+    return map
+  }, [weekdayConfigs])
+  const normalizeLessons = useCallback(
+    (lessons: Lesson[]) => {
+      let changed = false
+      const normalized = lessons.map(lesson => {
+        if (!lesson || typeof lesson.weekday !== "string") return lesson
+        const canonical = weekdayCanonicalMap.get(lesson.weekday)
+        if (!canonical || canonical === lesson.weekday) return lesson
+        changed = true
+        return { ...lesson, weekday: canonical }
+      })
+      return changed ? normalized : lessons
+    },
+    [weekdayCanonicalMap]
+  )
   const lessonTypeConfigs = useMemo(() => {
     const rawItems = t("schedule:lessonTypes.items", { returnObjects: true }) as unknown
     const rawOrder = t("schedule:lessonTypes.order", { returnObjects: true }) as unknown
     const items = rawItems && typeof rawItems === "object" && !Array.isArray(rawItems)
       ? (rawItems as Record<string, unknown>)
       : {}
-    const fallbackById = new Map(fallbackLessonTypes.map(item => [item.id, item]))
     const baseOrder = Array.isArray(rawOrder) && rawOrder.length > 0
       ? rawOrder.filter((id): id is string => typeof id === "string" && id.length > 0)
-      : fallbackLessonTypes.map(item => item.id)
+      : (Object.keys(items) as string[])
     const configs: LessonTypeConfig[] = []
     const seen = new Set<string>()
     const toConfig = (id: string, value?: unknown): LessonTypeConfig => {
-      const fallback = fallbackById.get(id) ?? {
+      const fallback = {
         id,
         backend: [id],
         label: id,
@@ -322,7 +347,8 @@ export default function Schedule() {
       if (seen.has(id)) continue
       configs.push(toConfig(id, value))
     }
-    return configs.length > 0 ? configs : fallbackLessonTypes
+    if (configs.length === 0) return [minimalLessonTypeFallback]
+    return configs
   }, [t])
   const lessonTypeById = useMemo(() => new Map(lessonTypeConfigs.map(config => [config.id, config])), [lessonTypeConfigs])
   const lessonTypeByBackend = useMemo(() => {
@@ -348,7 +374,7 @@ export default function Schedule() {
     () => lessonTypeConfigs.map(config => ({ value: config.id, label: config.label })),
     [lessonTypeConfigs]
   )
-  const defaultLessonType = lessonTypeOptions[0]?.value ?? fallbackLessonTypes[0]?.id ?? ""
+  const defaultLessonType = lessonTypeOptions[0]?.value ?? minimalLessonTypeFallback.id ?? ""
   const getLessonTypeColor = useCallback(
     (value?: string | null) => {
       if (!value) return defaultLessonTypeColor
@@ -477,19 +503,23 @@ export default function Schedule() {
     networkMode: "online",
     retry: 1,
   })
-  const groupSchedule = scheduleQuery.data ?? []
+  const groupScheduleRaw = scheduleQuery.data ?? []
+  const groupSchedule = useMemo(
+    () => normalizeLessons(groupScheduleRaw),
+    [groupScheduleRaw, normalizeLessons]
+  )
 
   useEffect(() => {
     if (!scheduleQuery.isSuccess) return
     if (activeGroupId == null) return
-    writeToStorage(scheduleStorageKey(activeGroupId), scheduleQuery.data)
-  }, [scheduleQuery.data, scheduleQuery.isSuccess, activeGroupId])
+    writeToStorage(scheduleStorageKey(activeGroupId), groupSchedule)
+  }, [scheduleQuery.isSuccess, activeGroupId, groupSchedule])
 
   const applyScheduleUpdate = (updater: (prev: Lesson[]) => Lesson[]) => {
     if (!scheduleKey || activeGroupId == null) return
     queryClient.setQueryData<Lesson[]>(scheduleKey, prev => {
       const base = Array.isArray(prev) ? [...prev] : []
-      const next = updater(base)
+      const next = normalizeLessons(updater(base))
       writeToStorage(scheduleStorageKey(activeGroupId), next)
       return next
     })

--- a/root/frontend/src/pages/__tests__/Schedule.translations.test.tsx
+++ b/root/frontend/src/pages/__tests__/Schedule.translations.test.tsx
@@ -1,0 +1,167 @@
+import { MemoryRouter } from "react-router-dom"
+import { render, screen, cleanup } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { LanguageProvider } from "@/contexts/LanguageContext"
+import Schedule from "@/pages/Schedule"
+import type { User } from "@/types/User"
+import type { ReactNode } from "react"
+
+type AuthState = {
+  isAuth: boolean
+  login: ReturnType<typeof vi.fn>
+  logout: ReturnType<typeof vi.fn>
+  refresh: ReturnType<typeof vi.fn>
+  user: User | null
+  loading: boolean
+  setUser: ReturnType<typeof vi.fn>
+}
+
+const apiMocks = vi.hoisted(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  patch: vi.fn(),
+  delete: vi.fn(),
+  put: vi.fn(),
+}))
+
+const baseUser: User = {
+  id: 1,
+  email: "student@example.com",
+  full_name: "Test Student",
+  role: "student",
+  group_id: 1,
+  avatar_url: null,
+  cover_url: null,
+  about: null,
+  record_book_number: null,
+  status: null,
+  institute: null,
+  course: null,
+  education_level: null,
+  track: null,
+  program: null,
+  telegram: null,
+  achievements: null,
+  department: null,
+  position: null,
+  spotify_connected: false,
+  spotify_display_name: null,
+  spotify_is_connected: false,
+  dnd_enabled: false,
+  dnd_start: null,
+  dnd_end: null,
+  is_active: true,
+}
+
+const authState: AuthState = {
+  isAuth: true,
+  login: vi.fn(),
+  logout: vi.fn(),
+  refresh: vi.fn(),
+  user: baseUser,
+  loading: false,
+  setUser: vi.fn(),
+}
+
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => authState,
+  currentUserQueryKey: ["users", "me"] as const,
+}))
+
+vi.mock("@/api/client", () => ({
+  __esModule: true,
+  default: {
+    get: apiMocks.get,
+    post: apiMocks.post,
+    patch: apiMocks.patch,
+    delete: apiMocks.delete,
+    put: apiMocks.put,
+    interceptors: { response: { use: vi.fn() } },
+  },
+}))
+
+const apiGetMock = apiMocks.get
+const apiPostMock = apiMocks.post
+const apiPatchMock = apiMocks.patch
+const apiDeleteMock = apiMocks.delete
+const apiPutMock = apiMocks.put
+
+vi.mock("@/components/PageFadeIn", () => ({
+  default: ({ children }: { children: ReactNode }) => <>{children}</>,
+}))
+
+function renderSchedule() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: 0 } },
+  })
+
+  const result = render(
+    <QueryClientProvider client={client}>
+      <LanguageProvider>
+        <MemoryRouter initialEntries={["/schedule"]}>
+          <Schedule />
+        </MemoryRouter>
+      </LanguageProvider>
+    </QueryClientProvider>
+  )
+
+  return { client, ...result }
+}
+
+describe("Schedule translations", () => {
+  beforeEach(() => {
+    localStorage.clear()
+    localStorage.setItem("ue:language", "en")
+    authState.user = { ...baseUser }
+    authState.loading = false
+    apiGetMock.mockReset()
+    apiPostMock.mockReset()
+    apiPatchMock.mockReset()
+    apiDeleteMock.mockReset()
+    apiPutMock.mockReset()
+    if (!(Element.prototype as any).scrollTo) {
+      ;(Element.prototype as any).scrollTo = vi.fn()
+    }
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it("renders English weekday headers and lesson labels", async () => {
+    apiGetMock.mockImplementation(async (url: string) => {
+      if (url === "/groups") {
+        return { data: [{ id: 1, name: "CS-101" }] }
+      }
+      if (url === "/schedule/1") {
+        return {
+          data: [
+            {
+              id: 42,
+              weekday: "Понедельник",
+              parity: "odd",
+              start_time: "2024-03-25T08:00:00",
+              end_time: "2024-03-25T09:30:00",
+              subject: "Linear Algebra",
+              teacher: "Ada Lovelace",
+              room: "101",
+              lesson_type: "Лекция",
+              group_id: 1,
+            },
+          ],
+        }
+      }
+      throw new Error(`Unhandled GET ${url}`)
+    })
+
+    const { client } = renderSchedule()
+
+    try {
+      expect(await screen.findByText("My schedule")).toBeInTheDocument()
+      expect(await screen.findByRole("columnheader", { name: "Monday" })).toBeInTheDocument()
+      expect(await screen.findByText("Lecture")).toBeInTheDocument()
+    } finally {
+      client.clear()
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- load weekday and lesson type metadata from i18n translations with canonical normalization and neutral fallbacks
- expand schedule translation data to expose backend identifiers in both English and Russian locales
- cover English rendering with a focused schedule translation test

## Testing
- npm run test -- Schedule.translations.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68f049b767608327bd19ca5f4a16d9c8