### PR TITLE
feat: localize schedule lesson metadata

### DIFF
--- a/root/app/api/schedule.py
+++ b/root/app/api/schedule.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Any, List, Mapping, Sequence
 
 from fastapi import (
     APIRouter,
@@ -16,7 +16,7 @@ from app import crud
 from app.api.deps import get_current_user
 from app.core.database import get_db
 from app.deps.cache import etag_matches, format_etag, get_cache
-from app.localization import resolve_locale, translate
+from app.localization import resolve_locale, translate, translate_lesson_type
 from app.models import models
 from app.schemas import schemas
 
@@ -25,6 +25,19 @@ router = APIRouter(prefix="/schedule", tags=["schedule"])
 
 def _schedule_cache_key(group_id: int) -> str:
     return f"schedule:group:{group_id}"
+
+
+def _localize_schedule_payload(
+    payload: Sequence[Mapping[str, Any]] | Sequence[Any], *, locale: str | None
+) -> list[dict[str, Any]]:
+    localized: list[dict[str, Any]] = []
+    for item in payload:
+        data = dict(item)
+        raw_type = data.get("lesson_type")
+        display = translate_lesson_type(raw_type, locale=locale)
+        data["lesson_type_display"] = display
+        localized.append(data)
+    return localized
 
 
 @router.post("", response_model=schemas.ScheduleOut)
@@ -49,10 +62,14 @@ async def add_schedule(
 @router.get("/{group_id}", response_model=List[schemas.ScheduleOut])
 async def get_schedule(
     group_id: int,
+    request: Request,
     response: Response,
     if_none_match: str | None = Header(default=None),
     db: AsyncSession = Depends(get_db),
 ):
+    locale = resolve_locale(request=request)
+    response.headers["Vary"] = "Accept-Language"
+    response.headers["Content-Language"] = locale
     cache = get_cache()
     cache_key = _schedule_cache_key(group_id)
     if cache.enabled:
@@ -62,19 +79,20 @@ async def get_schedule(
             if etag_matches(cached.etag, if_none_match):
                 return Response(
                     status_code=status.HTTP_304_NOT_MODIFIED,
-                    headers={"ETag": etag_header},
+                    headers={"ETag": etag_header, "Vary": "Accept-Language"},
                 )
             response.headers["ETag"] = etag_header
-            return cached.payload
+            return _localize_schedule_payload(cached.payload, locale=locale)
 
     rows = await crud.get_schedule_by_group(db, group_id)
     models_out = [schemas.ScheduleOut.model_validate(item) for item in rows]
     payload = jsonable_encoder(models_out)
+    localized_payload = _localize_schedule_payload(payload, locale=locale)
 
     if cache.enabled:
         entry = await cache.set(cache_key, payload)
         response.headers["ETag"] = format_etag(entry.etag)
-    return payload
+    return localized_payload
 
 
 @router.patch("/{schedule_id}", response_model=schemas.ScheduleOut)

--- a/root/app/crud/__init__.py
+++ b/root/app/crud/__init__.py
@@ -533,11 +533,7 @@ async def create_schedule(db: AsyncSession, data: schemas.ScheduleCreate):
         start_time=start_time,
         end_time=end_time,
         parity=getattr(data, "parity", "both"),
-        lesson_type=getattr(
-            data,
-            "lesson_type",
-            translate("schedule.lesson.default_type", locale="ru"),
-        ),
+        lesson_type=getattr(data, "lesson_type", None),
     )
     db.add(record)
     await db.commit()

--- a/root/app/localization.py
+++ b/root/app/localization.py
@@ -614,7 +614,7 @@ def translate_lesson_type(
 def weekday_aliases() -> Mapping[str, int]:
     aliases: dict[str, int] = {}
     for canonical, index in _WEEKDAY_INDEX.items():
-        for alias in _WEEKDAY_STATIC_ALIASES.get(canonical, ()): 
+        for alias in _WEEKDAY_STATIC_ALIASES.get(canonical, ()):
             normalized = _normalize_weekday_token(alias)
             if normalized:
                 aliases.setdefault(normalized, index)

--- a/root/app/localization.py
+++ b/root/app/localization.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from functools import lru_cache
 from typing import Any, Mapping
 
 SUPPORTED_LOCALES: set[str] = {"en", "ru"}
@@ -375,6 +376,20 @@ _TRANSLATIONS: Mapping[str, Mapping[str, str]] = {
         "ru": "Лекция",
         "en": "Lecture",
     },
+    "schedule.weekday.monday": {"ru": "Понедельник", "en": "Monday"},
+    "schedule.weekday.monday_short": {"ru": "пн", "en": "mon"},
+    "schedule.weekday.tuesday": {"ru": "Вторник", "en": "Tuesday"},
+    "schedule.weekday.tuesday_short": {"ru": "вт", "en": "tue"},
+    "schedule.weekday.wednesday": {"ru": "Среда", "en": "Wednesday"},
+    "schedule.weekday.wednesday_short": {"ru": "ср", "en": "wed"},
+    "schedule.weekday.thursday": {"ru": "Четверг", "en": "Thursday"},
+    "schedule.weekday.thursday_short": {"ru": "чт", "en": "thu"},
+    "schedule.weekday.friday": {"ru": "Пятница", "en": "Friday"},
+    "schedule.weekday.friday_short": {"ru": "пт", "en": "fri"},
+    "schedule.weekday.saturday": {"ru": "Суббота", "en": "Saturday"},
+    "schedule.weekday.saturday_short": {"ru": "сб", "en": "sat"},
+    "schedule.weekday.sunday": {"ru": "Воскресенье", "en": "Sunday"},
+    "schedule.weekday.sunday_short": {"ru": "вс", "en": "sun"},
     "schedule.query.group_id_description": {
         "ru": "Идентификатор группы",
         "en": "Group identifier",
@@ -546,6 +561,33 @@ _LESSON_TYPE_ALIASES: Mapping[str, str] = {
     "consultation": "consultation",
 }
 
+_WEEKDAY_INDEX: Mapping[str, int] = {
+    "monday": 0,
+    "tuesday": 1,
+    "wednesday": 2,
+    "thursday": 3,
+    "friday": 4,
+    "saturday": 5,
+    "sunday": 6,
+}
+
+_WEEKDAY_STATIC_ALIASES: Mapping[str, tuple[str, ...]] = {
+    "monday": ("monday", "mon"),
+    "tuesday": ("tuesday", "tue"),
+    "wednesday": ("wednesday", "wed"),
+    "thursday": ("thursday", "thu"),
+    "friday": ("friday", "fri"),
+    "saturday": ("saturday", "sat"),
+    "sunday": ("sunday", "sun"),
+}
+
+
+def _normalize_weekday_token(value: str | None) -> str | None:
+    if not value:
+        return None
+    normalized = "".join(ch for ch in str(value).lower() if ch.isalpha())
+    return normalized or None
+
 
 def translate_lesson_type(
     lesson_type: str | None, *, locale: str | None = None
@@ -568,6 +610,35 @@ def translate_lesson_type(
     return raw_value
 
 
+@lru_cache(maxsize=1)
+def weekday_aliases() -> Mapping[str, int]:
+    aliases: dict[str, int] = {}
+    for canonical, index in _WEEKDAY_INDEX.items():
+        for alias in _WEEKDAY_STATIC_ALIASES.get(canonical, ()): 
+            normalized = _normalize_weekday_token(alias)
+            if normalized:
+                aliases.setdefault(normalized, index)
+
+        for key_suffix in ("", "_short"):
+            translation_key = f"schedule.weekday.{canonical}{key_suffix}"
+            entry = _TRANSLATIONS.get(translation_key)
+            if not entry:
+                continue
+            for value in entry.values():
+                normalized = _normalize_weekday_token(value)
+                if normalized:
+                    aliases.setdefault(normalized, index)
+
+    return aliases
+
+
+def resolve_weekday_index(value: str | None) -> int | None:
+    normalized = _normalize_weekday_token(value)
+    if not normalized:
+        return None
+    return weekday_aliases().get(normalized)
+
+
 __all__ = [
     "SUPPORTED_LOCALES",
     "DEFAULT_LOCALE",
@@ -576,4 +647,6 @@ __all__ = [
     "localized_text",
     "translate",
     "translate_lesson_type",
+    "weekday_aliases",
+    "resolve_weekday_index",
 ]

--- a/root/app/models/models.py
+++ b/root/app/models/models.py
@@ -119,7 +119,7 @@ class Schedule(Base):
     start_time = Column(DateTime(timezone=True), index=True, nullable=False)
     end_time = Column(DateTime(timezone=True), index=True, nullable=False)
     parity = Column(String, default="both", index=True)
-    lesson_type = Column(String, default="Лекция")
+    lesson_type = Column(String, default=None)
 
     __table_args__ = (
         CheckConstraint("end_time > start_time", name="ck_schedule_time_order"),

--- a/root/app/schemas/schemas.py
+++ b/root/app/schemas/schemas.py
@@ -124,7 +124,7 @@ class ScheduleBase(BaseModel):
     start_time: datetime
     end_time: datetime
     parity: Optional[str] = "both"
-    lesson_type: Optional[str] = translate("schedule.lesson.default_type", locale="ru")
+    lesson_type: Optional[str] = None
 
 
 class ScheduleCreate(ScheduleBase):
@@ -145,6 +145,7 @@ class ScheduleUpdate(BaseModel):
 
 class ScheduleOut(OrmModel, ScheduleBase):
     id: int
+    lesson_type_display: Optional[str] = None
 
 
 class NewsCreate(BaseModel):

--- a/root/app/services/ical.py
+++ b/root/app/services/ical.py
@@ -5,39 +5,16 @@ from __future__ import annotations
 from datetime import date, datetime, time, timedelta, timezone
 from typing import Iterable, Sequence
 
-from app.localization import translate, translate_lesson_type
+from app.localization import (
+    resolve_weekday_index,
+    translate,
+    translate_lesson_type,
+)
 from app.models import models
-
-_WEEKDAY_ALIASES: dict[str, int] = {
-    "monday": 0,
-    "mon": 0,
-    "понедельник": 0,
-    "tuesday": 1,
-    "tue": 1,
-    "вторник": 1,
-    "wednesday": 2,
-    "wed": 2,
-    "среда": 2,
-    "thursday": 3,
-    "thu": 3,
-    "четверг": 3,
-    "friday": 4,
-    "fri": 4,
-    "пятница": 4,
-    "saturday": 5,
-    "sat": 5,
-    "суббота": 5,
-    "sunday": 6,
-    "sun": 6,
-    "воскресенье": 6,
-}
 
 
 def _weekday_index(value: str | None) -> int | None:
-    if not value:
-        return None
-    normalized = value.strip().lower()
-    return _WEEKDAY_ALIASES.get(normalized)
+    return resolve_weekday_index(value)
 
 
 def _ensure_time(value: datetime | time | None) -> time | None:

--- a/root/app/services/notification_templates.py
+++ b/root/app/services/notification_templates.py
@@ -9,7 +9,7 @@ from html import unescape
 from textwrap import shorten
 from typing import Any, Mapping
 
-from app.localization import translate
+from app.localization import SUPPORTED_LOCALES, translate
 
 _DEFAULT_ICON = "/maskable-icon-192.png"
 _DEFAULT_BADGE = _DEFAULT_ICON
@@ -18,6 +18,23 @@ _SYSTEM_ICON = "/guu_logo.png"
 
 _TAG_RE = re.compile(r"<[^>]+>")
 _SPACE_RE = re.compile(r"\s+")
+
+
+def _room_label_prefixes() -> set[str]:
+    prefixes: set[str] = set()
+    for locale_code in SUPPORTED_LOCALES:
+        template = translate(
+            "notifications.schedule.room_label", locale=locale_code, room=""
+        )
+        for variant in (template, template.replace(".", "")):
+            normalized = variant.strip().lower()
+            if normalized:
+                prefixes.add(normalized)
+    prefixes.update({"room", "aud"})
+    return prefixes
+
+
+_ROOM_LABEL_PREFIXES = _room_label_prefixes()
 
 
 def _clean_text(value: Any, *, limit: int | None = None) -> str | None:
@@ -39,12 +56,8 @@ def _format_room(value: Any, *, locale: str | None = None) -> str | None:
     room = _clean_text(value)
     if not room:
         return None
-    normalized = room.lower()
-    if (
-        normalized.startswith("ауд")
-        or normalized.startswith("aud")
-        or normalized.startswith("room")
-    ):
+    normalized = room.lower().strip()
+    if any(normalized.startswith(prefix) for prefix in _ROOM_LABEL_PREFIXES):
         return room
     return translate("notifications.schedule.room_label", locale=locale, room=room)
 

--- a/root/app/services/notifications.py
+++ b/root/app/services/notifications.py
@@ -13,7 +13,14 @@ from sqlalchemy.orm import selectinload
 
 from app.core.config import settings
 from app.core.database import async_session as _async_session
-from app.localization import localized_text, normalize_locale, resolve_locale, translate
+from app.localization import (
+    SUPPORTED_LOCALES,
+    localized_text,
+    normalize_locale,
+    resolve_locale,
+    translate,
+    translate_lesson_type,
+)
 from app.models.models import (
     Event,
     News,
@@ -34,6 +41,23 @@ def _current_local_time() -> dt.time:
 
 
 logger = logging.getLogger(__name__)
+
+
+def _room_label_prefixes() -> set[str]:
+    prefixes: set[str] = set()
+    for locale_code in SUPPORTED_LOCALES:
+        template = translate(
+            "notifications.schedule.room_label", locale=locale_code, room=""
+        )
+        for variant in (template, template.replace(".", "")):
+            normalized = variant.strip().lower()
+            if normalized:
+                prefixes.add(normalized)
+    prefixes.update({"room", "aud"})
+    return prefixes
+
+
+_ROOM_LABEL_PREFIXES = _room_label_prefixes()
 
 
 _TAG_RE = re.compile(r"<[^>]+>")
@@ -104,10 +128,12 @@ def build_schedule_reminder_message(
 ) -> tuple[str, str, str, dict[str, Any]]:
     start_dt = _ensure_aware(getattr(lesson, "start_time", None))
     start_local = start_dt.astimezone()
+    lesson_type_raw = getattr(lesson, "lesson_type", None)
+    lesson_type_display = translate_lesson_type(lesson_type_raw, locale=locale)
     payload_input = {
         "subject": getattr(lesson, "subject", None),
         "group": getattr(getattr(lesson, "group", None), "name", None),
-        "lesson_type": getattr(lesson, "lesson_type", None),
+        "lesson_type": lesson_type_display or lesson_type_raw,
         "teacher": getattr(lesson, "teacher", None),
         "room": getattr(lesson, "room", None),
         "starts_at": start_dt.isoformat(),
@@ -131,13 +157,15 @@ def build_schedule_reminder_message(
             "notifications.schedule.reminder.title", locale=locale
         )
     summary_parts: list[str] = []
-    if getattr(lesson, "lesson_type", None):
-        summary_parts.append(str(lesson.lesson_type))
+    if lesson_type_display:
+        summary_parts.append(lesson_type_display)
+    elif lesson_type_raw:
+        summary_parts.append(str(lesson_type_raw))
     room_value = getattr(lesson, "room", None)
     if room_value:
         room_text = str(room_value)
         normalized = room_text.strip().lower()
-        if normalized.startswith("ауд") or normalized.startswith("aud"):
+        if any(normalized.startswith(prefix) for prefix in _ROOM_LABEL_PREFIXES):
             summary_parts.append(room_text)
         else:
             summary_parts.append(
@@ -171,7 +199,8 @@ def build_schedule_reminder_message(
         "lessonId": getattr(lesson, "id", None),
         "subject": getattr(lesson, "subject", None),
         "groupId": getattr(lesson, "group_id", None),
-        "lessonType": getattr(lesson, "lesson_type", None),
+        "lessonType": lesson_type_display or lesson_type_raw,
+        "lessonTypeRaw": lesson_type_raw,
         "teacher": getattr(lesson, "teacher", None),
         "room": getattr(lesson, "room", None),
         "startText": when_line,

--- a/root/tests/test_schedule_ics.py
+++ b/root/tests/test_schedule_ics.py
@@ -120,7 +120,9 @@ def test_generate_schedule_ics_english_avoids_cyrillic_labels() -> None:
 
 
 @pytest.mark.anyio
-async def test_schedule_endpoint_localizes_lesson_type(async_client, db_session) -> None:
+async def test_schedule_endpoint_localizes_lesson_type(
+    async_client, db_session
+) -> None:
     group = models.Group(name="EN-01", course=1, faculty="IT")
     db_session.add(group)
     await db_session.commit()

--- a/root/tests/test_schedule_ics.py
+++ b/root/tests/test_schedule_ics.py
@@ -19,14 +19,14 @@ def test_generate_schedule_ics_includes_lessons() -> None:
         start_time=datetime(2024, 1, 1, 9, 0),
         end_time=datetime(2024, 1, 1, 10, 30),
         parity="both",
-        lesson_type="Лекция",
+        lesson_type="lecture",
     )
 
     ics = generate_schedule_ics(group, [lesson], weeks=1, locale="en")
 
     assert "BEGIN:VCALENDAR" in ics
     assert "END:VCALENDAR" in ics
-    expected_type = translate_lesson_type("Лекция", locale="en") or "Лекция"
+    expected_type = translate_lesson_type("lecture", locale="en") or "lecture"
     assert f"SUMMARY:Алгебра ({expected_type})" in ics
     assert "DTSTART:" in ics
     assert "DTEND:" in ics
@@ -58,7 +58,7 @@ async def test_schedule_ics_endpoint(async_client, db_session) -> None:
         start_time=datetime(2024, 1, 1, 9, 0),
         end_time=datetime(2024, 1, 1, 10, 30),
         parity="both",
-        lesson_type="Лекция",
+        lesson_type="practice",
     )
     db_session.add(lesson)
     await db_session.commit()
@@ -71,8 +71,10 @@ async def test_schedule_ics_endpoint(async_client, db_session) -> None:
     assert "schedule-" in disposition.lower()
     assert response.headers.get("content-language") == "en"
     assert "Алгебра" in response.text
+    expected_type_en = translate_lesson_type("practice", locale="en")
     expected_en = translate("schedule.ics.description.room", locale="en", room="А-101")
     assert expected_en in response.text
+    assert expected_type_en in response.text
 
     response_ru = await async_client.get(
         f"/schedule/ics?group={group.id}", headers={"Accept-Language": "ru"}
@@ -115,3 +117,40 @@ def test_generate_schedule_ics_english_avoids_cyrillic_labels() -> None:
 
     description_line = next(line for line in lines if line.startswith("DESCRIPTION:"))
     assert not _contains_cyrillic(description_line)
+
+
+@pytest.mark.anyio
+async def test_schedule_endpoint_localizes_lesson_type(async_client, db_session) -> None:
+    group = models.Group(name="EN-01", course=1, faculty="IT")
+    db_session.add(group)
+    await db_session.commit()
+    await db_session.refresh(group)
+
+    lesson = models.Schedule(
+        group_id=group.id,
+        subject="Physics",
+        teacher="Dr. Brown",
+        room="Room 101",
+        weekday="monday",
+        start_time=datetime(2024, 3, 4, 9, 0),
+        end_time=datetime(2024, 3, 4, 10, 30),
+        parity="both",
+        lesson_type="lecture",
+    )
+    db_session.add(lesson)
+    await db_session.commit()
+
+    response_en = await async_client.get(f"/schedule/{group.id}")
+    assert response_en.status_code == 200
+    payload_en = response_en.json()
+    assert payload_en[0]["lesson_type"] == "lecture"
+    expected_en = translate_lesson_type("lecture", locale="en")
+    assert payload_en[0]["lesson_type_display"] == expected_en
+
+    response_ru = await async_client.get(
+        f"/schedule/{group.id}", headers={"Accept-Language": "ru"}
+    )
+    assert response_ru.status_code == 200
+    payload_ru = response_ru.json()
+    expected_ru = translate_lesson_type("lecture", locale="ru")
+    assert payload_ru[0]["lesson_type_display"] == expected_ru


### PR DESCRIPTION
## Summary
- stop defaulting schedule.lesson_type to a Russian string and localize schedule responses via translate_lesson_type
- build weekday aliases from localization data and remove hard-coded Cyrillic checks in ICS/notification utilities
- update notification flows and tests to assert English translations for lesson types and ICS exports

## Testing
- `pytest`
- `pytest root/tests/test_schedule_ics.py`


------
https://chatgpt.com/codex/tasks/task_e_68f0e855bd9483279b1d5f7b84be8ca6