### PR TITLE
Fix map iframe selector to be locale agnostic

### DIFF
--- a/root/frontend/src/assets/themes.css
+++ b/root/frontend/src/assets/themes.css
@@ -856,7 +856,7 @@ body.dark .glass {
 }
 .map-page > iframe,
 .map-page .map-iframe,
-.map-page iframe[title="Карта кампуса ГУУ"]{
+.map-page iframe{
   position: absolute;
   inset: 0;
   width: 100%;


### PR DESCRIPTION
## Summary
- replace the map iframe selector in themes.css with a language-neutral variant to avoid relying on translated titles

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f12d1429c88327ac3253b0817824e3