### PR TITLE
feat(frontend): inject locale header via axios interceptor

### DIFF
--- a/root/frontend/src/api/__tests__/client.language.test.ts
+++ b/root/frontend/src/api/__tests__/client.language.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import { http, HttpResponse } from "msw"
+import api from "@/api/client"
+import i18n from "@/i18n/config"
+import { server } from "@/tests/mocks/server"
+
+type NewsPayload = { id: number; title: string; content: string }
+type EventPayload = { id: number; title: string; description: string }
+type NotificationPayload = { id: number; message: string }
+
+const isEnglishRequest = (request: Request) =>
+  (request.headers.get("accept-language") ?? "").toLowerCase().startsWith("en")
+
+const englishNews: NewsPayload[] = [
+  { id: 1, title: "Campus renovation update", content: "Construction finishes this fall." },
+]
+const russianNews: NewsPayload[] = [
+  { id: 1, title: "Обновление кампуса", content: "Строительство завершится осенью." },
+]
+const englishEvents: EventPayload[] = [
+  { id: 1, title: "Career fair", description: "Meet top tech employers." },
+]
+const russianEvents: EventPayload[] = [
+  { id: 1, title: "Ярмарка вакансий", description: "Встреча с ведущими работодателями." },
+]
+const englishNotifications: NotificationPayload[] = [
+  { id: 1, message: "New grade posted in Calculus." },
+]
+const russianNotifications: NotificationPayload[] = [
+  { id: 1, message: "Новая оценка по курсу 'Математический анализ'." },
+]
+
+describe("API language interceptor", () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage("en")
+  })
+
+  afterEach(async () => {
+    await i18n.changeLanguage("en")
+  })
+
+  it("requests English localized resources when the UI language is set to en", async () => {
+    const observedLanguages: string[] = []
+
+    server.use(
+      http.get("*/news", ({ request }) => {
+        const english = isEnglishRequest(request)
+        observedLanguages.push(request.headers.get("accept-language") ?? "")
+        return HttpResponse.json(english ? englishNews : russianNews)
+      }),
+      http.get("*/events", ({ request }) => {
+        const english = isEnglishRequest(request)
+        observedLanguages.push(request.headers.get("accept-language") ?? "")
+        return HttpResponse.json(english ? englishEvents : russianEvents)
+      }),
+      http.get("*/notifications", ({ request }) => {
+        const english = isEnglishRequest(request)
+        observedLanguages.push(request.headers.get("accept-language") ?? "")
+        return HttpResponse.json(english ? englishNotifications : russianNotifications)
+      }),
+      http.post("*/auth/login", async ({ request }) => {
+        const english = isEnglishRequest(request)
+        observedLanguages.push(request.headers.get("accept-language") ?? "")
+        return HttpResponse.json(
+          { detail: english ? "Invalid credentials" : "Неверные данные для входа" },
+          { status: 401 },
+        )
+      }),
+    )
+
+    const newsResponse = await api.get<NewsPayload[]>("/news")
+    expect(newsResponse.data[0].title).toBe("Campus renovation update")
+
+    const eventsResponse = await api.get<EventPayload[]>("/events")
+    expect(eventsResponse.data[0].title).toBe("Career fair")
+
+    const notificationsResponse = await api.get<NotificationPayload[]>("/notifications")
+    expect(notificationsResponse.data[0].message).toBe("New grade posted in Calculus.")
+
+    const loginResponse = await api.post<{ detail: string }>(
+      "/auth/login",
+      new URLSearchParams(),
+      { validateStatus: () => true },
+    )
+    expect(loginResponse.status).toBe(401)
+    expect(loginResponse.data.detail).toBe("Invalid credentials")
+
+    expect(new Set(observedLanguages)).toEqual(new Set(["en"]))
+  })
+
+  it("respects an explicit Accept-Language header override", async () => {
+    server.use(
+      http.get("*/news", ({ request }) =>
+        HttpResponse.json([
+          {
+            id: 1,
+            title: request.headers.get("accept-language") ?? "",
+            content: "",
+          },
+        ]),
+      ),
+    )
+
+    await i18n.changeLanguage("en")
+
+    const response = await api.get<NewsPayload[]>("/news", {
+      headers: { "Accept-Language": "ru" },
+    })
+
+    expect(response.data[0].title).toBe("ru")
+  })
+})

--- a/root/frontend/src/api/client.ts
+++ b/root/frontend/src/api/client.ts
@@ -63,19 +63,16 @@ api.interceptors.request.use((config) => {
   const currentLanguage = i18n.language || i18n.resolvedLanguage || "ru";
   const headerValue = resolveAcceptLanguage(currentLanguage);
 
-  if (config.headers instanceof AxiosHeaders) {
-    if (!config.headers.has(acceptLanguageHeader)) {
-      config.headers.set(acceptLanguageHeader, headerValue);
-    }
-    return config;
+  const headers = AxiosHeaders.from(config.headers ?? {});
+
+  if (
+    !headers.has(acceptLanguageHeader) &&
+    !headers.has(acceptLanguageHeader.toLowerCase())
+  ) {
+    headers.set(acceptLanguageHeader, headerValue);
   }
 
-  const headers = (config.headers ?? {}) as Record<string, unknown>;
-  const existing = headers[acceptLanguageHeader] ?? headers[acceptLanguageHeader.toLowerCase()];
-
-  if (existing == null) {
-    config.headers = { ...headers, [acceptLanguageHeader]: headerValue };
-  }
+  config.headers = headers;
 
   return config;
 });

--- a/root/frontend/src/api/client.ts
+++ b/root/frontend/src/api/client.ts
@@ -1,4 +1,10 @@
-import axios, { type AxiosInstance, type AxiosRequestConfig, type AxiosResponse } from "axios";
+import axios, {
+  AxiosHeaders,
+  type AxiosInstance,
+  type AxiosRequestConfig,
+  type AxiosResponse,
+} from "axios";
+import i18n from "@/i18n/config";
 
 export const API_UNAUTHORIZED_EVENT = "auth:unauthorized";
 export const SKIP_UNAUTHORIZED_HEADER = "X-Client-Skip-Unauthorized";
@@ -42,6 +48,37 @@ const api: ApiInstance = axios.create({
     "X-Requested-With": "XMLHttpRequest",
   },
 }) as ApiInstance;
+
+const acceptLanguageHeader = "Accept-Language";
+
+const resolveAcceptLanguage = (language?: string) => {
+  if (!language) return "ru";
+  const normalized = language.toLowerCase();
+  if (normalized.startsWith("en")) return "en";
+  if (normalized.startsWith("ru")) return "ru";
+  return "ru";
+};
+
+api.interceptors.request.use((config) => {
+  const currentLanguage = i18n.language || i18n.resolvedLanguage || "ru";
+  const headerValue = resolveAcceptLanguage(currentLanguage);
+
+  if (config.headers instanceof AxiosHeaders) {
+    if (!config.headers.has(acceptLanguageHeader)) {
+      config.headers.set(acceptLanguageHeader, headerValue);
+    }
+    return config;
+  }
+
+  const headers = (config.headers ?? {}) as Record<string, unknown>;
+  const existing = headers[acceptLanguageHeader] ?? headers[acceptLanguageHeader.toLowerCase()];
+
+  if (existing == null) {
+    config.headers = { ...headers, [acceptLanguageHeader]: headerValue };
+  }
+
+  return config;
+});
 
 api.interceptors.response.use(
   (r) => r,

--- a/root/frontend/src/components/NewsCard.tsx
+++ b/root/frontend/src/components/NewsCard.tsx
@@ -184,9 +184,7 @@ const NewsCardComponent: FC<NewsCardProps> = ({
         content_en: editData.content_en,
         image_url: imgUrl,
       }
-      await api.patch(`/news/${id}`, payload, {
-        headers: { "Accept-Language": language },
-      })
+      await api.patch(`/news/${id}`, payload)
       setEditData(prev => ({ ...prev, image_url: imgUrl }))
       closeEditDialog()
       onChange && onChange()
@@ -195,14 +193,12 @@ const NewsCardComponent: FC<NewsCardProps> = ({
     } finally {
       setLoading(false)
     }
-  }, [closeEditDialog, editData, id, language, newImage, onChange])
+  }, [closeEditDialog, editData, id, newImage, onChange])
 
   const handleDelete = useCallback(async () => {
     setLoading(true)
     try {
-      await api.delete(`/news/${id}`, {
-        headers: { "Accept-Language": language },
-      })
+      await api.delete(`/news/${id}`)
       onChange && onChange()
     } catch (e) {
       console.error(e)
@@ -210,7 +206,7 @@ const NewsCardComponent: FC<NewsCardProps> = ({
       setLoading(false)
       setConfirmDeleteOpen(false)
     }
-  }, [id, language, onChange])
+  }, [id, onChange])
 
   const handleCardClick = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
     if (editOpen) {

--- a/root/frontend/src/pages/News.tsx
+++ b/root/frontend/src/pages/News.tsx
@@ -105,7 +105,6 @@ const News = () => {
         const res = await axios.get<NewsItem[]>("/news", {
           headers: {
             ...(etag ? { "If-None-Match": etag } : {}),
-            "Accept-Language": language,
           },
           signal,
           validateStatus: (s) => s === 200 || s === 304,
@@ -212,9 +211,7 @@ const News = () => {
         ...(newsData.content_en.trim() ? { content_en: newsData.content_en } : {}),
       }
 
-      await axios.post("/news", payload, {
-        headers: { "Accept-Language": language },
-      })
+      await axios.post("/news", payload)
       setAddOpen(false)
       setNewsData(initialNews)
       setImageFile(null)

--- a/root/frontend/src/pages/NewsDetail.tsx
+++ b/root/frontend/src/pages/NewsDetail.tsx
@@ -48,10 +48,8 @@ type NewsItem = {
   created_at?: string
 }
 
-async function fetchNews(id: string, language: string) {
-  const { data } = await api.get<NewsItem>(`/news/${id}`, {
-    headers: { "Accept-Language": language },
-  })
+async function fetchNews(id: string) {
+  const { data } = await api.get<NewsItem>(`/news/${id}`)
   return data
 }
 
@@ -100,7 +98,7 @@ export default function NewsDetail() {
 
   const query = useQuery({
     queryKey: ["news", id, language],
-    queryFn: () => fetchNews(id, language),
+    queryFn: () => fetchNews(id),
     enabled: !!id,
     staleTime: 60000,
     retry: 1,
@@ -167,9 +165,7 @@ export default function NewsDetail() {
         content_en: editData.content_en,
         image_url: imageUrl,
       }
-      const { data } = await api.patch<NewsItem>(`/news/${query.data.id}`, payload, {
-        headers: { "Accept-Language": language },
-      })
+      const { data } = await api.patch<NewsItem>(`/news/${query.data.id}`, payload)
       queryClient.setQueryData(["news", id, language], data)
       await queryClient.invalidateQueries({ queryKey: ["news"] })
       setSnack(t("news:notifications.updated"))
@@ -186,9 +182,7 @@ export default function NewsDetail() {
     if (!query.data) return
     setDeleting(true)
     try {
-      await api.delete(`/news/${query.data.id}`, {
-        headers: { "Accept-Language": language },
-      })
+      await api.delete(`/news/${query.data.id}`)
       setSnack(t("news:notifications.deleted"))
       queryClient.removeQueries({ queryKey: ["news", id] })
       await queryClient.invalidateQueries({ queryKey: ["news"] })

--- a/root/frontend/src/pages/__tests__/Schedule.translations.test.tsx
+++ b/root/frontend/src/pages/__tests__/Schedule.translations.test.tsx
@@ -76,7 +76,7 @@ vi.mock("@/api/client", () => ({
     patch: apiMocks.patch,
     delete: apiMocks.delete,
     put: apiMocks.put,
-    interceptors: { response: { use: vi.fn() } },
+    interceptors: { response: { use: vi.fn() }, request: { use: vi.fn() } },
   },
 }))
 

--- a/root/frontend/src/tests/pageTranslations.test.tsx
+++ b/root/frontend/src/tests/pageTranslations.test.tsx
@@ -253,7 +253,7 @@ vi.mock("@/api/client", () => ({
     patch: apiPatchMock,
     delete: apiDeleteMock,
     put: apiPutMock,
-    interceptors: { response: { use: vi.fn() } },
+    interceptors: { response: { use: vi.fn() }, request: { use: vi.fn() } },
   },
   API_UNAUTHORIZED_EVENT: "auth:unauthorized",
   SKIP_UNAUTHORIZED_HEADER: "X-Client-Skip-Unauthorized",


### PR DESCRIPTION
## Summary
- add an axios request interceptor that injects the current UI language into the `Accept-Language` header
- remove now-redundant per-request language headers from news components
- add coverage to verify localized endpoints and header overrides, updating test doubles as needed

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68f1419cff04832793b321dfc982a5c6