### PR TITLE
Add localization tests for events and notifications

### DIFF
--- a/root/app/api/notifications.py
+++ b/root/app/api/notifications.py
@@ -7,7 +7,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps import get_current_user
 from app.core.database import get_db
-from app.localization import resolve_locale, translate
+from app.crud import sanitize_optional_text
+from app.localization import localized_text, resolve_locale, translate
 from app.models.models import Notification, Schedule, User
 from app.schemas.schemas import NotificationOut, NotificationsListOut
 from app.services.notifications import (
@@ -35,6 +36,55 @@ def _decode_cursor(value: Optional[str]) -> Optional[Tuple[datetime, int]]:
         return datetime.fromtimestamp(int(ms_s) / 1000.0, UTC), int(id_s)
     except Exception:
         return None
+
+
+def _localized_notification_field(
+    locale: str | None,
+    ru_value: str | None,
+    en_value: str | None,
+    *,
+    required: bool = False,
+) -> str | None:
+    ru_clean = sanitize_optional_text(ru_value)
+    en_clean = sanitize_optional_text(en_value)
+    value = localized_text(locale, ru=ru_clean, en=en_clean)
+    if value is not None:
+        return value
+    if required:
+        if isinstance(ru_value, str) and ru_value.strip():
+            return ru_value
+        if isinstance(en_value, str) and en_value.strip():
+            return en_value
+        return ru_value or en_value or ""
+    return ru_clean or en_clean
+
+
+def _serialize_notification(
+    record: Notification, locale: str | None
+) -> NotificationOut:
+    created_at = getattr(record, "created_at", None) or datetime.now(UTC)
+    data = {
+        "id": record.id,
+        "title": _localized_notification_field(
+            locale,
+            getattr(record, "title", None),
+            getattr(record, "title_en", None),
+            required=True,
+        ),
+        "body": _localized_notification_field(
+            locale,
+            getattr(record, "body", None),
+            getattr(record, "body_en", None),
+        ),
+        "title_en": sanitize_optional_text(getattr(record, "title_en", None)),
+        "body_en": sanitize_optional_text(getattr(record, "body_en", None)),
+        "type": getattr(record, "type", None),
+        "url": getattr(record, "url", None),
+        "created_at": created_at,
+        "read": getattr(record, "read", False),
+        "read_at": getattr(record, "read_at", None),
+    }
+    return NotificationOut.model_validate(data)
 
 
 @router.get("", response_model=NotificationsListOut)
@@ -85,7 +135,7 @@ async def list_notifications(
     )
 
     return NotificationsListOut(
-        items=[NotificationOut.from_orm(n) for n in items],
+        items=[_serialize_notification(n, locale) for n in items],
         unread_count=int(unread),
         has_more=has_more,
         next_cursor=next_cursor,

--- a/root/app/models/models.py
+++ b/root/app/models/models.py
@@ -248,7 +248,9 @@ class Notification(Base):
         Integer, ForeignKey("users.id", ondelete="CASCADE"), index=True, nullable=False
     )
     title = Column(String, nullable=False)
+    title_en = Column(String)
     body = Column(Text)
+    body_en = Column(Text)
     type = Column(String, index=True)
     url = Column(String)
     created_at = Column(DateTime(timezone=True), server_default=func.now(), index=True)

--- a/root/app/schemas/schemas.py
+++ b/root/app/schemas/schemas.py
@@ -287,6 +287,8 @@ class NotificationCreate(BaseModel):
     user_id: int
     title: str
     body: Optional[str] = None
+    title_en: Optional[str] = None
+    body_en: Optional[str] = None
     type: Optional[str] = None
     url: Optional[str] = None
 
@@ -295,6 +297,8 @@ class NotificationOut(OrmModel):
     id: int
     title: str
     body: Optional[str] = None
+    title_en: Optional[str] = None
+    body_en: Optional[str] = None
     type: Optional[str] = None
     url: Optional[str] = None
     created_at: datetime

--- a/root/tests/test_events_localization.py
+++ b/root/tests/test_events_localization.py
@@ -1,5 +1,6 @@
-import pytest
 from datetime import datetime, timedelta, timezone
+
+import pytest
 
 from app.auth.security import get_password_hash
 from app.models import models

--- a/root/tests/test_events_localization.py
+++ b/root/tests/test_events_localization.py
@@ -1,0 +1,97 @@
+import pytest
+from datetime import datetime, timedelta, timezone
+
+from app.auth.security import get_password_hash
+from app.models import models
+
+
+async def _login(async_client, email: str, password: str) -> dict[str, str]:
+    response = await async_client.post(
+        "/auth/login",
+        data={"username": email, "password": password},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert response.status_code == 200
+    token = response.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.mark.anyio
+async def test_events_localization(async_client, db_session, user_factory):
+    password = "TestEvent123!"
+    hashed = get_password_hash(password)
+    admin = await user_factory(role="admin")
+    student = await user_factory(hashed_password=hashed, is_active=True)
+
+    now = datetime.now(timezone.utc)
+    primary = models.Event(
+        title="Русское событие",
+        description="Описание по-русски",
+        location="Москва",
+        event_type="лекция",
+        about="Подробности",
+        title_en="English Event",
+        description_en="Description in English",
+        location_en="Moscow",
+        event_type_en="Lecture",
+        about_en="More details",
+        starts_at=now + timedelta(days=1),
+        ends_at=now + timedelta(days=1, hours=2),
+        created_by=admin.id,
+        is_active=True,
+    )
+    fallback = models.Event(
+        title="Только русский",
+        description="Без перевода",
+        location="Санкт-Петербург",
+        event_type="встреча",
+        about="Описание только на русском",
+        starts_at=now + timedelta(days=2),
+        ends_at=now + timedelta(days=2, hours=3),
+        created_by=admin.id,
+        is_active=True,
+    )
+
+    db_session.add_all([primary, fallback])
+    await db_session.commit()
+    await db_session.refresh(primary)
+    await db_session.refresh(fallback)
+
+    headers = await _login(async_client, student.email, password)
+
+    response_en = await async_client.get(
+        "/events",
+        headers={**headers, "Accept-Language": "en"},
+    )
+    assert response_en.status_code == 200
+    payload_en = {item["id"]: item for item in response_en.json()}
+
+    assert payload_en[primary.id]["title"] == "English Event"
+    assert payload_en[primary.id]["description"] == "Description in English"
+    assert payload_en[primary.id]["location"] == "Moscow"
+    assert payload_en[primary.id]["event_type"] == "Lecture"
+    assert payload_en[primary.id]["about"] == "More details"
+    assert payload_en[primary.id]["title_en"] == "English Event"
+    assert payload_en[primary.id]["description_en"] == "Description in English"
+
+    assert payload_en[fallback.id]["title"] == "Только русский"
+    assert payload_en[fallback.id]["description"] == "Без перевода"
+    assert payload_en[fallback.id]["location"] == "Санкт-Петербург"
+    assert payload_en[fallback.id]["event_type"] == "встреча"
+    assert payload_en[fallback.id]["about"] == "Описание только на русском"
+    assert payload_en[fallback.id]["title_en"] is None
+
+    response_ru = await async_client.get(
+        "/events",
+        headers={**headers, "Accept-Language": "ru"},
+    )
+    assert response_ru.status_code == 200
+    payload_ru = {item["id"]: item for item in response_ru.json()}
+
+    assert payload_ru[primary.id]["title"] == "Русское событие"
+    assert payload_ru[primary.id]["description"] == "Описание по-русски"
+    assert payload_ru[primary.id]["location"] == "Москва"
+    assert payload_ru[primary.id]["event_type"] == "лекция"
+    assert payload_ru[primary.id]["about"] == "Подробности"
+    assert payload_ru[fallback.id]["title"] == "Только русский"
+    assert payload_ru[fallback.id]["description"] == "Без перевода"

--- a/root/tests/test_notifications_localization.py
+++ b/root/tests/test_notifications_localization.py
@@ -1,0 +1,75 @@
+import pytest
+
+from app.auth.security import get_password_hash
+from app.models import models
+
+
+async def _login(async_client, email: str, password: str) -> dict[str, str]:
+    response = await async_client.post(
+        "/auth/login",
+        data={"username": email, "password": password},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert response.status_code == 200
+    token = response.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.mark.anyio
+async def test_notifications_localization(async_client, db_session, user_factory):
+    password = "Notify123!"
+    hashed = get_password_hash(password)
+    user = await user_factory(hashed_password=hashed, is_active=True)
+
+    primary = models.Notification(
+        user_id=user.id,
+        title="Новое уведомление",
+        body="Русский текст",
+        title_en="New notification",
+        body_en="English body",
+    )
+    fallback = models.Notification(
+        user_id=user.id,
+        title="Без перевода",
+        body="Только русский текст",
+    )
+    db_session.add_all([primary, fallback])
+    await db_session.commit()
+    await db_session.refresh(primary)
+    await db_session.refresh(fallback)
+
+    headers = await _login(async_client, user.email, password)
+
+    response_en = await async_client.get(
+        "/notifications",
+        headers={**headers, "Accept-Language": "en"},
+    )
+    assert response_en.status_code == 200
+    body_en = response_en.json()
+    items_en = {item["id"]: item for item in body_en["items"]}
+
+    assert items_en[primary.id]["title"] == "New notification"
+    assert items_en[primary.id]["body"] == "English body"
+    assert items_en[primary.id]["title_en"] == "New notification"
+    assert items_en[primary.id]["body_en"] == "English body"
+
+    assert items_en[fallback.id]["title"] == "Без перевода"
+    assert items_en[fallback.id]["body"] == "Только русский текст"
+    assert items_en[fallback.id]["title_en"] is None
+    assert items_en[fallback.id]["body_en"] is None
+
+    response_ru = await async_client.get(
+        "/notifications",
+        headers={**headers, "Accept-Language": "ru"},
+    )
+    assert response_ru.status_code == 200
+    body_ru = response_ru.json()
+    items_ru = {item["id"]: item for item in body_ru["items"]}
+
+    assert items_ru[primary.id]["title"] == "Новое уведомление"
+    assert items_ru[primary.id]["body"] == "Русский текст"
+    assert items_ru[fallback.id]["title"] == "Без перевода"
+    assert items_ru[fallback.id]["body"] == "Только русский текст"
+
+    assert body_en["unread_count"] == 2
+    assert body_ru["unread_count"] == 2


### PR DESCRIPTION
## Summary
- add async localization tests for events and notifications endpoints covering Accept-Language toggling
- expose optional English fields on notifications and localize serialized payloads to pass new tests

## Testing
- PYTHONPATH=root pytest root/tests/test_events_localization.py root/tests/test_notifications_localization.py

------
https://chatgpt.com/codex/tasks/task_e_68f154333204832798982dae15fdbe45