### PR TITLE
Add locale key parity test for en/ru translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Content-Security-Policy:
 - `ENABLE_STRICT_SECURITY_HEADERS=true ENABLE_COOP=true uvicorn app.main:app --host 0.0.0.0 --port 8000` — пример запуска production-инстанса со строгими заголовками (COOP/COEP включайте по необходимости, проксируйте статику через reverse-proxy).
 - `pytest` — прогнать автотесты (включая smoke-тесты заголовков, статики и Alembic).
 - `npm run lhci --prefix root/frontend` — собрать фронтенд, запустить Lighthouse CI с бюджетами (`budget.json`) и сохранить HTML-отчёты в `root/frontend/.lighthouseci`.
+- `npm run i18n:check --prefix root/frontend` — сверить ключи переводов между `src/i18n/locales/en` и `src/i18n/locales/ru`. Тест входит в общий `npm run test --prefix root/frontend`, но эту команду удобно запускать отдельно при изменениях JSON-файлов переводов.
 
 > 💡 Перед пушем прогоните Lighthouse локально: CI падает при регрессе бюджетов, зато отчёты можно посмотреть в `root/frontend/.lighthouseci/*.report.html`.
 

--- a/root/frontend/package.json
+++ b/root/frontend/package.json
@@ -16,6 +16,7 @@
     "test": "vitest run",
     "test:ci": "vitest run --reporter=default --reporter=junit --outputFile=vitest-report.xml",
     "test:watch": "vitest",
+    "i18n:check": "vitest run src/tests/translationParity.test.ts",
     "test:e2e": "playwright test",
     "lhci": "lhci autorun --budget-path=../../budget.json --upload.target=filesystem --upload.outputDir=.lighthouseci",
     "analyze": "ANALYZE=1 vite build",

--- a/root/frontend/src/tests/translationParity.test.ts
+++ b/root/frontend/src/tests/translationParity.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const LOCALES_ROOT = path.resolve(__dirname, '../i18n/locales');
+const BASE_LOCALE = path.join(LOCALES_ROOT, 'en');
+const TARGET_LOCALE = path.join(LOCALES_ROOT, 'ru');
+
+/**
+ * Перечень путей, которые можно пропускать при сравнении.
+ * Указывайте полный путь через точку (например, "events.synonyms").
+ */
+const IGNORED_PATH_PREFIXES = [
+  // 'events.synonyms',
+];
+
+const isIgnored = (keyPath: string) =>
+  IGNORED_PATH_PREFIXES.some(
+    (ignoredPrefix) =>
+      keyPath === ignoredPrefix || keyPath.startsWith(`${ignoredPrefix}.`),
+  );
+
+type JsonValue = string | number | boolean | null | JsonObject | JsonValue[];
+
+interface JsonObject {
+  [key: string]: JsonValue;
+}
+
+const readJson = (filePath: string) =>
+  JSON.parse(readFileSync(filePath, 'utf-8')) as JsonObject;
+
+const flattenKeys = (value: JsonValue, prefix = '', keys = new Set<string>()) => {
+  if (Array.isArray(value)) {
+    if (prefix && !isIgnored(prefix)) {
+      keys.add(prefix);
+    }
+    return keys;
+  }
+
+  if (value && typeof value === 'object') {
+    for (const [key, nestedValue] of Object.entries(value)) {
+      const nextPath = prefix ? `${prefix}.${key}` : key;
+      if (isIgnored(nextPath)) {
+        continue;
+      }
+
+      if (nestedValue && typeof nestedValue === 'object' && !Array.isArray(nestedValue)) {
+        flattenKeys(nestedValue, nextPath, keys);
+        continue;
+      }
+
+      keys.add(nextPath);
+    }
+
+    return keys;
+  }
+
+  if (prefix) {
+    keys.add(prefix);
+  }
+
+  return keys;
+};
+
+const collectLocaleFiles = (localePath: string) => {
+  const files = new Map<string, string>();
+
+  const walk = (relativeDir: string) => {
+    const absoluteDir = path.join(localePath, relativeDir);
+    for (const entry of readdirSync(absoluteDir, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        walk(path.join(relativeDir, entry.name));
+        continue;
+      }
+
+      if (!entry.isFile()) {
+        continue;
+      }
+
+      if (!entry.name.endsWith('.json')) {
+        continue;
+      }
+
+      const relativePath = path
+        .join(relativeDir, entry.name)
+        .replaceAll(path.sep, path.posix.sep);
+      files.set(relativePath, path.join(absoluteDir, entry.name));
+    }
+  };
+
+  walk('');
+
+  return files;
+};
+
+describe('i18n locales parity between en and ru', () => {
+  const baseFiles = collectLocaleFiles(BASE_LOCALE);
+  const targetFiles = collectLocaleFiles(TARGET_LOCALE);
+
+  const baseFileNames = Array.from(baseFiles.keys()).sort();
+  const targetFileNames = Array.from(targetFiles.keys()).sort();
+
+  it('exposes the same set of locale files', () => {
+    expect(targetFileNames).toEqual(baseFileNames);
+  });
+
+  const allFiles = new Set([...baseFiles.keys(), ...targetFiles.keys()]);
+
+  for (const relativePath of allFiles) {
+    it(`has matching keys in ${relativePath}`, () => {
+      expect(targetFiles.has(relativePath)).toBe(true);
+      expect(baseFiles.has(relativePath)).toBe(true);
+
+      const baseJson = readJson(baseFiles.get(relativePath)!);
+      const targetJson = readJson(targetFiles.get(relativePath)!);
+
+      const baseKeys = Array.from(flattenKeys(baseJson)).sort();
+      const targetKeys = Array.from(flattenKeys(targetJson)).sort();
+
+      const missingInTarget = baseKeys.filter((key) => !targetKeys.includes(key));
+      const missingInBase = targetKeys.filter((key) => !baseKeys.includes(key));
+
+      const errorMessages = [] as string[];
+      if (missingInTarget.length > 0) {
+        errorMessages.push(
+          `Missing ${missingInTarget.length} key(s) in ru → ${missingInTarget.join(', ')}`,
+        );
+      }
+
+      if (missingInBase.length > 0) {
+        errorMessages.push(
+          `Missing ${missingInBase.length} key(s) in en → ${missingInBase.join(', ')}`,
+        );
+      }
+
+      if (errorMessages.length > 0) {
+        throw new Error(errorMessages.join('\n'));
+      }
+
+      expect(targetKeys).toEqual(baseKeys);
+    });
+  }
+});

--- a/root/frontend/src/tests/translationParity.test.ts
+++ b/root/frontend/src/tests/translationParity.test.ts
@@ -13,7 +13,7 @@ const TARGET_LOCALE = path.join(LOCALES_ROOT, 'ru');
  * Перечень путей, которые можно пропускать при сравнении.
  * Указывайте полный путь через точку (например, "events.synonyms").
  */
-const IGNORED_PATH_PREFIXES = [
+const IGNORED_PATH_PREFIXES: string[] = [
   // 'events.synonyms',
 ];
 
@@ -32,7 +32,11 @@ interface JsonObject {
 const readJson = (filePath: string) =>
   JSON.parse(readFileSync(filePath, 'utf-8')) as JsonObject;
 
-const flattenKeys = (value: JsonValue, prefix = '', keys = new Set<string>()) => {
+const flattenKeys = (
+  value: JsonValue,
+  prefix = '',
+  keys: Set<string> = new Set<string>(),
+) => {
   if (Array.isArray(value)) {
     if (prefix && !isIgnored(prefix)) {
       keys.add(prefix);
@@ -86,7 +90,8 @@ const collectLocaleFiles = (localePath: string) => {
 
       const relativePath = path
         .join(relativeDir, entry.name)
-        .replaceAll(path.sep, path.posix.sep);
+        .split(path.sep)
+        .join(path.posix.sep);
       files.set(relativePath, path.join(absoluteDir, entry.name));
     }
   };


### PR DESCRIPTION
## Summary
- add a Vitest suite that recursively compares translation key sets between the English and Russian locale directories
- expose an npm script to run the locale parity check in isolation
- document how to run the translation parity check locally in the project README

## Testing
- npm run i18n:check --prefix root/frontend

------
https://chatgpt.com/codex/tasks/task_e_68f166f58b7c83279f9d053f8ddf4f61