### PR TITLE
Use translated title for Spotify card

### DIFF
--- a/root/frontend/src/components/SpotifyConnect.tsx
+++ b/root/frontend/src/components/SpotifyConnect.tsx
@@ -83,7 +83,7 @@ export default function SpotifyConnect() {
 
   return (
     <Card sx={{ mt: 2 }}>
-      <CardHeader title="Spotify" />
+      <CardHeader title={t("settings:integrations.spotify.title")} />
       <CardContent>
         {!spotifyEnabled ? (
           <Button onClick={connect} variant="contained" disabled={actionLoading}>


### PR DESCRIPTION
## Summary
- use the existing i18n key for the Spotify integration card header

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f175afdc88832797121f9cb6357420