### PR TITLE
Add localized profile contact link titles

### DIFF
--- a/root/frontend/src/i18n/locales/en/profile.json
+++ b/root/frontend/src/i18n/locales/en/profile.json
@@ -9,7 +9,9 @@
   "aria": {
     "page": "Profile",
     "copyEmail": "Copy email",
-    "copyTelegram": "Copy Telegram handle"
+    "copyTelegram": "Copy Telegram handle",
+    "openEmail": "Open email",
+    "openTelegram": "Open Telegram"
   },
   "buttons": {
     "showQr": "Show QR"

--- a/root/frontend/src/i18n/locales/ru/profile.json
+++ b/root/frontend/src/i18n/locales/ru/profile.json
@@ -9,7 +9,9 @@
   "aria": {
     "page": "Профиль",
     "copyEmail": "Скопировать email",
-    "copyTelegram": "Скопировать ник в Telegram"
+    "copyTelegram": "Скопировать ник в Telegram",
+    "openEmail": "Открыть почтовый клиент",
+    "openTelegram": "Открыть Telegram"
   },
   "buttons": {
     "showQr": "Показать QR"

--- a/root/frontend/src/pages/Profile.tsx
+++ b/root/frontend/src/pages/Profile.tsx
@@ -911,7 +911,12 @@ export default function Profile() {
                         <Stack direction="row" spacing={1} alignItems="center" sx={{ minWidth: 0, flex: 1 }}>
                           <EmailIcon aria-hidden sx={{ fontSize: 22 }} />
                           <Typography sx={{ fontWeight: 800, wordBreak: "break-word", flex: 1 }}>
-                            <a href={`mailto:${user!.email}`} style={{ color: "inherit", textDecoration: "none" }} data-testid="profile-email-link" title="Email">
+                            <a
+                              href={`mailto:${user!.email}`}
+                              style={{ color: "inherit", textDecoration: "none" }}
+                              data-testid="profile-email-link"
+                              title={t("profile:aria.openEmail")}
+                            >
                               {user!.email}
                             </a>
                           </Typography>
@@ -937,7 +942,14 @@ export default function Profile() {
                           <Stack direction="row" spacing={1} alignItems="center" sx={{ minWidth: 0, flex: 1 }}>
                             <TelegramIcon aria-hidden sx={{ fontSize: 22 }} />
                             <Typography sx={{ fontWeight: 800, wordBreak: "break-word", flex: 1 }}>
-                              <a href={telegramHref} target="_blank" rel="noopener noreferrer" style={{ color: "inherit", textDecoration: "none" }} data-testid="profile-telegram-link" title="Telegram">
+                              <a
+                                href={telegramHref}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                style={{ color: "inherit", textDecoration: "none" }}
+                                data-testid="profile-telegram-link"
+                                title={t("profile:aria.openTelegram")}
+                              >
                                 {user!.telegram}
                               </a>
                             </Typography>


### PR DESCRIPTION
## Summary
- add translation entries for the email and Telegram contact link titles
- update the profile contact links to use the localized title attributes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f1f466009483279ab80d9280e9f844