### PR TITLE
Add localization support to file upload errors

### DIFF
--- a/root/app/api/events.py
+++ b/root/app/api/events.py
@@ -131,9 +131,7 @@ async def upload_event_file(
             status_code=403,
             detail=translate("errors.forbidden", locale=locale),
         )
-    url = await save_attachment(
-        file, "event_files", f"event_{id}", locale=locale
-    )
+    url = await save_attachment(file, "event_files", f"event_{id}", locale=locale)
     ef = models.EventFile(event_id=id, file_url=url)
     db.add(ef)
     await db.commit()

--- a/root/app/api/events.py
+++ b/root/app/api/events.py
@@ -131,7 +131,9 @@ async def upload_event_file(
             status_code=403,
             detail=translate("errors.forbidden", locale=locale),
         )
-    url = await save_attachment(file, "event_files", f"event_{id}")
+    url = await save_attachment(
+        file, "event_files", f"event_{id}", locale=locale
+    )
     ef = models.EventFile(event_id=id, file_url=url)
     db.add(ef)
     await db.commit()
@@ -167,7 +169,7 @@ async def upload_event_image(
             status_code=403,
             detail=translate("errors.forbidden", locale=locale),
         )
-    url = await save_upload(file, "event_images", "event")
+    url = await save_upload(file, "event_images", "event", locale=locale)
     return {"url": url}
 
 

--- a/root/app/api/news.py
+++ b/root/app/api/news.py
@@ -292,7 +292,7 @@ async def upload_news_image(
             status_code=403,
             detail=translate("errors.forbidden", locale=locale),
         )
-    url = await save_upload(file, "news_images", "news")
+    url = await save_upload(file, "news_images", "news", locale=locale)
     return {"url": url}
 
 

--- a/root/app/api/users.py
+++ b/root/app/api/users.py
@@ -262,10 +262,15 @@ async def update_me(
 @users_router.post("/me/avatar", response_model=schemas.UserOut)
 async def upload_avatar(
     file: UploadFile = File(...),
+    *,
+    request: Request,
     db: AsyncSession = Depends(get_db),
     user: models.User = Depends(get_current_user),
 ):
-    url = await save_upload(file, "avatars", f"user_{user.id}_avatar")
+    locale = resolve_locale(request=request, user=user)
+    url = await save_upload(
+        file, "avatars", f"user_{user.id}_avatar", locale=locale
+    )
     db_user = await db.get(models.User, user.id)
     db_user.avatar_url = url
     await db.commit()
@@ -276,10 +281,15 @@ async def upload_avatar(
 @users_router.post("/me/cover", response_model=schemas.UserOut)
 async def upload_cover(
     file: UploadFile = File(...),
+    *,
+    request: Request,
     db: AsyncSession = Depends(get_db),
     user: models.User = Depends(get_current_user),
 ):
-    url = await save_upload(file, "covers", f"user_{user.id}_cover")
+    locale = resolve_locale(request=request, user=user)
+    url = await save_upload(
+        file, "covers", f"user_{user.id}_cover", locale=locale
+    )
     db_user = await db.get(models.User, user.id)
     db_user.cover_url = url
     await db.commit()

--- a/root/app/api/users.py
+++ b/root/app/api/users.py
@@ -268,9 +268,7 @@ async def upload_avatar(
     user: models.User = Depends(get_current_user),
 ):
     locale = resolve_locale(request=request, user=user)
-    url = await save_upload(
-        file, "avatars", f"user_{user.id}_avatar", locale=locale
-    )
+    url = await save_upload(file, "avatars", f"user_{user.id}_avatar", locale=locale)
     db_user = await db.get(models.User, user.id)
     db_user.avatar_url = url
     await db.commit()
@@ -287,9 +285,7 @@ async def upload_cover(
     user: models.User = Depends(get_current_user),
 ):
     locale = resolve_locale(request=request, user=user)
-    url = await save_upload(
-        file, "covers", f"user_{user.id}_cover", locale=locale
-    )
+    url = await save_upload(file, "covers", f"user_{user.id}_cover", locale=locale)
     db_user = await db.get(models.User, user.id)
     db_user.cover_url = url
     await db.commit()

--- a/root/app/api/utils.py
+++ b/root/app/api/utils.py
@@ -3,7 +3,13 @@ from fastapi import UploadFile
 from app.utils.files import save_image
 
 
-async def save_upload(file: UploadFile, subdir: str, prefix: str) -> str:
+async def save_upload(
+    file: UploadFile,
+    subdir: str,
+    prefix: str,
+    *,
+    locale: str | None = None,
+) -> str:
     """Persist an uploaded file using the shared image helper."""
 
-    return await save_image(file, subdir, prefix)
+    return await save_image(file, subdir, prefix, locale=locale)

--- a/root/app/localization.py
+++ b/root/app/localization.py
@@ -160,6 +160,22 @@ _TRANSLATIONS: Mapping[str, Mapping[str, str]] = {
         "ru": "Доступ запрещён",
         "en": "Access denied",
     },
+    "errors.files.too_large": {
+        "ru": "Размер файла превышает допустимый предел",
+        "en": "Uploaded file exceeds the allowed size",
+    },
+    "errors.files.unsupported_type": {
+        "ru": "Неподдерживаемый тип файла",
+        "en": "Unsupported media type",
+    },
+    "errors.files.content_type_mismatch": {
+        "ru": "Тип содержимого не соответствует объявленному",
+        "en": "Content type does not match the declared value",
+    },
+    "errors.files.unsupported_extension": {
+        "ru": "Неподдерживаемое расширение файла",
+        "en": "Unsupported file extension",
+    },
     "errors.events.registration_forbidden": {
         "ru": "Регистрация на мероприятия недоступна для вашей роли",
         "en": "Event registration is not available for your role",

--- a/root/app/utils/files.py
+++ b/root/app/utils/files.py
@@ -10,6 +10,7 @@ from urllib.parse import unquote, urlparse
 from fastapi import HTTPException, UploadFile, status
 
 from app.core.config import settings
+from app.localization import translate
 
 logger = logging.getLogger(__name__)
 
@@ -36,12 +37,14 @@ def _ensure_dir(p: Path) -> None:
     p.mkdir(parents=True, exist_ok=True)
 
 
-async def _read_limited(upload: UploadFile, limit: int) -> bytes:
+async def _read_limited(
+    upload: UploadFile, limit: int, *, locale: str | None = None
+) -> bytes:
     data = await upload.read(limit + 1)
     if len(data) > limit:
         raise HTTPException(
             status_code=status.HTTP_413_CONTENT_TOO_LARGE,
-            detail="file too large",
+            detail=translate("errors.files.too_large", locale=locale),
         )
     return data
 
@@ -143,24 +146,26 @@ def _gen_name(prefix: str, ext: str) -> str:
     return f"{safe_prefix}_{token}{ext}"
 
 
-async def save_image(upload: UploadFile, subdir: str, prefix: str) -> str:
+async def save_image(
+    upload: UploadFile, subdir: str, prefix: str, *, locale: str | None = None
+) -> str:
     declared_type = (upload.content_type or "").lower()
     if declared_type not in ALLOWED_IMAGE_TYPES:
         raise HTTPException(
             status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
-            detail="unsupported media type",
+            detail=translate("errors.files.unsupported_type", locale=locale),
         )
-    data = await _read_limited(upload, MAX_IMAGE_SIZE)
+    data = await _read_limited(upload, MAX_IMAGE_SIZE, locale=locale)
     detected_type = _detect_image_mime(data)
     if detected_type not in ALLOWED_IMAGE_TYPES:
         raise HTTPException(
             status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
-            detail="unsupported media type",
+            detail=translate("errors.files.unsupported_type", locale=locale),
         )
     if detected_type != declared_type:
         raise HTTPException(
             status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
-            detail="content type mismatch",
+            detail=translate("errors.files.content_type_mismatch", locale=locale),
         )
     ext = _PREFERRED_EXTENSIONS.get(detected_type) or _ext_from_mime(detected_type)
     name = _gen_name(prefix, ext)
@@ -174,14 +179,16 @@ async def save_image(upload: UploadFile, subdir: str, prefix: str) -> str:
     return f"/static/{sanitized_subdir}/{name}"
 
 
-async def save_attachment(upload: UploadFile, subdir: str, prefix: str) -> str:
+async def save_attachment(
+    upload: UploadFile, subdir: str, prefix: str, *, locale: str | None = None
+) -> str:
     declared_raw = (upload.content_type or "").strip()
     declared_type = _normalize_mime_type(declared_raw)
     allowed_types = settings.event_file_allowed_mime_types_set
     if not declared_type or (allowed_types and declared_type not in allowed_types):
         raise HTTPException(
             status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
-            detail="unsupported media type",
+            detail=translate("errors.files.unsupported_type", locale=locale),
         )
 
     original_name = upload.filename or ""
@@ -196,19 +203,19 @@ async def save_attachment(upload: UploadFile, subdir: str, prefix: str) -> str:
         limit = 0
     if limit <= 0:
         limit = 1
-    data = await _read_limited(upload, limit)
+    data = await _read_limited(upload, limit, locale=locale)
 
     detected_type = detect_mime_type(data) or ""
     if detected_type:
         if allowed_types and detected_type not in allowed_types:
             raise HTTPException(
                 status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
-                detail="unsupported media type",
+                detail=translate("errors.files.unsupported_type", locale=locale),
             )
         if declared_type and detected_type != declared_type:
             raise HTTPException(
                 status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
-                detail="content type mismatch",
+                detail=translate("errors.files.content_type_mismatch", locale=locale),
             )
 
     def _ext_without_dot_from_mime(mime: str) -> str:
@@ -229,7 +236,7 @@ async def save_attachment(upload: UploadFile, subdir: str, prefix: str) -> str:
     ):
         raise HTTPException(
             status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
-            detail="unsupported file extension",
+            detail=translate("errors.files.unsupported_extension", locale=locale),
         )
 
     candidate_exts: tuple[str, ...] = (
@@ -249,7 +256,7 @@ async def save_attachment(upload: UploadFile, subdir: str, prefix: str) -> str:
     if not chosen_ext_without_dot and allowed_exts:
         raise HTTPException(
             status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
-            detail="unsupported file extension",
+            detail=translate("errors.files.unsupported_extension", locale=locale),
         )
 
     if not chosen_ext_without_dot:

--- a/root/tests/test_event_file_upload.py
+++ b/root/tests/test_event_file_upload.py
@@ -9,10 +9,10 @@ from starlette.datastructures import Headers
 
 from app.api import events
 from app.core.config import settings
+from app.localization import translate
 from app.models import models
 from app.schemas import schemas
 from app.utils import files
-from app.localization import translate
 
 
 async def _create_event(db_session, user: models.User) -> models.Event:
@@ -96,9 +96,7 @@ async def test_upload_event_file_rejects_large_payload(
         )
 
     assert excinfo.value.status_code == status.HTTP_413_CONTENT_TOO_LARGE
-    assert excinfo.value.detail == translate(
-        "errors.files.too_large", locale="en"
-    )
+    assert excinfo.value.detail == translate("errors.files.too_large", locale="en")
     folder = tmp_path / "event_files"
     assert not folder.exists()
 

--- a/root/tests/test_event_file_upload.py
+++ b/root/tests/test_event_file_upload.py
@@ -12,6 +12,7 @@ from app.core.config import settings
 from app.models import models
 from app.schemas import schemas
 from app.utils import files
+from app.localization import translate
 
 
 async def _create_event(db_session, user: models.User) -> models.Event:
@@ -95,6 +96,9 @@ async def test_upload_event_file_rejects_large_payload(
         )
 
     assert excinfo.value.status_code == status.HTTP_413_CONTENT_TOO_LARGE
+    assert excinfo.value.detail == translate(
+        "errors.files.too_large", locale="en"
+    )
     folder = tmp_path / "event_files"
     assert not folder.exists()
 
@@ -123,6 +127,9 @@ async def test_upload_event_file_rejects_forbidden_type(
         )
 
     assert excinfo.value.status_code == status.HTTP_415_UNSUPPORTED_MEDIA_TYPE
+    assert excinfo.value.detail == translate(
+        "errors.files.unsupported_type", locale="en"
+    )
     folder = tmp_path / "event_files"
     assert not folder.exists()
 
@@ -156,7 +163,9 @@ async def test_upload_event_file_rejects_mismatched_magic_bytes(
         )
 
     assert excinfo.value.status_code == status.HTTP_415_UNSUPPORTED_MEDIA_TYPE
-    assert excinfo.value.detail == "content type mismatch"
+    assert excinfo.value.detail == translate(
+        "errors.files.content_type_mismatch", locale="en"
+    )
     folder = tmp_path / "event_files"
     assert not folder.exists()
 

--- a/root/tests/test_file_utils.py
+++ b/root/tests/test_file_utils.py
@@ -3,10 +3,11 @@ import io
 import re
 
 import pytest
-from fastapi import UploadFile
+from fastapi import HTTPException, UploadFile
 from starlette.datastructures import Headers
 
 from app.core.config import settings
+from app.localization import translate
 from app.utils import files
 
 
@@ -48,3 +49,42 @@ async def test_save_image_offloads_io(tmp_path, monkeypatch):
     assert any(stored.iterdir())
     assert any(func is files._ensure_dir for func, _, _ in calls)
     assert any(func.__name__ == "write_bytes" for func, _, _ in calls)
+
+
+@pytest.mark.parametrize(
+    "locale",
+    ["ru", "en", "de"],
+)
+@pytest.mark.asyncio
+async def test_save_image_reports_localized_unsupported_type(locale):
+    upload = UploadFile(
+        filename="avatar.gif",
+        file=io.BytesIO(b"GIF89a" + b"\x00" * 10),
+        headers=Headers({"content-type": "image/gif"}),
+    )
+
+    with pytest.raises(HTTPException) as excinfo:
+        await files.save_image(upload, "avatars", "Profile Pic", locale=locale)
+
+    assert excinfo.value.detail == translate(
+        "errors.files.unsupported_type", locale=locale
+    )
+
+
+@pytest.mark.asyncio
+async def test_save_image_reports_localized_size_limit(monkeypatch):
+    payload = b"\x89PNG\r\n\x1a\n" + b"\x00" * 10
+    upload = UploadFile(
+        filename="avatar.png",
+        file=io.BytesIO(payload),
+        headers=Headers({"content-type": "image/png"}),
+    )
+
+    monkeypatch.setattr(files, "MAX_IMAGE_SIZE", 1)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await files.save_image(upload, "avatars", "Profile Pic", locale="ru")
+
+    assert excinfo.value.detail == translate(
+        "errors.files.too_large", locale="ru"
+    )

--- a/root/tests/test_file_utils.py
+++ b/root/tests/test_file_utils.py
@@ -85,6 +85,4 @@ async def test_save_image_reports_localized_size_limit(monkeypatch):
     with pytest.raises(HTTPException) as excinfo:
         await files.save_image(upload, "avatars", "Profile Pic", locale="ru")
 
-    assert excinfo.value.detail == translate(
-        "errors.files.too_large", locale="ru"
-    )
+    assert excinfo.value.detail == translate("errors.files.too_large", locale="ru")


### PR DESCRIPTION
## Summary
- add localized file error messages and use them when validating uploads
- propagate the resolved locale through upload helpers so file errors respect user language
- extend file upload tests to cover localized error messaging and fallback behaviour

## Testing
- pytest root/tests/test_file_utils.py root/tests/test_event_file_upload.py

------
https://chatgpt.com/codex/tasks/task_e_68f1fab2045483279fcf40826253807f