### PR TITLE
Fix Vite dev proxy intercepting static shell translations

### DIFF
--- a/root/frontend/vite.config.mts
+++ b/root/frontend/vite.config.mts
@@ -70,8 +70,8 @@ export default defineConfig(({ mode }) => {
   const proxy = {
     "/api": mk(true),
     "/auth": mk(),
-    "/static": mk(),
-    "/media": mk(),
+    "/static/": mk(),
+    "/media/": mk(),
     "/spotify": mk(),
     "/notifications": mk(),
     "/push": mk(),


### PR DESCRIPTION
## Summary
- narrow the Vite dev proxy rules for static and media assets so that `/static-shell-i18n.js` is served locally

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f2605e5a0883278b722bdb661b83bb