### PR TITLE
Fix notifications read field serialization

### DIFF
--- a/root/app/api/notifications.py
+++ b/root/app/api/notifications.py
@@ -81,7 +81,7 @@ def _serialize_notification(
         "type": getattr(record, "type", None),
         "url": getattr(record, "url", None),
         "created_at": created_at,
-        "read": getattr(record, "read", False),
+        "read": bool(getattr(record, "read", False)),
         "read_at": getattr(record, "read_at", None),
     }
     return NotificationOut.model_validate(data)


### PR DESCRIPTION
## Summary
- ensure notification list serialization always casts the `read` attribute to a boolean

## Testing
- pytest root/tests/test_notifications_api.py -q

------
https://chatgpt.com/codex/tasks/task_e_68f263c4759883279e13e5c859515cfe