### PR TITLE
Handle missing notification timestamps gracefully

### DIFF
--- a/root/app/api/notifications.py
+++ b/root/app/api/notifications.py
@@ -19,7 +19,11 @@ from app.services.notifications import (
 router = APIRouter(prefix="/notifications", tags=["notifications"])
 
 
-def _ensure_utc(dt: datetime) -> datetime:
+def _ensure_utc(dt: datetime | None) -> datetime:
+    """Normalize datetimes from the database to aware UTC values."""
+
+    if not isinstance(dt, datetime):
+        return datetime.now(UTC)
     return dt.astimezone(UTC) if dt.tzinfo else dt.replace(tzinfo=UTC)
 
 

--- a/root/tests/test_notifications_api.py
+++ b/root/tests/test_notifications_api.py
@@ -1,6 +1,6 @@
 import pytest
 from httpx import AsyncClient
-from sqlalchemy import select
+from sqlalchemy import select, update
 
 from app.auth.security import get_password_hash
 from app.models.models import Notification
@@ -68,3 +68,36 @@ async def test_clear_notifications_removes_only_current_user(
 
     assert remaining_user == []
     assert len(remaining_other) == 1
+
+
+@pytest.mark.anyio
+async def test_list_notifications_handles_missing_created_at(
+    async_client: AsyncClient,
+    user_factory,
+    db_session,
+):
+    password = "MissingTime123!"
+    hashed = get_password_hash(password)
+    user = await user_factory(hashed_password=hashed, is_active=True)
+
+    headers = await _login(async_client, user.email, password)
+
+    notification = Notification(user_id=user.id, title="Без времени", body="Тест")
+    db_session.add(notification)
+    await db_session.commit()
+
+    await db_session.execute(
+        update(Notification)
+        .where(Notification.id == notification.id)
+        .values(created_at=None)
+    )
+    await db_session.commit()
+
+    response = await async_client.get("/notifications", headers=headers)
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["items"], "Expected at least one notification"
+    first = payload["items"][0]
+    assert first["title"] == "Без времени"
+    assert first["created_at"], "created_at should be populated even if missing in DB"


### PR DESCRIPTION
## Summary
- normalize notification timestamps in the list endpoint so null values no longer crash pagination cursors
- cover the regression with a notifications API test that forces a missing `created_at`

## Testing
- pytest tests/test_notifications_api.py -q

------
https://chatgpt.com/codex/tasks/task_e_68f2c81170248327968434e981f7665e