### PR TITLE
Handle malformed notification payloads

### DIFF
--- a/root/app/api/notifications.py
+++ b/root/app/api/notifications.py
@@ -1,5 +1,5 @@
-from datetime import UTC, datetime, timedelta
 from collections.abc import Mapping
+from datetime import UTC, datetime, timedelta
 from typing import Any, Optional, Tuple
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
@@ -51,7 +51,9 @@ def _parse_datetime(value: Any) -> datetime | None:
             except (OverflowError, OSError, ValueError):
                 return None
         else:
-            return parsed.astimezone(UTC) if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+            return (
+                parsed.astimezone(UTC) if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+            )
 
     return None
 

--- a/root/app/api/notifications.py
+++ b/root/app/api/notifications.py
@@ -1,8 +1,9 @@
 from datetime import UTC, datetime, timedelta
-from typing import Optional, Tuple
+from collections.abc import Mapping
+from typing import Any, Optional, Tuple
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-from sqlalchemy import and_, delete, desc, func, or_, select, update
+from sqlalchemy import String, and_, delete, desc, func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps import get_current_user
@@ -19,12 +20,47 @@ from app.services.notifications import (
 router = APIRouter(prefix="/notifications", tags=["notifications"])
 
 
-def _ensure_utc(dt: datetime | None) -> datetime:
+def _parse_datetime(value: Any) -> datetime | None:
+    """Attempt to coerce various inputs into an aware UTC datetime."""
+
+    if isinstance(value, datetime):
+        return value.astimezone(UTC) if value.tzinfo else value.replace(tzinfo=UTC)
+
+    if isinstance(value, (int, float)):
+        try:
+            return datetime.fromtimestamp(value, UTC)
+        except (OverflowError, OSError, ValueError):
+            return None
+
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        candidate = text.replace("Z", "+00:00")
+        try:
+            parsed = datetime.fromisoformat(candidate)
+        except ValueError:
+            try:
+                numeric = float(text)
+            except ValueError:
+                return None
+            if numeric > 1e12:
+                numeric /= 1000.0
+            try:
+                return datetime.fromtimestamp(numeric, UTC)
+            except (OverflowError, OSError, ValueError):
+                return None
+        else:
+            return parsed.astimezone(UTC) if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+
+    return None
+
+
+def _ensure_utc(dt: Any) -> datetime:
     """Normalize datetimes from the database to aware UTC values."""
 
-    if not isinstance(dt, datetime):
-        return datetime.now(UTC)
-    return dt.astimezone(UTC) if dt.tzinfo else dt.replace(tzinfo=UTC)
+    parsed = _parse_datetime(dt)
+    return parsed or datetime.now(UTC)
 
 
 def _encode_cursor(dt: datetime, nid: int) -> str:
@@ -64,29 +100,38 @@ def _localized_notification_field(
 
 
 def _serialize_notification(
-    record: Notification, locale: str | None
+    record: Notification | Mapping[str, Any], locale: str | None
 ) -> NotificationOut:
-    created_at = getattr(record, "created_at", None) or datetime.now(UTC)
+    if isinstance(record, Mapping):
+        getter = record.get
+    else:
+        getter = record.__getattribute__  # type: ignore[attr-defined]
+
+    created_at = _ensure_utc(getter("created_at", None))
+    read_at_raw = getter("read_at", None)
+    read_at = _parse_datetime(read_at_raw) if read_at_raw else None
+    type_raw = getter("type", None)
+    url_raw = getter("url", None)
     data = {
-        "id": record.id,
+        "id": getter("id"),
         "title": _localized_notification_field(
             locale,
-            getattr(record, "title", None),
-            getattr(record, "title_en", None),
+            getter("title", None),
+            getter("title_en", None),
             required=True,
         ),
         "body": _localized_notification_field(
             locale,
-            getattr(record, "body", None),
-            getattr(record, "body_en", None),
+            getter("body", None),
+            getter("body_en", None),
         ),
-        "title_en": sanitize_optional_text(getattr(record, "title_en", None)),
-        "body_en": sanitize_optional_text(getattr(record, "body_en", None)),
-        "type": getattr(record, "type", None),
-        "url": getattr(record, "url", None),
+        "title_en": sanitize_optional_text(getter("title_en", None)),
+        "body_en": sanitize_optional_text(getter("body_en", None)),
+        "type": sanitize_optional_text(type_raw),
+        "url": sanitize_optional_text(url_raw),
         "created_at": created_at,
-        "read": bool(getattr(record, "read", False)),
-        "read_at": getattr(record, "read_at", None),
+        "read": bool(getter("read", False)),
+        "read_at": read_at,
     }
     return NotificationOut.model_validate(data)
 
@@ -100,7 +145,9 @@ async def list_notifications(
     user: User = Depends(get_current_user),
 ):
     locale = resolve_locale(request=request, user=user)
-    where = [Notification.user_id == user.id]
+    table = Notification.__table__
+    cols = table.c
+    where = [cols.user_id == user.id]
     if cursor:
         parsed = _decode_cursor(cursor)
         if not parsed:
@@ -112,18 +159,29 @@ async def list_notifications(
         c_dt = _ensure_utc(c_dt)
         where.append(
             or_(
-                Notification.created_at < c_dt,
-                and_(Notification.created_at == c_dt, Notification.id < c_id),
+                cols.created_at < c_dt,
+                and_(cols.created_at == c_dt, cols.id < c_id),
             )
         )
 
     q_items = (
-        select(Notification)
+        select(
+            cols.id,
+            cols.title,
+            cols.title_en,
+            cols.body,
+            cols.body_en,
+            cols.type,
+            cols.url,
+            cols.created_at.cast(String).label("created_at"),
+            cols.read,
+            cols.read_at.cast(String).label("read_at"),
+        )
         .where(and_(*where))
-        .order_by(desc(Notification.created_at), desc(Notification.id))
+        .order_by(desc(cols.created_at), desc(cols.id))
         .limit(limit + 1)
     )
-    rows = (await db.execute(q_items)).scalars().all()
+    rows = (await db.execute(q_items)).mappings().all()
     items = rows[:limit]
     has_more = len(rows) > limit
 
@@ -132,11 +190,12 @@ async def list_notifications(
     )
     unread = (await db.execute(q_unread)).scalar_one() or 0
 
-    next_cursor = (
-        _encode_cursor(_ensure_utc(items[-1].created_at), items[-1].id)
-        if items and has_more
-        else None
-    )
+    next_cursor = None
+    if items and has_more:
+        last = items[-1]
+        last_created = _ensure_utc(last["created_at"])
+        last_id = last["id"]
+        next_cursor = _encode_cursor(last_created, last_id)
 
     return NotificationsListOut(
         items=[_serialize_notification(n, locale) for n in items],

--- a/root/app/crud/__init__.py
+++ b/root/app/crud/__init__.py
@@ -28,12 +28,21 @@ _EVENT_TIME_ORDER_KEY = "validation.events.end_after_start"
 _EVENT_TIME_PAIR_KEY = "validation.events.times_required"
 
 
-def sanitize_optional_text(value: str | None) -> str | None:
+def sanitize_optional_text(value: Any) -> str | None:
+    """Normalize optional text values to strings."""
+
     if value is None:
         return None
-    if isinstance(value, str) and not value.strip():
-        return None
-    return value
+    if isinstance(value, (bytes, bytearray)):
+        try:
+            decoded = value.decode("utf-8")
+        except Exception:
+            decoded = value.decode("utf-8", "ignore")
+        return decoded if decoded.strip() else None
+    if isinstance(value, str):
+        return value if value.strip() else None
+    text = str(value)
+    return text if text.strip() else None
 
 
 async def create_user(db: AsyncSession, user_in: schemas.UserCreate):

--- a/root/tests/test_notifications_api.py
+++ b/root/tests/test_notifications_api.py
@@ -1,6 +1,6 @@
 import pytest
 from httpx import AsyncClient
-from sqlalchemy import select, update
+from sqlalchemy import select, text, update
 
 from app.auth.security import get_password_hash
 from app.models.models import Notification
@@ -93,7 +93,10 @@ async def test_list_notifications_handles_missing_created_at(
     )
     await db_session.commit()
 
-    response = await async_client.get("/notifications", headers=headers)
+    response = await async_client.get(
+        "/notifications?lang=ru",
+        headers=headers,
+    )
 
     assert response.status_code == 200
     payload = response.json()
@@ -101,3 +104,76 @@ async def test_list_notifications_handles_missing_created_at(
     first = payload["items"][0]
     assert first["title"] == "Без времени"
     assert first["created_at"], "created_at should be populated even if missing in DB"
+
+
+@pytest.mark.anyio
+async def test_list_notifications_handles_invalid_data(
+    async_client: AsyncClient,
+    user_factory,
+    db_session,
+):
+    password = "DataMismatch123!"
+    hashed = get_password_hash(password)
+    user = await user_factory(hashed_password=hashed, is_active=True)
+
+    headers = await _login(async_client, user.email, password)
+
+    notification = Notification(
+        user_id=user.id,
+        title="Странное уведомление",
+        body="Странное тело",
+        read=True,
+    )
+    db_session.add(notification)
+    await db_session.commit()
+
+    await db_session.execute(
+        text(
+            """
+            UPDATE notifications
+            SET title_en = :title_en,
+                body_en = :body_en,
+                type = :type_value,
+                url = :url_value,
+                created_at = :created_at,
+                read_at = :read_at
+            WHERE id = :id
+            """
+        ),
+        {
+            "title_en": 123,
+            "body_en": b"bytes",
+            "type_value": "{'kind': 'system'}",
+            "url_value": 456,
+            "created_at": "not-a-valid-date",
+            "read_at": " ",
+            "id": notification.id,
+        },
+    )
+    await db_session.commit()
+
+    response = await async_client.get(
+        "/notifications?lang=ru",
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["items"], "Expected at least one notification"
+    first = payload["items"][0]
+
+    assert first["title"] == "Странное уведомление"
+    assert first["body"] == "Странное тело"
+    assert first["title_en"] == "123"
+    assert first["body_en"] == "bytes"
+    assert first["type"] == "{'kind': 'system'}"
+    assert first["url"] == "456"
+    assert first["read"] is True
+    assert first["read_at"] is None
+
+    created_at = first["created_at"]
+    assert created_at
+    # Should be parseable as ISO datetime
+    from datetime import datetime
+
+    datetime.fromisoformat(created_at.replace("Z", "+00:00"))


### PR DESCRIPTION
## Summary
- harden the notifications listing endpoint against malformed rows by coercing timestamps and cleaning text data
- normalize optional text values to strings to avoid pydantic validation failures
- add a regression test covering notifications with inconsistent database values

## Testing
- pytest root/tests -k notifications -vv

------
https://chatgpt.com/codex/tasks/task_e_68f2cd050d408327936a287e229937b7