### PR TITLE
Fix serialization of ORM notifications records

### DIFF
--- a/root/app/api/notifications.py
+++ b/root/app/api/notifications.py
@@ -107,7 +107,13 @@ def _serialize_notification(
     if isinstance(record, Mapping):
         getter = record.get
     else:
-        getter = record.__getattribute__  # type: ignore[attr-defined]
+        # ``getattr`` gracefully falls back to a default value, unlike
+        # ``object.__getattribute__`` which expects only the attribute name.
+        # Using a small wrapper keeps the ``getter`` interface consistent for
+        # mapping and ORM objects alike, preventing ``TypeError`` when
+        # additional arguments are supplied (as ``dict.get`` supports).
+        def getter(key: str, default: Any = None) -> Any:
+            return getattr(record, key, default)
 
     created_at = _ensure_utc(getter("created_at", None))
     read_at_raw = getter("read_at", None)

--- a/root/tests/test_notifications_api.py
+++ b/root/tests/test_notifications_api.py
@@ -2,6 +2,7 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy import select, text, update
 
+from app.api.notifications import _serialize_notification
 from app.auth.security import get_password_hash
 from app.models.models import Notification
 
@@ -177,3 +178,24 @@ async def test_list_notifications_handles_invalid_data(
     from datetime import datetime
 
     datetime.fromisoformat(created_at.replace("Z", "+00:00"))
+
+
+def test_serialize_notification_accepts_orm_instance():
+    notification = Notification(
+        id=42,
+        user_id=10,
+        title="Прямой доступ",
+        body="Проверка",
+        type="system",
+        url="/test",
+        read=True,
+    )
+
+    serialized = _serialize_notification(notification, locale="ru")
+
+    assert serialized.id == 42
+    assert serialized.title == "Прямой доступ"
+    assert serialized.body == "Проверка"
+    assert serialized.type == "system"
+    assert serialized.url == "/test"
+    assert serialized.read is True


### PR DESCRIPTION
## Summary
- wrap attribute access in the notifications serializer so ORM objects no longer raise TypeError
- add a regression test covering serialization of ORM Notification instances

## Testing
- pytest root/tests/test_notifications_api.py -q

------
https://chatgpt.com/codex/tasks/task_e_68f3a1aad77483279d0006826d2c6b68