### PR TITLE
Fix QR code generation import and add event detail test

### DIFF
--- a/root/app/api/events.py
+++ b/root/app/api/events.py
@@ -1,4 +1,5 @@
 import logging
+import uuid
 from typing import List
 
 from fastapi import (

--- a/root/tests/test_event_time_constraints.py
+++ b/root/tests/test_event_time_constraints.py
@@ -3,8 +3,8 @@ from datetime import datetime, timedelta, timezone
 import pytest
 from sqlalchemy.exc import IntegrityError
 
-from app.auth.security import get_password_hash
 from app import crud
+from app.auth.security import get_password_hash
 from app.localization import translate
 from app.models import models
 from app.schemas import schemas

--- a/root/tests/test_event_time_constraints.py
+++ b/root/tests/test_event_time_constraints.py
@@ -3,12 +3,24 @@ from datetime import datetime, timedelta, timezone
 import pytest
 from sqlalchemy.exc import IntegrityError
 
+from app.auth.security import get_password_hash
 from app import crud
 from app.localization import translate
 from app.models import models
 from app.schemas import schemas
 
 pytestmark = pytest.mark.anyio("asyncio")
+
+
+async def _login(async_client, email: str, password: str) -> dict[str, str]:
+    response = await async_client.post(
+        "/auth/login",
+        data={"username": email, "password": password},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert response.status_code == 200
+    token = response.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
 
 
 async def test_create_event_guard(db_session, user_factory):
@@ -107,3 +119,39 @@ async def test_get_all_events_respects_locale(db_session, user_factory):
     assert en_events[0].event_type == "Lecture"
     assert ru_events[0].about == "Русский текст"
     assert en_events[0].about == "English text"
+
+
+async def test_event_detail_returns_qr_code_after_registration(
+    async_client, db_session, user_factory
+):
+    password = "QrCodePass123!"
+    student = await user_factory(
+        hashed_password=get_password_hash(password), is_active=True
+    )
+    admin = await user_factory(role="admin")
+
+    now = datetime.now(timezone.utc)
+    event = models.Event(
+        title="QR enabled",
+        starts_at=now + timedelta(hours=1),
+        ends_at=now + timedelta(hours=2),
+        created_by=admin.id,
+        is_active=True,
+    )
+    db_session.add(event)
+    await db_session.commit()
+    await db_session.refresh(event)
+
+    headers = await _login(async_client, student.email, password)
+
+    attend_response = await async_client.post(
+        "/events/attendance", headers=headers, json={"event_id": event.id}
+    )
+    assert attend_response.status_code == 200
+    qr_code = attend_response.json()["qr_code"]
+    assert qr_code
+
+    detail_response = await async_client.get(f"/events/{event.id}", headers=headers)
+    assert detail_response.status_code == 200
+    payload = detail_response.json()
+    assert payload["my_qr_code"] == qr_code


### PR DESCRIPTION
## Summary
- add an explicit uuid import for event detail QR code generation
- add automated coverage ensuring event details return QR codes after registration

## Testing
- pytest root/tests/test_event_time_constraints.py

------
https://chatgpt.com/codex/tasks/task_e_68f3cc90f2788327942651ab3221d41f