### PR TITLE
Restrict user creation endpoint to admins

### DIFF
--- a/root/app/api/users.py
+++ b/root/app/api/users.py
@@ -298,8 +298,14 @@ async def create_user(
     data: schemas.UserCreate,
     request: Request,
     db: AsyncSession = Depends(get_db),
+    user: models.User = Depends(get_current_user),
 ):
-    locale = resolve_locale(request=request)
+    locale = resolve_locale(request=request, user=user)
+    if user.role != "admin":
+        raise HTTPException(
+            status_code=403,
+            detail=translate("errors.forbidden", locale=locale),
+        )
     if data.role in ["teacher", "admin"]:
         if not data.invite_code:
             raise HTTPException(

--- a/root/tests/test_auth_security.py
+++ b/root/tests/test_auth_security.py
@@ -1,4 +1,5 @@
 import pytest
+from fastapi import status
 from passlib.hash import bcrypt
 
 from app.auth.security import (
@@ -124,3 +125,90 @@ async def test_login_migrates_legacy_hash(async_client, user_factory, db_session
     await db_session.refresh(user)
     assert user.hashed_password.startswith("$argon2id$")
     assert verify_password(password, user.hashed_password)
+
+
+@pytest.mark.anyio
+async def test_create_user_requires_authentication(async_client):
+    payload = {
+        "email": "unauthorized@example.com",
+        "password": "ValidPass123!",
+        "role": "student",
+    }
+
+    response = await async_client.post("/users", json=payload)
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.anyio
+async def test_create_user_forbidden_for_non_admin(async_client, user_factory):
+    password = "UserPass123!"
+    user = await user_factory(
+        role="student",
+        hashed_password=get_password_hash(password),
+    )
+
+    login_response = await async_client.post(
+        "/auth/login",
+        data={"username": user.email, "password": password},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+
+    assert login_response.status_code == status.HTTP_200_OK
+    token = login_response.json()["access_token"]
+
+    payload = {
+        "email": "new-student@example.com",
+        "password": "ValidPass456!",
+        "role": "student",
+    }
+
+    response = await async_client.post(
+        "/users",
+        json=payload,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept-Language": "en",
+        },
+    )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.json() == {"detail": "Access denied"}
+
+
+@pytest.mark.anyio
+async def test_create_user_allows_admin(async_client, user_factory):
+    password = "AdminPass123!"
+    admin = await user_factory(
+        role="admin",
+        hashed_password=get_password_hash(password),
+    )
+
+    login_response = await async_client.post(
+        "/auth/login",
+        data={"username": admin.email, "password": password},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+
+    assert login_response.status_code == status.HTTP_200_OK
+    token = login_response.json()["access_token"]
+
+    payload = {
+        "email": "created-by-admin@example.com",
+        "password": "ValidPass789!",
+        "role": "student",
+    }
+
+    response = await async_client.post(
+        "/users",
+        json=payload,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept-Language": "en",
+        },
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    body = response.json()
+    assert body["email"] == payload["email"]
+    assert body["role"] == "student"


### PR DESCRIPTION
## Summary
- require authentication and admin role when creating users via the /users endpoint
- return a localized 403 error for non-admin callers
- add tests covering anonymous, non-admin, and admin access to the user creation route

## Testing
- pytest tests/test_auth_security.py

------
https://chatgpt.com/codex/tasks/task_e_68f3d7c9867c8327bff944d995ae9de0