### PR TITLE
Add active session tracking for JWT authentication

### DIFF
--- a/root/alembic/versions/202503010001_create_active_sessions_table.py
+++ b/root/alembic/versions/202503010001_create_active_sessions_table.py
@@ -3,6 +3,7 @@
 from typing import Sequence, Union
 
 import sqlalchemy as sa
+
 from alembic import op
 
 # revision identifiers, used by Alembic.
@@ -39,9 +40,7 @@ def upgrade() -> None:
     op.create_index(
         "ix_active_sessions_revoked_at", "active_sessions", ["revoked_at"], unique=False
     )
-    op.create_index(
-        "ix_active_sessions_jti", "active_sessions", ["jti"], unique=True
-    )
+    op.create_index("ix_active_sessions_jti", "active_sessions", ["jti"], unique=True)
 
 
 def downgrade() -> None:

--- a/root/alembic/versions/202503010001_create_active_sessions_table.py
+++ b/root/alembic/versions/202503010001_create_active_sessions_table.py
@@ -1,0 +1,53 @@
+"""Create active sessions table."""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "202503010001"
+down_revision: Union[str, None] = "202502010001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Apply Create active sessions table."""
+    op.create_table(
+        "active_sessions",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("jti", sa.String(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.UniqueConstraint("jti", name="uq_active_sessions_jti"),
+    )
+    op.create_index(
+        "ix_active_sessions_user_id", "active_sessions", ["user_id"], unique=False
+    )
+    op.create_index(
+        "ix_active_sessions_expires_at", "active_sessions", ["expires_at"], unique=False
+    )
+    op.create_index(
+        "ix_active_sessions_revoked_at", "active_sessions", ["revoked_at"], unique=False
+    )
+    op.create_index(
+        "ix_active_sessions_jti", "active_sessions", ["jti"], unique=True
+    )
+
+
+def downgrade() -> None:
+    """Revert Create active sessions table."""
+    op.drop_index("ix_active_sessions_jti", table_name="active_sessions")
+    op.drop_index("ix_active_sessions_revoked_at", table_name="active_sessions")
+    op.drop_index("ix_active_sessions_expires_at", table_name="active_sessions")
+    op.drop_index("ix_active_sessions_user_id", table_name="active_sessions")
+    op.drop_table("active_sessions")

--- a/root/app/api/deps.py
+++ b/root/app/api/deps.py
@@ -1,10 +1,10 @@
+from datetime import UTC, datetime
 from typing import Annotated
 
-from datetime import UTC, datetime
 from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import OAuth2PasswordBearer
-from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth.security import decode_token
 from app.core.database import get_db

--- a/root/app/api/deps.py
+++ b/root/app/api/deps.py
@@ -1,13 +1,15 @@
 from typing import Annotated
 
+from datetime import UTC, datetime
 from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import OAuth2PasswordBearer
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
 
 from app.auth.security import decode_token
 from app.core.database import get_db
 from app.localization import resolve_locale, translate
-from app.models.models import User
+from app.models.models import ActiveSession, User
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/login", auto_error=False)
 
@@ -30,11 +32,28 @@ async def get_current_user(
     if not payload:
         raise credentials_exception
     sub = payload.get("sub")
+    jti = payload.get("jti")
     try:
         user_id = int(sub)
     except (TypeError, ValueError):
         raise credentials_exception
     user = await db.get(User, user_id)
     if not user or not user.is_active:
+        raise credentials_exception
+    if not jti:
+        raise credentials_exception
+    res = await db.execute(select(ActiveSession).where(ActiveSession.jti == jti))
+    session = res.scalars().first()
+    now = datetime.now(UTC)
+    if not session or session.user_id != user.id:
+        raise credentials_exception
+    if session.revoked_at is not None:
+        raise credentials_exception
+    expires_at = session.expires_at
+    if expires_at is None:
+        raise credentials_exception
+    if expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=UTC)
+    if expires_at <= now:
         raise credentials_exception
     return user

--- a/root/app/api/spotify.py
+++ b/root/app/api/spotify.py
@@ -183,7 +183,7 @@ async def _ensure_access_token(
 
 @router.get("/auth-url", response_model=SpotifyAuthURL)
 async def spotify_auth_url(user: User = Depends(get_current_user)):
-    state = create_access_token(str(user.id), expires_delta=10)
+    state = await create_access_token(str(user.id), expires_delta=10)
     params = {
         "client_id": settings.spotify_client_id,
         "response_type": "code",

--- a/root/app/auth/auth.py
+++ b/root/app/auth/auth.py
@@ -8,13 +8,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth.security import (
     create_access_token,
+    decode_token,
     get_password_hash,
     verify_and_update_password,
 )
 from app.core.config import settings
 from app.core.database import get_db
 from app.localization import resolve_locale, translate
-from app.models.models import User
+from app.models.models import ActiveSession, User
 from app.schemas.schemas import Token, UserCreate
 from app.utils.ratelimit import sensitive_route_limit
 
@@ -107,7 +108,7 @@ async def login(
         user.hashed_password = new_hash
         await db.commit()
         await db.refresh(user)
-    token = create_access_token(str(user_id))
+    token = await create_access_token(str(user_id), db=db)
     _set_access_token_cookie(response, token)
     return {"access_token": token, "token_type": "bearer"}
 
@@ -158,7 +159,7 @@ async def login_json(
         user.hashed_password = new_hash
         await db.commit()
         await db.refresh(user)
-    token = create_access_token(str(user_id))
+    token = await create_access_token(str(user_id), db=db)
     _set_access_token_cookie(response, token)
     return {"access_token": token, "token_type": "bearer"}
 
@@ -195,8 +196,30 @@ async def register(
 
 
 @router.post("/logout", status_code=status.HTTP_200_OK)
-async def logout(response: Response):
+async def logout(
+    response: Response,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+):
     """Terminate the client session."""
+
+    raw_token: str | None = None
+    auth_header = request.headers.get("Authorization")
+    if auth_header:
+        scheme, _, value = auth_header.partition(" ")
+        if scheme.lower() == "bearer":
+            raw_token = value.strip() or None
+    if raw_token is None:
+        raw_token = request.cookies.get("access_token")
+
+    payload = decode_token(raw_token) if raw_token else None
+    jti = payload.get("jti") if payload else None
+    if jti:
+        res = await db.execute(select(ActiveSession).where(ActiveSession.jti == jti))
+        session = res.scalars().first()
+        if session and session.revoked_at is None:
+            session.revoked_at = datetime.now(UTC)
+            await db.commit()
 
     _clear_access_token_cookie(response)
     return {"status": "ok"}

--- a/root/app/auth/security.py
+++ b/root/app/auth/security.py
@@ -123,7 +123,9 @@ async def create_access_token(
         try:
             user_id = int(sub)
         except (TypeError, ValueError):  # pragma: no cover - defensive guard
-            raise ValueError("sub must be an integer when persisting sessions") from None
+            raise ValueError(
+                "sub must be an integer when persisting sessions"
+            ) from None
         session = ActiveSession(user_id=user_id, jti=jti, expires_at=expires_at)
         db.add(session)
         await db.commit()

--- a/root/app/auth/security.py
+++ b/root/app/auth/security.py
@@ -1,12 +1,15 @@
 from datetime import datetime, timedelta, timezone
 from typing import Any, Union
+from uuid import uuid4
 
 from jose import JWTError, jwt
 from passlib.context import CryptContext
 from passlib.hash import bcrypt as passlib_bcrypt
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
 from app.localization import translate
+from app.models.models import ActiveSession
 
 PASSWORD_MIN_LENGTH = 8
 PASSWORD_MAX_LENGTH = 200
@@ -96,20 +99,35 @@ def get_password_hash(password: str, *, locale: str | None = None) -> str:
     return pwd_context.hash(password)
 
 
-def create_access_token(
-    sub: Union[str, Any], expires_delta: int | None = None, extra: dict | None = None
+async def create_access_token(
+    sub: Union[str, Any],
+    expires_delta: int | None = None,
+    extra: dict | None = None,
+    db: AsyncSession | None = None,
 ) -> str:
     minutes = expires_delta or settings.access_token_expire_minutes
     now = datetime.now(timezone.utc)
+    expires_at = now + timedelta(minutes=minutes)
+    jti = str(uuid4())
     payload = {
         "sub": str(sub),
         "iat": now,
         "nbf": now,
-        "exp": now + timedelta(minutes=minutes),
+        "exp": expires_at,
+        "jti": jti,
     }
     if extra:
         payload.update(extra)
-    return jwt.encode(payload, settings.secret_key, algorithm=settings.algorithm)
+    token = jwt.encode(payload, settings.secret_key, algorithm=settings.algorithm)
+    if db is not None:
+        try:
+            user_id = int(sub)
+        except (TypeError, ValueError):  # pragma: no cover - defensive guard
+            raise ValueError("sub must be an integer when persisting sessions") from None
+        session = ActiveSession(user_id=user_id, jti=jti, expires_at=expires_at)
+        db.add(session)
+        await db.commit()
+    return token
 
 
 def decode_token(token: str) -> dict | None:

--- a/root/app/models/models.py
+++ b/root/app/models/models.py
@@ -88,6 +88,12 @@ class User(Base):
         back_populates="user",
         passive_deletes=True,
     )
+    sessions = relationship(
+        "ActiveSession",
+        back_populates="user",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+    )
 
     @property
     def spotify_connected(self) -> bool:
@@ -154,6 +160,24 @@ class Event(Base):
     __table_args__ = (
         CheckConstraint("ends_at > starts_at", name="ck_event_time_order"),
     )
+
+
+class ActiveSession(Base):
+    __tablename__ = "active_sessions"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(
+        Integer,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    jti = Column(String, nullable=False, unique=True, index=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    expires_at = Column(DateTime(timezone=True), nullable=False, index=True)
+    revoked_at = Column(DateTime(timezone=True), nullable=True, index=True)
+
+    user = relationship("User", back_populates="sessions")
 
 
 class EventAttendance(Base):

--- a/root/app/models/models.py
+++ b/root/app/models/models.py
@@ -173,7 +173,9 @@ class ActiveSession(Base):
         index=True,
     )
     jti = Column(String, nullable=False, unique=True, index=True)
-    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    created_at = Column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
     expires_at = Column(DateTime(timezone=True), nullable=False, index=True)
     revoked_at = Column(DateTime(timezone=True), nullable=True, index=True)
 

--- a/root/tests/test_auth_cookie_flow.py
+++ b/root/tests/test_auth_cookie_flow.py
@@ -1,6 +1,8 @@
 import pytest
+from sqlalchemy import select
 
-from app.auth.security import get_password_hash
+from app.auth.security import decode_token, get_password_hash
+from app.models.models import ActiveSession
 
 pytestmark = pytest.mark.anyio("asyncio")
 
@@ -67,3 +69,38 @@ async def test_logout_clears_cookie(async_client, user_factory):
 
     profile_response = await async_client.get("/users/me")
     assert profile_response.status_code == 401
+
+
+async def test_token_reuse_after_logout_rejected(
+    async_client, user_factory, db_session
+):
+    password = "ReusePass789!"
+    user = await _create_active_user(user_factory, password)
+
+    login_response = await _login(async_client, user.email, password)
+    assert login_response.status_code == 200
+    token = login_response.json()["access_token"]
+
+    payload = decode_token(token)
+    assert payload is not None
+    jti = payload.get("jti")
+    assert jti
+
+    result = await db_session.execute(
+        select(ActiveSession).where(ActiveSession.jti == jti)
+    )
+    session = result.scalars().first()
+    assert session is not None and session.revoked_at is None
+
+    headers = {"Authorization": f"Bearer {token}"}
+    ok_response = await async_client.get("/users/me", headers=headers)
+    assert ok_response.status_code == 200
+
+    logout_response = await async_client.post("/auth/logout", headers=headers)
+    assert logout_response.status_code == 200
+
+    await db_session.refresh(session)
+    assert session.revoked_at is not None
+
+    rejected = await async_client.get("/users/me", headers=headers)
+    assert rejected.status_code == 401


### PR DESCRIPTION
## Summary
- add an `active_sessions` table and ORM model to persist JWT metadata per user
- issue access tokens with `jti` identifiers, enforce active session checks, and revoke sessions during logout
- extend authentication tests to cover token invalidation after logout

## Testing
- pytest root/tests/test_auth_cookie_flow.py

------
https://chatgpt.com/codex/tasks/task_e_68f3dd3e27108327a6c25a96044432aa