### PR TITLE
Add stats endpoints with aggregate computations

### DIFF
--- a/root/app/api/stats.py
+++ b/root/app/api/stats.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app import crud
+from app.api.deps import get_current_user
+from app.core.database import get_db
+from app.models import models
+
+router = APIRouter(prefix="/stats", tags=["stats"])
+
+
+_PERIOD_ALIASES = {
+    "30d": 30,
+    "90d": 90,
+    "180d": 180,
+}
+
+
+def _resolve_period(period: str | None) -> int:
+    if not period:
+        return 30
+    period_key = period.strip().lower()
+    return _PERIOD_ALIASES.get(period_key, 30)
+
+
+@router.get("/attendance")
+async def attendance_summary(
+    period: str = Query("30d"),
+    db: AsyncSession = Depends(get_db),
+    user: models.User = Depends(get_current_user),
+):
+    days = _resolve_period(period)
+    return await crud.get_attendance_stats(db, user_id=user.id, period_days=days)
+
+
+@router.get("/grades")
+async def grade_summary(
+    period: str = Query("30d"),
+    db: AsyncSession = Depends(get_db),
+    user: models.User = Depends(get_current_user),
+):
+    days = _resolve_period(period)
+    return await crud.get_grade_stats(db, user_id=user.id, period_days=days)
+
+
+@router.get("/participation")
+async def participation_summary(
+    period: str = Query("30d"),
+    db: AsyncSession = Depends(get_db),
+    user: models.User = Depends(get_current_user),
+):
+    days = _resolve_period(period)
+    return await crud.get_participation_stats(db, user_id=user.id, period_days=days)

--- a/root/app/crud/__init__.py
+++ b/root/app/crud/__init__.py
@@ -618,9 +618,7 @@ async def get_attendance_stats(
         models.Event.starts_at < now,
     )
     total_events = await db.scalar(
-        select(func.count())
-        .select_from(models.Event)
-        .where(*base_event_filter)
+        select(func.count()).select_from(models.Event).where(*base_event_filter)
     )
     total_events = int(total_events or 0)
 
@@ -769,8 +767,7 @@ async def get_grade_stats(
             current_entries.append(entry)
 
     previous_rows = await db.execute(
-        select(models.Notification)
-        .where(
+        select(models.Notification).where(
             models.Notification.user_id == user_id,
             models.Notification.type == "grade",
             models.Notification.created_at >= previous_start,
@@ -847,7 +844,14 @@ async def get_participation_stats(
     total_hours = 0.0
     event_types = set()
     recent = []
-    for event_id, registered_at, starts_at, ends_at, title, event_type in current_entries:
+    for (
+        event_id,
+        registered_at,
+        starts_at,
+        ends_at,
+        title,
+        event_type,
+    ) in current_entries:
         if event_id not in unique_events:
             unique_events[event_id] = (starts_at, ends_at)
             if starts_at and ends_at:

--- a/root/app/crud/__init__.py
+++ b/root/app/crud/__init__.py
@@ -1,5 +1,6 @@
+import json
 import uuid
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any, Dict, List, Optional, Sequence
 
 from sqlalchemy import and_, func, or_, select
@@ -594,3 +595,285 @@ async def delete_user(db: AsyncSession, user_id: int):
         raise ValueError(translate("errors.users.not_found"))
     await db.delete(user)
     await db.commit()
+
+
+def _dt_to_iso(value: datetime | None) -> str:
+    if value is None:
+        return ""
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=UTC)
+    return value.astimezone(UTC).isoformat()
+
+
+async def get_attendance_stats(
+    db: AsyncSession, *, user_id: int, period_days: int
+) -> Dict[str, Any]:
+    now = datetime.now(UTC)
+    window_start = now - timedelta(days=period_days)
+    previous_start = window_start - timedelta(days=period_days)
+
+    base_event_filter = (
+        models.Event.is_active.is_(True),
+        models.Event.starts_at >= window_start,
+        models.Event.starts_at < now,
+    )
+    total_events = await db.scalar(
+        select(func.count())
+        .select_from(models.Event)
+        .where(*base_event_filter)
+    )
+    total_events = int(total_events or 0)
+
+    attendance_filter = (
+        models.EventAttendance.user_id == user_id,
+        models.EventAttendance.event_id == models.Event.id,
+        *base_event_filter,
+    )
+    attended_events = await db.scalar(
+        select(func.count())
+        .select_from(models.EventAttendance)
+        .join(models.Event, models.Event.id == models.EventAttendance.event_id)
+        .where(*attendance_filter)
+    )
+    attended_events = int(attended_events or 0)
+
+    percent = (attended_events / total_events * 100) if total_events else 0.0
+
+    previous_events = await db.scalar(
+        select(func.count())
+        .select_from(models.Event)
+        .where(
+            models.Event.is_active.is_(True),
+            models.Event.starts_at >= previous_start,
+            models.Event.starts_at < window_start,
+        )
+    )
+    previous_events = int(previous_events or 0)
+
+    previous_attended = await db.scalar(
+        select(func.count())
+        .select_from(models.EventAttendance)
+        .join(models.Event, models.Event.id == models.EventAttendance.event_id)
+        .where(
+            models.EventAttendance.user_id == user_id,
+            models.Event.starts_at >= previous_start,
+            models.Event.starts_at < window_start,
+            models.Event.is_active.is_(True),
+        )
+    )
+    previous_attended = int(previous_attended or 0)
+    previous_percent = (
+        previous_attended / previous_events * 100 if previous_events else 0.0
+    )
+
+    recent_rows = await db.execute(
+        select(
+            models.EventAttendance.registered_at,
+            models.Event.starts_at,
+            models.Event.title,
+        )
+        .join(models.Event, models.Event.id == models.EventAttendance.event_id)
+        .where(*attendance_filter)
+        .order_by(models.EventAttendance.registered_at.desc())
+        .limit(5)
+    )
+    recent = []
+    for registered_at, starts_at, title in recent_rows.all():
+        date_source = starts_at or registered_at
+        recent.append(
+            {
+                "date": _dt_to_iso(date_source),
+                "status": "present",
+                "course": title or None,
+            }
+        )
+
+    return {
+        "percent": round(percent, 2),
+        "present": attended_events,
+        "total": total_events,
+        "trend": round(percent - previous_percent, 2),
+        "window_label": f"last {period_days} days",
+        "recent": recent,
+    }
+
+
+def _parse_grade_payload(
+    body: str | None, *, fallback_title: str, fallback_date: datetime | None
+) -> Dict[str, Any] | None:
+    if not body:
+        return None
+    try:
+        payload = json.loads(body)
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    score = payload.get("score")
+    try:
+        score_value = float(score)
+    except (TypeError, ValueError):
+        return None
+    max_score = payload.get("max")
+    max_value = None
+    if max_score is not None:
+        try:
+            max_value = float(max_score)
+        except (TypeError, ValueError):
+            max_value = None
+    course = payload.get("course")
+    if not isinstance(course, str) or not course.strip():
+        course = fallback_title
+    date_raw = payload.get("date")
+    if isinstance(date_raw, str):
+        try:
+            parsed = datetime.fromisoformat(date_raw)
+        except ValueError:
+            parsed = None
+    else:
+        parsed = None
+    date_value = parsed or fallback_date
+    return {
+        "course": course,
+        "score": score_value,
+        "max": max_value,
+        "date": _dt_to_iso(date_value),
+    }
+
+
+async def get_grade_stats(
+    db: AsyncSession, *, user_id: int, period_days: int
+) -> Dict[str, Any]:
+    now = datetime.now(UTC)
+    window_start = now - timedelta(days=period_days)
+    previous_start = window_start - timedelta(days=period_days)
+
+    current_rows = await db.execute(
+        select(models.Notification)
+        .where(
+            models.Notification.user_id == user_id,
+            models.Notification.type == "grade",
+            models.Notification.created_at >= window_start,
+            models.Notification.created_at < now,
+        )
+        .order_by(models.Notification.created_at.desc())
+    )
+    current_entries = []
+    for notification in current_rows.scalars():
+        entry = _parse_grade_payload(
+            notification.body,
+            fallback_title=notification.title or "",
+            fallback_date=notification.created_at,
+        )
+        if entry:
+            current_entries.append(entry)
+
+    previous_rows = await db.execute(
+        select(models.Notification)
+        .where(
+            models.Notification.user_id == user_id,
+            models.Notification.type == "grade",
+            models.Notification.created_at >= previous_start,
+            models.Notification.created_at < window_start,
+        )
+    )
+    previous_entries = []
+    for notification in previous_rows.scalars():
+        entry = _parse_grade_payload(
+            notification.body,
+            fallback_title=notification.title or "",
+            fallback_date=notification.created_at,
+        )
+        if entry:
+            previous_entries.append(entry)
+
+    def _average(items: List[Dict[str, Any]]) -> float:
+        if not items:
+            return 0.0
+        return sum(item["score"] for item in items) / len(items)
+
+    average = _average(current_entries)
+    previous_average = _average(previous_entries)
+
+    max_values = [item["max"] for item in current_entries if item.get("max")]
+    scale = "5"
+    if any(value and value > 5 for value in max_values):
+        scale = "100"
+
+    recent = current_entries[:5]
+
+    return {
+        "average": round(average, 2) if current_entries else 0.0,
+        "scale": scale,
+        "trend": round(average - previous_average, 2),
+        "recent": recent,
+    }
+
+
+async def get_participation_stats(
+    db: AsyncSession, *, user_id: int, period_days: int
+) -> Dict[str, Any]:
+    now = datetime.now(UTC)
+    window_start = now - timedelta(days=period_days)
+    previous_start = window_start - timedelta(days=period_days)
+
+    def _attendance_query(start: datetime, end: datetime):
+        return (
+            select(
+                models.EventAttendance.event_id,
+                models.EventAttendance.registered_at,
+                models.Event.starts_at,
+                models.Event.ends_at,
+                models.Event.title,
+                models.Event.event_type,
+            )
+            .join(models.Event, models.Event.id == models.EventAttendance.event_id)
+            .where(
+                models.EventAttendance.user_id == user_id,
+                models.Event.starts_at >= start,
+                models.Event.starts_at < end,
+                models.Event.is_active.is_(True),
+            )
+        )
+
+    current_rows = await db.execute(
+        _attendance_query(window_start, now).order_by(models.Event.starts_at.desc())
+    )
+    current_entries = current_rows.all()
+    previous_rows = await db.execute(_attendance_query(previous_start, window_start))
+    previous_entries = previous_rows.all()
+
+    unique_events = {}
+    total_hours = 0.0
+    event_types = set()
+    recent = []
+    for event_id, registered_at, starts_at, ends_at, title, event_type in current_entries:
+        if event_id not in unique_events:
+            unique_events[event_id] = (starts_at, ends_at)
+            if starts_at and ends_at:
+                start_dt = _ensure_utc(starts_at)
+                end_dt = _ensure_utc(ends_at)
+                if end_dt > start_dt:
+                    total_hours += (end_dt - start_dt).total_seconds() / 3600
+        if event_type:
+            event_types.add(event_type)
+        recent.append(
+            {
+                "title": title or "",
+                "date": _dt_to_iso(starts_at or registered_at),
+                "role": event_type or None,
+            }
+        )
+
+    recent.sort(key=lambda item: item["date"], reverse=True)
+    recent = recent[:5]
+
+    previous_event_ids = {row[0] for row in previous_entries}
+
+    return {
+        "events": len(unique_events),
+        "hours": round(total_hours, 2) if total_hours else 0.0,
+        "groups": len(event_types),
+        "trend": len(unique_events) - len(previous_event_ids),
+        "recent": recent,
+    }

--- a/root/app/main.py
+++ b/root/app/main.py
@@ -10,9 +10,9 @@ from sqlalchemy import text
 from app.api.events import router as events_router
 from app.api.news import router as news_router
 from app.api.notifications import router as notifications_router
-from app.api.stats import router as stats_router
 from app.api.schedule import router as schedule_api_router
 from app.api.spotify import router as spotify_router
+from app.api.stats import router as stats_router
 from app.api.users import router as users_router
 from app.auth.auth import router as auth_router
 from app.core.config import settings

--- a/root/app/main.py
+++ b/root/app/main.py
@@ -10,6 +10,7 @@ from sqlalchemy import text
 from app.api.events import router as events_router
 from app.api.news import router as news_router
 from app.api.notifications import router as notifications_router
+from app.api.stats import router as stats_router
 from app.api.schedule import router as schedule_api_router
 from app.api.spotify import router as spotify_router
 from app.api.users import router as users_router
@@ -152,3 +153,4 @@ app.include_router(users_router)
 app.include_router(events_router)
 app.include_router(news_router)
 app.include_router(schedule_api_router)
+app.include_router(stats_router)

--- a/root/frontend/tests/e2e/utils/mockApi.ts
+++ b/root/frontend/tests/e2e/utils/mockApi.ts
@@ -293,11 +293,66 @@ export async function useMockApi(page: Page) {
       return;
     }
 
-    if (pathname.startsWith("api/stats")) {
+    if (pathname === "api/stats/attendance") {
       await route.fulfill({
         status: 200,
         contentType: "application/json",
-        body: JSON.stringify({}),
+        body: JSON.stringify({
+          percent: 82,
+          present: 18,
+          total: 22,
+          trend: 6.5,
+          window_label: "last 30 days",
+          recent: [
+            {
+              date: new Date().toISOString(),
+              status: "present",
+              course: "Discrete Math",
+            },
+          ],
+        }),
+      });
+      return;
+    }
+
+    if (pathname === "api/stats/grades") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          average: 4.7,
+          scale: "5",
+          trend: 0.4,
+          recent: [
+            {
+              course: "Physics",
+              score: 5,
+              max: 5,
+              date: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString(),
+            },
+          ],
+        }),
+      });
+      return;
+    }
+
+    if (pathname === "api/stats/participation") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          events: 4,
+          hours: 12,
+          groups: 3,
+          trend: 1,
+          recent: [
+            {
+              title: "Volunteer Day",
+              date: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString(),
+              role: "volunteer",
+            },
+          ],
+        }),
       });
       return;
     }

--- a/root/tests/test_stats_api.py
+++ b/root/tests/test_stats_api.py
@@ -1,0 +1,272 @@
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.auth.security import get_password_hash
+from app.models import models
+
+
+async def _login(async_client, email: str, password: str) -> dict[str, str]:
+    response = await async_client.post(
+        "/auth/login",
+        data={"username": email, "password": password},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert response.status_code == 200
+    token = response.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "path",
+    ["/stats/attendance", "/stats/grades", "/stats/participation"],
+)
+async def test_stats_requires_auth(async_client, path):
+    response = await async_client.get(path)
+    assert response.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_attendance_stats_returns_expected_payload(
+    async_client, db_session, user_factory
+):
+    now = datetime.now(timezone.utc)
+    admin = await user_factory(role="admin")
+    password = "StatsPass123!"
+    hashed = get_password_hash(password)
+    student = await user_factory(hashed_password=hashed, is_active=True)
+
+    current_attended = models.Event(
+        title="Functional Analysis",
+        description="Lecture",
+        location="Auditorium A",
+        event_type="lecture",
+        starts_at=now - timedelta(days=5),
+        ends_at=now - timedelta(days=5) + timedelta(hours=2),
+        created_by=admin.id,
+        is_active=True,
+    )
+    current_attended_2 = models.Event(
+        title="Modern Physics",
+        description="Seminar",
+        location="Room 204",
+        event_type="seminar",
+        starts_at=now - timedelta(days=2),
+        ends_at=now - timedelta(days=2) + timedelta(hours=3),
+        created_by=admin.id,
+        is_active=True,
+    )
+    current_missed = models.Event(
+        title="Statistics",
+        description="Workshop",
+        location="Room 101",
+        event_type="workshop",
+        starts_at=now - timedelta(days=8),
+        ends_at=now - timedelta(days=8) + timedelta(hours=2),
+        created_by=admin.id,
+        is_active=True,
+    )
+    previous_attended = models.Event(
+        title="Linear Algebra",
+        description="Lecture",
+        location="Auditorium B",
+        event_type="lecture",
+        starts_at=now - timedelta(days=35),
+        ends_at=now - timedelta(days=35) + timedelta(hours=2),
+        created_by=admin.id,
+        is_active=True,
+    )
+    previous_missed = models.Event(
+        title="Computer Science",
+        description="Seminar",
+        location="Lab 5",
+        event_type="seminar",
+        starts_at=now - timedelta(days=50),
+        ends_at=now - timedelta(days=50) + timedelta(hours=2),
+        created_by=admin.id,
+        is_active=True,
+    )
+
+    db_session.add_all(
+        [
+            current_attended,
+            current_attended_2,
+            current_missed,
+            previous_attended,
+            previous_missed,
+        ]
+    )
+    await db_session.commit()
+
+    attendances = [
+        models.EventAttendance(
+            user_id=student.id,
+            event_id=current_attended.id,
+            registered_at=now - timedelta(days=5, hours=1),
+        ),
+        models.EventAttendance(
+            user_id=student.id,
+            event_id=current_attended_2.id,
+            registered_at=now - timedelta(days=2, hours=2),
+        ),
+        models.EventAttendance(
+            user_id=student.id,
+            event_id=previous_attended.id,
+            registered_at=now - timedelta(days=34),
+        ),
+    ]
+    db_session.add_all(attendances)
+    await db_session.commit()
+
+    headers = await _login(async_client, student.email, password)
+
+    response = await async_client.get("/stats/attendance", headers=headers)
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload["present"] == 2
+    assert payload["total"] == 3
+    assert payload["percent"] == pytest.approx(66.67, rel=1e-2)
+    assert payload["trend"] == pytest.approx(16.67, rel=1e-2)
+    assert payload["window_label"].startswith("last ")
+    assert len(payload["recent"]) == 2
+    assert payload["recent"][0]["status"] == "present"
+    assert payload["recent"][0]["course"] == "Modern Physics"
+
+
+@pytest.mark.anyio
+async def test_grade_stats_parse_notifications(async_client, db_session, user_factory):
+    now = datetime.now(timezone.utc)
+    password = "GradesPass456!"
+    hashed = get_password_hash(password)
+    student = await user_factory(hashed_password=hashed, is_active=True)
+
+    current_grade_one = models.Notification(
+        user_id=student.id,
+        title="Physics",
+        type="grade",
+        body=json.dumps(
+            {
+                "course": "Physics",
+                "score": 5,
+                "max": 5,
+                "date": (now - timedelta(days=4)).isoformat(),
+            }
+        ),
+        created_at=now - timedelta(days=4),
+    )
+    current_grade_two = models.Notification(
+        user_id=student.id,
+        title="Chemistry",
+        type="grade",
+        body=json.dumps(
+            {
+                "course": "Chemistry",
+                "score": 4.5,
+                "max": 5,
+                "date": (now - timedelta(days=2)).isoformat(),
+            }
+        ),
+        created_at=now - timedelta(days=2),
+    )
+    previous_grade = models.Notification(
+        user_id=student.id,
+        title="History",
+        type="grade",
+        body=json.dumps({"course": "History", "score": 3, "max": 5}),
+        created_at=now - timedelta(days=45),
+    )
+
+    db_session.add_all([current_grade_one, current_grade_two, previous_grade])
+    await db_session.commit()
+
+    headers = await _login(async_client, student.email, password)
+    response = await async_client.get("/stats/grades", headers=headers)
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload["average"] == pytest.approx(4.75, rel=1e-3)
+    assert payload["scale"] == "5"
+    assert payload["trend"] == pytest.approx(1.75, rel=1e-3)
+    assert len(payload["recent"]) == 2
+    assert {item["course"] for item in payload["recent"]} == {"Physics", "Chemistry"}
+
+
+@pytest.mark.anyio
+async def test_participation_stats_summarize_events(
+    async_client, db_session, user_factory
+):
+    now = datetime.now(timezone.utc)
+    admin = await user_factory(role="admin")
+    password = "Participate789!"
+    hashed = get_password_hash(password)
+    student = await user_factory(hashed_password=hashed, is_active=True)
+
+    event_one = models.Event(
+        title="Hackathon",
+        description="Community project",
+        location="Innovation Hub",
+        event_type="club",
+        starts_at=now - timedelta(days=6),
+        ends_at=now - timedelta(days=6) + timedelta(hours=4),
+        created_by=admin.id,
+        is_active=True,
+    )
+    event_two = models.Event(
+        title="Volunteer Day",
+        description="City cleanup",
+        location="Downtown",
+        event_type="volunteer",
+        starts_at=now - timedelta(days=3),
+        ends_at=now - timedelta(days=3) + timedelta(hours=5),
+        created_by=admin.id,
+        is_active=True,
+    )
+    previous_event = models.Event(
+        title="STEM Fair",
+        description="Science exhibits",
+        location="Campus Hall",
+        event_type="club",
+        starts_at=now - timedelta(days=40),
+        ends_at=now - timedelta(days=40) + timedelta(hours=3),
+        created_by=admin.id,
+        is_active=True,
+    )
+
+    db_session.add_all([event_one, event_two, previous_event])
+    await db_session.commit()
+
+    db_session.add_all(
+        [
+            models.EventAttendance(
+                user_id=student.id,
+                event_id=event_one.id,
+                registered_at=now - timedelta(days=6, hours=1),
+            ),
+            models.EventAttendance(
+                user_id=student.id,
+                event_id=event_two.id,
+                registered_at=now - timedelta(days=3, hours=2),
+            ),
+            models.EventAttendance(
+                user_id=student.id,
+                event_id=previous_event.id,
+                registered_at=now - timedelta(days=39),
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    headers = await _login(async_client, student.email, password)
+    response = await async_client.get("/stats/participation", headers=headers)
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload["events"] == 2
+    assert payload["hours"] == pytest.approx(9.0, rel=1e-3)
+    assert payload["groups"] == 2
+    assert payload["trend"] == 1
+    assert len(payload["recent"]) == 2
+    assert {item["title"] for item in payload["recent"]} == {"Hackathon", "Volunteer Day"}

--- a/root/tests/test_stats_api.py
+++ b/root/tests/test_stats_api.py
@@ -269,4 +269,7 @@ async def test_participation_stats_summarize_events(
     assert payload["groups"] == 2
     assert payload["trend"] == 1
     assert len(payload["recent"]) == 2
-    assert {item["title"] for item in payload["recent"]} == {"Hackathon", "Volunteer Day"}
+    assert {item["title"] for item in payload["recent"]} == {
+        "Hackathon",
+        "Volunteer Day",
+    }


### PR DESCRIPTION
## Summary
- add a dedicated stats router exposing attendance, grade, and participation summaries
- compute aggregated metrics from events, attendance, and grade notifications
- cover the new API with backend tests and align frontend mocks with the payloads

## Testing
- pytest root/tests/test_stats_api.py
- npm --prefix root/frontend test -- src/tests/pageTranslations.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68f3e62ca8f48327956a6c6320129a70