### PR TITLE
Use static file helper for avatar deletion

### DIFF
--- a/root/app/api/users.py
+++ b/root/app/api/users.py
@@ -5,7 +5,6 @@ import smtplib
 import ssl
 from datetime import datetime, timedelta, timezone
 from email.message import EmailMessage
-from pathlib import Path
 from typing import List, Optional
 
 from fastapi import (
@@ -32,10 +31,8 @@ from app.core.database import get_db
 from app.localization import resolve_locale, translate
 from app.models import models
 from app.schemas import schemas
-from app.utils.email import (
-    RESET_TOKEN_EXPIRY_MINUTES,
-    build_reset_email_content,
-)
+from app.utils.email import RESET_TOKEN_EXPIRY_MINUTES, build_reset_email_content
+from app.utils.files import delete_static_file
 from app.utils.ratelimit import sensitive_route_limit
 
 logger = logging.getLogger(__name__)
@@ -368,14 +365,7 @@ async def delete_avatar(
 ):
     db_user = await db.get(models.User, user.id)
     if db_user.avatar_url:
-        base_dir = settings.static_dir_path
-        rel_path = db_user.avatar_url.replace("/static/", "", 1).lstrip("/")
-        avatar_path = base_dir / Path(rel_path)
-        if avatar_path.exists():
-            try:
-                avatar_path.unlink()
-            except Exception:
-                pass
+        await delete_static_file(db_user.avatar_url)
     db_user.avatar_url = None
     await db.commit()
     await db.refresh(db_user)

--- a/root/tests/test_user_profile_update.py
+++ b/root/tests/test_user_profile_update.py
@@ -1,7 +1,10 @@
+import uuid
+
 import pytest
 from httpx import AsyncClient
 
 from app.auth.security import get_password_hash
+from app.core.config import settings
 from app.models import models
 
 
@@ -70,3 +73,65 @@ async def test_update_profile_email_duplicate(async_client, user_factory, db_ses
 
     await db_session.refresh(user)
     assert user.email == "first-user@example.com"
+
+
+@pytest.mark.anyio
+async def test_delete_avatar_removes_file(async_client, user_factory, db_session):
+    password = "DeleteAvatar123!"
+    hashed = get_password_hash(password)
+    avatar_rel = f"avatars/test-avatar-{uuid.uuid4().hex}.png"
+    avatar_path = settings.static_dir_path / avatar_rel
+    avatar_path.parent.mkdir(parents=True, exist_ok=True)
+    avatar_path.write_bytes(b"avatar")
+
+    user = await user_factory(
+        hashed_password=hashed,
+        is_active=True,
+        avatar_url=f"/static/{avatar_rel}",
+    )
+
+    headers = await _login(async_client, user.email, password)
+
+    response = await async_client.delete("/users/me/avatar", headers=headers)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["avatar_url"] is None
+    assert not avatar_path.exists()
+
+    await db_session.refresh(user)
+    assert user.avatar_url is None
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("avatar_url", ["", "https://example.com/avatar.png"])
+async def test_delete_avatar_ignores_invalid_path(
+    async_client, user_factory, db_session, avatar_url
+):
+    password = "IgnoreAvatar123!"
+    hashed = get_password_hash(password)
+    sentinel_rel = f"avatars/sentinel-{uuid.uuid4().hex}.txt"
+    sentinel_path = settings.static_dir_path / sentinel_rel
+    sentinel_path.parent.mkdir(parents=True, exist_ok=True)
+    sentinel_path.write_text("keep")
+
+    try:
+        user = await user_factory(
+            hashed_password=hashed,
+            is_active=True,
+            avatar_url=avatar_url,
+        )
+
+        headers = await _login(async_client, user.email, password)
+
+        response = await async_client.delete("/users/me/avatar", headers=headers)
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["avatar_url"] is None
+        assert sentinel_path.exists()
+
+        await db_session.refresh(user)
+        assert user.avatar_url is None
+    finally:
+        sentinel_path.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary
- replace manual avatar file cleanup with the shared delete_static_file helper
- add regression tests covering avatar deletion for valid and invalid URLs

## Testing
- pytest root/tests/test_user_profile_update.py -k delete_avatar

------
https://chatgpt.com/codex/tasks/task_e_68f4381dbf808327b101f4242d57b802