### PR TITLE
Add rate limiting to registration endpoint

### DIFF
--- a/root/app/auth/auth.py
+++ b/root/app/auth/auth.py
@@ -164,7 +164,7 @@ async def login_json(
     return {"access_token": token, "token_type": "bearer"}
 
 
-@router.post("/register")
+@router.post("/register", dependencies=[Depends(sensitive_route_limit())])
 async def register(
     user: UserCreate,
     request: Request,

--- a/root/tests/test_auth_cookie_flow.py
+++ b/root/tests/test_auth_cookie_flow.py
@@ -3,8 +3,8 @@ from fastapi import status
 from sqlalchemy import select
 
 from app.auth.security import decode_token, get_password_hash
-from app.models.models import ActiveSession
 from app.localization import translate
+from app.models.models import ActiveSession
 
 pytestmark = pytest.mark.anyio("asyncio")
 

--- a/root/tests/test_auth_cookie_flow.py
+++ b/root/tests/test_auth_cookie_flow.py
@@ -1,8 +1,10 @@
 import pytest
+from fastapi import status
 from sqlalchemy import select
 
 from app.auth.security import decode_token, get_password_hash
 from app.models.models import ActiveSession
+from app.localization import translate
 
 pytestmark = pytest.mark.anyio("asyncio")
 
@@ -104,3 +106,25 @@ async def test_token_reuse_after_logout_rejected(
 
     rejected = await async_client.get("/users/me", headers=headers)
     assert rejected.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_register_rate_limit(async_client):
+    for attempt in range(4):
+        payload = {
+            "email": f"rate-limit-{attempt}@example.com",
+            "password": "ValidPass123!",
+            "full_name": "Rate Limited User",
+        }
+        response = await async_client.post("/auth/register", json=payload)
+        assert response.status_code == status.HTTP_200_OK
+
+    blocked_payload = {
+        "email": "rate-limit-final@example.com",
+        "password": "ValidPass123!",
+        "full_name": "Rate Limited User",
+    }
+    blocked = await async_client.post("/auth/register", json=blocked_payload)
+
+    assert blocked.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+    assert blocked.json()["detail"] == translate("errors.rate_limit.generic")


### PR DESCRIPTION
## Summary
- add the sensitive route rate limiter dependency to the registration endpoint so it uses the shared throttling policy
- ensure authentication tests cover the registration rate limiting behaviour

## Testing
- pytest root/tests/test_auth_cookie_flow.py::test_register_rate_limit -q

------
https://chatgpt.com/codex/tasks/task_e_68f43e0f207c8327896db588c46e56a6