### PR TITLE
refactor: serve frontend build from nginx runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,9 @@ jobs:
     defaults:
       run:
         working-directory: root/frontend
+    env:
+      # Keep in sync with the Docker builder stage.
+      VITE_BACKEND_ORIGIN: http://localhost:8000
     steps:
       - uses: actions/checkout@v5
       - name: Setup Node.js
@@ -242,6 +245,8 @@ jobs:
     defaults:
       run:
         working-directory: root/frontend
+    env:
+      VITE_BACKEND_ORIGIN: http://localhost:8000
     steps:
       - uses: actions/checkout@v5
       - name: Setup Node.js
@@ -272,6 +277,7 @@ jobs:
     env:
       PREVIEW_URL: ${{ vars.PREVIEW_URL || secrets.PREVIEW_URL || '' }}
       TARGET_PORT: 4174
+      VITE_BACKEND_ORIGIN: http://localhost:8000
     defaults:
       run:
         working-directory: root/frontend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,8 @@ services:
       - root/.env
     environment:
       DATABASE_URL: postgresql+psycopg://postgres:postgres@postgres:5432/university
-      FRONTEND_ORIGIN: http://localhost:5173
-      FRONTEND_ORIGINS: http://localhost:5173
+      FRONTEND_ORIGIN: http://localhost:8080
+      FRONTEND_ORIGINS: http://localhost:8080
       NOTIFICATIONS_SCHEDULER_INLINE_ENABLED: "false"
     depends_on:
       postgres:
@@ -23,15 +23,17 @@ services:
     build:
       context: .
       dockerfile: root/frontend.Dockerfile
-    environment:
-      VITE_BACKEND_ORIGIN: http://localhost:8000
-    depends_on:
-      backend:
-        condition: service_healthy
-      postgres:
-        condition: service_healthy
+      target: runtime
+      args:
+        VITE_BACKEND_ORIGIN: http://localhost:8000
     ports:
-      - "5173:5173"
+      - "8080:80"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1/ >/dev/null || exit 1"]
+      interval: 30s
+      timeout: 10s
+      start_period: 30s
+      retries: 5
 
   notifications-worker:
     build:

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -13,6 +13,19 @@ cp .env.production .env.local      # при необходимости
 VITE_BACKEND_ORIGIN=https://api.example.com npm run build
 ```
 
+## Docker image
+
+- `root/frontend.Dockerfile` собран в два этапа: на этапе `builder` запускается `npm ci && npm run build`, а финальный образ основан на `nginx:alpine` и содержит только содержимое `dist/`.
+- Значение `VITE_BACKEND_ORIGIN` передаётся через `--build-arg` (см. `docker-compose.yml`). Для локальной разработки оно уже выставлено в `http://localhost:8000`.
+- Статика отдаётся Nginx'ом с кэшированием: файлы в `assets/` получают заголовок `Cache-Control: public, max-age=31536000, immutable`, а `index.html` — `Cache-Control: no-cache`.
+- Контейнер слушает порт `80`. В docker-compose он проброшен на `8080`, поэтому SPA доступна на http://localhost:8080.
+
+```bash
+# пример локальной сборки
+docker compose build frontend
+docker compose up frontend
+```
+
 ## Reverse-proxy (Nginx)
 
 Если фронтенд и API находятся на разных хостах, проксируйте статику и медиа через тот же домен, что и SPA. Это избавит от CORS/Service Worker артефактов и позволит использовать абсолютные ссылки на API-домен.

--- a/root/frontend.Dockerfile
+++ b/root/frontend.Dockerfile
@@ -5,13 +5,18 @@ WORKDIR /app
 
 FROM base AS deps
 COPY root/frontend/package.json root/frontend/package-lock.json ./
-RUN --mount=type=cache,target=/root/.npm npm ci --include=dev
+RUN --mount=type=cache,target=/root/.npm npm ci
 
-FROM base AS runner
-RUN addgroup -S app && adduser -S -G app app
+FROM base AS builder
+ARG VITE_BACKEND_ORIGIN=http://localhost:8000
+ENV VITE_BACKEND_ORIGIN=$VITE_BACKEND_ORIGIN
 COPY --from=deps /app/node_modules ./node_modules
 COPY root/frontend ./
-USER app
-EXPOSE 5173
-HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=5 CMD wget -qO- http://127.0.0.1:5173/ >/dev/null || exit 1
-CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0", "--port", "5173"]
+RUN npm run build
+
+FROM nginx:1.27-alpine AS runtime
+COPY root/frontend/nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=builder /app/dist /usr/share/nginx/html
+EXPOSE 80
+HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=5 CMD wget -qO- http://127.0.0.1/ >/dev/null || exit 1
+CMD ["nginx", "-g", "daemon off;"]

--- a/root/frontend/nginx.conf
+++ b/root/frontend/nginx.conf
@@ -1,0 +1,23 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Cache hashed build assets for a long time.
+    location /assets/ {
+        try_files $uri =404;
+        add_header Cache-Control "public, max-age=31536000, immutable" always;
+    }
+
+    # Serve the SPA entry point for all other routes.
+    location / {
+        try_files $uri /index.html;
+        add_header Cache-Control "no-cache" always;
+    }
+
+    location = /index.html {
+        add_header Cache-Control "no-cache" always;
+    }
+}


### PR DESCRIPTION
## Summary
- refactor the frontend Dockerfile into a multi-stage build that compiles with Node and serves static assets with nginx
- add nginx configuration with long-lived cache headers for hashed assets and update docker-compose to run the runtime stage on port 8080
- document the new workflow and ensure CI uses the same backend origin as the Docker builder stage when producing artifacts

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f4427b1d9083279e52de67dc1e67a7