### PR TITLE
Add scheduled cleanup for expired sessions

### DIFF
--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -69,3 +69,8 @@ server {
 - При запуске API и воркера в разных процессах выключите встроенный планировщик в API, установив `NOTIFICATIONS_SCHEDULER_INLINE_ENABLED=false`.
 - Воркер публикует здоровье и метрики Prometheus на `http://<host>:9101/healthz` и `http://<host>:9101/metrics` (порт можно изменить через `NOTIFICATIONS_WORKER_METRICS_PORT`).
 - В docker-compose уже добавлен сервис `notifications-worker` с политикой перезапуска `unless-stopped`.
+
+## Очистка сессий пользователей
+
+- API автоматически удаляет устаревшие записи из `active_sessions` при старте и затем каждые 15 минут.
+- Частоту можно изменить переменной `SESSION_CLEANUP_INTERVAL_SECONDS` (минимум 30 секунд). Значение `0` выключает фоновой планировщик; при этом скрипт очистки можно запускать вручную, вызвав `python -m app.services.session_cleanup` внутри контейнера/виртуального окружения.

--- a/root/app/core/config.py
+++ b/root/app/core/config.py
@@ -141,6 +141,7 @@ class Settings(BaseSettings):
     notifications_scheduler_inline_enabled: bool = True
     notifications_worker_metrics_host: str = "0.0.0.0"
     notifications_worker_metrics_port: int = 9101
+    session_cleanup_interval_seconds: int = 900
     event_file_allowed_mime_types: str | list[str] = (
         "application/pdf,"
         "text/plain,"

--- a/root/app/main.py
+++ b/root/app/main.py
@@ -25,6 +25,11 @@ from app.routers.notifications import legacy_router as legacy_push_router
 from app.routers.notifications import router as push_router
 from app.routers.schedule import router as schedule_router
 from app.services.notifications import start_notifications_scheduler
+from app.services.session_cleanup import (
+    SessionCleanupConfig,
+    cleanup_expired_sessions,
+    start_session_cleanup_scheduler,
+)
 
 try:
     from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
@@ -39,17 +44,27 @@ async def lifespan(app: FastAPI):
         async with engine.begin() as conn:
             await conn.run_sync(Base.metadata.create_all)
     stop_scheduler = None
+    stop_session_cleanup = None
     if settings.is_development and settings.notifications_scheduler_inline_enabled:
         stop_scheduler = await start_notifications_scheduler(
             poll_seconds=settings.notifications_scheduler_poll_seconds,
             window_minutes=settings.notifications_scheduler_window_minutes,
             max_backoff_seconds=settings.notifications_scheduler_max_backoff_seconds,
         )
+    await cleanup_expired_sessions()
+    if settings.session_cleanup_interval_seconds > 0:
+        stop_session_cleanup = await start_session_cleanup_scheduler(
+            config=SessionCleanupConfig(
+                interval_seconds=settings.session_cleanup_interval_seconds
+            )
+        )
     try:
         yield
     finally:
         if stop_scheduler is not None:
             await stop_scheduler()
+        if stop_session_cleanup is not None:
+            await stop_session_cleanup()
         await shutdown_cache()
         shutdown_observability()
 

--- a/root/app/services/session_cleanup.py
+++ b/root/app/services/session_cleanup.py
@@ -1,0 +1,94 @@
+"""Utilities for removing expired authentication sessions."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from contextlib import suppress
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Awaitable, Callable
+
+from sqlalchemy import delete, or_
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import async_session
+from app.models.models import ActiveSession
+
+logger = logging.getLogger(__name__)
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+async def cleanup_expired_sessions(
+    *, db: AsyncSession | None = None, now: datetime | None = None
+) -> int:
+    """Remove sessions where the expiry or revocation timestamp has passed."""
+
+    owns_session = db is None
+    if now is None:
+        now = _now()
+    if owns_session:
+        async with async_session() as session:
+            return await cleanup_expired_sessions(db=session, now=now)
+
+    stmt = delete(ActiveSession).where(
+        or_(ActiveSession.expires_at <= now, ActiveSession.revoked_at <= now)
+    )
+    result = await db.execute(stmt)
+    await db.commit()
+    deleted = int(result.rowcount or 0)
+    if deleted:
+        logger.info("Removed %s expired sessions", deleted)
+    return deleted
+
+
+@dataclass(slots=True)
+class SessionCleanupConfig:
+    interval_seconds: int = 900
+
+    def normalized_interval(self) -> int:
+        return max(30, int(self.interval_seconds))
+
+
+async def start_session_cleanup_scheduler(
+    *, config: SessionCleanupConfig | None = None
+) -> Callable[[], Awaitable[None]]:
+    """Start background cleanup task for expired sessions."""
+
+    cfg = config or SessionCleanupConfig()
+    interval = cfg.normalized_interval()
+
+    async def _loop() -> None:
+        try:
+            while True:
+                try:
+                    await cleanup_expired_sessions()
+                except asyncio.CancelledError:
+                    raise
+                except Exception:  # pragma: no cover - defensive logging
+                    logger.exception("Failed to cleanup expired sessions")
+                await asyncio.sleep(interval)
+        except asyncio.CancelledError:
+            logger.info("Session cleanup loop cancelled")
+            raise
+
+    loop = asyncio.get_running_loop()
+    task = loop.create_task(_loop())
+
+    async def _stop() -> None:
+        if task.done():
+            with suppress(Exception):
+                task.result()
+            return
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+
+    return _stop
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience entrypoint
+    asyncio.run(cleanup_expired_sessions())

--- a/root/tests/conftest.py
+++ b/root/tests/conftest.py
@@ -157,6 +157,18 @@ async def async_client(
         main, "start_notifications_scheduler", _start_notifications_scheduler
     )
 
+    async def _start_session_cleanup_scheduler(
+        *args, **kwargs
+    ) -> Callable[[], Awaitable[None]]:
+        async def _stop() -> None:
+            return None
+
+        return _stop
+
+    monkeypatch.setattr(
+        main, "start_session_cleanup_scheduler", _start_session_cleanup_scheduler
+    )
+
     transport = httpx.ASGITransport(app=main.app)
     async with LifespanManager(main.app):
         async with httpx.AsyncClient(

--- a/root/tests/test_session_cleanup.py
+++ b/root/tests/test_session_cleanup.py
@@ -1,0 +1,49 @@
+import datetime as dt
+
+import pytest
+from sqlalchemy import select
+
+from app.models.models import ActiveSession, User
+from app.services.session_cleanup import cleanup_expired_sessions
+
+
+@pytest.mark.asyncio
+async def test_cleanup_expired_sessions_removes_expired(db_session):
+    now = dt.datetime.now(dt.UTC)
+
+    user = User(email="cleanup@example.com", hashed_password="x")
+    db_session.add(user)
+    await db_session.flush()
+
+    expired = ActiveSession(
+        user_id=user.id,
+        jti="expired",
+        expires_at=now - dt.timedelta(minutes=5),
+    )
+    revoked = ActiveSession(
+        user_id=user.id,
+        jti="revoked",
+        expires_at=now + dt.timedelta(hours=1),
+        revoked_at=now - dt.timedelta(minutes=2),
+    )
+    active = ActiveSession(
+        user_id=user.id,
+        jti="active",
+        expires_at=now + dt.timedelta(hours=2),
+    )
+    future_revocation = ActiveSession(
+        user_id=user.id,
+        jti="revoked-future",
+        expires_at=now + dt.timedelta(hours=2),
+        revoked_at=now + dt.timedelta(hours=1),
+    )
+
+    db_session.add_all([expired, revoked, active, future_revocation])
+    await db_session.commit()
+
+    removed = await cleanup_expired_sessions(now=now)
+    assert removed == 2
+
+    result = await db_session.execute(select(ActiveSession.jti))
+    remaining = {row[0] for row in result}
+    assert remaining == {"active", "revoked-future"}


### PR DESCRIPTION
## Summary
- add a session cleanup service that deletes expired or revoked ActiveSession records and exposes a CLI entrypoint
- invoke the cleanup on startup and schedule periodic execution with a configurable interval
- cover the cleanup behavior with unit tests and document operational guidance

## Testing
- pytest root/tests/test_session_cleanup.py

------
https://chatgpt.com/codex/tasks/task_e_68f4470658c48327b343d1a06a00080e