### PR TITLE
Add audit logging for authentication flows

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,6 +16,13 @@ To report a vulnerability, use the **Security** tab on GitHub and open a new **P
 - Password length requirements: **8–200 characters**. Unicode is fully supported and input is stored verbatim (no trimming or normalization).
 - Password changes and account provisioning use the same policy and algorithm, and the behaviour is covered by automated tests.
 
+## Authentication Audit Logging
+
+- Authentication and password-recovery endpoints emit structured JSON audit events through the `app.auth` and `app.users.audit` loggers. The payloads include the `event` name, a stringified `user_id` when known, the caller IP (`ip`) when available, and the current request correlation identifier (`request_id`). Reasons for success or failure are normalised tokens such as `authenticated`, `invalid_credentials`, `token_expired`, etc.
+- Logs inherit the JSON formatter defined in [`app/core/observability.py`](root/app/core/observability.py), so downstream consumers can parse them without regexes. Example pipelines include shipping stdout to your SIEM or subscribing to the OTLP stream when observability exporters are enabled.
+- Sensitive fields (passwords, reset tokens, email addresses) are never included. If additional context is required for an investigation, correlate by `request_id` or session identifiers rather than augmenting the log payloads with PII.
+- Operators should alert on high volumes of `auth.login.failure` or `password.reset.failed` events from a single IP, and reconcile `auth.logout.revoked` events with expected device revocations to detect account takeovers.
+
 ## HTTP Security Headers & Browser Hardening
 
 Our FastAPI middleware enables a strict set of transport and browser security headers in production:

--- a/root/app/api/users.py
+++ b/root/app/api/users.py
@@ -1,4 +1,5 @@
 import hashlib
+import json
 import logging
 import secrets
 import smtplib
@@ -28,6 +29,7 @@ from app.api.utils import save_upload
 from app.auth.security import get_password_hash
 from app.core.config import settings
 from app.core.database import get_db
+from app.core.observability import get_request_id
 from app.localization import resolve_locale, translate
 from app.models import models
 from app.schemas import schemas
@@ -36,6 +38,7 @@ from app.utils.files import delete_static_file
 from app.utils.ratelimit import sensitive_route_limit
 
 logger = logging.getLogger(__name__)
+audit_logger = logging.getLogger("app.users.audit")
 
 
 router = APIRouter()
@@ -157,6 +160,19 @@ async def forgot_password(
             user.full_name or "",
             locale,
         )
+        _audit_log(
+            "password.reset.initiated",
+            request,
+            user_id=user.id,
+            reason="initiated",
+        )
+    else:
+        _audit_log(
+            "password.reset.initiated",
+            request,
+            level=logging.WARNING,
+            reason="user_not_found",
+        )
     return {"ok": True}
 
 
@@ -178,13 +194,42 @@ async def reset_password(
         )
     )
     rec = result.scalar_one_or_none()
-    if not rec or rec.expires_at < datetime.now(timezone.utc):
+    now = datetime.now(timezone.utc)
+    if not rec:
+        _audit_log(
+            "password.reset.failed",
+            request,
+            level=logging.WARNING,
+            reason="token_invalid",
+        )
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=translate("errors.password.invalid_or_expired_link", locale=locale),
+        )
+    expires_at = rec.expires_at
+    if expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=timezone.utc)
+    if expires_at < now:
+        _audit_log(
+            "password.reset.failed",
+            request,
+            level=logging.WARNING,
+            user_id=rec.user_id,
+            reason="token_expired",
+        )
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=translate("errors.password.invalid_or_expired_link", locale=locale),
         )
     user = await db.get(models.User, rec.user_id)
     if not user or not getattr(user, "is_active", True):
+        _audit_log(
+            "password.reset.failed",
+            request,
+            level=logging.WARNING,
+            user_id=rec.user_id,
+            reason="user_inactive",
+        )
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=translate("errors.password.invalid_link", locale=locale),
@@ -203,6 +248,12 @@ async def reset_password(
         .values(used=True)
     )
     await db.commit()
+    _audit_log(
+        "password.reset.completed",
+        request,
+        user_id=rec.user_id,
+        reason="completed",
+    )
     return {"ok": True}
 
 
@@ -422,3 +473,26 @@ router.include_router(groups_router)
 
 
 __all__ = ["router"]
+
+
+def _audit_log(
+    event: str,
+    request: Request,
+    *,
+    level: int = logging.INFO,
+    user_id: int | str | None = None,
+    reason: str | None = None,
+) -> None:
+    request_id = get_request_id() or request.headers.get("x-request-id")
+    client_ip = request.client.host if request.client else None
+    payload: dict[str, str] = {"event": event}
+    if user_id is not None:
+        payload["user_id"] = str(user_id)
+    if request_id:
+        payload["request_id"] = request_id
+    if client_ip:
+        payload["ip"] = client_ip
+    if reason:
+        payload["reason"] = reason
+    audit_logger.log(level, json.dumps(payload, ensure_ascii=False))
+

--- a/root/app/api/users.py
+++ b/root/app/api/users.py
@@ -495,4 +495,3 @@ def _audit_log(
     if reason:
         payload["reason"] = reason
     audit_logger.log(level, json.dumps(payload, ensure_ascii=False))
-

--- a/root/app/auth/auth.py
+++ b/root/app/auth/auth.py
@@ -15,8 +15,8 @@ from app.auth.security import (
     verify_and_update_password,
 )
 from app.core.config import settings
-from app.core.observability import get_request_id
 from app.core.database import get_db
+from app.core.observability import get_request_id
 from app.localization import resolve_locale, translate
 from app.models.models import ActiveSession, User
 from app.schemas.schemas import Token, UserCreate
@@ -309,4 +309,3 @@ def _audit_log(
     if reason:
         payload["reason"] = reason
     logger.log(level, json.dumps(payload, ensure_ascii=False))
-

--- a/root/app/auth/auth.py
+++ b/root/app/auth/auth.py
@@ -1,3 +1,5 @@
+import json
+import logging
 from datetime import UTC, datetime, timedelta
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
@@ -13,11 +15,15 @@ from app.auth.security import (
     verify_and_update_password,
 )
 from app.core.config import settings
+from app.core.observability import get_request_id
 from app.core.database import get_db
 from app.localization import resolve_locale, translate
 from app.models.models import ActiveSession, User
 from app.schemas.schemas import Token, UserCreate
 from app.utils.ratelimit import sensitive_route_limit
+
+logger = logging.getLogger("app.auth")
+
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
@@ -78,6 +84,12 @@ async def login(
     res = await db.execute(select(User).where(User.email == email))
     user = res.scalars().first()
     if not user:
+        _audit_log(
+            "auth.login.failure",
+            request,
+            level=logging.WARNING,
+            reason="invalid_credentials",
+        )
         message = translate("errors.auth.credentials_invalid", locale=locale)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -90,6 +102,13 @@ async def login(
         form_data.password, user.hashed_password
     )
     if not verified:
+        _audit_log(
+            "auth.login.failure",
+            request,
+            level=logging.WARNING,
+            user_id=user.id,
+            reason="invalid_credentials",
+        )
         message = translate("errors.auth.credentials_invalid", locale=locale)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -97,6 +116,13 @@ async def login(
             headers={"WWW-Authenticate": "Bearer"},
         )
     if not user.is_active:
+        _audit_log(
+            "auth.login.failure",
+            request,
+            level=logging.WARNING,
+            user_id=user.id,
+            reason="inactive_user",
+        )
         message = translate("errors.auth.user_deactivated", locale=locale)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -110,6 +136,12 @@ async def login(
         await db.refresh(user)
     token = await create_access_token(str(user_id), db=db)
     _set_access_token_cookie(response, token)
+    _audit_log(
+        "auth.login.success",
+        request,
+        user_id=user_id,
+        reason="authenticated",
+    )
     return {"access_token": token, "token_type": "bearer"}
 
 
@@ -129,6 +161,12 @@ async def login_json(
     res = await db.execute(select(User).where(User.email == email))
     user = res.scalars().first()
     if not user:
+        _audit_log(
+            "auth.login.failure",
+            request,
+            level=logging.WARNING,
+            reason="invalid_credentials",
+        )
         message = translate("errors.auth.credentials_invalid", locale=locale)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -141,6 +179,13 @@ async def login_json(
         payload.password, user.hashed_password
     )
     if not verified:
+        _audit_log(
+            "auth.login.failure",
+            request,
+            level=logging.WARNING,
+            user_id=user.id,
+            reason="invalid_credentials",
+        )
         message = translate("errors.auth.credentials_invalid", locale=locale)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -148,6 +193,13 @@ async def login_json(
             headers={"WWW-Authenticate": "Bearer"},
         )
     if not user.is_active:
+        _audit_log(
+            "auth.login.failure",
+            request,
+            level=logging.WARNING,
+            user_id=user.id,
+            reason="inactive_user",
+        )
         message = translate("errors.auth.user_deactivated", locale=locale)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -161,6 +213,12 @@ async def login_json(
         await db.refresh(user)
     token = await create_access_token(str(user_id), db=db)
     _set_access_token_cookie(response, token)
+    _audit_log(
+        "auth.login.success",
+        request,
+        user_id=user_id,
+        reason="authenticated",
+    )
     return {"access_token": token, "token_type": "bearer"}
 
 
@@ -220,6 +278,35 @@ async def logout(
         if session and session.revoked_at is None:
             session.revoked_at = datetime.now(UTC)
             await db.commit()
+            _audit_log(
+                "auth.logout.revoked",
+                request,
+                user_id=session.user_id,
+                reason="user_initiated",
+            )
 
     _clear_access_token_cookie(response)
     return {"status": "ok"}
+
+
+def _audit_log(
+    event: str,
+    request: Request,
+    *,
+    level: int = logging.INFO,
+    user_id: int | str | None = None,
+    reason: str | None = None,
+) -> None:
+    request_id = get_request_id() or request.headers.get("x-request-id")
+    client_ip = request.client.host if request.client else None
+    payload: dict[str, str] = {"event": event}
+    if user_id is not None:
+        payload["user_id"] = str(user_id)
+    if request_id:
+        payload["request_id"] = request_id
+    if client_ip:
+        payload["ip"] = client_ip
+    if reason:
+        payload["reason"] = reason
+    logger.log(level, json.dumps(payload, ensure_ascii=False))
+

--- a/root/tests/test_audit_logs.py
+++ b/root/tests/test_audit_logs.py
@@ -1,0 +1,140 @@
+import json
+import logging
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.api.users import _hash_token
+from app.auth.security import get_password_hash
+from app.models import models
+from app.utils.email import RESET_TOKEN_EXPIRY_MINUTES
+
+
+pytestmark = pytest.mark.anyio("asyncio")
+
+
+def _find_event(caplog, logger_name: str, event: str) -> dict:
+    for record in reversed(caplog.records):
+        if record.name != logger_name:
+            continue
+        try:
+            payload = json.loads(record.message)
+        except json.JSONDecodeError:  # pragma: no cover - defensive guard
+            continue
+        if payload.get("event") == event:
+            return payload
+    raise AssertionError(f"event {event!r} not found for logger {logger_name!r}")
+
+
+async def test_login_success_logs_audit(async_client, user_factory, caplog):
+    caplog.set_level(logging.INFO)
+    caplog.clear()
+    hashed = get_password_hash("StrongPass123!")
+    user = await user_factory(hashed_password=hashed, is_active=True)
+
+    response = await async_client.post(
+        "/auth/login",
+        data={"username": user.email, "password": "StrongPass123!"},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+
+    assert response.status_code == 200
+
+    event = _find_event(caplog, "app.auth", "auth.login.success")
+    assert event["user_id"] == str(user.id)
+    assert event["reason"] == "authenticated"
+    assert "ip" in event or "request_id" in event
+
+
+async def test_login_failure_logs_audit(async_client, user_factory, caplog):
+    caplog.set_level(logging.INFO)
+    caplog.clear()
+    hashed = get_password_hash("ValidPass123!")
+    user = await user_factory(hashed_password=hashed, is_active=True)
+
+    response = await async_client.post(
+        "/auth/login",
+        data={"username": user.email, "password": "WrongPass!"},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+
+    assert response.status_code == 401
+
+    event = _find_event(caplog, "app.auth", "auth.login.failure")
+    assert event.get("reason") == "invalid_credentials"
+    assert "ip" in event or "request_id" in event
+
+
+async def test_logout_revocation_logs_audit(async_client, user_factory, caplog):
+    caplog.set_level(logging.INFO)
+    caplog.clear()
+    hashed = get_password_hash("LogoutPass123!")
+    user = await user_factory(hashed_password=hashed, is_active=True)
+
+    login_response = await async_client.post(
+        "/auth/login",
+        data={"username": user.email, "password": "LogoutPass123!"},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert login_response.status_code == 200
+    token = login_response.json()["access_token"]
+
+    logout_response = await async_client.post(
+        "/auth/logout",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert logout_response.status_code == 200
+
+    event = _find_event(caplog, "app.auth", "auth.logout.revoked")
+    assert event["user_id"] == str(user.id)
+    assert event["reason"] == "user_initiated"
+
+
+async def test_password_reset_initiation_audit(async_client, user_factory, caplog):
+    caplog.set_level(logging.INFO)
+    caplog.clear()
+    hashed = get_password_hash("ResetInitPass123!")
+    user = await user_factory(hashed_password=hashed, is_active=True)
+
+    response = await async_client.post(
+        "/password/forgot",
+        json={"email": user.email},
+    )
+
+    assert response.status_code == 200
+
+    event = _find_event(caplog, "app.users.audit", "password.reset.initiated")
+    assert event["user_id"] == str(user.id)
+    assert event["reason"] == "initiated"
+
+
+async def test_password_reset_completed_audit(async_client, user_factory, db_session, caplog):
+    caplog.set_level(logging.INFO)
+    caplog.clear()
+    hashed = get_password_hash("ResetCompletePass123!")
+    user = await user_factory(hashed_password=hashed, is_active=True)
+
+    token = "reset-token-value"
+    token_hash = _hash_token(token)
+    expires = datetime.now(timezone.utc) + timedelta(minutes=RESET_TOKEN_EXPIRY_MINUTES)
+    db_session.add(
+        models.PasswordResetToken(
+            user_id=user.id,
+            token_hash=token_hash,
+            expires_at=expires,
+            used=False,
+        )
+    )
+    await db_session.commit()
+
+    response = await async_client.post(
+        "/password/reset",
+        json={"token": token, "password": "BrandNewPass123!"},
+    )
+
+    assert response.status_code == 200
+
+    event = _find_event(caplog, "app.users.audit", "password.reset.completed")
+    assert event["user_id"] == str(user.id)
+    assert event["reason"] == "completed"
+

--- a/root/tests/test_audit_logs.py
+++ b/root/tests/test_audit_logs.py
@@ -9,7 +9,6 @@ from app.auth.security import get_password_hash
 from app.models import models
 from app.utils.email import RESET_TOKEN_EXPIRY_MINUTES
 
-
 pytestmark = pytest.mark.anyio("asyncio")
 
 
@@ -108,7 +107,9 @@ async def test_password_reset_initiation_audit(async_client, user_factory, caplo
     assert event["reason"] == "initiated"
 
 
-async def test_password_reset_completed_audit(async_client, user_factory, db_session, caplog):
+async def test_password_reset_completed_audit(
+    async_client, user_factory, db_session, caplog
+):
     caplog.set_level(logging.INFO)
     caplog.clear()
     hashed = get_password_hash("ResetCompletePass123!")
@@ -137,4 +138,3 @@ async def test_password_reset_completed_audit(async_client, user_factory, db_ses
     event = _find_event(caplog, "app.users.audit", "password.reset.completed")
     assert event["user_id"] == str(user.id)
     assert event["reason"] == "completed"
-


### PR DESCRIPTION
## Summary
- add structured audit logging to authentication endpoints and logout revocations
- emit audit events for password reset workflows and document consumption guidance
- cover audit logging behaviour with new tests

## Testing
- pytest root/tests/test_audit_logs.py

------
https://chatgpt.com/codex/tasks/task_e_68f44a4cb1ec83278b72d29fdde04ddd