### PR TITLE
Optimize uploaded images and document limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,17 @@ Key settings you may want to adjust for local development:
 | `SPOTIFY_*` | OAuth credentials required for Spotify integration. | Empty |
 | `VAPID_*` | Keys used to send web push notifications. | Empty |
 | `CACHE_*` & `RATE_LIMIT_*` | Toggle and configure caching and rate limiting backends. | In-memory |
+| `IMAGE_MAX_WIDTH` / `IMAGE_MAX_HEIGHT` | Bounding box applied to uploaded images before storage. | `1920` |
 | `ENABLE_OTEL`, `SENTRY_DSN` | Observability & error tracking toggles. | Disabled |
 
 Refer to [`root/app/core/config.py`](root/app/core/config.py) for the complete configuration model and validation logic. The `.env` file is loaded automatically when you start the backend or worker.
+
+## Image uploads
+
+Uploaded profile photos and news images are limited to **5&nbsp;MB**. The backend
+automatically resizes images so they fit within the `IMAGE_MAX_WIDTH` ×
+`IMAGE_MAX_HEIGHT` bounding box (default 1920×1920), strips EXIF metadata, and
+stores them as optimized WebP files (PNG when transparency is required).
 
 ## Running tests and linters
 

--- a/root/.env.example
+++ b/root/.env.example
@@ -15,6 +15,8 @@ ENABLE_COEP=false
 COEP_VALUE=credentialless
 
 STATIC_DIR=app/static
+IMAGE_MAX_WIDTH=1920
+IMAGE_MAX_HEIGHT=1920
 TRUSTED_HOSTS=localhost,127.0.0.1
 
 # ----- Mail -----

--- a/root/app/core/config.py
+++ b/root/app/core/config.py
@@ -68,6 +68,8 @@ class Settings(BaseSettings):
     frontend_origins: str | list[str] = ""
     app_base_url: str = "http://localhost:5173"
     static_dir: str = "app/static"
+    image_max_width: int = 1920
+    image_max_height: int = 1920
     trusted_hosts: str | list[str] = "localhost,127.0.0.1"
     environment: str = "development"
     auto_create_schema: bool = True

--- a/root/app/utils/files.py
+++ b/root/app/utils/files.py
@@ -11,6 +11,7 @@ from fastapi import HTTPException, UploadFile, status
 
 from app.core.config import settings
 from app.localization import translate
+from app.utils.images import optimize_image
 
 logger = logging.getLogger(__name__)
 
@@ -167,14 +168,27 @@ async def save_image(
             status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
             detail=translate("errors.files.content_type_mismatch", locale=locale),
         )
-    ext = _PREFERRED_EXTENSIONS.get(detected_type) or _ext_from_mime(detected_type)
+    try:
+        optimized_data, optimized_type = await asyncio.to_thread(
+            optimize_image,
+            data,
+            max_width=getattr(settings, "image_max_width", 0),
+            max_height=getattr(settings, "image_max_height", 0),
+        )
+    except ValueError:
+        raise HTTPException(
+            status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+            detail=translate("errors.files.unsupported_type", locale=locale),
+        ) from None
+
+    ext = _PREFERRED_EXTENSIONS.get(optimized_type) or _ext_from_mime(optimized_type)
     name = _gen_name(prefix, ext)
     base = settings.static_dir_path
     sanitized_subdir = subdir.strip("/ ")
     target_dir = base / sanitized_subdir
     await asyncio.to_thread(_ensure_dir, target_dir)
     path = target_dir / name
-    await asyncio.to_thread(path.write_bytes, data)
+    await asyncio.to_thread(path.write_bytes, optimized_data)
     # Return canonical public URL without accidental duplicate slashes.
     return f"/static/{sanitized_subdir}/{name}"
 

--- a/root/app/utils/images.py
+++ b/root/app/utils/images.py
@@ -1,0 +1,59 @@
+"""Image processing helpers for uploaded files."""
+
+from __future__ import annotations
+
+from io import BytesIO
+
+from PIL import Image, ImageOps, UnidentifiedImageError
+
+
+def _resolve_resample_filter() -> int:
+    """Return the best available high-quality resampling filter."""
+
+    resampling = getattr(Image, "Resampling", None)
+    if resampling is not None:
+        return resampling.LANCZOS
+    return Image.LANCZOS  # pragma: no cover - compatibility fallback
+
+
+def optimize_image(
+    data: bytes, *, max_width: int | None = None, max_height: int | None = None
+) -> tuple[bytes, str]:
+    """Resize and re-encode an image to an optimized PNG or WebP payload.
+
+    The helper ensures the image fits within the configured bounding box, strips
+    EXIF metadata, and converts the image to an efficient format.
+    """
+
+    try:
+        with Image.open(BytesIO(data)) as img:
+            img = ImageOps.exif_transpose(img)
+            width, height = img.size
+
+            max_w = int(max_width or 0)
+            max_h = int(max_height or 0)
+            if max_w <= 0:
+                max_w = width
+            if max_h <= 0:
+                max_h = height
+
+            if width > max_w or height > max_h:
+                resample = _resolve_resample_filter()
+                img.thumbnail((max_w, max_h), resample=resample)
+
+            has_alpha = "A" in img.getbands()
+            target_mode = "RGBA" if has_alpha else "RGB"
+            if img.mode != target_mode:
+                img = img.convert(target_mode)
+
+            buffer = BytesIO()
+            if has_alpha:
+                img.save(buffer, format="PNG", optimize=True)
+                mime = "image/png"
+            else:
+                img.save(buffer, format="WEBP", method=6, quality=85)
+                mime = "image/webp"
+    except (UnidentifiedImageError, OSError, ValueError) as exc:  # pragma: no cover - runtime guard
+        raise ValueError("Invalid image data") from exc
+
+    return buffer.getvalue(), mime

--- a/root/app/utils/images.py
+++ b/root/app/utils/images.py
@@ -53,7 +53,11 @@ def optimize_image(
             else:
                 img.save(buffer, format="WEBP", method=6, quality=85)
                 mime = "image/webp"
-    except (UnidentifiedImageError, OSError, ValueError) as exc:  # pragma: no cover - runtime guard
+    except (
+        UnidentifiedImageError,
+        OSError,
+        ValueError,
+    ) as exc:  # pragma: no cover - runtime guard
         raise ValueError("Invalid image data") from exc
 
     return buffer.getvalue(), mime

--- a/root/requirements-dev.txt
+++ b/root/requirements-dev.txt
@@ -4,3 +4,4 @@ httpx>=0.27
 asgi-lifespan>=2.1
 argon2-cffi>=23.1.0
 python-magic>=0.4.27
+Pillow>=10

--- a/root/requirements.txt
+++ b/root/requirements.txt
@@ -16,6 +16,7 @@ email-validator>=2.0
 httpx>=0.27
 python-multipart>=0.0.7
 python-magic>=0.4.27
+Pillow>=10
 aiofiles>=23.0
 pywebpush>=1.9
 psycopg[binary]>=3.1

--- a/root/tests/test_file_utils.py
+++ b/root/tests/test_file_utils.py
@@ -3,8 +3,8 @@ import io
 import re
 
 import pytest
-from PIL import Image
 from fastapi import HTTPException, UploadFile
+from PIL import Image
 from starlette.datastructures import Headers
 
 from app.core.config import settings

--- a/root/tests/test_file_utils.py
+++ b/root/tests/test_file_utils.py
@@ -3,6 +3,7 @@ import io
 import re
 
 import pytest
+from PIL import Image
 from fastapi import HTTPException, UploadFile
 from starlette.datastructures import Headers
 
@@ -23,11 +24,12 @@ def test_normalize_filename_prefix_compacts_symbols():
 
 @pytest.mark.asyncio
 async def test_save_image_offloads_io(tmp_path, monkeypatch):
-    png_header = b"\x89PNG\r\n\x1a\n"
-    body = png_header + b"\x00" * 10
+    buffer = io.BytesIO()
+    Image.new("RGB", (2, 2), color=(255, 0, 0)).save(buffer, format="PNG")
+    buffer.seek(0)
     upload = UploadFile(
         filename="avatar.png",
-        file=io.BytesIO(body),
+        file=buffer,
         headers=Headers({"content-type": "image/png"}),
     )
 
@@ -86,3 +88,62 @@ async def test_save_image_reports_localized_size_limit(monkeypatch):
         await files.save_image(upload, "avatars", "Profile Pic", locale="ru")
 
     assert excinfo.value.detail == translate("errors.files.too_large", locale="ru")
+
+
+@pytest.mark.asyncio
+async def test_save_image_resizes_and_converts_large_images(tmp_path, monkeypatch):
+    big = Image.new("RGB", (4000, 2000), color=(255, 0, 0))
+    buffer = io.BytesIO()
+    big.save(buffer, format="PNG")
+    buffer.seek(0)
+
+    upload = UploadFile(
+        filename="huge.png",
+        file=buffer,
+        headers=Headers({"content-type": "image/png"}),
+    )
+
+    monkeypatch.setattr(settings, "static_dir_path", tmp_path)
+    monkeypatch.setattr(settings, "image_max_width", 512)
+    monkeypatch.setattr(settings, "image_max_height", 512)
+
+    url = await files.save_image(upload, "avatars", "Large Pic")
+    rel_path = url.removeprefix("/static/")
+    stored_path = settings.static_dir_path / rel_path
+
+    assert stored_path.suffix == ".webp"
+    with Image.open(stored_path) as saved:
+        assert saved.format == "WEBP"
+        assert saved.width <= 512
+        assert saved.height <= 512
+        assert "exif" not in saved.info
+
+
+@pytest.mark.asyncio
+async def test_save_image_preserves_transparency_with_png(tmp_path, monkeypatch):
+    image = Image.new("RGBA", (300, 200), color=(0, 128, 255, 128))
+    buffer = io.BytesIO()
+    image.save(buffer, format="PNG")
+    buffer.seek(0)
+
+    upload = UploadFile(
+        filename="transparent.png",
+        file=buffer,
+        headers=Headers({"content-type": "image/png"}),
+    )
+
+    monkeypatch.setattr(settings, "static_dir_path", tmp_path)
+    monkeypatch.setattr(settings, "image_max_width", 512)
+    monkeypatch.setattr(settings, "image_max_height", 512)
+
+    url = await files.save_image(upload, "avatars", "Transparent Pic")
+    rel_path = url.removeprefix("/static/")
+    stored_path = settings.static_dir_path / rel_path
+
+    assert stored_path.suffix == ".png"
+    with Image.open(stored_path) as saved:
+        assert saved.format == "PNG"
+        assert saved.mode == "RGBA"
+        assert saved.width <= 300
+        assert saved.height <= 200
+        assert "exif" not in saved.info


### PR DESCRIPTION
## Summary
- add a Pillow-based helper that resizes uploads, strips EXIF data, and re-encodes them as WebP/PNG
- integrate the helper into image saving while exposing configurable max dimensions
- document the image limits, extend requirements, and cover the new behaviour with tests

## Testing
- pytest tests/test_file_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68f4ee64bb308327a1f4ca2e2c3259b5