### PR TITLE
Add configurable malware scanning for event attachments

### DIFF
--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -62,6 +62,12 @@ server {
 ## Системные зависимости backend
 
 - Для серверной проверки контента файлов используется `python-magic`, поэтому на хостах с backend нужно установить пакеты `libmagic` (например, `apt install libmagic1 libmagic-dev` для Debian/Ubuntu или `apk add file` в Alpine).
+- Для антивирусной проверки загружаемых файлов поднимите сервис `clamd` (например, из пакета `clamav-daemon` или Docker-образа `clamav/clamav`).
+  - Включите проверку, установив `EVENT_FILE_SCANNER_ENABLED=true`.
+  - По умолчанию backend подключается к `clamd` по TCP (`EVENT_FILE_SCANNER_HOST` и `EVENT_FILE_SCANNER_PORT`, стандартно `127.0.0.1:3310`).
+  - Для Unix-сокета укажите путь через `EVENT_FILE_SCANNER_SOCKET` (приоритетнее хоста/порта).
+  - Таймаут подключения задаётся переменной `EVENT_FILE_SCANNER_TIMEOUT` (секунды).
+  - При недоступности сканера запросы загрузки файлов вернут HTTP 503, а при обнаружении угрозы — HTTP 422 с локализованным сообщением.
 
 ## Notifications worker
 

--- a/root/app/core/config.py
+++ b/root/app/core/config.py
@@ -154,6 +154,12 @@ class Settings(BaseSettings):
     )
     event_file_allowed_extensions: str | list[str] = ".pdf,.txt,.doc,.docx,.xls,.xlsx"
     event_file_max_size_bytes: int = 10 * 1024 * 1024
+    event_file_scanner_enabled: bool = False
+    event_file_scanner_backend: str = "clamd"
+    event_file_scanner_host: str = "127.0.0.1"
+    event_file_scanner_port: int = 3310
+    event_file_scanner_socket: str = ""
+    event_file_scanner_timeout: float = 30.0
 
     @field_validator("coep_value")
     @classmethod

--- a/root/app/localization.py
+++ b/root/app/localization.py
@@ -176,6 +176,14 @@ _TRANSLATIONS: Mapping[str, Mapping[str, str]] = {
         "ru": "Неподдерживаемое расширение файла",
         "en": "Unsupported file extension",
     },
+    "errors.files.infected": {
+        "ru": "Файл содержит вредоносное содержимое",
+        "en": "The file contains malicious content",
+    },
+    "errors.files.scanner_unavailable": {
+        "ru": "Служба проверки файлов временно недоступна",
+        "en": "File scanning service is temporarily unavailable",
+    },
     "errors.events.registration_forbidden": {
         "ru": "Регистрация на мероприятия недоступна для вашей роли",
         "en": "Event registration is not available for your role",

--- a/root/app/services/file_scanner.py
+++ b/root/app/services/file_scanner.py
@@ -70,7 +70,11 @@ async def scan_for_malware(data: bytes, *, locale: str | None = None) -> None:
     if not getattr(settings, "event_file_scanner_enabled", False):
         return
 
-    backend = (getattr(settings, "event_file_scanner_backend", "clamd") or "clamd").strip().lower()
+    backend = (
+        (getattr(settings, "event_file_scanner_backend", "clamd") or "clamd")
+        .strip()
+        .lower()
+    )
 
     try:
         if backend == "clamd":

--- a/root/app/services/file_scanner.py
+++ b/root/app/services/file_scanner.py
@@ -1,0 +1,92 @@
+"""File scanning helpers for uploaded payloads."""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import logging
+from typing import Any
+
+from fastapi import HTTPException, status
+
+from app.core.config import settings
+from app.localization import translate
+
+logger = logging.getLogger(__name__)
+
+
+class FileScannerUnavailableError(RuntimeError):
+    """Raised when the configured malware scanner cannot be reached."""
+
+
+def _scan_with_clamd(data: bytes) -> str | None:
+    """Return the detected signature or ``None`` if the payload is clean."""
+
+    try:  # Import lazily so environments without clamd stay functional.
+        import clamd  # type: ignore[import]
+    except ImportError as exc:  # pragma: no cover - depends on optional dependency
+        raise FileScannerUnavailableError("python-clamd is not installed") from exc
+
+    timeout = float(getattr(settings, "event_file_scanner_timeout", 30.0) or 30.0)
+    socket_path = getattr(settings, "event_file_scanner_socket", "") or ""
+    host = getattr(settings, "event_file_scanner_host", "127.0.0.1")
+    port = int(getattr(settings, "event_file_scanner_port", 3310) or 3310)
+
+    try:
+        if socket_path:
+            client = clamd.ClamdUnixSocket(path=socket_path, timeout=timeout)
+        else:
+            client = clamd.ClamdNetworkSocket(host=host, port=port, timeout=timeout)
+
+        response: Any = client.instream(io.BytesIO(data))
+    except Exception as exc:  # pragma: no cover - network failure path
+        raise FileScannerUnavailableError("clamd scan failed") from exc
+
+    if not isinstance(response, dict) or "stream" not in response:
+        raise FileScannerUnavailableError("unexpected clamd response format")
+
+    result = response["stream"]
+    if isinstance(result, tuple) and len(result) >= 1:
+        status_value = (result[0] or "").upper()
+        signature = result[1] if len(result) > 1 else None
+    else:
+        raise FileScannerUnavailableError("malformed clamd response")
+
+    if status_value == "OK":
+        return None
+    if status_value == "FOUND":
+        return str(signature or "unknown")
+    if status_value == "ERROR":
+        raise FileScannerUnavailableError(str(signature or "clamd error"))
+    raise FileScannerUnavailableError(f"unsupported clamd status: {status_value}")
+
+
+async def scan_for_malware(data: bytes, *, locale: str | None = None) -> None:
+    """Scan ``data`` for malware and raise an HTTP error when a threat is found."""
+
+    if not data:
+        return
+
+    if not getattr(settings, "event_file_scanner_enabled", False):
+        return
+
+    backend = (getattr(settings, "event_file_scanner_backend", "clamd") or "clamd").strip().lower()
+
+    try:
+        if backend == "clamd":
+            signature = await asyncio.to_thread(_scan_with_clamd, data)
+        else:
+            raise FileScannerUnavailableError(f"unsupported scanner backend: {backend}")
+    except FileScannerUnavailableError as exc:
+        logger.error("File scanner unavailable: %s", exc)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=translate("errors.files.scanner_unavailable", locale=locale),
+        ) from exc
+
+    if signature:
+        logger.warning("File scanner detected malware: %s", signature)
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=translate("errors.files.infected", locale=locale),
+        )

--- a/root/app/utils/files.py
+++ b/root/app/utils/files.py
@@ -11,6 +11,7 @@ from fastapi import HTTPException, UploadFile, status
 
 from app.core.config import settings
 from app.localization import translate
+from app.services.file_scanner import scan_for_malware
 from app.utils.images import optimize_image
 
 logger = logging.getLogger(__name__)
@@ -283,6 +284,7 @@ async def save_attachment(
     target_dir = base / sanitized_subdir
     await asyncio.to_thread(_ensure_dir, target_dir)
     path = target_dir / name
+    await scan_for_malware(data, locale=locale)
     await asyncio.to_thread(path.write_bytes, data)
     return f"/static/{sanitized_subdir}/{name}"
 

--- a/root/requirements-dev.txt
+++ b/root/requirements-dev.txt
@@ -4,4 +4,5 @@ httpx>=0.27
 asgi-lifespan>=2.1
 argon2-cffi>=23.1.0
 python-magic>=0.4.27
+clamd>=1.0.2
 Pillow>=10

--- a/root/requirements.txt
+++ b/root/requirements.txt
@@ -16,6 +16,7 @@ email-validator>=2.0
 httpx>=0.27
 python-multipart>=0.0.7
 python-magic>=0.4.27
+clamd>=1.0.2
 Pillow>=10
 aiofiles>=23.0
 pywebpush>=1.9

--- a/root/tests/test_event_file_upload.py
+++ b/root/tests/test_event_file_upload.py
@@ -169,6 +169,83 @@ async def test_upload_event_file_rejects_mismatched_magic_bytes(
 
 
 @pytest.mark.anyio("asyncio")
+async def test_upload_event_file_rejects_infected_payload(
+    tmp_path, monkeypatch, db_session, user_factory
+):
+    admin = await user_factory(role="admin")
+    event = await _create_event(db_session, admin)
+
+    payload = b"clean-looking"
+    upload = UploadFile(
+        filename="notes.txt",
+        file=io.BytesIO(payload),
+        headers=Headers({"content-type": "text/plain"}),
+    )
+
+    monkeypatch.setattr(settings, "static_dir_path", tmp_path)
+    monkeypatch.setattr(settings, "event_file_allowed_mime_types", ["text/plain"])
+    monkeypatch.setattr(settings, "event_file_allowed_extensions", [".txt"])
+    monkeypatch.setattr(settings, "event_file_max_size_bytes", 1024)
+
+    async def fake_scan(data: bytes, *, locale: str | None = None) -> None:
+        assert data == payload
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=translate("errors.files.infected", locale=locale),
+        )
+
+    monkeypatch.setattr(files, "scan_for_malware", fake_scan)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await events.upload_event_file(
+            event.id, upload, request=None, db=db_session, user=admin
+        )
+
+    assert excinfo.value.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert excinfo.value.detail == translate("errors.files.infected", locale="en")
+    folder = tmp_path / "event_files"
+    assert not folder.exists()
+
+
+@pytest.mark.anyio("asyncio")
+async def test_upload_event_file_allows_clean_payload_with_scanner(
+    tmp_path, monkeypatch, db_session, user_factory
+):
+    admin = await user_factory(role="admin")
+    event = await _create_event(db_session, admin)
+
+    payload = b"safe data"
+    upload = UploadFile(
+        filename="notes.txt",
+        file=io.BytesIO(payload),
+        headers=Headers({"content-type": "text/plain"}),
+    )
+
+    monkeypatch.setattr(settings, "static_dir_path", tmp_path)
+    monkeypatch.setattr(settings, "event_file_allowed_mime_types", ["text/plain"])
+    monkeypatch.setattr(settings, "event_file_allowed_extensions", [".txt"])
+    monkeypatch.setattr(settings, "event_file_max_size_bytes", 1024)
+
+    calls: list[tuple[bytes, str | None]] = []
+
+    async def fake_scan(data: bytes, *, locale: str | None = None) -> None:
+        calls.append((data, locale))
+        return None
+
+    monkeypatch.setattr(files, "scan_for_malware", fake_scan)
+
+    result = await events.upload_event_file(
+        event.id, upload, request=None, db=db_session, user=admin
+    )
+
+    assert result.event_id == event.id
+    assert calls and calls[0][0] == payload
+    stored_path = tmp_path / "event_files" / result.file_url.rsplit("/", 1)[-1]
+    assert stored_path.exists()
+    assert stored_path.read_bytes() == payload
+
+
+@pytest.mark.anyio("asyncio")
 async def test_update_event_replaces_image_removes_old_file(
     tmp_path, monkeypatch, db_session, user_factory
 ):


### PR DESCRIPTION
## Summary
- add a pluggable ClamAV-backed scanner for uploaded event attachments
- gate uploads on malware scan results with localized errors and new settings
- expand tests, dependencies, and deployment docs for the scanning service

## Testing
- pytest root/tests/test_event_file_upload.py *(fails: ModuleNotFoundError: No module named 'PIL')*


------
https://chatgpt.com/codex/tasks/task_e_68f4f05e0d1c8327871d3dd17662e685