### PR TITLE
Add configurable concurrency limit for web push notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Key settings you may want to adjust for local development:
 | `SMTP_*` | Outgoing email server configuration. | Empty (email disabled) |
 | `SPOTIFY_*` | OAuth credentials required for Spotify integration. | Empty |
 | `VAPID_*` | Keys used to send web push notifications. | Empty |
+| `NOTIFICATIONS_WEBPUSH_CONCURRENCY_LIMIT` | Maximum number of simultaneous web push delivery jobs. | `10` |
 | `CACHE_*` & `RATE_LIMIT_*` | Toggle and configure caching and rate limiting backends. | In-memory |
 | `IMAGE_MAX_WIDTH` / `IMAGE_MAX_HEIGHT` | Bounding box applied to uploaded images before storage. | `1920` |
 | `ENABLE_OTEL`, `SENTRY_DSN` | Observability & error tracking toggles. | Disabled |

--- a/root/app/core/config.py
+++ b/root/app/core/config.py
@@ -143,6 +143,7 @@ class Settings(BaseSettings):
     notifications_scheduler_inline_enabled: bool = True
     notifications_worker_metrics_host: str = "0.0.0.0"
     notifications_worker_metrics_port: int = 9101
+    notifications_webpush_concurrency_limit: int = 10
     session_cleanup_interval_seconds: int = 900
     event_file_allowed_mime_types: str | list[str] = (
         "application/pdf,"

--- a/root/app/services/notifications.py
+++ b/root/app/services/notifications.py
@@ -388,6 +388,23 @@ async def create_notifications_for_users(
             send_jobs: list[tuple[PushSubscription, int]] = []
             tasks: list[Awaitable[WebPushResult]] = []
 
+            limit = int(getattr(settings, "notifications_webpush_concurrency_limit", 0) or 0)
+            semaphore: asyncio.Semaphore | None = None
+            if limit > 0:
+                semaphore = asyncio.Semaphore(limit)
+
+            async def _send_push(
+                subscription: PushSubscription, payload: Mapping[str, Any]
+            ) -> WebPushResult:
+                if semaphore is None:
+                    return await asyncio.to_thread(
+                        send_web_push, subscription, payload
+                    )
+                async with semaphore:
+                    return await asyncio.to_thread(
+                        send_web_push, subscription, payload
+                    )
+
             for sub in subs:
                 user_id = int(getattr(sub, "user_id", 0) or 0)
                 notification_id = notification_ids_by_user.get(user_id)
@@ -406,7 +423,7 @@ async def create_notifications_for_users(
                     base_payload, getattr(sub, "user", None), now_time=now_time
                 )
                 send_jobs.append((sub, notification_id))
-                tasks.append(asyncio.to_thread(send_web_push, sub, prepared_payload))
+                tasks.append(_send_push(sub, prepared_payload))
 
             if tasks:
                 results = await asyncio.gather(*tasks, return_exceptions=True)

--- a/root/app/services/notifications.py
+++ b/root/app/services/notifications.py
@@ -388,7 +388,9 @@ async def create_notifications_for_users(
             send_jobs: list[tuple[PushSubscription, int]] = []
             tasks: list[Awaitable[WebPushResult]] = []
 
-            limit = int(getattr(settings, "notifications_webpush_concurrency_limit", 0) or 0)
+            limit = int(
+                getattr(settings, "notifications_webpush_concurrency_limit", 0) or 0
+            )
             semaphore: asyncio.Semaphore | None = None
             if limit > 0:
                 semaphore = asyncio.Semaphore(limit)
@@ -397,13 +399,9 @@ async def create_notifications_for_users(
                 subscription: PushSubscription, payload: Mapping[str, Any]
             ) -> WebPushResult:
                 if semaphore is None:
-                    return await asyncio.to_thread(
-                        send_web_push, subscription, payload
-                    )
+                    return await asyncio.to_thread(send_web_push, subscription, payload)
                 async with semaphore:
-                    return await asyncio.to_thread(
-                        send_web_push, subscription, payload
-                    )
+                    return await asyncio.to_thread(send_web_push, subscription, payload)
 
             for sub in subs:
                 user_id = int(getattr(sub, "user_id", 0) or 0)

--- a/root/tests/test_notifications_push.py
+++ b/root/tests/test_notifications_push.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import json
+import time
 from collections.abc import Iterator
+from threading import Lock
 from types import SimpleNamespace
 from typing import Any
 
@@ -21,6 +23,7 @@ from app.models.models import PushSubscription
 from app.routers.notifications import _serialize_subscription
 from app.services import notifications
 from app.services import webpush as webpush_module
+from app.services.webpush import WebPushResult
 
 
 @pytest.fixture
@@ -339,3 +342,72 @@ async def test_notify_about_news_uses_locale(
 
     assert captures[1]["title"] == "Новая новость: Русский заголовок"
     assert captures[1]["body"].startswith("Русский текст")
+    assert captures[1]["payload"]["headline"] == "Русский заголовок"
+
+
+@pytest.mark.anyio
+async def test_create_notifications_limits_concurrent_push_tasks(
+    db_session,
+    user_factory,
+    monkeypatch: pytest.MonkeyPatch,
+    _configured_webpush_settings,
+):
+    limit = 2
+    monkeypatch.setattr(settings, "notifications_webpush_concurrency_limit", limit)
+
+    users = [await user_factory(is_active=True) for _ in range(6)]
+    for idx, user in enumerate(users):
+        db_session.add(
+            PushSubscription(
+                user_id=user.id,
+                endpoint=f"https://push.example.test/{idx}",
+                auth=f"auth-{idx}",
+                p256dh=f"p256-{idx}",
+                topics=["news"],
+            )
+        )
+    await db_session.commit()
+
+    async def _noop_schema(_db):
+        return None
+
+    monkeypatch.setattr(notifications, "ensure_push_subscription_schema", _noop_schema)
+
+    active = 0
+    max_active = 0
+    lock = Lock()
+    call_count = 0
+
+    def _fake_send_web_push(subscription, payload):
+        nonlocal active, max_active, call_count
+        with lock:
+            active += 1
+            call_count += 1
+            if active > max_active:
+                max_active = active
+        time.sleep(0.02)
+        with lock:
+            active -= 1
+        return WebPushResult(
+            subscription_id=subscription.id,
+            endpoint=subscription.endpoint,
+            user_id=subscription.user_id,
+            status="sent",
+            status_code=201,
+        )
+
+    monkeypatch.setattr(notifications, "send_web_push", _fake_send_web_push)
+
+    created = await notifications.create_notifications_for_users(
+        db_session,
+        title="Test",
+        body="Body",
+        type="news",
+        url="/news",
+        user_ids=[user.id for user in users],
+        topic="news",
+    )
+
+    assert created == len(users)
+    assert call_count == len(users)
+    assert max_active == limit


### PR DESCRIPTION
## Summary
- enforce a configurable concurrency limit when dispatching web push notifications
- expose a new NOTIFICATIONS_WEBPUSH_CONCURRENCY_LIMIT setting with a production-friendly default
- document the new configuration and add coverage that ensures the limit is respected

## Testing
- pytest tests/test_notifications_push.py

------
https://chatgpt.com/codex/tasks/task_e_68f4faf736e88327a95e567f80c488d6