### PR TITLE
Optimize schedule reminder notifications batching

### DIFF
--- a/root/app/services/notifications.py
+++ b/root/app/services/notifications.py
@@ -2,6 +2,7 @@ import asyncio
 import datetime as dt
 import logging
 import re
+from collections import defaultdict
 from datetime import UTC
 from html import unescape
 from textwrap import shorten
@@ -466,57 +467,85 @@ async def generate_schedule_reminders(
     q = select(Schedule).where(
         and_(Schedule.start_time >= now, Schedule.start_time <= soon)
     )
-    rows = (await db.execute(q)).scalars().all()
-    if not rows:
+    schedules = (await db.execute(q)).scalars().all()
+    if not schedules:
         return 0
-    total_created = 0
-    for sch in rows:
-        title, body, tag, data_payload = build_schedule_reminder_message(sch)
-        uids_all = (
-            (await db.execute(select(User.id).where(User.group_id == sch.group_id)))
-            .scalars()
-            .all()
-        )
-        if not uids_all:
+
+    schedules_by_group: dict[int, list[Schedule]] = defaultdict(list)
+    message_payloads: dict[int, tuple[str, str, str, dict[str, Any]]] = {}
+    titles: set[str] = set()
+    for schedule in schedules:
+        schedules_by_group[int(schedule.group_id)].append(schedule)
+        payload = build_schedule_reminder_message(schedule)
+        message_payloads[int(schedule.id)] = payload
+        titles.add(payload[0])
+
+    group_ids = list(schedules_by_group.keys())
+    if not group_ids:
+        return 0
+
+    users_stmt = select(User.id, User.group_id).where(User.group_id.in_(group_ids))
+    user_rows = await db.execute(users_stmt)
+    group_users: dict[int, set[int]] = defaultdict(set)
+    for user_id, group_id in user_rows:
+        if user_id is None or group_id is None:
             continue
-        dup_since = now - dt.timedelta(minutes=30)
-        existing_q = (
-            select(Notification.user_id)
+        group_users[int(group_id)].add(int(user_id))
+
+    if not any(group_users.values()):
+        return 0
+
+    dup_since = now - dt.timedelta(minutes=30)
+    all_user_ids = {uid for users in group_users.values() for uid in users}
+    existing_by_title: dict[str, set[int]] = defaultdict(set)
+    if titles and all_user_ids:
+        existing_stmt = (
+            select(Notification.user_id, Notification.title)
             .where(
-                and_(
-                    Notification.user_id.in_(
-                        select(User.id).where(User.group_id == sch.group_id)
-                    ),
-                    Notification.title == title,
-                    Notification.url == "/schedule",
-                    Notification.created_at >= dup_since,
-                )
+                Notification.user_id.in_(all_user_ids),
+                Notification.url == "/schedule",
+                Notification.created_at >= dup_since,
+                Notification.title.in_(titles),
             )
             .distinct()
         )
-        existing = set((await db.execute(existing_q)).scalars().all())
-        to_notify = [u for u in uids_all if u not in existing]
-        if not to_notify:
+        existing_rows = await db.execute(existing_stmt)
+        for user_id, title in existing_rows:
+            if user_id is None or title is None:
+                continue
+            existing_by_title[str(title)].add(int(user_id))
+
+    action_title = translate("notifications.actions.open_schedule", locale=None)
+    total_created = 0
+    for group_id, group_schedules in schedules_by_group.items():
+        user_ids = group_users.get(group_id)
+        if not user_ids:
             continue
-        action_title = translate("notifications.actions.open_schedule", locale=None)
-        total_created += await create_notifications_for_users(
-            db,
-            title=title,
-            body=body,
-            type="schedule.reminder",
-            url="/schedule",
-            tag=tag,
-            actions=[
-                {
-                    "action": "open-schedule",
-                    "title": action_title,
-                    "url": "/schedule",
-                }
-            ],
-            payload_data=data_payload,
-            user_ids=to_notify,
-            topic="schedule",
-        )
+        for schedule in group_schedules:
+            title, body, tag, data_payload = message_payloads[int(schedule.id)]
+            already_notified = existing_by_title.get(title, set())
+            to_notify = [uid for uid in user_ids if uid not in already_notified]
+            if not to_notify:
+                continue
+            total_created += await create_notifications_for_users(
+                db,
+                title=title,
+                body=body,
+                type="schedule.reminder",
+                url="/schedule",
+                tag=tag,
+                actions=[
+                    {
+                        "action": "open-schedule",
+                        "title": action_title,
+                        "url": "/schedule",
+                    }
+                ],
+                payload_data=data_payload,
+                user_ids=to_notify,
+                topic="schedule",
+            )
+            existing_by_title[title].update(to_notify)
     return total_created
 
 

--- a/root/app/utils/files.py
+++ b/root/app/utils/files.py
@@ -279,12 +279,12 @@ async def save_attachment(
 
     ext_for_name = f".{chosen_ext_without_dot}" if chosen_ext_without_dot else ""
     name = _gen_name(prefix, ext_for_name)
+    await scan_for_malware(data, locale=locale)
     base = settings.static_dir_path
     sanitized_subdir = subdir.strip("/ ")
     target_dir = base / sanitized_subdir
-    await asyncio.to_thread(_ensure_dir, target_dir)
     path = target_dir / name
-    await scan_for_malware(data, locale=locale)
+    await asyncio.to_thread(_ensure_dir, target_dir)
     await asyncio.to_thread(path.write_bytes, data)
     return f"/static/{sanitized_subdir}/{name}"
 

--- a/root/frontend/src/pages/Settings.tsx
+++ b/root/frontend/src/pages/Settings.tsx
@@ -275,10 +275,7 @@ export default function Settings() {
   const [avatarVersion, setAvatarVersion] = useState(Date.now())
   const [coverVersion, setCoverVersion] = useState(Date.now())
 
-  const sessionsKey = useMemo(
-    () => ["auth", "sessions", user?.id ?? "me"],
-    [user?.id]
-  )
+  const sessionsKey = useMemo(() => ["auth", "sessions", user?.id ?? "me"], [user?.id])
 
   const fetchSessions = useCallback(async () => {
     const { data } = await api.get<ActiveSession[]>("/auth/sessions")
@@ -1067,7 +1064,10 @@ export default function Settings() {
               <Typography variant="h6" sx={{ color: "var(--page-text)", mb: 0.5 }}>
                 {t("settings:sessions.title")}
               </Typography>
-              <Typography variant="body2" sx={{ color: "color-mix(in srgb, var(--page-text) 72%, transparent)" }}>
+              <Typography
+                variant="body2"
+                sx={{ color: "color-mix(in srgb, var(--page-text) 72%, transparent)" }}
+              >
                 {t("settings:sessions.subtitle")}
               </Typography>
 
@@ -1141,9 +1141,7 @@ export default function Settings() {
                         }
                       >
                         <ListItemText
-                          primary={
-                            session.user_agent || t("settings:sessions.unknownDevice")
-                          }
+                          primary={session.user_agent || t("settings:sessions.unknownDevice")}
                           secondary={details}
                           primaryTypographyProps={{
                             sx: {

--- a/root/frontend/src/pages/Settings.tsx
+++ b/root/frontend/src/pages/Settings.tsx
@@ -295,10 +295,7 @@ export default function Settings() {
     staleTime: 30_000,
   })
 
-  const sessionList = useMemo(
-    () => (Array.isArray(sessions) ? sessions : []),
-    [sessions]
-  )
+  const sessionList = useMemo(() => (Array.isArray(sessions) ? sessions : []), [sessions])
 
   const revokeSessionMutation = useMutation({
     mutationFn: async (sessionId: number) => {

--- a/root/frontend/src/pages/Settings.tsx
+++ b/root/frontend/src/pages/Settings.tsx
@@ -295,6 +295,11 @@ export default function Settings() {
     staleTime: 30_000,
   })
 
+  const sessionList = useMemo(
+    () => (Array.isArray(sessions) ? sessions : []),
+    [sessions]
+  )
+
   const revokeSessionMutation = useMutation({
     mutationFn: async (sessionId: number) => {
       const { data } = await api.delete<ActiveSession>(`/auth/sessions/${sessionId}`)
@@ -1082,13 +1087,13 @@ export default function Settings() {
                 <Alert severity="error" variant="outlined" sx={{ mt: 2 }}>
                   {sessionsErrorMessage}
                 </Alert>
-              ) : sessions.length === 0 ? (
+              ) : sessionList.length === 0 ? (
                 <Typography variant="body2" sx={{ mt: 2, color: "var(--page-text)" }}>
                   {t("settings:sessions.empty")}
                 </Typography>
               ) : (
                 <List disablePadding sx={{ mt: 1 }}>
-                  {sessions.map((session) => {
+                  {sessionList.map((session) => {
                     const lastSeen = session.last_seen_at ?? session.created_at
                     const lastSeenText = t("settings:sessions.lastSeen.value", {
                       value: formatSessionTimestamp(lastSeen),

--- a/root/tests/test_notifications_service.py
+++ b/root/tests/test_notifications_service.py
@@ -1,15 +1,18 @@
 import asyncio
 import datetime as dt
 import logging
+from contextlib import contextmanager
 
 import pytest
-from sqlalchemy import select
+from sqlalchemy import delete, event, select
 
 from app.core.config import settings
 from app.models.models import (
+    Group,
     Notification,
     NotificationDelivery,
     PushSubscription,
+    Schedule,
     User,
 )
 from app.services import notifications as notifications_module
@@ -25,6 +28,29 @@ from app.services.webpush import WebPushResult
 def _reset_vapid_cache() -> None:
     for cached in ("VAPID_PUBLIC_KEY", "VAPID_PRIVATE_KEY", "WEBPUSH_SUBJECT"):
         settings.__dict__.pop(cached, None)
+
+
+@contextmanager
+def _count_queries(session):
+    queries = 0
+    engine = session.bind
+    if engine is None:
+        yield lambda: queries
+        return
+
+    sync_engine = engine.sync_engine
+
+    def _before_cursor_execute(
+        _conn, _cursor, _statement, _parameters, _context, _executemany
+    ) -> None:
+        nonlocal queries
+        queries += 1
+
+    event.listen(sync_engine, "before_cursor_execute", _before_cursor_execute)
+    try:
+        yield lambda: queries
+    finally:
+        event.remove(sync_engine, "before_cursor_execute", _before_cursor_execute)
 
 
 @pytest.fixture
@@ -168,6 +194,59 @@ async def test_create_notifications_records_skip_without_credentials(
     assert delivery.status == "skipped_no_credentials"
     assert delivery.delivered_at is None
     _reset_vapid_cache()
+
+
+@pytest.mark.anyio
+async def test_generate_schedule_reminders_query_count_constant(
+    db_session, user_factory, monkeypatch: pytest.MonkeyPatch
+):
+    group = Group(name="G1")
+    db_session.add(group)
+    await db_session.commit()
+    await db_session.refresh(group)
+
+    await user_factory(group_id=group.id)
+
+    async def _fake_create(*_args, **_kwargs) -> int:
+        return 0
+
+    monkeypatch.setattr(
+        notifications_module,
+        "create_notifications_for_users",
+        _fake_create,
+    )
+
+    async def _prepare_lessons(count: int) -> None:
+        await db_session.execute(delete(Schedule))
+        await db_session.commit()
+        now = dt.datetime.now(dt.timezone.utc)
+        lessons = [
+            Schedule(
+                group_id=group.id,
+                subject=f"Subject {idx}",
+                teacher="Teacher",
+                room="101",
+                weekday="monday",
+                start_time=now + dt.timedelta(minutes=idx + 1),
+                end_time=now + dt.timedelta(minutes=idx + 2),
+            )
+            for idx in range(count)
+        ]
+        db_session.add_all(lessons)
+        await db_session.commit()
+
+    async def _run_with_count(count: int) -> int:
+        await _prepare_lessons(count)
+        with _count_queries(db_session) as get_count:
+            await notifications_module.generate_schedule_reminders(
+                db_session, window_minutes=15
+            )
+        return get_count()
+
+    single_count = await _run_with_count(1)
+    many_count = await _run_with_count(5)
+
+    assert single_count == many_count
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- batch schedule reminder user lookups by group to avoid redundant SQL queries
- prefetch existing reminders for all affected users in a single query before dispatching
- add query counting test and helper to ensure reminder generation query count stays flat

## Testing
- pytest root/tests/test_notifications_service.py -k generate_schedule_reminders

------
https://chatgpt.com/codex/tasks/task_e_68f4feddfb1c8327b3cfdc7c8d36c317