### PR TITLE
Encrypt Spotify tokens at rest

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Key settings you may want to adjust for local development:
 | `APP_BASE_URL` | Base URL used inside emails and notifications. | `http://localhost:5173` |
 | `SMTP_*` | Outgoing email server configuration. | Empty (email disabled) |
 | `SPOTIFY_*` | OAuth credentials required for Spotify integration. | Empty |
+| `SPOTIFY_TOKEN_SECRET` | Comma-separated Fernet keys used to encrypt Spotify access/refresh tokens (first key is used for new data). | Empty |
 | `VAPID_*` | Keys used to send web push notifications. | Empty |
 | `NOTIFICATIONS_WEBPUSH_CONCURRENCY_LIMIT` | Maximum number of simultaneous web push delivery jobs. | `10` |
 | `CACHE_*` & `RATE_LIMIT_*` | Toggle and configure caching and rate limiting backends. | In-memory |

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -14,6 +14,54 @@ cp .env.production .env.local      # при необходимости
 VITE_BACKEND_ORIGIN=https://api.example.com npm run build
 ```
 
+### Spotify токены
+
+- Backend шифрует Spotify access/refresh токены с помощью Fernet. Перед включением интеграции задайте `SPOTIFY_TOKEN_SECRET` — это base64-строка из `Fernet.generate_key()`.
+
+```bash
+python - <<'PY'
+from cryptography.fernet import Fernet
+print(Fernet.generate_key().decode())
+PY
+```
+
+- Для ротации используйте несколько ключей, перечисленных через запятую: новый ключ укажите первым, старый оставьте вторым (`SPOTIFY_TOKEN_SECRET="new_key,old_key"`). После деплоя выполните скрипт ниже, чтобы перешифровать уже сохранённые значения и убрать зависимость от старого ключа, затем удалите его из переменной и перезапустите сервисы.
+
+```bash
+python - <<'PY'
+import asyncio
+from sqlalchemy import text
+
+from app.core.database import async_session
+from app.utils.encryption import rotate_encrypted_string
+
+
+async def main() -> None:
+    async with async_session() as session:
+        rows = await session.execute(
+            text(
+                "SELECT id, spotify_access_token, spotify_refresh_token FROM users"
+            )
+        )
+        for row in rows.all():
+            await session.execute(
+                text(
+                    "UPDATE users SET spotify_access_token = :access, "
+                    "spotify_refresh_token = :refresh WHERE id = :user_id"
+                ),
+                {
+                    "user_id": row.id,
+                    "access": rotate_encrypted_string(row.spotify_access_token),
+                    "refresh": rotate_encrypted_string(row.spotify_refresh_token),
+                },
+            )
+        await session.commit()
+
+
+asyncio.run(main())
+PY
+```
+
 ## Docker image
 
 - `root/frontend.Dockerfile` собран в два этапа: на этапе `builder` запускается `npm ci && npm run build`, а финальный образ основан на `nginx:alpine` и содержит только содержимое `dist/`.

--- a/root/alembic/versions/202503150001_encrypt_spotify_tokens.py
+++ b/root/alembic/versions/202503150001_encrypt_spotify_tokens.py
@@ -6,7 +6,6 @@ import sqlalchemy as sa
 from sqlalchemy.orm import Session
 
 from alembic import op
-
 from app.utils.encryption import decrypt_string, encrypt_string
 
 # revision identifiers, used by Alembic.
@@ -20,7 +19,9 @@ def _column_exists(bind, table_name: str, column_name: str) -> bool:
     inspector = sa.inspect(bind)
     if table_name not in inspector.get_table_names():
         return False
-    return column_name in {column["name"] for column in inspector.get_columns(table_name)}
+    return column_name in {
+        column["name"] for column in inspector.get_columns(table_name)
+    }
 
 
 def _encrypt_existing_tokens(session: Session) -> None:
@@ -32,9 +33,7 @@ def _encrypt_existing_tokens(session: Session) -> None:
         return
 
     rows = session.execute(
-        sa.text(
-            "SELECT id, spotify_access_token, spotify_refresh_token FROM users"
-        )
+        sa.text("SELECT id, spotify_access_token, spotify_refresh_token FROM users")
     ).all()
     for row in rows:
         access = encrypt_string(row.spotify_access_token)
@@ -64,9 +63,7 @@ def _decrypt_existing_tokens(session: Session) -> None:
         return
 
     rows = session.execute(
-        sa.text(
-            "SELECT id, spotify_access_token, spotify_refresh_token FROM users"
-        )
+        sa.text("SELECT id, spotify_access_token, spotify_refresh_token FROM users")
     ).all()
     for row in rows:
         access = decrypt_string(row.spotify_access_token)

--- a/root/alembic/versions/202503150001_encrypt_spotify_tokens.py
+++ b/root/alembic/versions/202503150001_encrypt_spotify_tokens.py
@@ -1,0 +1,163 @@
+"""Encrypt Spotify tokens using Fernet."""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Session
+
+from alembic import op
+
+from app.utils.encryption import decrypt_string, encrypt_string
+
+# revision identifiers, used by Alembic.
+revision: str = "202503150001"
+down_revision: Union[str, None] = "202503010001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _column_exists(bind, table_name: str, column_name: str) -> bool:
+    inspector = sa.inspect(bind)
+    if table_name not in inspector.get_table_names():
+        return False
+    return column_name in {column["name"] for column in inspector.get_columns(table_name)}
+
+
+def _encrypt_existing_tokens(session: Session) -> None:
+    bind = session.get_bind()
+    if not (
+        _column_exists(bind, "users", "spotify_access_token")
+        and _column_exists(bind, "users", "spotify_refresh_token")
+    ):
+        return
+
+    rows = session.execute(
+        sa.text(
+            "SELECT id, spotify_access_token, spotify_refresh_token FROM users"
+        )
+    ).all()
+    for row in rows:
+        access = encrypt_string(row.spotify_access_token)
+        refresh = encrypt_string(row.spotify_refresh_token)
+        session.execute(
+            sa.text(
+                "UPDATE users SET "
+                "spotify_access_token_encrypted = :access, "
+                "spotify_refresh_token_encrypted = :refresh "
+                "WHERE id = :user_id"
+            ),
+            {
+                "access": access,
+                "refresh": refresh,
+                "user_id": row.id,
+            },
+        )
+    session.commit()
+
+
+def _decrypt_existing_tokens(session: Session) -> None:
+    bind = session.get_bind()
+    if not (
+        _column_exists(bind, "users", "spotify_access_token")
+        and _column_exists(bind, "users", "spotify_refresh_token")
+    ):
+        return
+
+    rows = session.execute(
+        sa.text(
+            "SELECT id, spotify_access_token, spotify_refresh_token FROM users"
+        )
+    ).all()
+    for row in rows:
+        access = decrypt_string(row.spotify_access_token)
+        refresh = decrypt_string(row.spotify_refresh_token)
+        session.execute(
+            sa.text(
+                "UPDATE users SET "
+                "spotify_access_token_plain = :access, "
+                "spotify_refresh_token_plain = :refresh "
+                "WHERE id = :user_id"
+            ),
+            {
+                "access": access,
+                "refresh": refresh,
+                "user_id": row.id,
+            },
+        )
+    session.commit()
+
+
+def upgrade() -> None:
+    """Apply Encrypt Spotify tokens using Fernet."""
+
+    op.add_column(
+        "users",
+        sa.Column("spotify_access_token_encrypted", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "users",
+        sa.Column("spotify_refresh_token_encrypted", sa.Text(), nullable=True),
+    )
+
+    bind = op.get_bind()
+    session = Session(bind=bind)
+    try:
+        _encrypt_existing_tokens(session)
+    finally:
+        session.close()
+
+    if _column_exists(bind, "users", "spotify_access_token"):
+        op.drop_column("users", "spotify_access_token")
+    if _column_exists(bind, "users", "spotify_refresh_token"):
+        op.drop_column("users", "spotify_refresh_token")
+
+    if _column_exists(bind, "users", "spotify_access_token_encrypted"):
+        op.alter_column(
+            "users",
+            "spotify_access_token_encrypted",
+            new_column_name="spotify_access_token",
+        )
+    if _column_exists(bind, "users", "spotify_refresh_token_encrypted"):
+        op.alter_column(
+            "users",
+            "spotify_refresh_token_encrypted",
+            new_column_name="spotify_refresh_token",
+        )
+
+
+def downgrade() -> None:
+    """Revert Encrypt Spotify tokens using Fernet."""
+
+    op.add_column(
+        "users",
+        sa.Column("spotify_access_token_plain", sa.String(), nullable=True),
+    )
+    op.add_column(
+        "users",
+        sa.Column("spotify_refresh_token_plain", sa.String(), nullable=True),
+    )
+
+    bind = op.get_bind()
+    session = Session(bind=bind)
+    try:
+        _decrypt_existing_tokens(session)
+    finally:
+        session.close()
+
+    if _column_exists(bind, "users", "spotify_access_token"):
+        op.drop_column("users", "spotify_access_token")
+    if _column_exists(bind, "users", "spotify_refresh_token"):
+        op.drop_column("users", "spotify_refresh_token")
+
+    if _column_exists(bind, "users", "spotify_access_token_plain"):
+        op.alter_column(
+            "users",
+            "spotify_access_token_plain",
+            new_column_name="spotify_access_token",
+        )
+    if _column_exists(bind, "users", "spotify_refresh_token_plain"):
+        op.alter_column(
+            "users",
+            "spotify_refresh_token_plain",
+            new_column_name="spotify_refresh_token",
+        )

--- a/root/app/api/spotify.py
+++ b/root/app/api/spotify.py
@@ -101,9 +101,9 @@ async def _save_tokens(
     scope: Optional[str],
     expires_in: int | str | None,
 ):
-    user.spotify_access_token = access
-    if refresh:
-        user.spotify_refresh_token = refresh
+    user.spotify_access_token = access or None
+    if refresh is not None:
+        user.spotify_refresh_token = refresh or None
     seconds = _coerce_expires(expires_in)
     # Refresh a little earlier to compensate for latency and clock skew.
     user.spotify_token_expires_at = _now_utc() + timedelta(seconds=seconds - 10)
@@ -127,11 +127,12 @@ async def _ensure_access_token(
     """
 
     now = _now_utc()
-    token = user.spotify_access_token
+    token = user.spotify_access_token or None
     exp = _ensure_utc(user.spotify_token_expires_at)
     if token and exp and exp > now:
         return token
-    if not user.spotify_refresh_token:
+    refresh_token = user.spotify_refresh_token or None
+    if not refresh_token:
         if not token and not user.spotify_is_connected:
             # The user never connected Spotify or already disconnected it;
             # returning ``None`` allows the caller to fall back gracefully.
@@ -147,7 +148,7 @@ async def _ensure_access_token(
             "https://accounts.spotify.com/api/token",
             data={
                 "grant_type": "refresh_token",
-                "refresh_token": user.spotify_refresh_token,
+                "refresh_token": refresh_token,
             },
             headers={
                 "Authorization": "Basic "

--- a/root/app/core/config.py
+++ b/root/app/core/config.py
@@ -82,6 +82,7 @@ class Settings(BaseSettings):
     mail_from: str = "no-reply@example.com"
     spotify_client_id: str = ""
     spotify_client_secret: str = ""
+    spotify_token_secret: str = ""
     spotify_redirect_uri: str = "http://localhost:8000/spotify/callback"
     spotify_scopes: str = "user-read-currently-playing user-read-playback-state"
     vapid_public_key: str = ""

--- a/root/app/models/models.py
+++ b/root/app/models/models.py
@@ -19,6 +19,7 @@ from sqlalchemy.orm import relationship
 
 from app.core.database import Base
 from app.models.enums import UserRole
+from app.utils.encryption import EncryptedString
 
 ROLE_VALUES_SQL = ", ".join(f"'{role.value}'" for role in UserRole)
 
@@ -61,8 +62,8 @@ class User(Base):
     dnd_end = Column(Time(timezone=False))
 
     spotify_user_id = Column(String, unique=True, index=True)
-    spotify_access_token = Column(String)
-    spotify_refresh_token = Column(String)
+    spotify_access_token = Column(EncryptedString())
+    spotify_refresh_token = Column(EncryptedString())
     spotify_token_expires_at = Column(DateTime(timezone=True), index=True)
     spotify_scope = Column(String)
     spotify_display_name = Column(String)

--- a/root/app/utils/encryption.py
+++ b/root/app/utils/encryption.py
@@ -31,7 +31,9 @@ def _normalize_secret(secret: str) -> str:
 
 @lru_cache(maxsize=4)
 def _build_cipher(raw_secret: str) -> Fernet | MultiFernet:
-    secrets = [_normalize_secret(item) for item in raw_secret.split(",") if item.strip()]
+    secrets = [
+        _normalize_secret(item) for item in raw_secret.split(",") if item.strip()
+    ]
     if not secrets:
         raise SpotifyEncryptionError("SPOTIFY_TOKEN_SECRET is not configured")
     ciphers = [Fernet(secret.encode("utf-8")) for secret in secrets]

--- a/root/app/utils/encryption.py
+++ b/root/app/utils/encryption.py
@@ -1,0 +1,121 @@
+"""Utilities for encrypting sensitive application data."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Optional
+
+from cryptography.fernet import Fernet, InvalidToken, MultiFernet
+from sqlalchemy.types import Text, TypeDecorator
+
+from app.core.config import settings
+
+
+class SpotifyEncryptionError(RuntimeError):
+    """Raised when Spotify token encryption fails."""
+
+
+def _normalize_secret(secret: str) -> str:
+    value = secret.strip()
+    if not value:
+        raise SpotifyEncryptionError("SPOTIFY_TOKEN_SECRET contains an empty entry")
+    # ``Fernet`` will validate the key format; propagate errors with more context.
+    try:
+        Fernet(value.encode("utf-8"))
+    except Exception as exc:  # pragma: no cover - cryptography defines several types
+        raise SpotifyEncryptionError(
+            "Invalid SPOTIFY_TOKEN_SECRET entry; expected a Fernet key"
+        ) from exc
+    return value
+
+
+@lru_cache(maxsize=4)
+def _build_cipher(raw_secret: str) -> Fernet | MultiFernet:
+    secrets = [_normalize_secret(item) for item in raw_secret.split(",") if item.strip()]
+    if not secrets:
+        raise SpotifyEncryptionError("SPOTIFY_TOKEN_SECRET is not configured")
+    ciphers = [Fernet(secret.encode("utf-8")) for secret in secrets]
+    if len(ciphers) == 1:
+        return ciphers[0]
+    return MultiFernet(ciphers)
+
+
+def _get_cipher() -> Fernet | MultiFernet:
+    raw = settings.spotify_token_secret.strip()
+    if not raw:
+        raise SpotifyEncryptionError("SPOTIFY_TOKEN_SECRET is not configured")
+    return _build_cipher(raw)
+
+
+def reset_cached_cipher() -> None:
+    """Clear the cached cipher (useful in tests when the key changes)."""
+
+    _build_cipher.cache_clear()
+
+
+def encrypt_string(value: Optional[str | bytes]) -> Optional[str]:
+    """Encrypt a value using the configured Fernet key.
+
+    Empty strings are normalised to ``None`` to avoid storing meaningless blobs.
+    """
+
+    if value is None:
+        return None
+    if isinstance(value, bytes):
+        if not value:
+            return None
+        data = value
+    else:
+        if value == "":
+            return None
+        data = value.encode("utf-8")
+    token = _get_cipher().encrypt(data)
+    return token.decode("utf-8")
+
+
+def decrypt_string(value: Optional[str | bytes]) -> Optional[str]:
+    """Decrypt a value previously produced by :func:`encrypt_string`."""
+
+    if value is None:
+        return None
+    if isinstance(value, bytes):
+        if not value:
+            return None
+        token = value
+    else:
+        if value == "":
+            return None
+        token = value.encode("utf-8")
+    try:
+        data = _get_cipher().decrypt(token)
+    except InvalidToken as exc:
+        raise SpotifyEncryptionError("Failed to decrypt stored Spotify token") from exc
+    return data.decode("utf-8")
+
+
+def rotate_encrypted_string(value: Optional[str | bytes]) -> Optional[str]:
+    """Re-encrypt a token with the primary key when multiple keys are provided."""
+
+    if value is None:
+        return None
+    cipher = _get_cipher()
+    raw = value.encode("utf-8") if isinstance(value, str) else value
+    if not raw:
+        return None
+    if isinstance(cipher, MultiFernet):
+        rotated = cipher.rotate(raw)
+        return rotated.decode("utf-8")
+    return value if isinstance(value, str) else value.decode("utf-8")
+
+
+class EncryptedString(TypeDecorator[str]):
+    """TypeDecorator that transparently encrypts/decrypts string values."""
+
+    impl = Text
+    cache_ok = True
+
+    def process_bind_param(self, value: Optional[str], dialect):  # type: ignore[override]
+        return encrypt_string(value)
+
+    def process_result_value(self, value: Optional[str], dialect):  # type: ignore[override]
+        return decrypt_string(value)

--- a/root/tests/conftest.py
+++ b/root/tests/conftest.py
@@ -34,6 +34,9 @@ os.environ.setdefault("ALGORITHM", "HS256")
 os.environ.setdefault("ACCESS_TOKEN_EXPIRE_MINUTES", "30")
 os.environ.setdefault("STATIC_DIR", "app/test-static")
 os.environ.setdefault("ENVIRONMENT", "testing")
+os.environ.setdefault(
+    "SPOTIFY_TOKEN_SECRET", "aN-c6G_Gi7q0E8VnXW0fvkYlCYwH14r2raXI5Qun7Ss="
+)
 os.environ.setdefault("RATE_LIMIT_ENABLED", "true")
 os.environ.setdefault("RATE_LIMIT_DEFAULT", "5/minute,10/hour")
 os.environ.setdefault("RATE_LIMIT_SENSITIVE", "4/minute")

--- a/root/tests/test_spotify_fallback.py
+++ b/root/tests/test_spotify_fallback.py
@@ -293,7 +293,9 @@ async def test_now_playing_disconnects_on_unauthorized_response(
     assert user.spotify_refresh_token is None
 
 
-async def test_spotify_tokens_are_encrypted_in_database(db_session, user_factory) -> None:
+async def test_spotify_tokens_are_encrypted_in_database(
+    db_session, user_factory
+) -> None:
     user = await user_factory(is_active=True)
 
     await _save_tokens(
@@ -341,9 +343,7 @@ async def test_ensure_access_token_returns_plaintext(db_session, user_factory) -
     assert token == "plaintext-token"
 
     raw = await db_session.execute(
-        sa.text(
-            "SELECT spotify_access_token FROM users WHERE id = :user_id"
-        ),
+        sa.text("SELECT spotify_access_token FROM users WHERE id = :user_id"),
         {"user_id": user.id},
     )
     stored_token = raw.scalar_one()

--- a/root/tests/test_spotify_fallback.py
+++ b/root/tests/test_spotify_fallback.py
@@ -2,9 +2,10 @@ from datetime import datetime, timedelta, timezone
 
 import httpx
 import pytest
+import sqlalchemy as sa
 from httpx import AsyncClient
 
-from app.api.spotify import _fallback_now_playing
+from app.api.spotify import _ensure_access_token, _fallback_now_playing, _save_tokens
 
 _spotify_fallback_now_playing = _fallback_now_playing
 from app.auth.security import get_password_hash
@@ -290,3 +291,60 @@ async def test_now_playing_disconnects_on_unauthorized_response(
     assert user.spotify_is_connected is False
     assert user.spotify_access_token is None
     assert user.spotify_refresh_token is None
+
+
+async def test_spotify_tokens_are_encrypted_in_database(db_session, user_factory) -> None:
+    user = await user_factory(is_active=True)
+
+    await _save_tokens(
+        db_session,
+        user,
+        access="access-token-value",
+        refresh="refresh-token-value",
+        scope="user-read-currently-playing",
+        expires_in=3600,
+    )
+
+    row = await db_session.execute(
+        sa.text(
+            "SELECT spotify_access_token, spotify_refresh_token FROM users "
+            "WHERE id = :user_id"
+        ),
+        {"user_id": user.id},
+    )
+    stored_access, stored_refresh = row.one()
+
+    assert stored_access is not None
+    assert stored_refresh is not None
+    assert stored_access != "access-token-value"
+    assert stored_refresh != "refresh-token-value"
+
+    await db_session.refresh(user)
+    assert user.spotify_access_token == "access-token-value"
+    assert user.spotify_refresh_token == "refresh-token-value"
+
+
+async def test_ensure_access_token_returns_plaintext(db_session, user_factory) -> None:
+    user = await user_factory(is_active=True)
+
+    await _save_tokens(
+        db_session,
+        user,
+        access="plaintext-token",
+        refresh="plaintext-refresh",
+        scope="user-read-email",
+        expires_in=7200,
+    )
+
+    token = await _ensure_access_token(db_session, user)
+
+    assert token == "plaintext-token"
+
+    raw = await db_session.execute(
+        sa.text(
+            "SELECT spotify_access_token FROM users WHERE id = :user_id"
+        ),
+        {"user_id": user.id},
+    )
+    stored_token = raw.scalar_one()
+    assert stored_token != "plaintext-token"


### PR DESCRIPTION
## Summary
- add a Fernet-backed type decorator for Spotify tokens and wire it into the user model
- migrate existing token data to encrypted storage and normalize the Spotify API helpers
- document the new SPOTIFY_TOKEN_SECRET and cover the behavior with tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f55d1210848327ba4eb7b0790f7ca3