### PR TITLE
Add scheduled cleanup for stale notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ Key settings you may want to adjust for local development:
 | `SPOTIFY_TOKEN_SECRET` | Comma-separated Fernet keys used to encrypt Spotify access/refresh tokens (first key is used for new data). | Empty |
 | `VAPID_*` | Keys used to send web push notifications. | Empty |
 | `NOTIFICATIONS_WEBPUSH_CONCURRENCY_LIMIT` | Maximum number of simultaneous web push delivery jobs. | `10` |
+| `NOTIFICATIONS_RETENTION_DAYS` | Number of days to keep read notifications before purging them. | `90` |
+| `NOTIFICATIONS_RETENTION_CLEANUP_INTERVAL_SECONDS` | Interval between background retention cleanup runs. | `86400` |
 | `CACHE_*` & `RATE_LIMIT_*` | Toggle and configure caching and rate limiting backends. | In-memory |
 | `IMAGE_MAX_WIDTH` / `IMAGE_MAX_HEIGHT` | Bounding box applied to uploaded images before storage. | `1920` |
 | `ENABLE_OTEL`, `SENTRY_DSN` | Observability & error tracking toggles. | Disabled |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -43,6 +43,12 @@ Cross-Origin Resource Sharing (CORS) is also tightened: wildcard origins are rej
   2. Call `POST /push/admin/disable-user` with the target `user_id`. The endpoint removes every `PushSubscription` row for that account and returns the number of deleted entries.
   3. Confirm the user no longer has active subscriptions before finalising account removal.
 
+## Notification Retention
+
+- Read notifications are purged automatically after **90 days** by default. Unread notifications are preserved regardless of age so users can review unseen alerts.
+- The cleanup job runs on a dedicated background scheduler; tune its cadence with `NOTIFICATIONS_RETENTION_CLEANUP_INTERVAL_SECONDS` (defaults to 86,400 seconds / 24 hours).
+- Set `NOTIFICATIONS_RETENTION_DAYS=0` to disable automatic notification retention if your policy mandates manual review before deletion.
+
 ## Frontend Profile Cache Hardening
 
 - The React auth context now persists a **versioned, minimal snapshot** of the authenticated user. Only the fields required for optimistic UI (currently the numeric `id`, `full_name`, and `avatar_url`) are written to `localStorage`.

--- a/root/app/core/config.py
+++ b/root/app/core/config.py
@@ -145,6 +145,8 @@ class Settings(BaseSettings):
     notifications_worker_metrics_host: str = "0.0.0.0"
     notifications_worker_metrics_port: int = 9101
     notifications_webpush_concurrency_limit: int = 10
+    notifications_retention_days: int = 90
+    notifications_retention_cleanup_interval_seconds: int = 86_400
     session_cleanup_interval_seconds: int = 900
     event_file_allowed_mime_types: str | list[str] = (
         "application/pdf,"

--- a/root/app/main.py
+++ b/root/app/main.py
@@ -25,7 +25,14 @@ from app.deps.cache import shutdown_cache
 from app.routers.notifications import legacy_router as legacy_push_router
 from app.routers.notifications import router as push_router
 from app.routers.schedule import router as schedule_router
-from app.services.notifications import start_notifications_scheduler
+from app.services.notifications import (
+    cleanup_stale_notifications,
+    start_notifications_scheduler,
+)
+from app.services.notifications_retention import (
+    NotificationsRetentionConfig,
+    start_notifications_retention_scheduler,
+)
 from app.services.session_cleanup import (
     SessionCleanupConfig,
     cleanup_expired_sessions,
@@ -45,6 +52,7 @@ async def lifespan(app: FastAPI):
         async with engine.begin() as conn:
             await conn.run_sync(Base.metadata.create_all)
     stop_scheduler = None
+    stop_notifications_retention = None
     stop_session_cleanup = None
     if settings.is_development and settings.notifications_scheduler_inline_enabled:
         stop_scheduler = await start_notifications_scheduler(
@@ -52,7 +60,20 @@ async def lifespan(app: FastAPI):
             window_minutes=settings.notifications_scheduler_window_minutes,
             max_backoff_seconds=settings.notifications_scheduler_max_backoff_seconds,
         )
+    await cleanup_stale_notifications(
+        retention_days=settings.notifications_retention_days
+    )
     await cleanup_expired_sessions()
+    if (
+        settings.notifications_retention_days > 0
+        and settings.notifications_retention_cleanup_interval_seconds > 0
+    ):
+        stop_notifications_retention = await start_notifications_retention_scheduler(
+            config=NotificationsRetentionConfig(
+                retention_days=settings.notifications_retention_days,
+                interval_seconds=settings.notifications_retention_cleanup_interval_seconds,
+            )
+        )
     if settings.session_cleanup_interval_seconds > 0:
         stop_session_cleanup = await start_session_cleanup_scheduler(
             config=SessionCleanupConfig(
@@ -64,6 +85,8 @@ async def lifespan(app: FastAPI):
     finally:
         if stop_scheduler is not None:
             await stop_scheduler()
+        if stop_notifications_retention is not None:
+            await stop_notifications_retention()
         if stop_session_cleanup is not None:
             await stop_session_cleanup()
         await shutdown_cache()

--- a/root/app/services/notifications.py
+++ b/root/app/services/notifications.py
@@ -8,7 +8,7 @@ from html import unescape
 from textwrap import shorten
 from typing import Any, Awaitable, Callable, Mapping, Optional, Sequence
 
-from sqlalchemy import and_, func, insert, select
+from sqlalchemy import and_, delete, func, insert, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -102,6 +102,62 @@ def _build_delivery_row(
     if detail:
         row["detail"] = str(detail)
     return row
+
+
+async def cleanup_stale_notifications(
+    *,
+    db: AsyncSession | None = None,
+    retention_days: int | None = None,
+    now: dt.datetime | None = None,
+) -> tuple[int, int]:
+    """Remove notifications and deliveries older than the retention window.
+
+    Unread notifications are preserved regardless of age. Returns a tuple with
+    counts of deleted notifications and deliveries respectively.
+    """
+
+    if retention_days is None:
+        retention_days = getattr(settings, "notifications_retention_days", 0) or 0
+
+    retention_days = int(retention_days)
+
+    if retention_days <= 0:
+        return (0, 0)
+
+    now_value = now or dt.datetime.now(UTC)
+
+    if db is None:
+        async with _async_session() as session:
+            return await cleanup_stale_notifications(
+                db=session, retention_days=retention_days, now=now_value
+            )
+
+    cutoff = now_value - dt.timedelta(days=int(retention_days))
+
+    deliveries_stmt = delete(NotificationDelivery).where(
+        NotificationDelivery.attempted_at < cutoff
+    )
+    notifications_stmt = delete(Notification).where(
+        Notification.created_at < cutoff,
+        or_(Notification.read.is_(True), Notification.read_at.is_not(None)),
+    )
+
+    deliveries_result = await db.execute(deliveries_stmt)
+    notifications_result = await db.execute(notifications_stmt)
+    await db.commit()
+
+    deliveries_deleted = int(deliveries_result.rowcount or 0)
+    notifications_deleted = int(notifications_result.rowcount or 0)
+
+    if notifications_deleted or deliveries_deleted:
+        logger.info(
+            "Removed %s notifications and %s deliveries older than %s days",
+            notifications_deleted,
+            deliveries_deleted,
+            retention_days,
+        )
+
+    return notifications_deleted, deliveries_deleted
 
 
 async def _fetch_active_user_ids(

--- a/root/app/services/notifications_retention.py
+++ b/root/app/services/notifications_retention.py
@@ -31,6 +31,7 @@ async def start_notifications_retention_scheduler(
     cfg = config or NotificationsRetentionConfig()
     retention_days = cfg.normalized_retention_days()
     if retention_days <= 0:
+
         async def _noop() -> None:
             return None
 

--- a/root/app/services/notifications_retention.py
+++ b/root/app/services/notifications_retention.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from contextlib import suppress
+from dataclasses import dataclass
+from typing import Awaitable, Callable
+
+from app.services.notifications import cleanup_stale_notifications
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class NotificationsRetentionConfig:
+    retention_days: int = 90
+    interval_seconds: int = 86_400
+
+    def normalized_retention_days(self) -> int:
+        return max(0, int(self.retention_days))
+
+    def normalized_interval(self) -> int:
+        return max(300, int(self.interval_seconds))
+
+
+async def start_notifications_retention_scheduler(
+    *, config: NotificationsRetentionConfig | None = None
+) -> Callable[[], Awaitable[None]]:
+    """Start background task that purges stale notifications periodically."""
+
+    cfg = config or NotificationsRetentionConfig()
+    retention_days = cfg.normalized_retention_days()
+    if retention_days <= 0:
+        async def _noop() -> None:
+            return None
+
+        logger.info(
+            "Notifications retention scheduler disabled (retention_days=%s)",
+            retention_days,
+        )
+        return _noop
+
+    interval = cfg.normalized_interval()
+
+    async def _loop() -> None:
+        try:
+            while True:
+                try:
+                    await cleanup_stale_notifications(retention_days=retention_days)
+                except asyncio.CancelledError:
+                    raise
+                except Exception:  # pragma: no cover - defensive logging
+                    logger.exception("Failed to cleanup stale notifications")
+                await asyncio.sleep(interval)
+        except asyncio.CancelledError:
+            logger.info("Notifications retention loop cancelled")
+            raise
+
+    loop = asyncio.get_running_loop()
+    task = loop.create_task(_loop())
+
+    async def _stop() -> None:
+        if task.done():
+            with suppress(Exception):
+                task.result()
+            return
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+
+    return _stop

--- a/root/tests/conftest.py
+++ b/root/tests/conftest.py
@@ -160,6 +160,20 @@ async def async_client(
         main, "start_notifications_scheduler", _start_notifications_scheduler
     )
 
+    async def _start_notifications_retention_scheduler(
+        *args, **kwargs
+    ) -> Callable[[], Awaitable[None]]:
+        async def _stop() -> None:
+            return None
+
+        return _stop
+
+    monkeypatch.setattr(
+        main,
+        "start_notifications_retention_scheduler",
+        _start_notifications_retention_scheduler,
+    )
+
     async def _start_session_cleanup_scheduler(
         *args, **kwargs
     ) -> Callable[[], Awaitable[None]]:

--- a/root/tests/test_notifications_retention.py
+++ b/root/tests/test_notifications_retention.py
@@ -1,0 +1,121 @@
+import datetime as dt
+
+import pytest
+from sqlalchemy import select
+
+from app.models.models import Notification, NotificationDelivery
+from app.services.notifications import cleanup_stale_notifications
+
+
+@pytest.mark.anyio
+async def test_cleanup_stale_notifications_respects_read_state(db_session, user_factory):
+    now = dt.datetime(2024, 1, 1, tzinfo=dt.timezone.utc)
+    user = await user_factory()
+
+    old_read = Notification(
+        user_id=user.id,
+        title="Old read",
+        body="body",
+        type="info",
+        url="/old-read",
+        created_at=now - dt.timedelta(days=120),
+        read=True,
+        read_at=now - dt.timedelta(days=119),
+    )
+    old_unread = Notification(
+        user_id=user.id,
+        title="Old unread",
+        body="body",
+        type="info",
+        url="/old-unread",
+        created_at=now - dt.timedelta(days=120),
+        read=False,
+        read_at=None,
+    )
+    recent_read = Notification(
+        user_id=user.id,
+        title="Recent read",
+        body="body",
+        type="info",
+        url="/recent-read",
+        created_at=now - dt.timedelta(days=10),
+        read=True,
+        read_at=now - dt.timedelta(days=9),
+    )
+
+    deliveries = [
+        NotificationDelivery(
+            notification=old_read,
+            channel="webpush",
+            status="sent",
+            attempted_at=now - dt.timedelta(days=110),
+            delivered_at=now - dt.timedelta(days=110),
+        ),
+        NotificationDelivery(
+            notification=old_unread,
+            channel="webpush",
+            status="sent",
+            attempted_at=now - dt.timedelta(days=110),
+            delivered_at=now - dt.timedelta(days=110),
+        ),
+        NotificationDelivery(
+            notification=recent_read,
+            channel="webpush",
+            status="sent",
+            attempted_at=now - dt.timedelta(days=5),
+            delivered_at=now - dt.timedelta(days=5),
+        ),
+    ]
+
+    db_session.add_all([old_read, old_unread, recent_read, *deliveries])
+    await db_session.flush()
+    recent_read_id = recent_read.id
+    await db_session.commit()
+
+    deleted_notifications, deleted_deliveries = await cleanup_stale_notifications(
+        db=db_session, retention_days=90, now=now
+    )
+
+    assert deleted_notifications == 1
+    assert deleted_deliveries == 2
+
+    remaining_notifications = (
+        await db_session.execute(select(Notification).order_by(Notification.id))
+    ).scalars().all()
+    remaining_titles = {notification.title for notification in remaining_notifications}
+    assert remaining_titles == {"Old unread", "Recent read"}
+
+    remaining_deliveries = (
+        await db_session.execute(select(NotificationDelivery).order_by(NotificationDelivery.id))
+    ).scalars().all()
+    assert [delivery.notification_id for delivery in remaining_deliveries] == [recent_read_id]
+
+
+@pytest.mark.anyio
+async def test_cleanup_stale_notifications_disabled(db_session, user_factory):
+    now = dt.datetime(2024, 1, 1, tzinfo=dt.timezone.utc)
+    user = await user_factory()
+
+    old_read = Notification(
+        user_id=user.id,
+        title="Keep me",
+        body="body",
+        type="info",
+        url="/keep",
+        created_at=now - dt.timedelta(days=200),
+        read=True,
+        read_at=now - dt.timedelta(days=199),
+    )
+    db_session.add(old_read)
+    await db_session.commit()
+
+    deleted_notifications, deleted_deliveries = await cleanup_stale_notifications(
+        db=db_session, retention_days=0, now=now
+    )
+
+    assert deleted_notifications == 0
+    assert deleted_deliveries == 0
+
+    remaining = (await db_session.execute(select(Notification))).scalars().all()
+    assert len(remaining) == 1
+    assert remaining[0].title == "Keep me"

--- a/root/tests/test_notifications_retention.py
+++ b/root/tests/test_notifications_retention.py
@@ -8,7 +8,9 @@ from app.services.notifications import cleanup_stale_notifications
 
 
 @pytest.mark.anyio
-async def test_cleanup_stale_notifications_respects_read_state(db_session, user_factory):
+async def test_cleanup_stale_notifications_respects_read_state(
+    db_session, user_factory
+):
     now = dt.datetime(2024, 1, 1, tzinfo=dt.timezone.utc)
     user = await user_factory()
 
@@ -80,15 +82,25 @@ async def test_cleanup_stale_notifications_respects_read_state(db_session, user_
     assert deleted_deliveries == 2
 
     remaining_notifications = (
-        await db_session.execute(select(Notification).order_by(Notification.id))
-    ).scalars().all()
+        (await db_session.execute(select(Notification).order_by(Notification.id)))
+        .scalars()
+        .all()
+    )
     remaining_titles = {notification.title for notification in remaining_notifications}
     assert remaining_titles == {"Old unread", "Recent read"}
 
     remaining_deliveries = (
-        await db_session.execute(select(NotificationDelivery).order_by(NotificationDelivery.id))
-    ).scalars().all()
-    assert [delivery.notification_id for delivery in remaining_deliveries] == [recent_read_id]
+        (
+            await db_session.execute(
+                select(NotificationDelivery).order_by(NotificationDelivery.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert [delivery.notification_id for delivery in remaining_deliveries] == [
+        recent_read_id
+    ]
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- add a retention cleanup routine that prunes old notification records while preserving unread entries
- wire the cleanup into a configurable background scheduler and document the new retention settings
- cover the retention behaviour with targeted tests and adjust fixtures to avoid spawning real schedulers

## Testing
- pytest tests/test_notifications_retention.py

------
https://chatgpt.com/codex/tasks/task_e_68f566d517088327a599f1786a27d59a