### PR TITLE
Separate development dependencies from runtime requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,47 @@ jobs:
           audit_file root/requirements.txt
           audit_file root/requirements-dev.txt
 
+  verify-runtime-reqs:
+    name: Verify runtime requirements
+    runs-on: ubuntu-latest
+    needs: run-hooks
+    steps:
+      - uses: actions/checkout@v5
+      - name: Ensure requirements.txt excludes test-only packages
+        run: |
+          python - <<'PY'
+          import pathlib
+          import re
+          import sys
+
+          banned = {
+              "pytest",
+              "pytest-asyncio",
+              "pytest-cov",
+              "pre-commit",
+              "fakeredis",
+              "asgi-lifespan",
+          }
+
+          req_path = pathlib.Path("root/requirements.txt")
+          violations: list[str] = []
+          for raw_line in req_path.read_text().splitlines():
+              line = raw_line.strip()
+              if not line or line.startswith("#"):
+                  continue
+              name = re.split(r"[<=>!\\[]", line, 1)[0].strip().lower()
+              if name in banned:
+                  violations.append(raw_line.strip())
+
+          if violations:
+              print("::error::test/development packages found in requirements.txt:")
+              for entry in violations:
+                  print(f"  - {entry}")
+              sys.exit(1)
+
+          print("Runtime requirements look clean.")
+          PY
+
   backend-tests:
     name: Backend tests
     runs-on: ubuntu-latest
@@ -133,18 +174,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt -r requirements-dev.txt
-          pip install asgi-lifespan pytest-asyncio httpx
-      - name: Verify test deps
-        run: |
-          python - <<'PY'
-          import sys
-          try:
-              import asgi_lifespan, httpx, pytest_asyncio
-              print("OK: asgi_lifespan/httpx/pytest_asyncio installed")
-          except Exception as e:
-              print("Import check failed:", e)
-              sys.exit(1)
-          PY
       - name: Run pytest
         run: pytest --cov=app --cov-report=xml --cov-report=term-missing --junitxml=pytest-report.xml
       - name: Upload coverage artifact

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ This command builds the backend, frontend, and notifications worker images, star
 cd root
 python -m venv .venv
 source .venv/bin/activate
-pip install -r requirements-dev.txt
+pip install -r requirements.txt -r requirements-dev.txt
 uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
 ```
 
@@ -109,6 +109,11 @@ stores them as optimized WebP files (PNG when transparency is required).
 ## Running tests and linters
 
 ### Backend
+- Install backend development dependencies:
+  ```bash
+  cd root
+  pip install -r requirements.txt -r requirements-dev.txt
+  ```
 - Run the unit test suite:
   ```bash
   cd root

--- a/root/requirements-dev.txt
+++ b/root/requirements-dev.txt
@@ -1,8 +1,7 @@
+# Development and testing dependencies
 pytest>=8.3
 pytest-asyncio>=0.23
-httpx>=0.27
-asgi-lifespan>=2.1
-argon2-cffi>=23.1.0
-python-magic>=0.4.27
-clamd>=1.0.2
-Pillow>=10
+pytest-cov>=5
+fakeredis>=2
+asgi-lifespan>=2.1.0
+pre-commit>=3.8

--- a/root/requirements.txt
+++ b/root/requirements.txt
@@ -23,13 +23,7 @@ pywebpush>=1.9
 psycopg[binary]>=3.1
 slowapi>=0.1.9
 redis>=5
-fakeredis>=2
 aiosqlite>=0.19
-pytest>=8
-pre-commit>=3.8
-pytest-asyncio>=0.23
-pytest-cov>=5
-asgi-lifespan>=2.1.0
 prometheus-client>=0.20
 
 opentelemetry-api==1.37.0

--- a/start-dev.ps1
+++ b/start-dev.ps1
@@ -10,10 +10,9 @@ if (!(Test-Path ".venv")) { py -3 -m venv .venv }
 $python = Join-Path $api ".venv\Scripts\python.exe"
 
 & $python -m pip install -U pip wheel
+& $python -m pip install -r requirements.txt
 if (Test-Path "requirements-dev.txt") {
   & $python -m pip install -r requirements-dev.txt
-} else {
-  & $python -m pip install -r requirements.txt
 }
 
 $env:APP_ENV = "development"


### PR DESCRIPTION
## Summary
- move testing and tooling dependencies from root/requirements.txt into root/requirements-dev.txt
- update local dev script, documentation, and backend CI job to install dev extras on top of runtime packages
- add a CI check that fails when root/requirements.txt includes known test-only dependencies

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f5692adf148327b8589304bdf9ae03