### PR TITLE
Support partial news updates with optional schema

### DIFF
--- a/root/app/api/news.py
+++ b/root/app/api/news.py
@@ -3,6 +3,7 @@ from typing import Any, List
 
 from fastapi import (
     APIRouter,
+    Body,
     Depends,
     File,
     Header,
@@ -214,8 +215,8 @@ async def get_news(
 @router.patch("/{id}", response_model=schemas.NewsOut)
 async def update_news(
     id: int,
-    data: schemas.NewsCreate,
     request: Request,
+    data: schemas.NewsUpdate | None = Body(default=None),
     db: AsyncSession = Depends(get_db),
     user: models.User = Depends(get_current_user),
 ):
@@ -231,7 +232,7 @@ async def update_news(
             status_code=403,
             detail=translate("errors.forbidden", locale=locale),
         )
-    updates = data.model_dump(exclude_unset=True)
+    updates = data.model_dump(exclude_unset=True) if data else {}
     if "title_en" in updates:
         updates["title_en"] = crud.sanitize_optional_text(updates.get("title_en"))
     if "content_en" in updates:

--- a/root/app/schemas/schemas.py
+++ b/root/app/schemas/schemas.py
@@ -156,6 +156,14 @@ class NewsCreate(BaseModel):
     image_url: Optional[str] = None
 
 
+class NewsUpdate(BaseModel):
+    title: Optional[str] = None
+    content: Optional[str] = None
+    title_en: Optional[str] = None
+    content_en: Optional[str] = None
+    image_url: Optional[str] = None
+
+
 class NewsOut(OrmModel, NewsCreate):
     id: int
     created_at: datetime

--- a/root/tests/test_news_image_cleanup.py
+++ b/root/tests/test_news_image_cleanup.py
@@ -24,14 +24,10 @@ async def test_update_news_removes_replaced_image(
 
     monkeypatch.setattr(settings, "static_dir_path", tmp_path)
 
-    payload = schemas.NewsCreate(
-        title=record.title,
-        content=record.content,
-        image_url="/static/news_images/new.png",
-    )
+    payload = schemas.NewsUpdate(image_url="/static/news_images/new.png")
 
     updated = await news.update_news(
-        record.id, payload, request=None, db=db_session, user=admin
+        record.id, request=None, data=payload, db=db_session, user=admin
     )
 
     assert updated.image_url == "/static/news_images/new.png"

--- a/root/tests/test_news_localization.py
+++ b/root/tests/test_news_localization.py
@@ -1,6 +1,8 @@
 import pytest
 
+from app.api import news
 from app.models import models
+from app.schemas import schemas
 
 
 @pytest.mark.anyio
@@ -50,3 +52,60 @@ async def test_news_localization_preference(async_client, db_session):
     assert payload_ru["title"] == "Только русский"
     assert payload_ru["content"] == "Контент без перевода"
     assert payload_ru["title_en"] is None
+
+
+@pytest.mark.anyio("asyncio")
+@pytest.mark.parametrize(
+    "payload_kwargs, expected_changes",
+    [
+        ({"title_en": "Updated English"}, {"title_en": "Updated English"}),
+        (
+            {"image_url": "/static/news_images/new-image.png"},
+            {"image_url": "/static/news_images/new-image.png"},
+        ),
+    ],
+)
+async def test_partial_news_updates_keep_other_fields(
+    payload_kwargs,
+    expected_changes,
+    db_session,
+    user_factory,
+):
+    admin = await user_factory(role="admin")
+    record = models.News(
+        title="Новость дня",
+        content="Русский текст",
+        title_en="Daily News",
+        content_en="English text",
+        image_url="/static/news_images/original.png",
+    )
+    db_session.add(record)
+    await db_session.commit()
+    await db_session.refresh(record)
+
+    original_values = {
+        "title": record.title,
+        "content": record.content,
+        "title_en": record.title_en,
+        "content_en": record.content_en,
+        "image_url": record.image_url,
+    }
+
+    payload = schemas.NewsUpdate(**payload_kwargs)
+    await news.update_news(
+        record.id,
+        request=None,
+        data=payload,
+        db=db_session,
+        user=admin,
+    )
+
+    stored = await db_session.get(models.News, record.id)
+    assert stored is not None
+
+    for field, expected in expected_changes.items():
+        assert getattr(stored, field) == expected
+
+    for field, original in original_values.items():
+        if field not in expected_changes:
+            assert getattr(stored, field) == original


### PR DESCRIPTION
## Summary
- add a `NewsUpdate` schema so PATCH payloads can send only the fields that change
- update the `update_news` endpoint to accept optional bodies while preserving English-field sanitization
- extend news tests to cover partial updates and adjust image cleanup coverage for the new schema

## Testing
- pytest root/tests/test_news_localization.py root/tests/test_news_image_cleanup.py

------
https://chatgpt.com/codex/tasks/task_e_68f597668d3c832780502f99844df99a