### PR TITLE
Ensure news responses include language headers

### DIFF
--- a/root/app/api/news.py
+++ b/root/app/api/news.py
@@ -71,6 +71,13 @@ def _non_empty_text(value: Any) -> str | None:
     return None
 
 
+def _set_language_headers(response: Response, locale: str) -> None:
+    from app.main import _ensure_vary_header as ensure_vary_header
+
+    response.headers["Content-Language"] = locale
+    ensure_vary_header(response, "Accept-Language")
+
+
 def _localized_text(locale: str, ru_value: Any, en_value: Any) -> str:
     normalized = _normalized_cache_locale(locale)
     candidates: tuple[Any, ...]
@@ -146,6 +153,7 @@ async def news_list(
 ):
     locale = resolve_locale(request=request)
     cache = get_cache()
+    normalized_locale = _normalized_cache_locale(locale)
     cache_key = _news_list_cache_key(locale)
     legacy_key = _LEGACY_NEWS_LIST_CACHE_KEY if locale == DEFAULT_LOCALE else None
 
@@ -156,11 +164,14 @@ async def news_list(
         if cached:
             etag_header = format_etag(cached.etag)
             if etag_matches(cached.etag, if_none_match):
-                return Response(
+                not_modified = Response(
                     status_code=status.HTTP_304_NOT_MODIFIED,
                     headers={"ETag": etag_header},
                 )
+                _set_language_headers(not_modified, normalized_locale)
+                return not_modified
             response.headers["ETag"] = etag_header
+            _set_language_headers(response, normalized_locale)
             return cached.payload
 
     rows = await crud.get_news_list(db)
@@ -170,6 +181,7 @@ async def news_list(
     if cache.enabled:
         entry = await cache.set(cache_key, encoded)
         response.headers["ETag"] = format_etag(entry.etag)
+    _set_language_headers(response, normalized_locale)
     return encoded
 
 
@@ -183,6 +195,7 @@ async def get_news(
 ):
     locale = resolve_locale(request=request)
     cache = get_cache()
+    normalized_locale = _normalized_cache_locale(locale)
     cache_key = _news_item_cache_key(id, locale)
     legacy_key = _legacy_news_item_cache_key(id) if locale == DEFAULT_LOCALE else None
     if cache.enabled:
@@ -192,11 +205,14 @@ async def get_news(
         if cached:
             etag_header = format_etag(cached.etag)
             if etag_matches(cached.etag, if_none_match):
-                return Response(
+                not_modified = Response(
                     status_code=status.HTTP_304_NOT_MODIFIED,
                     headers={"ETag": etag_header},
                 )
+                _set_language_headers(not_modified, normalized_locale)
+                return not_modified
             response.headers["ETag"] = etag_header
+            _set_language_headers(response, normalized_locale)
             return cached.payload
     q = await db.get(models.News, id)
     if not q:
@@ -209,6 +225,7 @@ async def get_news(
     if cache.enabled:
         entry = await cache.set(cache_key, encoded)
         response.headers["ETag"] = format_etag(entry.etag)
+    _set_language_headers(response, normalized_locale)
     return encoded
 
 

--- a/root/tests/test_news_localization.py
+++ b/root/tests/test_news_localization.py
@@ -5,6 +5,13 @@ from app.models import models
 from app.schemas import schemas
 
 
+def _assert_language_headers(response, expected_language: str) -> None:
+    assert response.headers.get("Content-Language") == expected_language
+    vary_header = response.headers.get("Vary", "")
+    vary_values = {value.strip() for value in vary_header.split(",") if value.strip()}
+    assert "Accept-Language" in vary_values
+
+
 @pytest.mark.anyio
 async def test_news_localization_preference(async_client, db_session):
     primary = models.News(
@@ -52,6 +59,76 @@ async def test_news_localization_preference(async_client, db_session):
     assert payload_ru["title"] == "Только русский"
     assert payload_ru["content"] == "Контент без перевода"
     assert payload_ru["title_en"] is None
+
+
+@pytest.mark.anyio
+async def test_news_list_localization_headers_cache(async_client, db_session, fake_cache):
+    _ = fake_cache
+    record = models.News(
+        title="Новость дня",
+        content="Русский текст",
+        title_en="Daily News",
+        content_en="English text",
+    )
+    db_session.add(record)
+    await db_session.commit()
+    await db_session.refresh(record)
+
+    headers = {"Accept-Language": "en"}
+
+    first = await async_client.get("/news", headers=headers)
+    assert first.status_code == 200
+    _assert_language_headers(first, "en")
+    etag = first.headers.get("ETag")
+    assert etag
+
+    not_modified = await async_client.get(
+        "/news", headers={**headers, "If-None-Match": etag}
+    )
+    assert not_modified.status_code == 304
+    _assert_language_headers(not_modified, "en")
+    assert not_modified.headers.get("ETag") == etag
+
+    cached = await async_client.get("/news", headers=headers)
+    assert cached.status_code == 200
+    _assert_language_headers(cached, "en")
+    assert cached.headers.get("ETag") == etag
+
+
+@pytest.mark.anyio
+async def test_news_detail_localization_headers_cache(
+    async_client, db_session, fake_cache
+):
+    _ = fake_cache
+    record = models.News(
+        title="Новость дня",
+        content="Русский текст",
+        title_en="Daily News",
+        content_en="English text",
+    )
+    db_session.add(record)
+    await db_session.commit()
+    await db_session.refresh(record)
+
+    headers = {"Accept-Language": "en"}
+
+    first = await async_client.get(f"/news/{record.id}", headers=headers)
+    assert first.status_code == 200
+    _assert_language_headers(first, "en")
+    etag = first.headers.get("ETag")
+    assert etag
+
+    not_modified = await async_client.get(
+        f"/news/{record.id}", headers={**headers, "If-None-Match": etag}
+    )
+    assert not_modified.status_code == 304
+    _assert_language_headers(not_modified, "en")
+    assert not_modified.headers.get("ETag") == etag
+
+    cached = await async_client.get(f"/news/{record.id}", headers=headers)
+    assert cached.status_code == 200
+    _assert_language_headers(cached, "en")
+    assert cached.headers.get("ETag") == etag
 
 
 @pytest.mark.anyio("asyncio")

--- a/root/tests/test_news_localization.py
+++ b/root/tests/test_news_localization.py
@@ -62,7 +62,9 @@ async def test_news_localization_preference(async_client, db_session):
 
 
 @pytest.mark.anyio
-async def test_news_list_localization_headers_cache(async_client, db_session, fake_cache):
+async def test_news_list_localization_headers_cache(
+    async_client, db_session, fake_cache
+):
     _ = fake_cache
     record = models.News(
         title="Новость дня",


### PR DESCRIPTION
## Summary
- ensure the news list and detail endpoints attach Content-Language and Vary headers for localized payloads, including 304 responses
- add localization header tests covering cache hits and misses for both news list and detail routes

## Testing
- pytest root/tests/test_news_localization.py

------
https://chatgpt.com/codex/tasks/task_e_68f599d458808327b9a7df7a00d35de3