### PR TITLE
Preserve Vary header entries for schedule responses

### DIFF
--- a/root/app/api/schedule.py
+++ b/root/app/api/schedule.py
@@ -1,4 +1,5 @@
-from typing import Any, List, Mapping, Sequence
+from functools import lru_cache
+from typing import Any, Callable, List, Mapping, Sequence
 
 from fastapi import (
     APIRouter,
@@ -19,6 +20,13 @@ from app.deps.cache import etag_matches, format_etag, get_cache
 from app.localization import resolve_locale, translate, translate_lesson_type
 from app.models import models
 from app.schemas import schemas
+
+
+@lru_cache(maxsize=1)
+def _get_vary_helper() -> Callable[[Response, str], None]:
+    from app.main import _ensure_vary_header
+
+    return _ensure_vary_header
 
 router = APIRouter(prefix="/schedule", tags=["schedule"])
 
@@ -68,7 +76,7 @@ async def get_schedule(
     db: AsyncSession = Depends(get_db),
 ):
     locale = resolve_locale(request=request)
-    response.headers["Vary"] = "Accept-Language"
+    _get_vary_helper()(response, "Accept-Language")
     response.headers["Content-Language"] = locale
     cache = get_cache()
     cache_key = _schedule_cache_key(group_id)
@@ -77,10 +85,10 @@ async def get_schedule(
         if cached:
             etag_header = format_etag(cached.etag)
             if etag_matches(cached.etag, if_none_match):
-                return Response(
-                    status_code=status.HTTP_304_NOT_MODIFIED,
-                    headers={"ETag": etag_header, "Vary": "Accept-Language"},
-                )
+                cached_response = Response(status_code=status.HTTP_304_NOT_MODIFIED)
+                cached_response.headers["ETag"] = etag_header
+                _get_vary_helper()(cached_response, "Accept-Language")
+                return cached_response
             response.headers["ETag"] = etag_header
             return _localize_schedule_payload(cached.payload, locale=locale)
 

--- a/root/app/api/schedule.py
+++ b/root/app/api/schedule.py
@@ -28,6 +28,7 @@ def _get_vary_helper() -> Callable[[Response, str], None]:
 
     return _ensure_vary_header
 
+
 router = APIRouter(prefix="/schedule", tags=["schedule"])
 
 

--- a/root/tests/test_schedule_ics.py
+++ b/root/tests/test_schedule_ics.py
@@ -156,3 +156,56 @@ async def test_schedule_endpoint_localizes_lesson_type(
     payload_ru = response_ru.json()
     expected_ru = translate_lesson_type("lecture", locale="ru")
     assert payload_ru[0]["lesson_type_display"] == expected_ru
+
+
+@pytest.mark.anyio
+async def test_schedule_endpoint_preserves_existing_vary_values(
+    async_client, db_session, fake_cache
+) -> None:
+    _ = fake_cache
+    group = models.Group(name="VU-01", course=2, faculty="Physics")
+    db_session.add(group)
+    await db_session.commit()
+    await db_session.refresh(group)
+
+    lesson = models.Schedule(
+        group_id=group.id,
+        subject="Astronomy",
+        teacher="Dr. Stone",
+        room="Planetarium",
+        weekday="tuesday",
+        start_time=datetime(2024, 4, 2, 14, 0),
+        end_time=datetime(2024, 4, 2, 15, 30),
+        parity="both",
+        lesson_type="seminar",
+    )
+    db_session.add(lesson)
+    await db_session.commit()
+
+    headers = {
+        "Origin": "http://localhost:5173",
+        "Accept-Language": "ru",
+    }
+    fresh_response = await async_client.get(f"/schedule/{group.id}", headers=headers)
+    assert fresh_response.status_code == 200
+    fresh_vary_values = {
+        value.strip()
+        for value in fresh_response.headers.get("Vary", "").split(",")
+        if value.strip()
+    }
+    assert {"Origin", "Accept-Language"} <= fresh_vary_values
+
+    etag = fresh_response.headers.get("ETag")
+    assert etag
+
+    cached_response = await async_client.get(
+        f"/schedule/{group.id}",
+        headers={**headers, "If-None-Match": etag},
+    )
+    assert cached_response.status_code == 304
+    cached_vary_values = {
+        value.strip()
+        for value in cached_response.headers.get("Vary", "").split(",")
+        if value.strip()
+    }
+    assert {"Origin", "Accept-Language"} <= cached_vary_values


### PR DESCRIPTION
## Summary
- use the shared vary helper when attaching `Accept-Language` to schedule responses
- ensure 304 cache hits reuse the helper so existing `Vary` values survive
- add a regression test that checks the combined `Vary` header for fresh and cached schedule responses

## Testing
- PYTHONPATH=root pytest root/tests/test_schedule_ics.py

------
https://chatgpt.com/codex/tasks/task_e_68f59e6078fc8327a2dbf48d49c8f7e7