### PR TITLE
Add localization headers and caching headers to events API

### DIFF
--- a/root/app/api/events.py
+++ b/root/app/api/events.py
@@ -1,17 +1,23 @@
+import hashlib
+import json
 import logging
 import uuid
-from typing import List
+from functools import lru_cache
+from typing import Any, List, Tuple
 
 from fastapi import (
     APIRouter,
     Depends,
     File,
+    Header,
     HTTPException,
     Query,
     Request,
+    Response,
     UploadFile,
     status,
 )
+from fastapi.encoders import jsonable_encoder
 from sqlalchemy import and_, delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -19,6 +25,7 @@ from app import crud
 from app.api.deps import get_current_user
 from app.api.utils import save_upload
 from app.core.database import get_db
+from app.deps.cache import etag_matches, format_etag
 from app.localization import resolve_locale, translate
 from app.models import models
 from app.schemas import schemas
@@ -29,6 +36,31 @@ logger = logging.getLogger(__name__)
 
 
 router = APIRouter(prefix="/events", tags=["events"])
+
+
+@lru_cache(maxsize=1)
+def _get_vary_helper():
+    from app.main import _ensure_vary_header
+
+    return _ensure_vary_header
+
+
+def _set_language_headers(response: Response, locale: str) -> None:
+    response.headers["Content-Language"] = locale
+    _get_vary_helper()(response, "Accept-Language")
+
+
+def _encode_payload_with_etag(payload: Any) -> Tuple[Any, str, str]:
+    encoded = jsonable_encoder(payload)
+    serialized = json.dumps(
+        encoded,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    digest = hashlib.sha256(serialized).hexdigest()
+    weak_header = f"W/{format_etag(digest)}"
+    return encoded, digest, weak_header
 
 
 @router.post("", response_model=schemas.EventOut)
@@ -57,15 +89,18 @@ async def create_event(
 @router.get("", response_model=List[schemas.EventOut])
 async def all_events(
     request: Request,
+    response: Response,
     db: AsyncSession = Depends(get_db),
     user: models.User = Depends(get_current_user),
     search: str = Query("", alias="search"),
     type: str = Query("", alias="type"),
     location: str = Query("", alias="location"),
     is_active: bool = Query(True, alias="is_active"),
+    if_none_match: str | None = Header(default=None),
 ):
     locale = resolve_locale(request=request, user=user)
-    return await crud.get_all_events(
+    _set_language_headers(response, locale)
+    payload = await crud.get_all_events(
         db,
         user_id=user.id,
         search=search,
@@ -74,6 +109,14 @@ async def all_events(
         is_active=is_active,
         locale=locale,
     )
+    encoded, digest, weak_header = _encode_payload_with_etag(payload)
+    if etag_matches(digest, if_none_match):
+        not_modified = Response(status_code=status.HTTP_304_NOT_MODIFIED)
+        not_modified.headers["ETag"] = weak_header
+        _set_language_headers(not_modified, locale)
+        return not_modified
+    response.headers["ETag"] = weak_header
+    return encoded
 
 
 @router.post("/attendance", response_model=schemas.EventAttendanceOut)
@@ -104,11 +147,22 @@ async def unregister_event(
 @router.get("/my", response_model=List[schemas.EventOut])
 async def my_events(
     request: Request,
+    response: Response,
     db: AsyncSession = Depends(get_db),
     user: models.User = Depends(get_current_user),
+    if_none_match: str | None = Header(default=None),
 ):
     locale = resolve_locale(request=request, user=user)
-    return await crud.get_my_events(db, user_id=user.id, locale=locale)
+    _set_language_headers(response, locale)
+    payload = await crud.get_my_events(db, user_id=user.id, locale=locale)
+    encoded, digest, weak_header = _encode_payload_with_etag(payload)
+    if etag_matches(digest, if_none_match):
+        not_modified = Response(status_code=status.HTTP_304_NOT_MODIFIED)
+        not_modified.headers["ETag"] = weak_header
+        _set_language_headers(not_modified, locale)
+        return not_modified
+    response.headers["ETag"] = weak_header
+    return encoded
 
 
 @router.post("/{id}/upload_file", response_model=schemas.EventFileOut)
@@ -270,10 +324,13 @@ async def delete_event(
 async def get_event(
     id: int,
     request: Request,
+    response: Response,
     db: AsyncSession = Depends(get_db),
     user: models.User = Depends(get_current_user),
+    if_none_match: str | None = Header(default=None),
 ):
     locale = resolve_locale(request=request, user=user)
+    _set_language_headers(response, locale)
     q = await db.get(models.Event, id)
     if not q:
         raise HTTPException(
@@ -310,7 +367,7 @@ async def get_event(
             .where(models.EventAttendance.event_id == q.id)
         )
     ).scalar()
-    return crud.serialize_event(
+    payload = crud.serialize_event(
         q,
         locale,
         participant_count=participant_count,
@@ -318,6 +375,14 @@ async def get_event(
         is_registered=attendance is not None,
         my_qr_code=attendance.qr_code if attendance else None,
     )
+    encoded, digest, weak_header = _encode_payload_with_etag(payload)
+    if etag_matches(digest, if_none_match):
+        not_modified = Response(status_code=status.HTTP_304_NOT_MODIFIED)
+        not_modified.headers["ETag"] = weak_header
+        _set_language_headers(not_modified, locale)
+        return not_modified
+    response.headers["ETag"] = weak_header
+    return encoded
 
 
 @router.delete("/file/{file_id}", response_model=dict)

--- a/root/frontend/src/pages/Dashboard.tsx
+++ b/root/frontend/src/pages/Dashboard.tsx
@@ -3,6 +3,7 @@ import {
   useMemo,
   useState,
   useCallback,
+  useRef,
   type KeyboardEvent,
   type CSSProperties,
 } from "react"
@@ -223,6 +224,7 @@ export default function Dashboard() {
   const [schedule, setSchedule] = useState<Lesson[]>([])
 
   const [eventsScope, setEventsScope] = useState<"today" | "week">("today")
+  const eventsEtagRef = useRef<string | null>(null)
 
   const parity = useMemo(nowParity, [])
   const todayIndex = time.getDay()
@@ -313,7 +315,21 @@ export default function Dashboard() {
 
   const fetchEvents = useCallback(async () => {
     try {
-      const r = await axios.get("/events", { params: { is_active: true } })
+      const previousTag = eventsEtagRef.current
+      const r = await axios.get("/events", {
+        params: { is_active: true },
+        headers: previousTag ? { "If-None-Match": previousTag } : undefined,
+        validateStatus: (status: number) => status >= 200 && status < 400,
+      })
+      const responseTag = r.headers?.etag
+      if (responseTag) {
+        eventsEtagRef.current = responseTag
+      } else {
+        eventsEtagRef.current = null
+      }
+      if (r.status === 304) {
+        return
+      }
       const arr = Array.isArray(r.data) ? r.data : []
       const sorted = arr
         .filter((e) => e.starts_at)
@@ -322,6 +338,7 @@ export default function Dashboard() {
       setCache<EventItem[]>("dash:events", sorted.slice(0, 30))
     } catch {
       setEvents([])
+      eventsEtagRef.current = null
     } finally {
       setLoadingEvents(false)
     }

--- a/root/frontend/src/pages/Events.tsx
+++ b/root/frontend/src/pages/Events.tsx
@@ -6,6 +6,7 @@ import {
   useState,
   useCallback,
   useMemo,
+  useRef,
   type SyntheticEvent,
   type CSSProperties,
 } from "react"
@@ -114,6 +115,7 @@ const Events = () => {
   const [filterAnchor, setFilterAnchor] = useState<HTMLElement | null>(null)
   const filtersOpen = Boolean(filterAnchor)
   const filtersActive = Boolean(type?.trim() || location?.trim())
+  const etagCacheRef = useRef<Record<string, string>>({})
 
   useEffect(() => {
     const t = (searchParams.get("tab") as typeof tab) || "active"
@@ -154,10 +156,34 @@ const Events = () => {
                 location: dLocation,
               }
 
+        const keyBase =
+          tab === "my"
+            ? `my:${language}`
+            : `${tab}:${language}:${String(isActiveFilter)}:${dSearch}:${dType}:${dLocation}`
+        const headers = etagCacheRef.current[keyBase]
+          ? { "If-None-Match": etagCacheRef.current[keyBase] }
+          : undefined
+        const requestConfig = {
+          signal,
+          params,
+          headers,
+          validateStatus: (status: number) => status >= 200 && status < 400,
+        } as const
+
         const res =
           tab === "my"
-            ? await axios.get<Event[]>("/events/my", { signal })
-            : await axios.get<Event[]>("/events", { params, signal })
+            ? await axios.get<Event[]>("/events/my", requestConfig)
+            : await axios.get<Event[]>("/events", requestConfig)
+
+        const receivedEtag = res.headers?.etag
+        if (receivedEtag) {
+          etagCacheRef.current[keyBase] = receivedEtag
+        } else {
+          delete etagCacheRef.current[keyBase]
+        }
+        if (res.status === 304) {
+          return
+        }
 
         setEvents(Array.isArray(res.data) ? res.data : [])
       } catch (err: any) {
@@ -168,7 +194,7 @@ const Events = () => {
         setLoading(false)
       }
     },
-    [tab, dSearch, dType, dLocation]
+    [tab, dSearch, dType, dLocation, language]
   )
 
   useEffect(() => {

--- a/root/tests/test_events_localization.py
+++ b/root/tests/test_events_localization.py
@@ -1,5 +1,7 @@
 from datetime import datetime, timedelta, timezone
 
+from fastapi import status
+
 import pytest
 
 from app.auth.security import get_password_hash
@@ -65,6 +67,15 @@ async def test_events_localization(async_client, db_session, user_factory):
         headers={**headers, "Accept-Language": "en"},
     )
     assert response_en.status_code == 200
+    assert response_en.headers.get("Content-Language") == "en"
+    vary_en = response_en.headers.get("Vary", "")
+    assert any(
+        value.strip().lower() == "accept-language"
+        for value in vary_en.split(",")
+        if value.strip()
+    )
+    etag_en = response_en.headers.get("ETag")
+    assert etag_en
     payload_en = {item["id"]: item for item in response_en.json()}
 
     assert payload_en[primary.id]["title"] == "English Event"
@@ -87,6 +98,14 @@ async def test_events_localization(async_client, db_session, user_factory):
         headers={**headers, "Accept-Language": "ru"},
     )
     assert response_ru.status_code == 200
+    assert response_ru.headers.get("Content-Language") == "ru"
+    vary_ru = response_ru.headers.get("Vary", "")
+    assert any(
+        value.strip().lower() == "accept-language"
+        for value in vary_ru.split(",")
+        if value.strip()
+    )
+    assert response_ru.headers.get("ETag")
     payload_ru = {item["id"]: item for item in response_ru.json()}
 
     assert payload_ru[primary.id]["title"] == "Русское событие"
@@ -96,3 +115,90 @@ async def test_events_localization(async_client, db_session, user_factory):
     assert payload_ru[primary.id]["about"] == "Подробности"
     assert payload_ru[fallback.id]["title"] == "Только русский"
     assert payload_ru[fallback.id]["description"] == "Без перевода"
+
+
+@pytest.mark.anyio
+async def test_events_etag_and_not_modified(async_client, db_session, user_factory):
+    password = "TestEvent456!"
+    hashed = get_password_hash(password)
+    admin = await user_factory(role="admin")
+    student = await user_factory(hashed_password=hashed, is_active=True)
+
+    now = datetime.now(timezone.utc)
+    event = models.Event(
+        title="Test event",
+        description="Primary description",
+        location="Campus",
+        title_en="Test event EN",
+        description_en="Primary description EN",
+        location_en="Campus EN",
+        starts_at=now + timedelta(days=1),
+        ends_at=now + timedelta(days=1, hours=1),
+        created_by=admin.id,
+        is_active=True,
+    )
+    db_session.add(event)
+    await db_session.commit()
+    await db_session.refresh(event)
+
+    attendance = models.EventAttendance(
+        event_id=event.id,
+        user_id=student.id,
+        qr_code="qr-test",
+    )
+    db_session.add(attendance)
+    await db_session.commit()
+
+    headers = await _login(async_client, student.email, password)
+    base_headers = {**headers, "Accept-Language": "en"}
+
+    list_response = await async_client.get("/events", headers=base_headers)
+    assert list_response.status_code == status.HTTP_200_OK
+    list_etag = list_response.headers.get("ETag")
+    assert list_etag
+
+    list_not_modified = await async_client.get(
+        "/events",
+        headers={**base_headers, "If-None-Match": list_etag},
+    )
+    assert list_not_modified.status_code == status.HTTP_304_NOT_MODIFIED
+    assert list_not_modified.headers.get("Content-Language") == "en"
+    vary_list = list_not_modified.headers.get("Vary", "")
+    assert any(
+        value.strip().lower() == "accept-language"
+        for value in vary_list.split(",")
+        if value.strip()
+    )
+    assert list_not_modified.headers.get("ETag") == list_etag
+
+    my_response = await async_client.get("/events/my", headers=base_headers)
+    assert my_response.status_code == status.HTTP_200_OK
+    my_etag = my_response.headers.get("ETag")
+    assert my_etag
+
+    my_not_modified = await async_client.get(
+        "/events/my",
+        headers={**base_headers, "If-None-Match": my_etag},
+    )
+    assert my_not_modified.status_code == status.HTTP_304_NOT_MODIFIED
+    assert my_not_modified.headers.get("Content-Language") == "en"
+    assert my_not_modified.headers.get("ETag") == my_etag
+
+    headers = await _login(async_client, student.email, password)
+    detail_headers = {**headers, "Accept-Language": "en"}
+
+    detail_response = await async_client.get(
+        f"/events/{event.id}",
+        headers=detail_headers,
+    )
+    assert detail_response.status_code == status.HTTP_200_OK
+    detail_etag = detail_response.headers.get("ETag")
+    assert detail_etag
+
+    detail_not_modified = await async_client.get(
+        f"/events/{event.id}",
+        headers={**detail_headers, "If-None-Match": detail_etag},
+    )
+    assert detail_not_modified.status_code == status.HTTP_304_NOT_MODIFIED
+    assert detail_not_modified.headers.get("Content-Language") == "en"
+    assert detail_not_modified.headers.get("ETag") == detail_etag

--- a/root/tests/test_events_localization.py
+++ b/root/tests/test_events_localization.py
@@ -1,8 +1,7 @@
 from datetime import datetime, timedelta, timezone
 
-from fastapi import status
-
 import pytest
+from fastapi import status
 
 from app.auth.security import get_password_hash
 from app.models import models


### PR DESCRIPTION
## Summary
- ensure events endpoints add language headers, compute weak ETags, and honour If-None-Match requests
- forward If-None-Match headers from the dashboard and events pages while handling 304 responses gracefully
- extend localization tests to cover language headers and conditional request behaviour for events

## Testing
- pytest root/tests/test_events_localization.py

------
https://chatgpt.com/codex/tasks/task_e_68f5a0807ce483279626c2882876b0ec