### PR TITLE
Ensure notifications responses advertise language and disable caching

### DIFF
--- a/root/app/api/notifications.py
+++ b/root/app/api/notifications.py
@@ -3,7 +3,7 @@ from collections.abc import Mapping
 from datetime import UTC, datetime, timedelta
 from typing import Any, Optional, Tuple
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from pydantic import ValidationError
 from sqlalchemy import (
     String,
@@ -30,6 +30,7 @@ from app.services.notifications import (
     build_schedule_reminder_message,
     create_notifications_for_users,
 )
+from app.main import _ensure_vary_header
 
 logger = logging.getLogger(__name__)
 
@@ -344,12 +345,17 @@ def _serialize_notification(
 @router.get("", response_model=NotificationsListOut)
 async def list_notifications(
     request: Request,
+    response: Response,
     cursor: Optional[str] = Query(None),
     limit: int = Query(20, ge=1, le=100),
     db: AsyncSession = Depends(get_db),
     user: User = Depends(get_current_user),
 ):
     locale = resolve_locale(request=request, user=user)
+    response.headers["Content-Language"] = locale or ""
+    _ensure_vary_header(response, "Accept-Language")
+    response.headers["Cache-Control"] = "no-store, max-age=0"
+    response.headers["Pragma"] = "no-cache"
     cursor_info: Optional[Tuple[datetime, int]] = None
     if cursor:
         parsed = _decode_cursor(cursor)
@@ -461,6 +467,7 @@ async def clear_notifications(
 @router.post("/check-schedule", response_model=NotificationsListOut)
 async def check_schedule_and_generate(
     request: Request,
+    response: Response,
     lookahead_minutes: int = Query(15, ge=1, le=180),
     db: AsyncSession = Depends(get_db),
     user: User = Depends(get_current_user),
@@ -468,7 +475,7 @@ async def check_schedule_and_generate(
     locale = resolve_locale(request=request, user=user)
     if not user.group_id:
         return await list_notifications(
-            request=request, db=db, user=user, limit=20, cursor=None
+            request=request, response=response, db=db, user=user, limit=20, cursor=None
         )
 
     now = datetime.now(UTC)
@@ -525,5 +532,10 @@ async def check_schedule_and_generate(
         )
 
     return await list_notifications(
-        request=request, db=db, user=user, limit=20, cursor=None
+        request=request,
+        response=response,
+        db=db,
+        user=user,
+        limit=20,
+        cursor=None,
     )

--- a/root/app/api/notifications.py
+++ b/root/app/api/notifications.py
@@ -24,13 +24,13 @@ from app.api.deps import get_current_user
 from app.core.database import get_db
 from app.crud import sanitize_optional_text
 from app.localization import localized_text, resolve_locale, translate
+from app.main import _ensure_vary_header
 from app.models.models import Notification, Schedule, User
 from app.schemas.schemas import NotificationOut, NotificationsListOut
 from app.services.notifications import (
     build_schedule_reminder_message,
     create_notifications_for_users,
 )
-from app.main import _ensure_vary_header
 
 logger = logging.getLogger(__name__)
 

--- a/root/tests/test_notifications_api.py
+++ b/root/tests/test_notifications_api.py
@@ -238,6 +238,7 @@ async def test_list_notifications_sets_language_and_cache_headers(
     assert follow_up.headers.get("Cache-Control") == "no-store, max-age=0"
     assert follow_up.headers.get("Pragma") == "no-cache"
 
+
 def test_serialize_notification_accepts_orm_instance():
     notification = Notification(
         id=42,

--- a/root/tests/test_notifications_api.py
+++ b/root/tests/test_notifications_api.py
@@ -1,4 +1,4 @@
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import pytest
 from httpx import AsyncClient
@@ -181,6 +181,62 @@ async def test_list_notifications_handles_invalid_data(
 
     datetime.fromisoformat(created_at.replace("Z", "+00:00"))
 
+
+@pytest.mark.anyio
+async def test_list_notifications_sets_language_and_cache_headers(
+    async_client: AsyncClient,
+    user_factory,
+    db_session,
+):
+    password = "Headers123!"
+    hashed = get_password_hash(password)
+    user = await user_factory(hashed_password=hashed, is_active=True)
+
+    headers = await _login(async_client, user.email, password)
+
+    now = datetime.now(UTC)
+    notifications = [
+        Notification(
+            user_id=user.id,
+            title="First",
+            body="Test",
+            created_at=now - timedelta(minutes=5),
+        ),
+        Notification(
+            user_id=user.id,
+            title="Second",
+            body="Test",
+            created_at=now,
+        ),
+    ]
+    db_session.add_all(notifications)
+    await db_session.commit()
+
+    response = await async_client.get(
+        "/notifications?lang=en&limit=1",
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    assert response.headers.get("Content-Language") == "en"
+    assert "Accept-Language" in response.headers.get("Vary", "")
+    assert response.headers.get("Cache-Control") == "no-store, max-age=0"
+    assert response.headers.get("Pragma") == "no-cache"
+
+    payload = response.json()
+    cursor = payload.get("next_cursor")
+    assert cursor
+
+    follow_up = await async_client.get(
+        f"/notifications?cursor={cursor}&lang=en&limit=1",
+        headers=headers,
+    )
+
+    assert follow_up.status_code == 200
+    assert follow_up.headers.get("Content-Language") == "en"
+    assert "Accept-Language" in follow_up.headers.get("Vary", "")
+    assert follow_up.headers.get("Cache-Control") == "no-store, max-age=0"
+    assert follow_up.headers.get("Pragma") == "no-cache"
 
 def test_serialize_notification_accepts_orm_instance():
     notification = Notification(


### PR DESCRIPTION
## Summary
- add language and cache-control headers to the notifications listing endpoint
- reuse the same response headers when generating schedule-driven notifications
- extend notifications API tests to verify the new headers across paginated requests

## Testing
- pytest root/tests/test_notifications_api.py *(fails: ModuleNotFoundError: No module named 'fakeredis')*

------
https://chatgpt.com/codex/tasks/task_e_68f63980f148832784375b82c3258b03