### PR TITLE
Handle upload cleanup on commit failure

### DIFF
--- a/root/app/api/events.py
+++ b/root/app/api/events.py
@@ -189,8 +189,17 @@ async def upload_event_file(
     url = await save_attachment(file, "event_files", f"event_{id}", locale=locale)
     ef = models.EventFile(event_id=id, file_url=url)
     db.add(ef)
-    await db.commit()
-    await db.refresh(ef)
+    try:
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        await delete_static_file(url)
+        raise
+    try:
+        await db.refresh(ef)
+    except Exception:
+        await delete_static_file(url)
+        raise
     return ef
 
 

--- a/root/app/api/users.py
+++ b/root/app/api/users.py
@@ -331,9 +331,21 @@ async def upload_avatar(
     locale = resolve_locale(request=request, user=user)
     url = await save_upload(file, "avatars", f"user_{user.id}_avatar", locale=locale)
     db_user = await db.get(models.User, user.id)
+    previous_url = db_user.avatar_url
     db_user.avatar_url = url
-    await db.commit()
-    await db.refresh(db_user)
+    try:
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        db_user.avatar_url = previous_url
+        await delete_static_file(url)
+        raise
+    try:
+        await db.refresh(db_user)
+    except Exception:
+        db_user.avatar_url = previous_url
+        await delete_static_file(url)
+        raise
     return db_user
 
 
@@ -348,9 +360,21 @@ async def upload_cover(
     locale = resolve_locale(request=request, user=user)
     url = await save_upload(file, "covers", f"user_{user.id}_cover", locale=locale)
     db_user = await db.get(models.User, user.id)
+    previous_url = db_user.cover_url
     db_user.cover_url = url
-    await db.commit()
-    await db.refresh(db_user)
+    try:
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        db_user.cover_url = previous_url
+        await delete_static_file(url)
+        raise
+    try:
+        await db.refresh(db_user)
+    except Exception:
+        db_user.cover_url = previous_url
+        await delete_static_file(url)
+        raise
     return db_user
 
 

--- a/root/tests/test_event_file_upload.py
+++ b/root/tests/test_event_file_upload.py
@@ -72,6 +72,50 @@ async def test_upload_event_file_offloads_io(
 
 
 @pytest.mark.anyio("asyncio")
+async def test_upload_event_file_cleans_up_on_commit_failure(
+    tmp_path, monkeypatch, db_session, user_factory
+):
+    admin = await user_factory(role="admin")
+    event = await _create_event(db_session, admin)
+
+    payload = b"example data"
+    upload = UploadFile(
+        filename="notes.txt",
+        file=io.BytesIO(payload),
+        headers=Headers({"content-type": "text/plain"}),
+    )
+
+    monkeypatch.setattr(settings, "static_dir_path", tmp_path)
+    monkeypatch.setattr(settings, "event_file_allowed_mime_types", ["text/plain"])
+    monkeypatch.setattr(settings, "event_file_allowed_extensions", [".txt"])
+    monkeypatch.setattr(settings, "event_file_max_size_bytes", 1024)
+
+    delete_calls: list[str] = []
+    original_delete = events.delete_static_file
+
+    async def tracking_delete(url: str) -> None:
+        delete_calls.append(url)
+        await original_delete(url)
+
+    monkeypatch.setattr(events, "delete_static_file", tracking_delete)
+
+    async def failing_commit(*_args, **_kwargs):
+        raise RuntimeError("commit failed")
+
+    monkeypatch.setattr(db_session, "commit", failing_commit)
+
+    with pytest.raises(RuntimeError):
+        await events.upload_event_file(
+            event.id, upload, request=None, db=db_session, user=admin
+        )
+
+    folder = tmp_path / "event_files"
+    assert delete_calls, "delete_static_file should run on failure"
+    if folder.exists():
+        assert not any(folder.iterdir())
+
+
+@pytest.mark.anyio("asyncio")
 async def test_upload_event_file_rejects_large_payload(
     tmp_path, monkeypatch, db_session, user_factory
 ):

--- a/root/tests/test_user_profile_update.py
+++ b/root/tests/test_user_profile_update.py
@@ -1,12 +1,23 @@
 import asyncio
+import io
 import uuid
 
 import pytest
+from fastapi import UploadFile
 from httpx import AsyncClient
+from PIL import Image
+from starlette.datastructures import Headers
 
+from app.api import users
 from app.auth.security import get_password_hash
 from app.core.config import settings
 from app.models import models
+
+
+def _make_png_bytes(color: tuple[int, int, int] = (255, 0, 0)) -> bytes:
+    buffer = io.BytesIO()
+    Image.new("RGB", (1, 1), color=color).save(buffer, format="PNG")
+    return buffer.getvalue()
 
 
 async def _login(
@@ -136,6 +147,92 @@ async def test_delete_avatar_ignores_invalid_path(
         assert user.avatar_url is None
     finally:
         sentinel_path.unlink(missing_ok=True)
+
+
+@pytest.mark.anyio
+async def test_upload_avatar_cleans_up_on_commit_failure(
+    tmp_path, monkeypatch, db_session, user_factory
+):
+    user = await user_factory(is_active=True)
+
+    payload = _make_png_bytes()
+    upload = UploadFile(
+        filename="avatar.png",
+        file=io.BytesIO(payload),
+        headers=Headers({"content-type": "image/png"}),
+    )
+
+    monkeypatch.setattr(settings, "static_dir_path", tmp_path)
+
+    delete_calls: list[str] = []
+    original_delete = users.delete_static_file
+
+    async def tracking_delete(url: str) -> None:
+        delete_calls.append(url)
+        await original_delete(url)
+
+    monkeypatch.setattr(users, "delete_static_file", tracking_delete)
+
+    async def failing_commit(*_args, **_kwargs):
+        raise RuntimeError("commit failed")
+
+    monkeypatch.setattr(db_session, "commit", failing_commit)
+
+    with pytest.raises(RuntimeError):
+        await users.upload_avatar(
+            upload, request=None, db=db_session, user=user
+        )
+
+    avatar_dir = tmp_path / "avatars"
+    assert delete_calls, "delete_static_file should be invoked"
+    if avatar_dir.exists():
+        assert not any(avatar_dir.iterdir())
+
+    await db_session.refresh(user)
+    assert user.avatar_url is None
+
+
+@pytest.mark.anyio
+async def test_upload_cover_cleans_up_on_commit_failure(
+    tmp_path, monkeypatch, db_session, user_factory
+):
+    user = await user_factory(is_active=True)
+
+    payload = _make_png_bytes(color=(0, 255, 0))
+    upload = UploadFile(
+        filename="cover.png",
+        file=io.BytesIO(payload),
+        headers=Headers({"content-type": "image/png"}),
+    )
+
+    monkeypatch.setattr(settings, "static_dir_path", tmp_path)
+
+    delete_calls: list[str] = []
+    original_delete = users.delete_static_file
+
+    async def tracking_delete(url: str) -> None:
+        delete_calls.append(url)
+        await original_delete(url)
+
+    monkeypatch.setattr(users, "delete_static_file", tracking_delete)
+
+    async def failing_commit(*_args, **_kwargs):
+        raise RuntimeError("commit failed")
+
+    monkeypatch.setattr(db_session, "commit", failing_commit)
+
+    with pytest.raises(RuntimeError):
+        await users.upload_cover(
+            upload, request=None, db=db_session, user=user
+        )
+
+    cover_dir = tmp_path / "covers"
+    assert delete_calls, "delete_static_file should be invoked"
+    if cover_dir.exists():
+        assert not any(cover_dir.iterdir())
+
+    await db_session.refresh(user)
+    assert user.cover_url is None
 
 
 @pytest.mark.anyio

--- a/root/tests/test_user_profile_update.py
+++ b/root/tests/test_user_profile_update.py
@@ -179,9 +179,7 @@ async def test_upload_avatar_cleans_up_on_commit_failure(
     monkeypatch.setattr(db_session, "commit", failing_commit)
 
     with pytest.raises(RuntimeError):
-        await users.upload_avatar(
-            upload, request=None, db=db_session, user=user
-        )
+        await users.upload_avatar(upload, request=None, db=db_session, user=user)
 
     avatar_dir = tmp_path / "avatars"
     assert delete_calls, "delete_static_file should be invoked"
@@ -222,9 +220,7 @@ async def test_upload_cover_cleans_up_on_commit_failure(
     monkeypatch.setattr(db_session, "commit", failing_commit)
 
     with pytest.raises(RuntimeError):
-        await users.upload_cover(
-            upload, request=None, db=db_session, user=user
-        )
+        await users.upload_cover(upload, request=None, db=db_session, user=user)
 
     cover_dir = tmp_path / "covers"
     assert delete_calls, "delete_static_file should be invoked"


### PR DESCRIPTION
## Summary
- wrap event and profile upload endpoints in commit/refresh guards that remove newly saved files when persistence fails
- restore previous profile media URLs if the database commit errors and ensure temporary files are deleted
- add regression tests that simulate commit failures and assert file cleanup for event attachments and profile uploads

## Testing
- pytest root/tests/test_event_file_upload.py::test_upload_event_file_cleans_up_on_commit_failure root/tests/test_user_profile_update.py::test_upload_avatar_cleans_up_on_commit_failure root/tests/test_user_profile_update.py::test_upload_cover_cleans_up_on_commit_failure *(fails: ModuleNotFoundError: No module named 'fakeredis')*


------
https://chatgpt.com/codex/tasks/task_e_68f63c0d947c8327903d43537fe73853