### PR TITLE
Queue notifications for events and news via background jobs

### DIFF
--- a/root/app/api/events.py
+++ b/root/app/api/events.py
@@ -7,6 +7,7 @@ from typing import Any, List, Tuple
 
 from fastapi import (
     APIRouter,
+    BackgroundTasks,
     Depends,
     File,
     Header,
@@ -29,7 +30,7 @@ from app.deps.cache import etag_matches, format_etag
 from app.localization import resolve_locale, translate
 from app.models import models
 from app.schemas import schemas
-from app.services.notifications import notify_about_event
+from app.services import notification_queue
 from app.utils.files import delete_static_file, save_attachment
 
 logger = logging.getLogger(__name__)
@@ -67,6 +68,7 @@ def _encode_payload_with_etag(payload: Any) -> Tuple[Any, str, str]:
 async def create_event(
     data: schemas.EventCreate,
     request: Request,
+    background: BackgroundTasks,
     db: AsyncSession = Depends(get_db),
     user: models.User = Depends(get_current_user),
 ):
@@ -78,10 +80,14 @@ async def create_event(
         )
     record = await crud.create_event(db, data, user_id=user.id)
     try:
-        await notify_about_event(db, record, locale=locale)
+        background.add_task(
+            notification_queue.enqueue_event_notification,
+            record.id,
+            locale=locale,
+        )
     except Exception:
         logger.exception(
-            "Failed to dispatch event notification", extra={"event_id": record.id}
+            "Failed to enqueue event notification", extra={"event_id": record.id}
         )
     return crud.serialize_event(record, locale)
 

--- a/root/app/api/news.py
+++ b/root/app/api/news.py
@@ -3,6 +3,7 @@ from typing import Any, List
 
 from fastapi import (
     APIRouter,
+    BackgroundTasks,
     Body,
     Depends,
     File,
@@ -29,7 +30,7 @@ from app.localization import (
 )
 from app.models import models
 from app.schemas import schemas
-from app.services.notifications import notify_about_news
+from app.services import notification_queue
 from app.utils.files import delete_static_file
 
 logger = logging.getLogger(__name__)
@@ -122,6 +123,7 @@ def _news_cache_keys(news_id: int | None = None) -> list[str]:
 async def create_news(
     data: schemas.NewsCreate,
     request: Request,
+    background: BackgroundTasks,
     db: AsyncSession = Depends(get_db),
     user: models.User = Depends(get_current_user),
 ):
@@ -136,10 +138,14 @@ async def create_news(
     await cache.invalidate(*_news_cache_keys(record.id))
     serialized = _serialize_news(record, locale)
     try:
-        await notify_about_news(db, record, locale=locale)
+        background.add_task(
+            notification_queue.enqueue_news_notification,
+            record.id,
+            locale=locale,
+        )
     except Exception:
         logger.exception(
-            "Failed to dispatch news notification", extra={"news_id": record.id}
+            "Failed to enqueue news notification", extra={"news_id": record.id}
         )
     return schemas.NewsOut.model_validate(serialized)
 

--- a/root/app/api/notifications.py
+++ b/root/app/api/notifications.py
@@ -24,7 +24,6 @@ from app.api.deps import get_current_user
 from app.core.database import get_db
 from app.crud import sanitize_optional_text
 from app.localization import localized_text, resolve_locale, translate
-from app.main import _ensure_vary_header
 from app.models.models import Notification, Schedule, User
 from app.schemas.schemas import NotificationOut, NotificationsListOut
 from app.services.notifications import (
@@ -47,6 +46,12 @@ _MISSING_COLUMN_MARKERS = (
 def _is_missing_column_error(exc: SQLAlchemyError) -> bool:
     message = str(getattr(exc, "orig", exc)).lower()
     return any(marker in message for marker in _MISSING_COLUMN_MARKERS)
+
+
+def _ensure_vary_header(response: Response, header_name: str) -> None:
+    from app.main import _ensure_vary_header as ensure_vary
+
+    ensure_vary(response, header_name)
 
 
 def _parse_datetime(value: Any) -> datetime | None:

--- a/root/app/services/notification_queue.py
+++ b/root/app/services/notification_queue.py
@@ -1,0 +1,158 @@
+"""In-process queue for dispatching notification jobs asynchronously."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import Literal
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import async_session
+from app.models.models import Event, News, Notification
+from app.services.notifications import notify_about_event, notify_about_news
+
+logger = logging.getLogger(__name__)
+
+
+JobKind = Literal["event", "news"]
+
+
+@dataclass(slots=True, frozen=True)
+class NotificationJob:
+    """Queued notification delivery request."""
+
+    kind: JobKind
+    record_id: int
+    locale: str | None
+
+
+_job_queue: asyncio.Queue[NotificationJob] = asyncio.Queue()
+_worker_task: asyncio.Task[None] | None = None
+_worker_lock = asyncio.Lock()
+
+
+async def _ensure_worker() -> None:
+    """Ensure that a background worker is running to process queued jobs."""
+
+    global _worker_task
+
+    if _worker_task and not _worker_task.done():
+        return
+
+    async with _worker_lock:
+        if _worker_task and not _worker_task.done():
+            return
+        loop = asyncio.get_running_loop()
+        _worker_task = loop.create_task(_worker_loop())
+
+
+async def _worker_loop() -> None:
+    """Continuously process notification jobs from the queue."""
+
+    try:
+        while True:
+            job = await _job_queue.get()
+            try:
+                await _process_job(job)
+            except asyncio.CancelledError:  # pragma: no cover - cooperative shutdown
+                raise
+            except Exception:  # pragma: no cover - defensive guard
+                logger.exception("Failed to process notification job", extra={"job": job})
+            finally:
+                _job_queue.task_done()
+    except asyncio.CancelledError:  # pragma: no cover - cooperative shutdown
+        raise
+
+
+async def _notification_exists(
+    session: AsyncSession,
+    job: NotificationJob,
+) -> bool:
+    """Best-effort idempotency guard based on notification metadata."""
+
+    url: str | None
+    notif_type: str | None
+
+    if job.kind == "event":
+        url = f"/events/{job.record_id}"
+        notif_type = "events.new"
+    elif job.kind == "news":
+        url = f"/news/{job.record_id}"
+        notif_type = "news.new"
+    else:  # pragma: no cover - defensive guard
+        return False
+
+    if job.record_id <= 0:
+        return False
+
+    stmt = (
+        select(Notification.id)
+        .where(Notification.type == notif_type, Notification.url == url)
+        .limit(1)
+    )
+    result = await session.execute(stmt)
+    return result.scalar_one_or_none() is not None
+
+
+async def _process_job(job: NotificationJob) -> None:
+    async with async_session() as session:
+        if await _notification_exists(session, job):
+            logger.debug("Skipping duplicate notification job", extra={"job": job})
+            return
+        if job.kind == "event":
+            record = await session.get(Event, job.record_id)
+            if not record:
+                logger.info(
+                    "Event %s disappeared before notification dispatch", job.record_id
+                )
+                return
+            await notify_about_event(session, record, locale=job.locale)
+        elif job.kind == "news":
+            record = await session.get(News, job.record_id)
+            if not record:
+                logger.info(
+                    "News %s disappeared before notification dispatch", job.record_id
+                )
+                return
+            await notify_about_news(session, record, locale=job.locale)
+        else:  # pragma: no cover - defensive guard
+            logger.warning("Unsupported notification job", extra={"job": job})
+
+
+async def enqueue_event_notification(event_id: int, *, locale: str | None = None) -> None:
+    """Queue an event notification job for asynchronous delivery."""
+
+    await _job_queue.put(NotificationJob(kind="event", record_id=event_id, locale=locale))
+    await _ensure_worker()
+
+
+async def enqueue_news_notification(news_id: int, *, locale: str | None = None) -> None:
+    """Queue a news notification job for asynchronous delivery."""
+
+    await _job_queue.put(NotificationJob(kind="news", record_id=news_id, locale=locale))
+    await _ensure_worker()
+
+
+async def wait_for_all_jobs(timeout: float | None = None) -> None:
+    """Wait until the queue is empty. Intended for tests."""
+
+    if timeout is None:
+        await _job_queue.join()
+        return
+    await asyncio.wait_for(_job_queue.join(), timeout=timeout)
+
+
+async def reset_testing_state() -> None:
+    """Best-effort helper to clear pending jobs between tests."""
+
+    while not _job_queue.empty():
+        try:
+            _job_queue.get_nowait()
+        except asyncio.QueueEmpty:  # pragma: no cover - defensive guard
+            break
+        else:
+            _job_queue.task_done()
+

--- a/root/app/services/notification_queue.py
+++ b/root/app/services/notification_queue.py
@@ -60,7 +60,9 @@ async def _worker_loop() -> None:
             except asyncio.CancelledError:  # pragma: no cover - cooperative shutdown
                 raise
             except Exception:  # pragma: no cover - defensive guard
-                logger.exception("Failed to process notification job", extra={"job": job})
+                logger.exception(
+                    "Failed to process notification job", extra={"job": job}
+                )
             finally:
                 _job_queue.task_done()
     except asyncio.CancelledError:  # pragma: no cover - cooperative shutdown
@@ -122,10 +124,14 @@ async def _process_job(job: NotificationJob) -> None:
             logger.warning("Unsupported notification job", extra={"job": job})
 
 
-async def enqueue_event_notification(event_id: int, *, locale: str | None = None) -> None:
+async def enqueue_event_notification(
+    event_id: int, *, locale: str | None = None
+) -> None:
     """Queue an event notification job for asynchronous delivery."""
 
-    await _job_queue.put(NotificationJob(kind="event", record_id=event_id, locale=locale))
+    await _job_queue.put(
+        NotificationJob(kind="event", record_id=event_id, locale=locale)
+    )
     await _ensure_worker()
 
 
@@ -155,4 +161,3 @@ async def reset_testing_state() -> None:
             break
         else:
             _job_queue.task_done()
-

--- a/root/tests/test_notifications_service.py
+++ b/root/tests/test_notifications_service.py
@@ -6,6 +6,7 @@ from contextlib import contextmanager
 import pytest
 from sqlalchemy import delete, event, select
 
+from app.auth.security import get_password_hash
 from app.core.config import settings
 from app.models.models import (
     Group,
@@ -15,6 +16,7 @@ from app.models.models import (
     Schedule,
     User,
 )
+from app.services import notification_queue
 from app.services import notifications as notifications_module
 from app.services.notifications import (
     aggregate_notification_delivery_stats,
@@ -61,6 +63,23 @@ def configured_push_settings(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "vapid_subject", "mailto:test@example.com")
     yield
     _reset_vapid_cache()
+
+
+@pytest.fixture(autouse=True)
+async def reset_notification_queue_state() -> None:
+    await notification_queue.reset_testing_state()
+    yield
+    await notification_queue.reset_testing_state()
+
+
+async def _login(async_client, email: str, password: str) -> dict[str, str]:
+    response = await async_client.post(
+        "/auth/login",
+        data={"username": email, "password": password},
+    )
+    assert response.status_code == 200
+    token = response.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
 
 
 def test_is_user_in_quiet_hours_crosses_midnight():
@@ -280,3 +299,93 @@ async def test_scheduler_loop_logs_failures(monkeypatch: pytest.MonkeyPatch, cap
         "Failed to generate schedule reminders" in record.getMessage()
         for record in caplog.records
     )
+
+
+@pytest.mark.anyio
+async def test_event_creation_enqueues_notifications(
+    async_client,
+    db_session,
+    user_factory,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    admin = await user_factory(role="admin")
+    password = "Adm1nPass!"
+    admin.hashed_password = get_password_hash(password)
+    await db_session.commit()
+
+    headers = await _login(async_client, admin.email, password)
+
+    delivery_started = asyncio.Event()
+    calls = 0
+
+    async def _fake_create(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        delivery_started.set()
+        return 0
+
+    monkeypatch.setattr(
+        notifications_module,
+        "create_notifications_for_users",
+        _fake_create,
+    )
+
+    starts_at = dt.datetime.now(dt.timezone.utc) + dt.timedelta(hours=1)
+    ends_at = starts_at + dt.timedelta(hours=2)
+
+    payload = {
+        "title": "Async Event",
+        "description": "Test event",
+        "starts_at": starts_at.isoformat(),
+        "ends_at": ends_at.isoformat(),
+    }
+
+    response = await async_client.post("/events", json=payload, headers=headers)
+    assert response.status_code == 200
+    assert not delivery_started.is_set()
+
+    await notification_queue.wait_for_all_jobs(timeout=1.0)
+    await asyncio.wait_for(delivery_started.wait(), timeout=1.0)
+    assert calls == 1
+
+
+@pytest.mark.anyio
+async def test_news_creation_enqueues_notifications(
+    async_client,
+    db_session,
+    user_factory,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    admin = await user_factory(role="admin")
+    password = "Adm1nPass!"
+    admin.hashed_password = get_password_hash(password)
+    await db_session.commit()
+
+    headers = await _login(async_client, admin.email, password)
+
+    delivery_started = asyncio.Event()
+    calls = 0
+
+    async def _fake_create(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        delivery_started.set()
+        return 0
+
+    monkeypatch.setattr(
+        notifications_module,
+        "create_notifications_for_users",
+        _fake_create,
+    )
+
+    response = await async_client.post(
+        "/news",
+        json={"title": "Async News", "content": "Hello"},
+        headers=headers,
+    )
+    assert response.status_code == 200
+    assert not delivery_started.is_set()
+
+    await notification_queue.wait_for_all_jobs(timeout=1.0)
+    await asyncio.wait_for(delivery_started.wait(), timeout=1.0)
+    assert calls == 1


### PR DESCRIPTION
## Summary
- enqueue event and news notification dispatch through FastAPI background tasks
- add an asynchronous notification queue worker with idempotent dispatch safeguards
- extend notification service tests to cover enqueued delivery behavior and adjust notifications API import

## Testing
- pytest root/tests/test_notifications_service.py -k "enqueues" -q

------
https://chatgpt.com/codex/tasks/task_e_68f63e88a2d883279b5d6a65f5d8c885