### PR TITLE
Implement paginated events API and UI

### DIFF
--- a/root/app/api/events.py
+++ b/root/app/api/events.py
@@ -92,7 +92,7 @@ async def create_event(
     return crud.serialize_event(record, locale)
 
 
-@router.get("", response_model=List[schemas.EventOut])
+@router.get("", response_model=schemas.PaginatedEvents)
 async def all_events(
     request: Request,
     response: Response,
@@ -102,6 +102,13 @@ async def all_events(
     type: str = Query("", alias="type"),
     location: str = Query("", alias="location"),
     is_active: bool = Query(True, alias="is_active"),
+    limit: int = Query(
+        crud.DEFAULT_EVENTS_LIMIT,
+        ge=1,
+        le=crud.MAX_EVENTS_LIMIT,
+        alias="limit",
+    ),
+    cursor: int = Query(0, ge=0, alias="cursor"),
     if_none_match: str | None = Header(default=None),
 ):
     locale = resolve_locale(request=request, user=user)
@@ -114,6 +121,8 @@ async def all_events(
         location=location,
         is_active=is_active,
         locale=locale,
+        limit=limit,
+        cursor=cursor,
     )
     encoded, digest, weak_header = _encode_payload_with_etag(payload)
     if etag_matches(digest, if_none_match):

--- a/root/app/crud/__init__.py
+++ b/root/app/crud/__init__.py
@@ -252,6 +252,10 @@ def serialize_event(
     return schemas.EventOut.model_validate(data)
 
 
+DEFAULT_EVENTS_LIMIT = 20
+MAX_EVENTS_LIMIT = 50
+
+
 async def get_all_events(
     db: AsyncSession,
     user_id: int | None = None,
@@ -260,13 +264,18 @@ async def get_all_events(
     location: str = "",
     is_active: bool = True,
     locale: str | None = None,
+    *,
+    limit: int | None = None,
+    cursor: int | None = None,
 ):
-    q = select(models.Event)
     now = datetime.now(UTC)
+    safe_limit = max(1, min(MAX_EVENTS_LIMIT, limit or DEFAULT_EVENTS_LIMIT))
+    safe_cursor = max(0, cursor or 0)
 
+    conditions = []
     if search:
         like = f"%{search}%"
-        q = q.where(
+        conditions.append(
             or_(
                 models.Event.title.ilike(like),
                 models.Event.title_en.ilike(like),
@@ -277,7 +286,7 @@ async def get_all_events(
             )
         )
     if type:
-        q = q.where(
+        conditions.append(
             or_(
                 models.Event.event_type == type,
                 models.Event.event_type_en == type,
@@ -285,32 +294,45 @@ async def get_all_events(
         )
     if location:
         like = f"%{location}%"
-        q = q.where(
+        conditions.append(
             or_(
                 models.Event.location.ilike(like),
                 models.Event.location_en.ilike(like),
             )
         )
     if is_active:
-        q = q.where(models.Event.ends_at >= now)
+        conditions.append(models.Event.ends_at >= now)
     else:
-        q = q.where(models.Event.ends_at < now)
+        conditions.append(models.Event.ends_at < now)
 
-    events = (
-        (await db.execute(q.order_by(models.Event.starts_at.asc()))).scalars().all()
-    )
+    stmt = select(models.Event)
+    if conditions:
+        stmt = stmt.where(and_(*conditions))
+
+    ordered_stmt = stmt.order_by(models.Event.starts_at.asc(), models.Event.id.asc())
+    page_stmt = ordered_stmt.offset(safe_cursor).limit(safe_limit)
+    rows = await db.execute(page_stmt)
+    events = rows.scalars().all()
     ids = [e.id for e in events]
     counts = await _attendance_counts(db, ids)
     files_map = await _files_by_event(db, ids)
 
+    total_stmt = select(func.count()).select_from(models.Event)
+    if conditions:
+        total_stmt = total_stmt.where(and_(*conditions))
+    total = (await db.execute(total_stmt)).scalar_one()
+
     registered_ids: set[int] = set()
     qr_map: Dict[int, Optional[str]] = {}
-    if user_id:
+    if user_id and ids:
         attendance_rows = (
             (
                 await db.execute(
                     select(models.EventAttendance).where(
-                        models.EventAttendance.user_id == user_id
+                        and_(
+                            models.EventAttendance.user_id == user_id,
+                            models.EventAttendance.event_id.in_(ids),
+                        )
                     )
                 )
             )
@@ -327,8 +349,8 @@ async def get_all_events(
         registered_ids = {row.event_id for row in attendance_rows}
         qr_map = {row.event_id: row.qr_code for row in attendance_rows}
 
-    result: List[schemas.EventOut] = []
     normalized_locale = normalize_locale(locale)
+    result: List[schemas.EventOut] = []
     for event in events:
         files = files_map.get(event.id, [])
         result.append(
@@ -341,7 +363,18 @@ async def get_all_events(
                 my_qr_code=qr_map.get(event.id),
             )
         )
-    return result
+
+    next_cursor = safe_cursor + len(result)
+    has_more = next_cursor < total
+
+    return schemas.PaginatedEvents(
+        items=result,
+        total=total,
+        limit=safe_limit,
+        cursor=safe_cursor,
+        next_cursor=next_cursor if has_more else None,
+        has_more=has_more,
+    )
 
 
 async def create_event(db: AsyncSession, event: schemas.EventCreate, user_id: int):

--- a/root/app/schemas/schemas.py
+++ b/root/app/schemas/schemas.py
@@ -256,6 +256,15 @@ class EventOut(OrmModel):
     my_qr_code: Optional[str] = None
 
 
+class PaginatedEvents(BaseModel):
+    items: List[EventOut]
+    total: int
+    limit: int
+    cursor: int
+    next_cursor: Optional[int] = None
+    has_more: bool
+
+
 class EventAttendanceCreate(BaseModel):
     event_id: int
 

--- a/root/frontend/src/api/__tests__/client.language.test.ts
+++ b/root/frontend/src/api/__tests__/client.language.test.ts
@@ -3,6 +3,7 @@ import { http, HttpResponse } from "msw"
 import api from "@/api/client"
 import i18n from "@/i18n/config"
 import { server } from "@/tests/mocks/server"
+import type { PaginatedResponse } from "@/types/Pagination"
 
 type NewsPayload = { id: number; title: string; content: string }
 type EventPayload = { id: number; title: string; description: string }
@@ -51,7 +52,15 @@ describe("API language interceptor", () => {
       http.get("*/events", ({ request }) => {
         const english = isEnglishRequest(request)
         observedLanguages.push(request.headers.get("accept-language") ?? "")
-        return HttpResponse.json(english ? englishEvents : russianEvents)
+        const payload = english ? englishEvents : russianEvents
+        return HttpResponse.json({
+          items: payload,
+          total: payload.length,
+          limit: payload.length,
+          cursor: 0,
+          next_cursor: null,
+          has_more: false,
+        })
       }),
       http.get("*/notifications", ({ request }) => {
         const english = isEnglishRequest(request)
@@ -71,8 +80,8 @@ describe("API language interceptor", () => {
     const newsResponse = await api.get<NewsPayload[]>("/news")
     expect(newsResponse.data[0].title).toBe("Campus renovation update")
 
-    const eventsResponse = await api.get<EventPayload[]>("/events")
-    expect(eventsResponse.data[0].title).toBe("Career fair")
+    const eventsResponse = await api.get<PaginatedResponse<EventPayload>>("/events")
+    expect(eventsResponse.data.items[0].title).toBe("Career fair")
 
     const notificationsResponse = await api.get<NotificationPayload[]>("/notifications")
     expect(notificationsResponse.data[0].message).toBe("New grade posted in Calculus.")

--- a/root/frontend/src/i18n/locales/en/common.json
+++ b/root/frontend/src/i18n/locales/en/common.json
@@ -17,6 +17,7 @@
     "refresh": "Refresh",
     "uploadPhoto": "Upload photo",
     "changePhoto": "Change photo",
+    "loadMore": "Load more",
     "backToTop": "Back to top"
   },
   "statuses": {

--- a/root/frontend/src/i18n/locales/ru/common.json
+++ b/root/frontend/src/i18n/locales/ru/common.json
@@ -17,6 +17,7 @@
     "refresh": "Обновить",
     "uploadPhoto": "Загрузить фото",
     "changePhoto": "Изменить фото",
+    "loadMore": "Загрузить ещё",
     "backToTop": "Наверх"
   },
   "statuses": {

--- a/root/frontend/src/pages/Dashboard.tsx
+++ b/root/frontend/src/pages/Dashboard.tsx
@@ -30,6 +30,7 @@ import { Link, useNavigate } from "react-router-dom"
 import { cardHoverSx } from "@/constants/cardHover"
 import { useTranslation } from "react-i18next"
 import { getLocaleForLanguage, useLanguage } from "@/contexts/LanguageContext"
+import type { PaginatedResponse } from "@/types/Pagination"
 
 type NewsItem = {
   id: number
@@ -316,8 +317,8 @@ export default function Dashboard() {
   const fetchEvents = useCallback(async () => {
     try {
       const previousTag = eventsEtagRef.current
-      const r = await axios.get("/events", {
-        params: { is_active: true },
+      const r = await axios.get<PaginatedResponse<EventItem>>("/events", {
+        params: { is_active: true, limit: 50 },
         headers: previousTag ? { "If-None-Match": previousTag } : undefined,
         validateStatus: (status: number) => status >= 200 && status < 400,
       })
@@ -330,7 +331,7 @@ export default function Dashboard() {
       if (r.status === 304) {
         return
       }
-      const arr = Array.isArray(r.data) ? r.data : []
+      const arr = Array.isArray(r.data?.items) ? r.data.items : []
       const sorted = arr
         .filter((e) => e.starts_at)
         .sort((a, b) => String(a.starts_at).localeCompare(String(b.starts_at)))
@@ -412,8 +413,10 @@ export default function Dashboard() {
         .catch(() => {})
     if (type === "events")
       axios
-        .get("/events", { params: { is_active: true } })
-        .then((r) => setCache("prefetch:events", r.data))
+        .get<PaginatedResponse<EventItem>>("/events", { params: { is_active: true, limit: 20 } })
+        .then((r) =>
+          setCache("prefetch:events", Array.isArray(r.data?.items) ? r.data.items : [])
+        )
         .catch(() => {})
   }
 

--- a/root/frontend/src/pages/Events.tsx
+++ b/root/frontend/src/pages/Events.tsx
@@ -12,6 +12,7 @@ import {
 } from "react"
 import axios from "../api/client"
 import type { Event } from "@/types/Event"
+import type { PaginatedResponse } from "@/types/Pagination"
 import {
   Box,
   Tabs,
@@ -47,6 +48,8 @@ const tabs = [
   { key: "archive", is_active: false },
   { key: "my" },
 ] as const satisfies readonly EventTab[]
+
+const PAGE_SIZE = 12
 
 type EventDraft = {
   title: string
@@ -107,6 +110,8 @@ const Events = () => {
   const [eventData, setEventData] = useState<EventDraft>(initialEvent)
   const [imageUploading, setImageUploading] = useState(false)
   const [loading, setLoading] = useState(false)
+  const [loadingMore, setLoadingMore] = useState(false)
+  const [pagination, setPagination] = useState<PaginatedResponse<Event> | null>(null)
 
   const [createPreview, setCreatePreview] = useState<string | null>(null)
 
@@ -144,6 +149,9 @@ const Events = () => {
   const fetchEvents = useCallback(
     async (signal?: AbortSignal) => {
       setLoading(true)
+      if (tab !== "my") {
+        setPagination(null)
+      }
       try {
         const isActiveFilter = tab === "active" ? true : tab === "archive" ? false : undefined
         const params =
@@ -154,12 +162,14 @@ const Events = () => {
                 search: dSearch,
                 type: dType,
                 location: dLocation,
+                limit: PAGE_SIZE,
+                cursor: 0,
               }
 
         const keyBase =
           tab === "my"
             ? `my:${language}`
-            : `${tab}:${language}:${String(isActiveFilter)}:${dSearch}:${dType}:${dLocation}`
+            : `${tab}:${language}:${String(isActiveFilter)}:${dSearch}:${dType}:${dLocation}:limit:${PAGE_SIZE}`
         const headers = etagCacheRef.current[keyBase]
           ? { "If-None-Match": etagCacheRef.current[keyBase] }
           : undefined
@@ -170,11 +180,23 @@ const Events = () => {
           validateStatus: (status: number) => status >= 200 && status < 400,
         } as const
 
-        const res =
-          tab === "my"
-            ? await axios.get<Event[]>("/events/my", requestConfig)
-            : await axios.get<Event[]>("/events", requestConfig)
+        if (tab === "my") {
+          const res = await axios.get<Event[]>("/events/my", requestConfig)
+          const receivedEtag = res.headers?.etag
+          if (receivedEtag) {
+            etagCacheRef.current[keyBase] = receivedEtag
+          } else {
+            delete etagCacheRef.current[keyBase]
+          }
+          if (res.status === 304) {
+            return
+          }
+          setEvents(Array.isArray(res.data) ? res.data : [])
+          setPagination(null)
+          return
+        }
 
+        const res = await axios.get<PaginatedResponse<Event>>("/events", requestConfig)
         const receivedEtag = res.headers?.etag
         if (receivedEtag) {
           etagCacheRef.current[keyBase] = receivedEtag
@@ -185,10 +207,13 @@ const Events = () => {
           return
         }
 
-        setEvents(Array.isArray(res.data) ? res.data : [])
+        const data = res.data
+        setEvents(Array.isArray(data?.items) ? data.items : [])
+        setPagination(data ?? null)
       } catch (err: any) {
         if (err?.name !== "CanceledError" && err?.code !== "ERR_CANCELED") {
           setEvents([])
+          setPagination(null)
         }
       } finally {
         setLoading(false)
@@ -202,6 +227,57 @@ const Events = () => {
     fetchEvents(ctrl.signal)
     return () => ctrl.abort()
   }, [fetchEvents])
+
+  const loadMore = useCallback(async () => {
+    if (tab === "my" || loadingMore) return
+    const nextCursor = pagination?.next_cursor
+    if (nextCursor == null) return
+    setLoadingMore(true)
+    try {
+      const isActiveFilter = tab === "active" ? true : tab === "archive" ? false : undefined
+      const res = await axios.get<PaginatedResponse<Event>>("/events", {
+        params: {
+          is_active: isActiveFilter,
+          search: dSearch,
+          type: dType,
+          location: dLocation,
+          limit: PAGE_SIZE,
+          cursor: nextCursor,
+        },
+        validateStatus: (status: number) => status >= 200 && status < 300,
+      })
+      const data = res.data
+      const newItems = Array.isArray(data?.items) ? data.items : []
+      setEvents((prev) => {
+        const existing = Array.isArray(prev) ? [...prev] : []
+        const seen = new Set(existing.map((item) => item.id))
+        newItems.forEach((item) => {
+          if (seen.has(item.id)) {
+            const index = existing.findIndex((evt) => evt.id === item.id)
+            if (index >= 0) existing[index] = item
+          } else {
+            existing.push(item)
+            seen.add(item.id)
+          }
+        })
+        return existing
+      })
+      setPagination((prev) => {
+        if (!data) return prev
+        if (!prev) return data
+        return {
+          ...prev,
+          ...data,
+        }
+      })
+    } catch (err: any) {
+      if (err?.name !== "CanceledError" && err?.code !== "ERR_CANCELED") {
+        setPagination((prev) => (prev ? { ...prev, has_more: false, next_cursor: null } : prev))
+      }
+    } finally {
+      setLoadingMore(false)
+    }
+  }, [tab, loadingMore, pagination?.next_cursor, dSearch, dType, dLocation])
 
   const handleTabChange = (_event: SyntheticEvent, newValue: EventTabKey) => setTab(newValue)
 
@@ -254,6 +330,7 @@ const Events = () => {
       closeCreate()
       setTab("active")
       setEvents((prev) => [res.data, ...prev])
+      setPagination((prev) => (prev ? { ...prev, total: prev.total + 1 } : prev))
       window.scrollTo({ top: 0, behavior: "smooth" })
     } catch {}
   }
@@ -600,6 +677,26 @@ const Events = () => {
           </Popover>
 
           {eventsContent}
+
+          {tab !== "my" && pagination?.has_more ? (
+            <Box display="flex" justifyContent="center" mt={4} mb={6}>
+              <Button
+                variant="outlined"
+                size="large"
+                onClick={loadMore}
+                disabled={loadingMore}
+                sx={{
+                  px: 3.5,
+                  borderRadius: 2,
+                  fontWeight: 600,
+                }}
+              >
+                {loadingMore
+                  ? t("common:statuses.loading")
+                  : t("common:buttons.loadMore", { defaultValue: "Load more" })}
+              </Button>
+            </Box>
+          ) : null}
 
           <Dialog open={createOpen} onClose={closeCreate}>
             <DialogTitle>{t("events:dialogs.create.title")}</DialogTitle>

--- a/root/frontend/src/setupTests.ts
+++ b/root/frontend/src/setupTests.ts
@@ -5,7 +5,7 @@ import { webcrypto } from "node:crypto"
 import { afterAll, afterEach, beforeAll, expect, vi } from "vitest"
 import { toHaveNoViolations } from "jest-axe"
 import { server } from "./tests/mocks/server"
-import { resetTestSessions } from "./tests/mocks/handlers"
+import { resetTestEvents, resetTestSessions } from "./tests/mocks/handlers"
 import i18n from "./i18n/config"
 
 expect.extend(toHaveNoViolations)
@@ -18,6 +18,7 @@ beforeAll(async () => {
 afterEach(() => {
   server.resetHandlers()
   resetTestSessions()
+  resetTestEvents()
 })
 afterAll(() => server.close())
 if (!(globalThis as any).TextEncoder) (globalThis as any).TextEncoder = TextEncoder

--- a/root/frontend/src/tests/mocks/handlers.ts
+++ b/root/frontend/src/tests/mocks/handlers.ts
@@ -1,6 +1,7 @@
 import { HttpResponse, http } from "msw"
 import type { User } from "@/types/User"
 import type { ActiveSession } from "@/types/Session"
+import type { Event } from "@/types/Event"
 
 type NewUserPayload = {
   email?: string
@@ -79,6 +80,51 @@ export const resetTestSessions = () => {
   testSessions.splice(0, testSessions.length, ...fresh)
 }
 
+const createBaseEvents = (): Event[] => {
+  const now = Date.now()
+  return Array.from({ length: 8 }, (_, index) => {
+    const start = new Date(now + index * 24 * 60 * 60 * 1000)
+    const end = new Date(start.getTime() + 90 * 60 * 1000)
+    const isoStart = start.toISOString()
+    const isoEnd = end.toISOString()
+    const id = index + 1
+    return {
+      id,
+      title: `Sample event ${id}`,
+      description: `Event description ${id}`,
+      title_en: `Sample event ${id}`,
+      description_en: `Event description ${id}`,
+      location: `Auditorium ${id}`,
+      location_en: `Auditorium ${id}`,
+      event_type: null,
+      event_type_en: null,
+      starts_at: isoStart,
+      ends_at: isoEnd,
+      created_by: 1,
+      created_at: new Date(now - 60 * 60 * 1000).toISOString(),
+      is_active: true,
+      speaker: null,
+      image_url: null,
+      about: null,
+      about_en: null,
+      files: [],
+      participant_count: 0,
+      is_registered: null,
+      my_qr_code: null,
+    }
+  })
+}
+
+export const testEvents: Event[] = createBaseEvents()
+
+export const setTestEvents = (events: Event[]) => {
+  testEvents.splice(0, testEvents.length, ...events)
+}
+
+export const resetTestEvents = () => {
+  setTestEvents(createBaseEvents())
+}
+
 export const handlers = [
   http.get("*/users/me", () => HttpResponse.json(testUser)),
   http.get("*/auth/sessions", () => HttpResponse.json(testSessions)),
@@ -93,6 +139,28 @@ export const handlers = [
     session.last_seen_at = now
     session.is_current = false
     return HttpResponse.json(session)
+  }),
+  http.get("*/events", ({ request }) => {
+    const url = new URL(request.url)
+    if (url.pathname.endsWith("/events/my")) {
+      return HttpResponse.json(testEvents.slice(0, 3))
+    }
+    const limitRaw = Number(url.searchParams.get("limit") ?? "")
+    const cursorRaw = Number(url.searchParams.get("cursor") ?? "")
+    const limit = Number.isFinite(limitRaw) && limitRaw > 0 ? limitRaw : 20
+    const cursor = Number.isFinite(cursorRaw) && cursorRaw >= 0 ? cursorRaw : 0
+    const slice = testEvents.slice(cursor, cursor + limit)
+    const total = testEvents.length
+    const nextCursor = cursor + slice.length
+    const hasMore = nextCursor < total
+    return HttpResponse.json({
+      items: slice,
+      total,
+      limit,
+      cursor,
+      next_cursor: hasMore ? nextCursor : null,
+      has_more: hasMore,
+    })
   }),
   http.post("*/users", async ({ request }) => {
     const body = (await request.json()) as NewUserPayload

--- a/root/frontend/src/tests/pageTranslations.test.tsx
+++ b/root/frontend/src/tests/pageTranslations.test.tsx
@@ -180,7 +180,17 @@ const {
     if (url === "/stats/attendance") return Promise.resolve({ data: attendanceSummary })
     if (url === "/stats/grades") return Promise.resolve({ data: gradeSummary })
     if (url === "/stats/participation") return Promise.resolve({ data: participationSummary })
-    if (url === "/events") return Promise.resolve({ data: [sampleEvent] })
+    if (url === "/events")
+      return Promise.resolve({
+        data: {
+          items: [sampleEvent],
+          total: 1,
+          limit: 20,
+          cursor: 0,
+          next_cursor: null,
+          has_more: false,
+        },
+      })
     if (url === "/events/my") return Promise.resolve({ data: [] })
     if (url === "/news") return Promise.resolve({ data: newsItems })
     if (url === "/notifications") return Promise.resolve({ data: notificationsResponse })

--- a/root/frontend/src/tests/pages/EventsPagination.test.tsx
+++ b/root/frontend/src/tests/pages/EventsPagination.test.tsx
@@ -1,0 +1,111 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { MemoryRouter } from "react-router-dom"
+import { describe, expect, it, beforeEach, vi } from "vitest"
+import Events from "@/pages/Events"
+import { AuthContext } from "@/contexts/AuthContext"
+import type { Event } from "@/types/Event"
+import { setTestEvents } from "../mocks/handlers"
+
+vi.mock("../../components/EventCard", () => ({
+  __esModule: true,
+  default: ({ title }: { title: string }) => (
+    <div data-testid="event-card">
+      <span>{title}</span>
+    </div>
+  ),
+}))
+
+const buildEvent = (id: number): Event => {
+  const start = new Date(Date.now() + id * 60 * 60 * 1000)
+  const end = new Date(start.getTime() + 60 * 60 * 1000)
+  return {
+    id,
+    title: `Paginated event ${id}`,
+    description: `Description ${id}`,
+    title_en: `Paginated event ${id}`,
+    description_en: `Description ${id}`,
+    location: `Hall ${id}`,
+    location_en: `Hall ${id}`,
+    event_type: null,
+    event_type_en: null,
+    starts_at: start.toISOString(),
+    ends_at: end.toISOString(),
+    created_by: 1,
+    created_at: new Date().toISOString(),
+    is_active: true,
+    speaker: null,
+    image_url: null,
+    about: null,
+    about_en: null,
+    files: [],
+    participant_count: 0,
+    is_registered: null,
+    my_qr_code: null,
+  }
+}
+
+const authValue = {
+  isAuth: true,
+  login: vi.fn(),
+  logout: vi.fn(),
+  user: {
+    id: 1,
+    email: "user@example.com",
+    full_name: "Test User",
+    role: "student",
+    group_id: null,
+    avatar_url: null,
+    cover_url: null,
+    about: null,
+    record_book_number: null,
+    status: null,
+    institute: null,
+    course: null,
+    education_level: null,
+    track: null,
+    program: null,
+    telegram: null,
+    achievements: null,
+    department: null,
+    position: null,
+    spotify_connected: false,
+    spotify_display_name: null,
+    spotify_is_connected: null,
+    dnd_enabled: false,
+    dnd_start: null,
+    dnd_end: null,
+    is_active: true,
+  },
+  loading: false,
+  setUser: vi.fn(),
+  refresh: vi.fn(),
+}
+
+describe("Events pagination UI", () => {
+  beforeEach(() => {
+    const events = Array.from({ length: 15 }, (_, index) => buildEvent(index + 1))
+    setTestEvents(events)
+  })
+
+  it("loads additional pages when clicking load more", async () => {
+    const user = userEvent.setup()
+
+    render(
+      <AuthContext.Provider value={authValue}>
+        <MemoryRouter>
+          <Events />
+        </MemoryRouter>
+      </AuthContext.Provider>
+    )
+
+    expect(await screen.findByText("Paginated event 1")).toBeInTheDocument()
+    await waitFor(() => expect(screen.getAllByTestId("event-card")).toHaveLength(12))
+
+    const loadMoreButton = await screen.findByRole("button", { name: /load more/i })
+    await user.click(loadMoreButton)
+
+    await waitFor(() => expect(screen.getAllByTestId("event-card")).toHaveLength(15))
+    expect(await screen.findByText("Paginated event 13")).toBeInTheDocument()
+  })
+})

--- a/root/frontend/src/types/Pagination.ts
+++ b/root/frontend/src/types/Pagination.ts
@@ -1,0 +1,8 @@
+export interface PaginatedResponse<T> {
+  items: T[]
+  total: number
+  limit: number
+  cursor: number
+  next_cursor: number | null
+  has_more: boolean
+}

--- a/root/frontend/tests/e2e/app.spec.ts
+++ b/root/frontend/tests/e2e/app.spec.ts
@@ -74,4 +74,21 @@ test.describe("University ecosystem app", () => {
     await expect(page.getByText("Сессия завершена")).toBeVisible()
     await expect(page.getByText("Завершена")).toBeVisible()
   })
+
+  test("allows loading additional events from the events page", async ({ page }) => {
+    const mock = await useMockApi(page)
+    await mock.login(page)
+
+    await page.goto("/events")
+    await page.waitForURL(/\/events$/)
+
+    await expect(page.getByText(/Событие 10/)).toBeVisible()
+    const loadMore = page.getByRole("button", { name: /Загрузить ещё|Load more/ })
+    await expect(loadMore).toBeVisible()
+
+    await loadMore.click()
+
+    await expect(page.getByText(/Событие 27/)).toBeVisible()
+    await expect(loadMore).toBeHidden()
+  })
 })

--- a/root/frontend/tests/e2e/utils/mockApi.ts
+++ b/root/frontend/tests/e2e/utils/mockApi.ts
@@ -51,22 +51,36 @@ const mockNews = [
   },
 ]
 
-const mockEvents = [
-  {
-    id: 10,
-    title: "Хакатон ГУУ",
-    title_en: "GUU Hackathon",
-    description: "Командные соревнования по разработке.",
-    description_en: "A collaborative coding challenge.",
-    starts_at: "2025-01-05T09:00:00",
-    location: "Актовый зал",
-    location_en: "Assembly Hall",
-    event_type: "хакатон",
-    event_type_en: "Hackathon",
+const now = new Date()
+const mockEvents = Array.from({ length: 18 }, (_, index) => {
+  const id = index + 10
+  const start = new Date(now.getTime() + (index + 1) * 24 * 60 * 60 * 1000)
+  const end = new Date(start.getTime() + 2 * 60 * 60 * 1000)
+  return {
+    id,
+    title: `Событие ${id}`,
+    title_en: `Event ${id}`,
+    description: `Описание события ${id}`,
+    description_en: `Event description ${id}`,
+    location: `Корпус A, зал ${index + 1}`,
+    location_en: `Building A, hall ${index + 1}`,
+    event_type: null,
+    event_type_en: null,
+    starts_at: start.toISOString(),
+    ends_at: end.toISOString(),
+    created_at: now.toISOString(),
+    created_by: 1,
+    is_active: true,
+    speaker: null,
+    image_url: null,
     about: null,
     about_en: null,
-  },
-]
+    files: [],
+    participant_count: index * 5,
+    is_registered: false,
+    my_qr_code: null,
+  }
+})
 
 const mockSchedule = [
   {
@@ -277,10 +291,35 @@ export async function useMockApi(page: Page) {
     }
 
     if (pathname.startsWith("api/events")) {
+      if (pathname === "api/events/my") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(mockEvents.slice(0, 3)),
+        })
+        return
+      }
+
+      const limitParam = Number(url.searchParams.get("limit") ?? "")
+      const cursorParam = Number(url.searchParams.get("cursor") ?? "")
+      const limit = Number.isFinite(limitParam) && limitParam > 0 ? limitParam : 20
+      const cursor = Number.isFinite(cursorParam) && cursorParam >= 0 ? cursorParam : 0
+      const slice = mockEvents.slice(cursor, cursor + limit)
+      const total = mockEvents.length
+      const nextCursor = cursor + slice.length
+      const hasMore = nextCursor < total
+
       await route.fulfill({
         status: 200,
         contentType: "application/json",
-        body: JSON.stringify(mockEvents),
+        body: JSON.stringify({
+          items: slice,
+          total,
+          limit,
+          cursor,
+          next_cursor: hasMore ? nextCursor : null,
+          has_more: hasMore,
+        }),
       })
       return
     }
@@ -491,7 +530,7 @@ export async function useMockApi(page: Page) {
       const emailField = currentPage.locator('input[name="username"]')
       await emailField.fill("student@example.com")
       await currentPage.locator('input[name="password"]').fill("Password123")
-      await currentPage.getByRole("button", { name: "Войти" }).click()
+      await currentPage.getByRole("button", { name: /Sign in|Войти/ }).click()
       await expect(currentPage).toHaveURL(/\/dashboard$/)
     },
   }

--- a/root/tests/test_event_time_constraints.py
+++ b/root/tests/test_event_time_constraints.py
@@ -104,21 +104,25 @@ async def test_get_all_events_respects_locale(db_session, user_factory):
     await db_session.commit()
     await db_session.refresh(event)
 
-    ru_events = await crud.get_all_events(db_session, user_id=student.id, locale="ru")
-    en_events = await crud.get_all_events(db_session, user_id=student.id, locale="en")
+    ru_events = await crud.get_all_events(
+        db_session, user_id=student.id, locale="ru"
+    )
+    en_events = await crud.get_all_events(
+        db_session, user_id=student.id, locale="en"
+    )
 
-    assert ru_events[0].title == "Русское название"
-    assert ru_events[0].title_en == "English title"
-    assert en_events[0].title == "English title"
-    assert en_events[0].title_en == "English title"
-    assert ru_events[0].description == "Описание"
-    assert en_events[0].description == "English description"
-    assert ru_events[0].location == "Москва"
-    assert en_events[0].location == "Moscow"
-    assert ru_events[0].event_type == "лекция"
-    assert en_events[0].event_type == "Lecture"
-    assert ru_events[0].about == "Русский текст"
-    assert en_events[0].about == "English text"
+    assert ru_events.items[0].title == "Русское название"
+    assert ru_events.items[0].title_en == "English title"
+    assert en_events.items[0].title == "English title"
+    assert en_events.items[0].title_en == "English title"
+    assert ru_events.items[0].description == "Описание"
+    assert en_events.items[0].description == "English description"
+    assert ru_events.items[0].location == "Москва"
+    assert en_events.items[0].location == "Moscow"
+    assert ru_events.items[0].event_type == "лекция"
+    assert en_events.items[0].event_type == "Lecture"
+    assert ru_events.items[0].about == "Русский текст"
+    assert en_events.items[0].about == "English text"
 
 
 async def test_event_detail_returns_qr_code_after_registration(

--- a/root/tests/test_event_time_constraints.py
+++ b/root/tests/test_event_time_constraints.py
@@ -104,12 +104,8 @@ async def test_get_all_events_respects_locale(db_session, user_factory):
     await db_session.commit()
     await db_session.refresh(event)
 
-    ru_events = await crud.get_all_events(
-        db_session, user_id=student.id, locale="ru"
-    )
-    en_events = await crud.get_all_events(
-        db_session, user_id=student.id, locale="en"
-    )
+    ru_events = await crud.get_all_events(db_session, user_id=student.id, locale="ru")
+    en_events = await crud.get_all_events(db_session, user_id=student.id, locale="en")
 
     assert ru_events.items[0].title == "Русское название"
     assert ru_events.items[0].title_en == "English title"

--- a/root/tests/test_events_localization.py
+++ b/root/tests/test_events_localization.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta, timezone
 import pytest
 from fastapi import status
 
+from app import crud
 from app.auth.security import get_password_hash
 from app.models import models
 
@@ -75,7 +76,10 @@ async def test_events_localization(async_client, db_session, user_factory):
     )
     etag_en = response_en.headers.get("ETag")
     assert etag_en
-    payload_en = {item["id"]: item for item in response_en.json()}
+    data_en = response_en.json()
+    assert data_en["total"] == 2
+    assert data_en["limit"] >= len(data_en["items"])
+    payload_en = {item["id"]: item for item in data_en["items"]}
 
     assert payload_en[primary.id]["title"] == "English Event"
     assert payload_en[primary.id]["description"] == "Description in English"
@@ -105,7 +109,10 @@ async def test_events_localization(async_client, db_session, user_factory):
         if value.strip()
     )
     assert response_ru.headers.get("ETag")
-    payload_ru = {item["id"]: item for item in response_ru.json()}
+    data_ru = response_ru.json()
+    assert data_ru["total"] == 2
+    assert data_ru["cursor"] == 0
+    payload_ru = {item["id"]: item for item in data_ru["items"]}
 
     assert payload_ru[primary.id]["title"] == "Русское событие"
     assert payload_ru[primary.id]["description"] == "Описание по-русски"
@@ -201,3 +208,79 @@ async def test_events_etag_and_not_modified(async_client, db_session, user_facto
     assert detail_not_modified.status_code == status.HTTP_304_NOT_MODIFIED
     assert detail_not_modified.headers.get("Content-Language") == "en"
     assert detail_not_modified.headers.get("ETag") == detail_etag
+
+
+@pytest.mark.anyio
+async def test_events_pagination_semantics(async_client, db_session, user_factory):
+    password = "PaginationPass123!"
+    hashed = get_password_hash(password)
+    admin = await user_factory(role="admin")
+    student = await user_factory(hashed_password=hashed, is_active=True)
+
+    base_start = datetime.now(timezone.utc) + timedelta(days=1)
+    events = []
+    for i in range(7):
+        record = models.Event(
+            title=f"Event {i}",
+            description=f"Description {i}",
+            location="Campus",
+            starts_at=base_start + timedelta(days=i),
+            ends_at=base_start + timedelta(days=i, hours=2),
+            created_by=admin.id,
+            is_active=True,
+        )
+        events.append(record)
+    db_session.add_all(events)
+    await db_session.commit()
+
+    headers = await _login(async_client, student.email, password)
+
+    first = await async_client.get(
+        "/events",
+        headers=headers,
+        params={"limit": 3},
+    )
+    assert first.status_code == status.HTTP_200_OK
+    first_data = first.json()
+    assert first_data["limit"] == 3
+    assert first_data["cursor"] == 0
+    assert len(first_data["items"]) == 3
+    assert first_data["has_more"] is True
+    assert first_data["next_cursor"] == 3
+
+    second = await async_client.get(
+        "/events",
+        headers=headers,
+        params={"limit": 3, "cursor": first_data["next_cursor"]},
+    )
+    assert second.status_code == status.HTTP_200_OK
+    second_data = second.json()
+    assert second_data["cursor"] == 3
+    assert len(second_data["items"]) == 3
+    assert second_data["has_more"] is True
+    assert second_data["next_cursor"] == 6
+
+    third = await async_client.get(
+        "/events",
+        headers=headers,
+        params={"cursor": second_data["next_cursor"]},
+    )
+    assert third.status_code == status.HTTP_200_OK
+    third_data = third.json()
+    assert third_data["cursor"] == 6
+    assert len(third_data["items"]) == 1
+    assert third_data["has_more"] is False
+    assert third_data["next_cursor"] is None
+    assert third_data["total"] == 7
+
+    default_response = await async_client.get("/events", headers=headers)
+    assert default_response.status_code == status.HTTP_200_OK
+    assert default_response.json()["limit"] == crud.DEFAULT_EVENTS_LIMIT
+
+    capped = await async_client.get(
+        "/events",
+        headers=headers,
+        params={"limit": crud.MAX_EVENTS_LIMIT},
+    )
+    assert capped.status_code == status.HTTP_200_OK
+    assert capped.json()["limit"] == crud.MAX_EVENTS_LIMIT


### PR DESCRIPTION
## Summary
- add cursor-based pagination metadata to the events API and expose the new query parameters
- adapt the frontend pages, types, and mocks to consume paginated responses and provide load-more UX
- extend localization plus unit/e2e coverage for the paginated flow

## Testing
- pytest root/tests/test_events_localization.py root/tests/test_event_time_constraints.py
- npm --prefix root/frontend run test:e2e -- --grep "events"

------
https://chatgpt.com/codex/tasks/task_e_68f642746d988327bbfecc8583171937