### PR TITLE
Fix formatting in attempted_at migration

### DIFF
--- a/root/alembic/versions/202505010001_add_attempted_at_to_notification_deliveries.py
+++ b/root/alembic/versions/202505010001_add_attempted_at_to_notification_deliveries.py
@@ -2,6 +2,8 @@
 
 from typing import Sequence, Union
 
+import textwrap
+
 import sqlalchemy as sa
 
 from alembic import op
@@ -52,16 +54,26 @@ def upgrade() -> None:
         # Prefer historical timestamps when available to avoid inflating retention windows.
         op.execute(
             sa.text(
-                "UPDATE {table} AS nd "
-                "SET {column} = COALESCE(nd.delivered_at, n.created_at, NOW()) "
-                "FROM notifications AS n "
-                "WHERE nd.notification_id = n.id AND nd.{column} IS NULL"
-            ).format(table=_TABLE_NAME, column=_COLUMN_NAME)
+                textwrap.dedent(
+                    """
+                    UPDATE {table} AS nd
+                    SET {column} = COALESCE(nd.delivered_at, n.created_at, NOW())
+                    FROM notifications AS n
+                    WHERE nd.notification_id = n.id AND nd.{column} IS NULL
+                    """
+                ).format(table=_TABLE_NAME, column=_COLUMN_NAME)
+            )
         )
         op.execute(
             sa.text(
-                "UPDATE {table} " "SET {column} = NOW() " "WHERE {column} IS NULL"
-            ).format(table=_TABLE_NAME, column=_COLUMN_NAME)
+                textwrap.dedent(
+                    """
+                    UPDATE {table}
+                    SET {column} = NOW()
+                    WHERE {column} IS NULL
+                    """
+                ).format(table=_TABLE_NAME, column=_COLUMN_NAME)
+            )
         )
 
         with op.batch_alter_table(_TABLE_NAME) as batch_op:

--- a/root/alembic/versions/202505010001_add_attempted_at_to_notification_deliveries.py
+++ b/root/alembic/versions/202505010001_add_attempted_at_to_notification_deliveries.py
@@ -1,8 +1,7 @@
 """Add attempted_at column to notification deliveries."""
 
-from typing import Sequence, Union
-
 import textwrap
+from typing import Sequence, Union
 
 import sqlalchemy as sa
 


### PR DESCRIPTION
## Summary
- fix the attempted_at migration by formatting SQL strings before passing them to `sa.text`
- use `textwrap.dedent` to keep multi-line SQL readable and avoid runtime errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f652b226148327a15bebc74f9ceaca