### PR TITLE
Add timezone support to user quiet hours

### DIFF
--- a/root/alembic/versions/202505250001_add_timezone_to_users.py
+++ b/root/alembic/versions/202505250001_add_timezone_to_users.py
@@ -3,6 +3,7 @@
 from typing import Sequence, Union
 
 import sqlalchemy as sa
+
 from alembic import op
 
 # revision identifiers, used by Alembic.

--- a/root/alembic/versions/202505250001_add_timezone_to_users.py
+++ b/root/alembic/versions/202505250001_add_timezone_to_users.py
@@ -1,0 +1,50 @@
+"""Add timezone column to users"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "202505250001"
+down_revision: Union[str, None] = "202505200001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_TABLE_NAME = "users"
+_TIMEZONE_COLUMN = sa.Column("timezone", sa.String(length=64), nullable=True)
+
+
+def _table_exists(bind, table_name: str) -> bool:
+    inspector = sa.inspect(bind)
+    return table_name in inspector.get_table_names()
+
+
+def _column_exists(bind, table_name: str, column_name: str) -> bool:
+    if not _table_exists(bind, table_name):
+        return False
+    inspector = sa.inspect(bind)
+    return any(col["name"] == column_name for col in inspector.get_columns(table_name))
+
+
+def upgrade() -> None:
+    """Apply Add timezone column to users."""
+    bind = op.get_bind()
+
+    if not _table_exists(bind, _TABLE_NAME):
+        return
+
+    if not _column_exists(bind, _TABLE_NAME, _TIMEZONE_COLUMN.name):
+        op.add_column(_TABLE_NAME, _TIMEZONE_COLUMN)
+
+
+def downgrade() -> None:
+    """Revert Add timezone column to users."""
+    bind = op.get_bind()
+
+    if not _table_exists(bind, _TABLE_NAME):
+        return
+
+    if _column_exists(bind, _TABLE_NAME, _TIMEZONE_COLUMN.name):
+        op.drop_column(_TABLE_NAME, _TIMEZONE_COLUMN.name)

--- a/root/app/localization.py
+++ b/root/app/localization.py
@@ -426,6 +426,10 @@ _TRANSLATIONS: Mapping[str, Mapping[str, str]] = {
         "ru": 'Укажите время начала и окончания режима "Не беспокоить"',
         "en": 'Provide both start and end times for "Do Not Disturb" mode',
     },
+    "validation.timezone.invalid": {
+        "ru": "Укажите корректный идентификатор часового пояса",
+        "en": "Enter a valid time zone identifier",
+    },
     "validation.events.end_after_start": {
         "ru": "Время окончания должно быть позже времени начала мероприятия",
         "en": "The end time must be later than the start time",

--- a/root/app/models/models.py
+++ b/root/app/models/models.py
@@ -60,6 +60,7 @@ class User(Base):
     dnd_enabled = Column(Boolean, default=False, nullable=False)
     dnd_start = Column(Time(timezone=False))
     dnd_end = Column(Time(timezone=False))
+    timezone = Column(String(64))
 
     spotify_user_id = Column(String, unique=True, index=True)
     spotify_access_token = Column(EncryptedString())

--- a/root/app/routers/notifications.py
+++ b/root/app/routers/notifications.py
@@ -627,9 +627,7 @@ async def send_test(
     for sub in subscriptions:
         if not subscription_supports_topic(sub, normalized_topic):
             continue
-        prepared = prepare_push_payload_for_user(
-            message, getattr(sub, "user", None)
-        )
+        prepared = prepare_push_payload_for_user(message, getattr(sub, "user", None))
         result = await _deliver_to_subscription(sub, prepared)
         results.append(result)
     summary = _aggregate_results(

--- a/root/app/routers/notifications.py
+++ b/root/app/routers/notifications.py
@@ -623,13 +623,12 @@ async def send_test(
             if value is not None:
                 message[field] = value
 
-    now_time = datetime.now().astimezone().time()
     results: list[WebPushResult] = []
     for sub in subscriptions:
         if not subscription_supports_topic(sub, normalized_topic):
             continue
         prepared = prepare_push_payload_for_user(
-            message, getattr(sub, "user", None), now_time=now_time
+            message, getattr(sub, "user", None)
         )
         result = await _deliver_to_subscription(sub, prepared)
         results.append(result)
@@ -740,13 +739,12 @@ async def broadcast(
     else:
         payload.pop("topic", None)
 
-    now_time = datetime.now().astimezone().time()
     results: list[WebPushResult] = []
     for subscription in subscriptions:
         if not subscription_supports_topic(subscription, topic):
             continue
         prepared = prepare_push_payload_for_user(
-            payload, getattr(subscription, "user", None), now_time=now_time
+            payload, getattr(subscription, "user", None)
         )
         results.append(await _deliver_to_subscription(subscription, prepared))
 

--- a/root/app/schemas/schemas.py
+++ b/root/app/schemas/schemas.py
@@ -1,7 +1,9 @@
 from datetime import datetime, time
 from typing import Any, List, Optional
 
-from pydantic import BaseModel, ConfigDict, EmailStr, Field, model_validator
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from pydantic import BaseModel, ConfigDict, EmailStr, Field, field_validator, model_validator
 
 from app.localization import translate
 from app.models.enums import UserRole
@@ -48,6 +50,7 @@ class UserBase(BaseModel):
     dnd_enabled: bool = False
     dnd_start: Optional[time] = None
     dnd_end: Optional[time] = None
+    timezone: Optional[str] = None
 
 
 class UserCreate(UserBase):
@@ -86,6 +89,21 @@ class UserProfileUpdate(BaseModel):
     dnd_enabled: Optional[bool] = None
     dnd_start: Optional[time] = None
     dnd_end: Optional[time] = None
+    timezone: Optional[str] = None
+
+    @field_validator("timezone")
+    @classmethod
+    def _validate_timezone(cls, value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        text = str(value).strip()
+        if not text:
+            return None
+        try:
+            ZoneInfo(text)
+        except (ZoneInfoNotFoundError, ValueError) as exc:
+            raise ValueError(translate("validation.timezone.invalid")) from exc
+        return text
 
     @model_validator(mode="before")
     def _validate_dnd(cls, data: Any) -> Any:

--- a/root/app/schemas/schemas.py
+++ b/root/app/schemas/schemas.py
@@ -1,9 +1,15 @@
 from datetime import datetime, time
 from typing import Any, List, Optional
-
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
-from pydantic import BaseModel, ConfigDict, EmailStr, Field, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    EmailStr,
+    Field,
+    field_validator,
+    model_validator,
+)
 
 from app.localization import translate
 from app.models.enums import UserRole

--- a/root/app/services/notifications.py
+++ b/root/app/services/notifications.py
@@ -8,6 +8,8 @@ from html import unescape
 from textwrap import shorten
 from typing import Any, Awaitable, Callable, Mapping, Optional, Sequence
 
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
 from sqlalchemy import and_, delete, func, insert, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -37,8 +39,22 @@ from app.services.push_topics import normalize_topic, subscription_supports_topi
 from app.services.webpush import WebPushResult, send_web_push
 
 
-def _current_local_time() -> dt.time:
-    return dt.datetime.now().astimezone().time()
+def _current_local_time(user: User | None = None) -> dt.time:
+    tz = UTC
+    if user is not None:
+        raw = getattr(user, "timezone", None)
+        if isinstance(raw, str):
+            candidate = raw.strip()
+            if candidate:
+                try:
+                    tz = ZoneInfo(candidate)
+                except (ZoneInfoNotFoundError, ValueError):
+                    tz = UTC
+    now = dt.datetime.now(tz)
+    current = now.timetz()
+    if current.tzinfo is not None:
+        current = current.replace(tzinfo=None)
+    return current
 
 
 logger = logging.getLogger(__name__)
@@ -295,7 +311,7 @@ def is_user_in_quiet_hours(
     start = getattr(user, "dnd_start", None)
     end = getattr(user, "dnd_end", None)
     if now_time is None:
-        now_time = _current_local_time()
+        now_time = _current_local_time(user)
     if start is None or end is None:
         return True
     if start == end:
@@ -441,7 +457,6 @@ async def create_notifications_for_users(
                 if normalized_actions:
                     base_payload["actions"] = normalized_actions
 
-            now_time = _current_local_time()
             send_jobs: list[tuple[PushSubscription, int]] = []
             tasks: list[Awaitable[WebPushResult]] = []
 
@@ -475,7 +490,7 @@ async def create_notifications_for_users(
                     )
                     continue
                 prepared_payload = prepare_push_payload_for_user(
-                    base_payload, getattr(sub, "user", None), now_time=now_time
+                    base_payload, getattr(sub, "user", None)
                 )
                 send_jobs.append((sub, notification_id))
                 tasks.append(_send_push(sub, prepared_payload))

--- a/root/app/services/notifications.py
+++ b/root/app/services/notifications.py
@@ -7,7 +7,6 @@ from datetime import UTC
 from html import unescape
 from textwrap import shorten
 from typing import Any, Awaitable, Callable, Mapping, Optional, Sequence
-
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from sqlalchemy import and_, delete, func, insert, or_, select

--- a/root/app/services/webpush.py
+++ b/root/app/services/webpush.py
@@ -16,6 +16,8 @@ from sqlalchemy import create_engine, delete, select, update
 from sqlalchemy.engine import make_url
 from sqlalchemy.orm import selectinload, sessionmaker
 
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
 from app.core.config import settings
 from app.core.database import async_session
 from app.core.rate_limit import RateLimitExceeded, RateLimitInfo, enforce_rate_limit
@@ -98,8 +100,22 @@ def _log_event(event: str, *, level: int = logging.INFO, **fields: Any) -> None:
         root_logger.log(level, "webpush.%s", event, extra={**extra})
 
 
-def _current_local_time() -> time:
-    return datetime.now().astimezone().time()
+def _current_local_time(user: Any | None = None) -> time:
+    tz = UTC
+    if user is not None:
+        raw = getattr(user, "timezone", None)
+        if isinstance(raw, str):
+            candidate = raw.strip()
+            if candidate:
+                try:
+                    tz = ZoneInfo(candidate)
+                except (ZoneInfoNotFoundError, ValueError):
+                    tz = UTC
+    now = datetime.now(tz)
+    current = now.timetz()
+    if current.tzinfo is not None:
+        current = current.replace(tzinfo=None)
+    return current
 
 
 def _is_user_in_quiet_hours(user: Any | None, *, now_time: time | None = None) -> bool:
@@ -108,7 +124,7 @@ def _is_user_in_quiet_hours(user: Any | None, *, now_time: time | None = None) -
     start = getattr(user, "dnd_start", None)
     end = getattr(user, "dnd_end", None)
     if now_time is None:
-        now_time = _current_local_time()
+        now_time = _current_local_time(user)
     if start is None or end is None:
         return True
     if start == end:

--- a/root/app/services/webpush.py
+++ b/root/app/services/webpush.py
@@ -10,13 +10,12 @@ from datetime import UTC, datetime, time
 from hashlib import sha256
 from typing import Any, Literal
 from urllib.parse import urlparse
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from pywebpush import WebPushException, webpush
 from sqlalchemy import create_engine, delete, select, update
 from sqlalchemy.engine import make_url
 from sqlalchemy.orm import selectinload, sessionmaker
-
-from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from app.core.config import settings
 from app.core.database import async_session

--- a/root/tests/test_migrations_runtime.py
+++ b/root/tests/test_migrations_runtime.py
@@ -88,7 +88,7 @@ def test_alembic_upgrade_head(tmp_path, dbname):
     insp = sa.inspect(engine)
     assert insp.has_table("users")
     user_columns = {col["name"] for col in insp.get_columns("users")}
-    assert {"dnd_enabled", "dnd_start", "dnd_end"}.issubset(user_columns)
+    assert {"dnd_enabled", "dnd_start", "dnd_end", "timezone"}.issubset(user_columns)
     assert insp.has_table("push_subscriptions")
     engine.dispose()
 

--- a/root/tests/test_notifications_service.py
+++ b/root/tests/test_notifications_service.py
@@ -18,6 +18,7 @@ from app.models.models import (
 )
 from app.services import notification_queue
 from app.services import notifications as notifications_module
+from app.services import webpush as webpush_module
 from app.services.notifications import (
     aggregate_notification_delivery_stats,
     create_notifications_for_users,
@@ -87,6 +88,52 @@ def test_is_user_in_quiet_hours_crosses_midnight():
     assert is_user_in_quiet_hours(user, now_time=dt.time(23, 15)) is True
     assert is_user_in_quiet_hours(user, now_time=dt.time(6, 45)) is True
     assert is_user_in_quiet_hours(user, now_time=dt.time(12, 0)) is False
+
+
+def test_is_user_in_quiet_hours_uses_user_timezone(monkeypatch: pytest.MonkeyPatch):
+    user = User(
+        dnd_enabled=True,
+        dnd_start=dt.time(21, 0),
+        dnd_end=dt.time(6, 0),
+        timezone="America/New_York",
+    )
+
+    base = dt.datetime(2024, 1, 1, 2, 30, tzinfo=dt.timezone.utc)
+
+    class _FixedDatetime(dt.datetime):
+        @classmethod
+        def now(cls, tz=None):
+            if tz is None:
+                return base.replace(tzinfo=None)
+            return base.astimezone(tz)
+
+    monkeypatch.setattr(notifications_module.dt, "datetime", _FixedDatetime)
+    assert is_user_in_quiet_hours(user) is True
+
+    monkeypatch.setattr(webpush_module, "datetime", _FixedDatetime)
+    assert webpush_module._is_user_in_quiet_hours(user) is True
+
+
+def test_is_user_in_quiet_hours_defaults_to_utc(monkeypatch: pytest.MonkeyPatch):
+    user = User(dnd_enabled=True, dnd_start=dt.time(1, 0), dnd_end=dt.time(5, 0))
+
+    base = dt.datetime(2024, 6, 1, 3, 0, tzinfo=dt.timezone.utc)
+
+    class _UtcDatetime(dt.datetime):
+        @classmethod
+        def now(cls, tz=None):
+            if tz is None:
+                return base.replace(tzinfo=None)
+            return base.astimezone(tz)
+
+    monkeypatch.setattr(notifications_module.dt, "datetime", _UtcDatetime)
+    assert is_user_in_quiet_hours(user) is True
+
+    user.timezone = "Invalid/Zone"
+    assert is_user_in_quiet_hours(user) is True
+
+    monkeypatch.setattr(webpush_module, "datetime", _UtcDatetime)
+    assert webpush_module._is_user_in_quiet_hours(user) is True
 
 
 def test_prepare_push_payload_applies_silent_mode():

--- a/root/tests/test_schemas.py
+++ b/root/tests/test_schemas.py
@@ -32,6 +32,14 @@ def test_user_profile_update_accepts_dnd_interval():
     assert payload.dnd_enabled is True
 
 
+def test_user_profile_update_validates_timezone():
+    payload = schemas.UserProfileUpdate(timezone="Europe/Berlin")
+    assert payload.timezone == "Europe/Berlin"
+
+    with pytest.raises(ValidationError):
+        schemas.UserProfileUpdate(timezone="Invalid/Zone")
+
+
 def test_event_create_requires_end_after_start():
     starts = datetime.now(timezone.utc)
     with pytest.raises(ValidationError):
@@ -77,4 +85,5 @@ async def test_user_out_contract(user_factory):
     assert data["dnd_enabled"] is False
     assert data["dnd_start"] is None
     assert data["dnd_end"] is None
+    assert data["timezone"] is None
     assert "hashed_password" not in data

--- a/root/tests/test_user_profile_update.py
+++ b/root/tests/test_user_profile_update.py
@@ -88,7 +88,9 @@ async def test_update_profile_email_duplicate(async_client, user_factory, db_ses
 
 
 @pytest.mark.anyio
-async def test_update_profile_timezone_persisted(async_client, user_factory, db_session):
+async def test_update_profile_timezone_persisted(
+    async_client, user_factory, db_session
+):
     password = "TimezonePersist123!"
     hashed = get_password_hash(password)
     user = await user_factory(

--- a/root/tests/test_user_profile_update.py
+++ b/root/tests/test_user_profile_update.py
@@ -88,6 +88,54 @@ async def test_update_profile_email_duplicate(async_client, user_factory, db_ses
 
 
 @pytest.mark.anyio
+async def test_update_profile_timezone_persisted(async_client, user_factory, db_session):
+    password = "TimezonePersist123!"
+    hashed = get_password_hash(password)
+    user = await user_factory(
+        hashed_password=hashed,
+        is_active=True,
+    )
+
+    headers = await _login(async_client, user.email, password)
+
+    response = await async_client.put(
+        "/users/me",
+        json={"timezone": "Europe/Paris"},
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["timezone"] == "Europe/Paris"
+
+    await db_session.refresh(user)
+    assert user.timezone == "Europe/Paris"
+
+
+@pytest.mark.anyio
+async def test_update_profile_timezone_invalid(async_client, user_factory):
+    password = "TimezoneInvalid123!"
+    hashed = get_password_hash(password)
+    user = await user_factory(
+        hashed_password=hashed,
+        is_active=True,
+    )
+
+    headers = await _login(async_client, user.email, password)
+
+    response = await async_client.put(
+        "/users/me",
+        json={"timezone": "Invalid/Zone"},
+        headers=headers,
+    )
+
+    assert response.status_code == 422
+    detail = response.json()["detail"][0]
+    assert detail["loc"][-1] == "timezone"
+    assert detail["msg"] == "Enter a valid time zone identifier"
+
+
+@pytest.mark.anyio
 async def test_delete_avatar_removes_file(async_client, user_factory, db_session):
     password = "DeleteAvatar123!"
     hashed = get_password_hash(password)


### PR DESCRIPTION
## Summary
- add a timezone column to users, expose it through API schemas, and validate updates with zoneinfo
- compute quiet-hour checks in notifications and webpush using each user’s timezone and adjust push routes accordingly
- cover timezone handling with migration, profile update, and quiet-hour regression tests

## Testing
- pytest root/tests/test_schemas.py root/tests/test_user_profile_update.py root/tests/test_notifications_service.py root/tests/test_migrations_runtime.py *(fails: ModuleNotFoundError: No module named 'fakeredis')*

------
https://chatgpt.com/codex/tasks/task_e_68f66a3887d08327bb34370a0c51ef1a