### PR TITLE
Add dedupe key for schedule reminders

### DIFF
--- a/root/alembic/versions/202506010001_add_dedupe_key_to_notifications.py
+++ b/root/alembic/versions/202506010001_add_dedupe_key_to_notifications.py
@@ -1,0 +1,73 @@
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "202506010001"
+down_revision: Union[str, None] = "202505250001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_TABLE_NAME = "notifications"
+_DEDUPE_COLUMN = sa.Column("dedupe_key", sa.String(length=255), nullable=True)
+_DEDUPE_INDEX_NAME = "ix_notifications_user_dedupe"
+
+
+def _table_exists(bind, table_name: str) -> bool:
+    inspector = sa.inspect(bind)
+    return table_name in inspector.get_table_names()
+
+
+def _column_exists(bind, table_name: str, column_name: str) -> bool:
+    if not _table_exists(bind, table_name):
+        return False
+    inspector = sa.inspect(bind)
+    return any(col["name"] == column_name for col in inspector.get_columns(table_name))
+
+
+def _index_exists(bind, table_name: str, index_name: str) -> bool:
+    if not _table_exists(bind, table_name):
+        return False
+    inspector = sa.inspect(bind)
+    return any(ix.get("name") == index_name for ix in inspector.get_indexes(table_name))
+
+
+def upgrade() -> None:
+    """Apply Add dedupe key to notifications."""
+    bind = op.get_bind()
+
+    if not _table_exists(bind, _TABLE_NAME):
+        return
+
+    if not _column_exists(bind, _TABLE_NAME, _DEDUPE_COLUMN.name):
+        op.add_column(_TABLE_NAME, _DEDUPE_COLUMN)
+
+    if not _index_exists(bind, _TABLE_NAME, _DEDUPE_INDEX_NAME):
+        op.create_index(
+            _DEDUPE_INDEX_NAME,
+            _TABLE_NAME,
+            ["user_id", "dedupe_key"],
+        )
+
+    op.execute(
+        sa.text(
+            "UPDATE notifications SET dedupe_key = 'legacy:' || CAST(id AS TEXT) "
+            "WHERE dedupe_key IS NULL"
+        )
+    )
+
+
+def downgrade() -> None:
+    """Revert Add dedupe key to notifications."""
+    bind = op.get_bind()
+
+    if not _table_exists(bind, _TABLE_NAME):
+        return
+
+    if _index_exists(bind, _TABLE_NAME, _DEDUPE_INDEX_NAME):
+        op.drop_index(_DEDUPE_INDEX_NAME, table_name=_TABLE_NAME)
+
+    if _column_exists(bind, _TABLE_NAME, _DEDUPE_COLUMN.name):
+        op.drop_column(_TABLE_NAME, _DEDUPE_COLUMN.name)

--- a/root/alembic/versions/202506010001_add_dedupe_key_to_notifications.py
+++ b/root/alembic/versions/202506010001_add_dedupe_key_to_notifications.py
@@ -1,6 +1,7 @@
 from typing import Sequence, Union
 
 import sqlalchemy as sa
+
 from alembic import op
 
 # revision identifiers, used by Alembic.

--- a/root/app/api/notifications.py
+++ b/root/app/api/notifications.py
@@ -507,17 +507,29 @@ async def check_schedule_and_generate(
             data_payload,
             title_translations,
             body_translations,
+            dedupe_key,
         ) = build_schedule_reminder_message(les, locale=locale)
         url = "/schedule"
 
-        dupe = select(func.count(Notification.id)).where(
-            and_(
-                Notification.user_id == user.id,
-                Notification.title == title,
-                Notification.url == url,
-                Notification.created_at >= now - timedelta(hours=1),
+        key_for_dedupe = dedupe_key or tag or title
+        if key_for_dedupe:
+            dupe = select(func.count(Notification.id)).where(
+                and_(
+                    Notification.user_id == user.id,
+                    Notification.dedupe_key == key_for_dedupe,
+                    Notification.url == url,
+                    Notification.created_at >= now - timedelta(hours=1),
+                )
             )
-        )
+        else:
+            dupe = select(func.count(Notification.id)).where(
+                and_(
+                    Notification.user_id == user.id,
+                    Notification.title == title,
+                    Notification.url == url,
+                    Notification.created_at >= now - timedelta(hours=1),
+                )
+            )
         exists = (await db.execute(dupe)).scalar_one() or 0
         if exists:
             continue
@@ -531,6 +543,7 @@ async def check_schedule_and_generate(
             type="schedule.reminder",
             url=url,
             tag=tag,
+            dedupe_key=key_for_dedupe,
             payload_data=data_payload,
             actions=[
                 {

--- a/root/app/models/models.py
+++ b/root/app/models/models.py
@@ -284,6 +284,7 @@ class Notification(Base):
     body_en = Column(Text)
     type = Column(String, index=True)
     url = Column(String)
+    dedupe_key = Column(String(255), index=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now(), index=True)
     read = Column(Boolean, default=False, index=True)
     read_at = Column(DateTime(timezone=True), index=True)
@@ -299,6 +300,7 @@ class Notification(Base):
     __table_args__ = (
         Index("ix_notifications_user_created", "user_id", "created_at"),
         Index("ix_notifications_dupe_check", "user_id", "title", "url", "created_at"),
+        Index("ix_notifications_user_dedupe", "user_id", "dedupe_key"),
     )
 
 

--- a/root/app/services/notifications.py
+++ b/root/app/services/notifications.py
@@ -223,13 +223,24 @@ def _ensure_aware(value: dt.datetime | None) -> dt.datetime:
 
 def build_schedule_reminder_message(
     lesson: Schedule, *, locale: str | None = None
-) -> tuple[str, str, str, dict[str, Any], dict[str, str], dict[str, str]]:
+) -> tuple[
+    str,
+    str,
+    str,
+    dict[str, Any],
+    dict[str, str],
+    dict[str, str],
+    str,
+]:
     start_dt = _ensure_aware(getattr(lesson, "start_time", None))
     start_local = start_dt.astimezone()
     lesson_type_raw = getattr(lesson, "lesson_type", None)
     when_line = f"{start_local.strftime('%d.%m')} · {start_local.strftime('%H:%M')}"
 
-    cache: dict[str, tuple[str, str, str, dict[str, Any]]] = {}
+    schedule_id = getattr(lesson, "id", None)
+    timestamp_part = str(int(start_dt.timestamp())) if start_dt else "timestamp"
+
+    cache: dict[str, tuple[str, str, str, dict[str, Any], str]] = {}
 
     def _render(locale_option: str | None) -> tuple[str, str, str, dict[str, Any]]:
         cache_key = locale_option if locale_option is not None else "__default__"
@@ -302,7 +313,12 @@ def build_schedule_reminder_message(
                 )
             )
         default_body = "\n".join(default_lines)
-        default_tag = f"schedule-reminder:{getattr(lesson, 'id', 'lesson')}:{int(start_dt.timestamp())}"
+        identifier_component = (
+            str(schedule_id)
+            if schedule_id is not None
+            else "lesson"
+        )
+        default_tag = f"schedule-reminder:{identifier_component}:{timestamp_part}"
         default_data: dict[str, Any] = {
             "url": "/schedule",
             "category": "schedule",
@@ -339,21 +355,41 @@ def build_schedule_reminder_message(
         filtered_data = {
             key: value for key, value in merged_data.items() if value not in (None, "")
         }
-        result = (title_value, body_value, tag_value, filtered_data)
+        dedupe_candidate = (
+            template.get("dedupeKey")
+            if template and template.get("dedupeKey") not in (None, "")
+            else template.get("dedupe_key")
+            if template and template.get("dedupe_key") not in (None, "")
+            else tag_value
+        )
+        dedupe_value = (
+            str(dedupe_candidate)
+            if dedupe_candidate not in (None, "")
+            else ""
+        )
+        result = (title_value, body_value, tag_value, filtered_data, dedupe_value)
         cache[cache_key] = result
         return result
 
-    title, body, tag, data_payload = _render(locale)
+    title, body, tag, data_payload, dedupe_value = _render(locale)
     title_translations: dict[str, str] = {}
     body_translations: dict[str, str] = {}
     for locale_code in SUPPORTED_LOCALES:
-        localized_title, localized_body, _, _ = _render(locale_code)
+        localized_title, localized_body, _, _, _ = _render(locale_code)
         if localized_title:
             title_translations[locale_code] = localized_title
         if localized_body:
             body_translations[locale_code] = localized_body
 
-    return title, body, tag, data_payload, title_translations, body_translations
+    return (
+        title,
+        body,
+        tag,
+        data_payload,
+        title_translations,
+        body_translations,
+        dedupe_value,
+    )
 
 
 def is_user_in_quiet_hours(
@@ -410,6 +446,7 @@ async def create_notifications_for_users(
     url: Optional[str] = None,
     badge: Optional[str] = None,
     tag: Optional[str] = None,
+    dedupe_key: Optional[str] = None,
     actions: Optional[Sequence[Mapping[str, Any]]] = None,
     payload_data: Optional[Mapping[str, Any]] = None,
     user_ids: Sequence[int],
@@ -436,6 +473,7 @@ async def create_notifications_for_users(
             body_en=notification_body_en,
             type=type,
             url=url,
+            dedupe_key=dedupe_key,
             created_at=now,
             read=False,
         )
@@ -608,14 +646,29 @@ async def generate_schedule_reminders(
 
     schedules_by_group: dict[int, list[Schedule]] = defaultdict(list)
     message_payloads: dict[
-        int, tuple[str, str, str, dict[str, Any], dict[str, str], dict[str, str]]
+        int,
+        tuple[
+            str,
+            str,
+            str,
+            dict[str, Any],
+            dict[str, str],
+            dict[str, str],
+            str,
+        ],
     ] = {}
-    titles: set[str] = set()
     for schedule in schedules:
         schedules_by_group[int(schedule.group_id)].append(schedule)
         payload = build_schedule_reminder_message(schedule)
         message_payloads[int(schedule.id)] = payload
-        titles.add(payload[0])
+    dedupe_keys: set[str] = {
+        str(key)
+        for key in (
+            payload[6] or payload[2] or payload[0]
+            for payload in message_payloads.values()
+        )
+        if key not in (None, "")
+    }
 
     group_ids = list(schedules_by_group.keys())
     if not group_ids:
@@ -634,23 +687,23 @@ async def generate_schedule_reminders(
 
     dup_since = now - dt.timedelta(minutes=30)
     all_user_ids = {uid for users in group_users.values() for uid in users}
-    existing_by_title: dict[str, set[int]] = defaultdict(set)
-    if titles and all_user_ids:
+    existing_by_dedupe: dict[str, set[int]] = defaultdict(set)
+    if dedupe_keys and all_user_ids:
         existing_stmt = (
-            select(Notification.user_id, Notification.title)
+            select(Notification.user_id, Notification.dedupe_key)
             .where(
                 Notification.user_id.in_(all_user_ids),
                 Notification.url == "/schedule",
                 Notification.created_at >= dup_since,
-                Notification.title.in_(titles),
+                Notification.dedupe_key.in_(dedupe_keys),
             )
             .distinct()
         )
         existing_rows = await db.execute(existing_stmt)
-        for user_id, title in existing_rows:
-            if user_id is None or title is None:
+        for user_id, dedupe_key in existing_rows:
+            if user_id is None or dedupe_key is None:
                 continue
-            existing_by_title[str(title)].add(int(user_id))
+            existing_by_dedupe[str(dedupe_key)].add(int(user_id))
 
     action_title = translate("notifications.actions.open_schedule", locale=None)
     total_created = 0
@@ -666,8 +719,10 @@ async def generate_schedule_reminders(
                 data_payload,
                 title_translations,
                 body_translations,
+                dedupe_key,
             ) = message_payloads[int(schedule.id)]
-            already_notified = existing_by_title.get(title, set())
+            key_for_dedupe = dedupe_key or tag or title
+            already_notified = existing_by_dedupe.get(key_for_dedupe, set())
             to_notify = [uid for uid in user_ids if uid not in already_notified]
             if not to_notify:
                 continue
@@ -680,6 +735,7 @@ async def generate_schedule_reminders(
                 type="schedule.reminder",
                 url="/schedule",
                 tag=tag,
+                dedupe_key=key_for_dedupe,
                 actions=[
                     {
                         "action": "open-schedule",
@@ -691,7 +747,7 @@ async def generate_schedule_reminders(
                 user_ids=to_notify,
                 topic="schedule",
             )
-            existing_by_title[title].update(to_notify)
+            existing_by_dedupe[key_for_dedupe].update(to_notify)
     return total_created
 
 

--- a/root/app/services/notifications.py
+++ b/root/app/services/notifications.py
@@ -313,11 +313,7 @@ def build_schedule_reminder_message(
                 )
             )
         default_body = "\n".join(default_lines)
-        identifier_component = (
-            str(schedule_id)
-            if schedule_id is not None
-            else "lesson"
-        )
+        identifier_component = str(schedule_id) if schedule_id is not None else "lesson"
         default_tag = f"schedule-reminder:{identifier_component}:{timestamp_part}"
         default_data: dict[str, Any] = {
             "url": "/schedule",
@@ -358,14 +354,14 @@ def build_schedule_reminder_message(
         dedupe_candidate = (
             template.get("dedupeKey")
             if template and template.get("dedupeKey") not in (None, "")
-            else template.get("dedupe_key")
-            if template and template.get("dedupe_key") not in (None, "")
-            else tag_value
+            else (
+                template.get("dedupe_key")
+                if template and template.get("dedupe_key") not in (None, "")
+                else tag_value
+            )
         )
         dedupe_value = (
-            str(dedupe_candidate)
-            if dedupe_candidate not in (None, "")
-            else ""
+            str(dedupe_candidate) if dedupe_candidate not in (None, "") else ""
         )
         result = (title_value, body_value, tag_value, filtered_data, dedupe_value)
         cache[cache_key] = result

--- a/root/tests/test_notifications_service.py
+++ b/root/tests/test_notifications_service.py
@@ -316,6 +316,60 @@ async def test_generate_schedule_reminders_query_count_constant(
 
 
 @pytest.mark.anyio
+async def test_generate_schedule_reminders_handles_duplicate_titles(
+    db_session, user_factory
+):
+    group = Group(name="G2")
+    db_session.add(group)
+    await db_session.commit()
+    await db_session.refresh(group)
+
+    user = await user_factory(group_id=group.id)
+
+    now = dt.datetime.now(dt.timezone.utc)
+    lessons = [
+        Schedule(
+            group_id=group.id,
+            subject="Mathematics",
+            teacher="Teacher",
+            room="201",
+            weekday="monday",
+            start_time=now + dt.timedelta(minutes=idx * 5 + 5),
+            end_time=now + dt.timedelta(minutes=idx * 5 + 55),
+        )
+        for idx in range(2)
+    ]
+    db_session.add_all(lessons)
+    await db_session.commit()
+
+    created = await notifications_module.generate_schedule_reminders(
+        db_session, window_minutes=30
+    )
+
+    assert created == 2
+
+    notifications = (
+        (
+            await db_session.execute(
+                select(Notification).where(Notification.user_id == user.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(notifications) == 2
+    dedupe_keys = {note.dedupe_key for note in notifications}
+    assert len(dedupe_keys) == 2
+    assert all(key and key.startswith("schedule-reminder") for key in dedupe_keys)
+
+    repeat_created = await notifications_module.generate_schedule_reminders(
+        db_session, window_minutes=30
+    )
+
+    assert repeat_created == 0
+
+
+@pytest.mark.anyio
 async def test_scheduler_loop_logs_failures(monkeypatch: pytest.MonkeyPatch, caplog):
     class _DummySession:
         async def __aenter__(self):


### PR DESCRIPTION
## Summary
- add a dedicated `dedupe_key` column for notifications along with an indexed backfill migration
- propagate schedule reminder dedupe keys through notification creation and API flows
- cover consecutive lessons with the same subject to ensure both reminders are delivered

## Testing
- `pytest root/tests/test_notifications_service.py -k duplicate_titles`
- `pytest root/tests/test_notification_templates.py`


------
https://chatgpt.com/codex/tasks/task_e_68f6755c58448327a3f425715b54d4f6