### PR TITLE
Add shutdown hook for notification queue worker

### DIFF
--- a/root/app/main.py
+++ b/root/app/main.py
@@ -26,6 +26,7 @@ from app.deps.cache import shutdown_cache
 from app.routers.notifications import legacy_router as legacy_push_router
 from app.routers.notifications import router as push_router
 from app.routers.schedule import router as schedule_router
+from app.services import notification_queue
 from app.services.notifications import (
     cleanup_stale_notifications,
     start_notifications_scheduler,
@@ -90,6 +91,7 @@ async def lifespan(app: FastAPI):
             await stop_notifications_retention()
         if stop_session_cleanup is not None:
             await stop_session_cleanup()
+        await notification_queue.shutdown_notification_queue()
         await shutdown_cache()
         shutdown_observability()
 

--- a/root/app/services/notification_queue.py
+++ b/root/app/services/notification_queue.py
@@ -57,6 +57,9 @@ def _get_loop_state() -> _LoopState:
     return state
 
 
+_WORKER_TASK_NAME = "notification-queue-worker"
+
+
 async def _ensure_worker() -> None:
     """Ensure that a background worker is running to process queued jobs."""
 
@@ -69,7 +72,9 @@ async def _ensure_worker() -> None:
         if state.worker_task and not state.worker_task.done():
             return
         loop = asyncio.get_running_loop()
-        state.worker_task = loop.create_task(_worker_loop(state.queue))
+        state.worker_task = loop.create_task(
+            _worker_loop(state.queue), name=_WORKER_TASK_NAME
+        )
 
 
 async def _worker_loop(queue: asyncio.Queue[NotificationJob]) -> None:
@@ -180,6 +185,31 @@ async def reset_testing_state() -> None:
     """Best-effort helper to clear pending jobs between tests."""
 
     queue = _get_loop_state().queue
+
+    while not queue.empty():
+        try:
+            queue.get_nowait()
+        except asyncio.QueueEmpty:  # pragma: no cover - defensive guard
+            break
+        else:
+            queue.task_done()
+
+
+async def shutdown_notification_queue() -> None:
+    """Stop the background worker and drain any pending jobs."""
+
+    state = _get_loop_state()
+    queue = state.queue
+    worker = state.worker_task
+
+    if worker is not None:
+        if not worker.done():
+            worker.cancel()
+            try:
+                await worker
+            except asyncio.CancelledError:
+                pass
+        state.worker_task = None
 
     while not queue.empty():
         try:

--- a/root/tests/conftest.py
+++ b/root/tests/conftest.py
@@ -79,6 +79,7 @@ from app.core.rate_limit import set_rate_limit_client_factory
 from app.deps import cache as cache_module
 from app.models import models
 from app.utils import ratelimit as ratelimit_module
+from app.services import notification_queue
 
 
 @pytest.fixture(scope="session")
@@ -88,6 +89,15 @@ def event_loop() -> AsyncIterator[asyncio.AbstractEventLoop]:
         yield loop
     finally:
         loop.close()
+
+
+@pytest.fixture(autouse=True)
+async def notification_queue_shutdown() -> AsyncIterator[None]:
+    await notification_queue.shutdown_notification_queue()
+    try:
+        yield
+    finally:
+        await notification_queue.shutdown_notification_queue()
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/root/tests/conftest.py
+++ b/root/tests/conftest.py
@@ -78,8 +78,8 @@ from app.core.database import Base, async_session, engine
 from app.core.rate_limit import set_rate_limit_client_factory
 from app.deps import cache as cache_module
 from app.models import models
-from app.utils import ratelimit as ratelimit_module
 from app.services import notification_queue
+from app.utils import ratelimit as ratelimit_module
 
 
 @pytest.fixture(scope="session")

--- a/root/tests/test_notification_queue_worker.py
+++ b/root/tests/test_notification_queue_worker.py
@@ -6,7 +6,9 @@ from app.services import notification_queue
 
 
 @pytest.mark.anyio
-async def test_shutdown_notification_queue_completes_jobs(monkeypatch: pytest.MonkeyPatch):
+async def test_shutdown_notification_queue_completes_jobs(
+    monkeypatch: pytest.MonkeyPatch,
+):
     processed_ids: list[int] = []
     processed_event = asyncio.Event()
 
@@ -33,7 +35,9 @@ async def test_shutdown_notification_queue_completes_jobs(monkeypatch: pytest.Mo
 
 
 @pytest.mark.anyio
-async def test_shutdown_notification_queue_does_not_leak_tasks(monkeypatch: pytest.MonkeyPatch):
+async def test_shutdown_notification_queue_does_not_leak_tasks(
+    monkeypatch: pytest.MonkeyPatch,
+):
     processed_event = asyncio.Event()
 
     async def _fake_process(job):

--- a/root/tests/test_notification_queue_worker.py
+++ b/root/tests/test_notification_queue_worker.py
@@ -1,0 +1,58 @@
+import asyncio
+
+import pytest
+
+from app.services import notification_queue
+
+
+@pytest.mark.anyio
+async def test_shutdown_notification_queue_completes_jobs(monkeypatch: pytest.MonkeyPatch):
+    processed_ids: list[int] = []
+    processed_event = asyncio.Event()
+
+    async def _fake_process(job):
+        processed_ids.append(job.record_id)
+        processed_event.set()
+
+    monkeypatch.setattr(notification_queue, "_process_job", _fake_process)
+
+    await notification_queue.enqueue_event_notification(42)
+
+    await asyncio.wait_for(processed_event.wait(), timeout=1.0)
+    await notification_queue.wait_for_all_jobs(timeout=1.0)
+
+    state = notification_queue._get_loop_state()
+    assert state.worker_task is not None
+    assert not state.worker_task.done()
+
+    await notification_queue.shutdown_notification_queue()
+
+    assert processed_ids == [42]
+    assert state.queue.empty()
+    assert state.worker_task is None or state.worker_task.done()
+
+
+@pytest.mark.anyio
+async def test_shutdown_notification_queue_does_not_leak_tasks(monkeypatch: pytest.MonkeyPatch):
+    processed_event = asyncio.Event()
+
+    async def _fake_process(job):
+        processed_event.set()
+
+    monkeypatch.setattr(notification_queue, "_process_job", _fake_process)
+
+    await notification_queue.enqueue_news_notification(77)
+
+    await asyncio.wait_for(processed_event.wait(), timeout=1.0)
+    await notification_queue.wait_for_all_jobs(timeout=1.0)
+
+    await notification_queue.shutdown_notification_queue()
+    await asyncio.sleep(0)
+
+    worker_tasks = [
+        task
+        for task in asyncio.all_tasks()
+        if task is not asyncio.current_task()
+        and task.get_name() == notification_queue._WORKER_TASK_NAME
+    ]
+    assert not worker_tasks

--- a/root/tests/test_notifications_service.py
+++ b/root/tests/test_notifications_service.py
@@ -68,9 +68,10 @@ def configured_push_settings(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @pytest.fixture(autouse=True)
 async def reset_notification_queue_state() -> None:
+    await notification_queue.shutdown_notification_queue()
     await notification_queue.reset_testing_state()
     yield
-    await notification_queue.reset_testing_state()
+    await notification_queue.shutdown_notification_queue()
 
 
 async def _login(async_client, email: str, password: str) -> dict[str, str]:


### PR DESCRIPTION
## Summary
- add a shutdown helper for the notification queue that cancels the worker and drains pending jobs
- invoke the shutdown during app teardown and test setup to avoid leaking background tasks
- cover the shutdown path with tests that verify jobs finish and the worker is cleaned up

## Testing
- pytest tests/test_notification_queue_worker.py -q

------
https://chatgpt.com/codex/tasks/task_e_68f6785c650c8327af48dbf984ef1f90