### PR TITLE
Add bounded notification queue metrics

### DIFF
--- a/root/app/core/config.py
+++ b/root/app/core/config.py
@@ -151,6 +151,8 @@ class Settings(BaseSettings):
     notifications_webpush_concurrency_limit: int = 10
     notifications_retention_days: int = 90
     notifications_retention_cleanup_interval_seconds: int = 86_400
+    notifications_queue_max_size: int = 1024
+    notifications_queue_enqueue_timeout_seconds: float = 0.5
     session_cleanup_interval_seconds: int = 900
     event_file_allowed_mime_types: str | list[str] = (
         "application/pdf,"

--- a/root/app/core/observability.py
+++ b/root/app/core/observability.py
@@ -515,6 +515,8 @@ def configure_worker_observability(*, worker_name: str | None = None) -> None:
         logging.getLogger(__name__).info(
             "Worker %s observability configured", worker_name
         )
+
+
 @dataclass
 class NotificationQueueMetrics:
     """Prometheus metrics describing the notification queue state."""
@@ -531,9 +533,7 @@ class NotificationQueueMetrics:
         # hence the type: ignore annotations.
         self.dropped_jobs_total._value.set(0)  # type: ignore[attr-defined]
         self.processing_latency_seconds._sum.set(0)  # type: ignore[attr-defined]
-        for bucket in getattr(
-            self.processing_latency_seconds, "_buckets", []
-        ):  # type: ignore[attr-defined]
+        for bucket in getattr(self.processing_latency_seconds, "_buckets", []):  # type: ignore[attr-defined]
             bucket.set(0)
 
 

--- a/root/app/core/observability.py
+++ b/root/app/core/observability.py
@@ -39,6 +39,7 @@ try:
         CollectorRegistry,
         Counter,
         Gauge,
+        Histogram,
         generate_latest,
     )
 except Exception:  # pragma: no cover - optional dependency guard
@@ -46,6 +47,7 @@ except Exception:  # pragma: no cover - optional dependency guard
     CollectorRegistry = None  # type: ignore[assignment]
     Counter = None  # type: ignore[assignment]
     Gauge = None  # type: ignore[assignment]
+    Histogram = None  # type: ignore[assignment]
 
     def generate_latest(_: object) -> bytes:  # type: ignore[misc]
         raise RuntimeError("prometheus-client is required for worker metrics")
@@ -77,6 +79,7 @@ _otel_configured = False
 _sqlalchemy_instrumented = False
 _otel_logger_provider: LoggerProvider | None = None
 _otel_logging_handler: LoggingHandler | None = None
+_notification_queue_metrics: "NotificationQueueMetrics | None" = None
 
 _request_id_ctx: ContextVar[str | None] = ContextVar("request_id", default=None)
 
@@ -512,3 +515,61 @@ def configure_worker_observability(*, worker_name: str | None = None) -> None:
         logging.getLogger(__name__).info(
             "Worker %s observability configured", worker_name
         )
+@dataclass
+class NotificationQueueMetrics:
+    """Prometheus metrics describing the notification queue state."""
+
+    queue_size: Gauge
+    dropped_jobs_total: Counter
+    processing_latency_seconds: Histogram
+
+    def reset(self) -> None:
+        """Best-effort helper used by tests to zero recorded values."""
+
+        self.queue_size.set(0)
+        # The internals below are implementation details of prometheus_client,
+        # hence the type: ignore annotations.
+        self.dropped_jobs_total._value.set(0)  # type: ignore[attr-defined]
+        self.processing_latency_seconds._sum.set(0)  # type: ignore[attr-defined]
+        for bucket in getattr(
+            self.processing_latency_seconds, "_buckets", []
+        ):  # type: ignore[attr-defined]
+            bucket.set(0)
+
+
+def get_notification_queue_metrics() -> NotificationQueueMetrics:
+    """Return a singleton bundle of Prometheus metrics for the queue."""
+
+    global _notification_queue_metrics
+    if _notification_queue_metrics is None:
+        if Gauge is None or Counter is None or Histogram is None:  # pragma: no cover
+            raise RuntimeError(
+                "prometheus-client is required to create notification queue metrics"
+            )
+
+        _notification_queue_metrics = NotificationQueueMetrics(
+            queue_size=Gauge(
+                "notification_queue_size",
+                "Number of pending notification jobs in the in-process queue",
+            ),
+            dropped_jobs_total=Counter(
+                "notification_queue_dropped_jobs_total",
+                "Total notification jobs dropped due to queue saturation",
+            ),
+            processing_latency_seconds=Histogram(
+                "notification_queue_processing_latency_seconds",
+                "Time spent processing individual notification jobs in seconds",
+                buckets=(
+                    0.01,
+                    0.05,
+                    0.1,
+                    0.5,
+                    1.0,
+                    2.5,
+                    5.0,
+                    10.0,
+                ),
+            ),
+        )
+
+    return _notification_queue_metrics

--- a/root/app/services/notification_queue.py
+++ b/root/app/services/notification_queue.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from dataclasses import dataclass
 from typing import Literal
 from weakref import WeakKeyDictionary
@@ -11,6 +12,11 @@ from weakref import WeakKeyDictionary
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import settings
+from app.core.observability import (
+    NotificationQueueMetrics,
+    get_notification_queue_metrics,
+)
 from app.core.database import async_session
 from app.models.models import Event, News, Notification
 from app.services.notifications import notify_about_event, notify_about_news
@@ -44,16 +50,32 @@ _loop_states: "WeakKeyDictionary[asyncio.AbstractEventLoop, _LoopState]" = (
 )
 
 
+_queue_metrics: NotificationQueueMetrics | None = None
+
+
+def _get_metrics() -> NotificationQueueMetrics | None:
+    global _queue_metrics
+    if _queue_metrics is None:
+        try:
+            _queue_metrics = get_notification_queue_metrics()
+        except RuntimeError:  # pragma: no cover - optional dependency
+            _queue_metrics = None
+    return _queue_metrics
+
+
 def _get_loop_state() -> _LoopState:
     loop = asyncio.get_running_loop()
     state = _loop_states.get(loop)
     if state is None:
         state = _LoopState(
-            queue=asyncio.Queue(),
+            queue=asyncio.Queue(maxsize=max(0, settings.notifications_queue_max_size)),
             worker_task=None,
             worker_lock=asyncio.Lock(),
         )
         _loop_states[loop] = state
+    metrics = _get_metrics()
+    if metrics is not None:
+        metrics.queue_size.set(state.queue.qsize())
     return state
 
 
@@ -80,9 +102,13 @@ async def _ensure_worker() -> None:
 async def _worker_loop(queue: asyncio.Queue[NotificationJob]) -> None:
     """Continuously process notification jobs from the queue."""
 
+    metrics = _get_metrics()
     try:
         while True:
             job = await queue.get()
+            if metrics is not None:
+                metrics.queue_size.set(queue.qsize())
+            started = time.perf_counter()
             try:
                 await _process_job(job)
             except asyncio.CancelledError:  # pragma: no cover - cooperative shutdown
@@ -92,9 +118,69 @@ async def _worker_loop(queue: asyncio.Queue[NotificationJob]) -> None:
                     "Failed to process notification job", extra={"job": job}
                 )
             finally:
+                if metrics is not None:
+                    elapsed = max(time.perf_counter() - started, 0.0)
+                    metrics.processing_latency_seconds.observe(elapsed)
                 queue.task_done()
     except asyncio.CancelledError:  # pragma: no cover - cooperative shutdown
         raise
+
+
+def _evict_oldest(queue: asyncio.Queue[NotificationJob]) -> NotificationJob | None:
+    try:
+        job = queue.get_nowait()
+    except asyncio.QueueEmpty:
+        return None
+    else:
+        queue.task_done()
+        return job
+
+
+async def _enqueue_job(job: NotificationJob) -> None:
+    state = _get_loop_state()
+    queue = state.queue
+    metrics = _get_metrics()
+    timeout = max(float(settings.notifications_queue_enqueue_timeout_seconds), 0.0)
+    enqueued = False
+
+    try:
+        queue.put_nowait(job)
+    except asyncio.QueueFull:
+        evicted = _evict_oldest(queue)
+        if metrics is not None:
+            metrics.dropped_jobs_total.inc()
+            metrics.queue_size.set(queue.qsize())
+        logger.warning(
+            "Notification queue full; dropped oldest job",
+            extra={"dropped_job": evicted, "job": job},
+        )
+        if timeout > 0:
+            try:
+                await asyncio.wait_for(queue.put(job), timeout=timeout)
+                enqueued = True
+            except asyncio.TimeoutError:
+                if metrics is not None:
+                    metrics.dropped_jobs_total.inc()
+                    metrics.queue_size.set(queue.qsize())
+                logger.warning(
+                    "Notification queue saturated; dropping job after timeout",
+                    extra={"job": job},
+                )
+                return
+        else:
+            if metrics is not None:
+                metrics.queue_size.set(queue.qsize())
+            logger.warning(
+                "Notification queue saturated; dropping job without timeout",
+                extra={"job": job},
+            )
+            return
+    else:
+        enqueued = True
+    if metrics is not None:
+        metrics.queue_size.set(queue.qsize())
+    if enqueued:
+        await _ensure_worker()
 
 
 async def _notification_exists(
@@ -157,17 +243,17 @@ async def enqueue_event_notification(
 ) -> None:
     """Queue an event notification job for asynchronous delivery."""
 
-    queue = _get_loop_state().queue
-    await queue.put(NotificationJob(kind="event", record_id=event_id, locale=locale))
-    await _ensure_worker()
+    await _enqueue_job(
+        NotificationJob(kind="event", record_id=event_id, locale=locale)
+    )
 
 
 async def enqueue_news_notification(news_id: int, *, locale: str | None = None) -> None:
     """Queue a news notification job for asynchronous delivery."""
 
-    queue = _get_loop_state().queue
-    await queue.put(NotificationJob(kind="news", record_id=news_id, locale=locale))
-    await _ensure_worker()
+    await _enqueue_job(
+        NotificationJob(kind="news", record_id=news_id, locale=locale)
+    )
 
 
 async def wait_for_all_jobs(timeout: float | None = None) -> None:
@@ -185,6 +271,7 @@ async def reset_testing_state() -> None:
     """Best-effort helper to clear pending jobs between tests."""
 
     queue = _get_loop_state().queue
+    metrics = _get_metrics()
 
     while not queue.empty():
         try:
@@ -193,6 +280,8 @@ async def reset_testing_state() -> None:
             break
         else:
             queue.task_done()
+    if metrics is not None:
+        metrics.queue_size.set(queue.qsize())
 
 
 async def shutdown_notification_queue() -> None:
@@ -201,6 +290,7 @@ async def shutdown_notification_queue() -> None:
     state = _get_loop_state()
     queue = state.queue
     worker = state.worker_task
+    metrics = _get_metrics()
 
     if worker is not None:
         if not worker.done():
@@ -218,3 +308,5 @@ async def shutdown_notification_queue() -> None:
             break
         else:
             queue.task_done()
+    if metrics is not None:
+        metrics.queue_size.set(queue.qsize())

--- a/root/app/services/notification_queue.py
+++ b/root/app/services/notification_queue.py
@@ -13,11 +13,11 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
+from app.core.database import async_session
 from app.core.observability import (
     NotificationQueueMetrics,
     get_notification_queue_metrics,
 )
-from app.core.database import async_session
 from app.models.models import Event, News, Notification
 from app.services.notifications import notify_about_event, notify_about_news
 
@@ -243,17 +243,13 @@ async def enqueue_event_notification(
 ) -> None:
     """Queue an event notification job for asynchronous delivery."""
 
-    await _enqueue_job(
-        NotificationJob(kind="event", record_id=event_id, locale=locale)
-    )
+    await _enqueue_job(NotificationJob(kind="event", record_id=event_id, locale=locale))
 
 
 async def enqueue_news_notification(news_id: int, *, locale: str | None = None) -> None:
     """Queue a news notification job for asynchronous delivery."""
 
-    await _enqueue_job(
-        NotificationJob(kind="news", record_id=news_id, locale=locale)
-    )
+    await _enqueue_job(NotificationJob(kind="news", record_id=news_id, locale=locale))
 
 
 async def wait_for_all_jobs(timeout: float | None = None) -> None:

--- a/root/tests/test_notification_queue_worker.py
+++ b/root/tests/test_notification_queue_worker.py
@@ -1,7 +1,9 @@
 import asyncio
 
 import pytest
+from prometheus_client import REGISTRY
 
+from app.core import observability
 from app.services import notification_queue
 
 
@@ -60,3 +62,68 @@ async def test_shutdown_notification_queue_does_not_leak_tasks(
         and task.get_name() == notification_queue._WORKER_TASK_NAME
     ]
     assert not worker_tasks
+
+
+def _metric_value(name: str) -> float | None:
+    return REGISTRY.get_sample_value(name)
+
+
+@pytest.mark.anyio
+async def test_notification_queue_records_drops_when_saturated(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    metrics = observability.get_notification_queue_metrics()
+    metrics.reset()
+    notification_queue._loop_states.clear()
+    monkeypatch.setattr(
+        notification_queue.settings,
+        "notifications_queue_max_size",
+        1,
+        raising=False,
+    )
+
+    async def _no_worker() -> None:
+        return None
+
+    monkeypatch.setattr(notification_queue, "_ensure_worker", _no_worker)
+
+    await notification_queue.enqueue_event_notification(1)
+    await notification_queue.enqueue_event_notification(2)
+
+    state = notification_queue._get_loop_state()
+    assert state.queue.qsize() == 1
+    assert [job.record_id for job in list(state.queue._queue)] == [2]
+
+    assert _metric_value("notification_queue_size") == pytest.approx(1.0)
+    assert _metric_value("notification_queue_dropped_jobs_total") == pytest.approx(1.0)
+
+    await notification_queue.reset_testing_state()
+    await notification_queue.shutdown_notification_queue()
+    notification_queue._loop_states.clear()
+
+
+@pytest.mark.anyio
+async def test_notification_queue_records_processing_latency(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    metrics = observability.get_notification_queue_metrics()
+    metrics.reset()
+    notification_queue._loop_states.clear()
+
+    async def _fake_process(job):
+        await asyncio.sleep(0.01)
+
+    monkeypatch.setattr(notification_queue, "_process_job", _fake_process)
+
+    await notification_queue.enqueue_event_notification(5)
+
+    await notification_queue.wait_for_all_jobs(timeout=1.0)
+    await notification_queue.shutdown_notification_queue()
+
+    count = _metric_value("notification_queue_processing_latency_seconds_count")
+    total = _metric_value("notification_queue_processing_latency_seconds_sum")
+    assert count == pytest.approx(1.0)
+    assert total is not None and total > 0
+    assert _metric_value("notification_queue_size") == pytest.approx(0.0)
+
+    notification_queue._loop_states.clear()


### PR DESCRIPTION
## Summary
- bound the in-process notification queue by configuration and expose saturation handling with logging
- export Prometheus metrics for queue depth, dropped jobs, and processing latency via the observability module
- extend worker tests to cover queue saturation and metric recording behavior

## Testing
- pytest root/tests/test_notification_queue_worker.py

------
https://chatgpt.com/codex/tasks/task_e_68f67ec601388327b094abf41533f633