### PR TITLE
Defer webpush sync engine initialization

### DIFF
--- a/root/app/services/webpush.py
+++ b/root/app/services/webpush.py
@@ -8,13 +8,14 @@ from copy import deepcopy
 from dataclasses import dataclass
 from datetime import UTC, datetime, time
 from hashlib import sha256
-from typing import Any, Literal
+from threading import Lock
+from typing import Any, Literal, cast
 from urllib.parse import urlparse
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from pywebpush import WebPushException, webpush
 from sqlalchemy import create_engine, delete, select, update
-from sqlalchemy.engine import make_url
+from sqlalchemy.engine import Engine, make_url
 from sqlalchemy.orm import selectinload, sessionmaker
 
 from app.core.config import settings
@@ -23,20 +24,48 @@ from app.core.rate_limit import RateLimitExceeded, RateLimitInfo, enforce_rate_l
 from app.localization import resolve_locale, translate
 from app.models.models import PushSubscription
 from app.services.notification_templates import render_notification_template
-from app.services.push_schema import ensure_push_subscription_schema_sync
+from app.services import push_schema
 from app.services.push_topics import normalize_topic, subscription_supports_topic
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.NOTSET)
 
-url = make_url(settings.database_url)
-if url.drivername.endswith("+asyncpg"):
-    url = url.set(drivername="postgresql+psycopg")
-elif url.drivername.endswith("+aiosqlite"):
-    url = url.set(drivername="sqlite")
-_sync_engine = create_engine(str(url), pool_pre_ping=True, future=True)
-ensure_push_subscription_schema_sync(_sync_engine)
-_Session = sessionmaker(bind=_sync_engine, autocommit=False, autoflush=False)
+_sync_url = make_url(settings.database_url)
+if _sync_url.drivername.endswith("+asyncpg"):
+    _sync_url = _sync_url.set(drivername="postgresql+psycopg")
+elif _sync_url.drivername.endswith("+aiosqlite"):
+    _sync_url = _sync_url.set(drivername="sqlite")
+
+_sync_engine: Engine | None = None
+_Session: sessionmaker | None = None
+_sync_init_lock = Lock()
+_async_init_lock = asyncio.Lock()
+
+
+def _initialize_sync_resources() -> None:
+    global _sync_engine, _Session
+    if _Session is not None:
+        return
+    engine = create_engine(str(_sync_url), pool_pre_ping=True, future=True)
+    push_schema.ensure_push_subscription_schema_sync(engine)
+    _sync_engine = engine
+    _Session = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+
+
+def _ensure_sync_sessionmaker() -> sessionmaker:
+    if _Session is None:
+        with _sync_init_lock:
+            if _Session is None:
+                _initialize_sync_resources()
+    return cast(sessionmaker, _Session)
+
+
+async def _ensure_async_sessionmaker() -> sessionmaker:
+    if _Session is None:
+        async with _async_init_lock:
+            if _Session is None:
+                await asyncio.to_thread(_ensure_sync_sessionmaker)
+    return cast(sessionmaker, _Session)
 
 _OPTION_KEYS: set[str] = {
     "actions",
@@ -539,7 +568,8 @@ def send_web_push(sub: PushSubscription, data: dict) -> WebPushResult:
         elif message:
             gone = "404" in message or "410" in message
         if gone:
-            with _Session() as session:
+            session_factory = _ensure_sync_sessionmaker()
+            with session_factory() as session:
                 session.execute(
                     delete(PushSubscription).where(PushSubscription.id == sub.id)
                 )
@@ -594,7 +624,8 @@ def send_web_push(sub: PushSubscription, data: dict) -> WebPushResult:
             error=str(exc),
         )
     now = datetime.now(UTC)
-    with _Session() as session:
+    session_factory = _ensure_sync_sessionmaker()
+    with session_factory() as session:
         session.execute(
             update(PushSubscription)
             .where(PushSubscription.id == sub.id)
@@ -640,6 +671,7 @@ async def send_to_user(
             retry_after=rate_info.retry_after,
         )
         return []
+    await _ensure_async_sessionmaker()
     async with async_session() as session:
         result = await session.execute(
             select(PushSubscription)
@@ -711,6 +743,7 @@ async def broadcast_to_topic(
             retry_after=rate_info.retry_after,
         )
         return []
+    await _ensure_async_sessionmaker()
     async with async_session() as session:
         result = await session.execute(
             select(PushSubscription)

--- a/root/app/services/webpush.py
+++ b/root/app/services/webpush.py
@@ -23,8 +23,8 @@ from app.core.database import async_session
 from app.core.rate_limit import RateLimitExceeded, RateLimitInfo, enforce_rate_limit
 from app.localization import resolve_locale, translate
 from app.models.models import PushSubscription
-from app.services.notification_templates import render_notification_template
 from app.services import push_schema
+from app.services.notification_templates import render_notification_template
 from app.services.push_topics import normalize_topic, subscription_supports_topic
 
 logger = logging.getLogger(__name__)
@@ -66,6 +66,7 @@ async def _ensure_async_sessionmaker() -> sessionmaker:
             if _Session is None:
                 await asyncio.to_thread(_ensure_sync_sessionmaker)
     return cast(sessionmaker, _Session)
+
 
 _OPTION_KEYS: set[str] = {
     "actions",

--- a/root/tests/test_webpush_config.py
+++ b/root/tests/test_webpush_config.py
@@ -1,3 +1,6 @@
+import importlib
+import sys
+
 import pytest
 
 from app.core.config import Settings, _validate_webpush_subject
@@ -42,3 +45,103 @@ def test_settings_webpush_subject_invalid(monkeypatch):
     settings = Settings()
     with pytest.raises(ValueError):
         _ = settings.WEBPUSH_SUBJECT
+
+
+def test_webpush_import_does_not_touch_database(monkeypatch):
+    import app.services.push_schema as push_schema
+
+    def _should_not_run(*_args, **_kwargs):  # pragma: no cover - safety net
+        raise AssertionError("webpush import attempted to access the database")
+
+    monkeypatch.setattr("sqlalchemy.create_engine", _should_not_run)
+    monkeypatch.setattr(
+        push_schema,
+        "ensure_push_subscription_schema_sync",
+        _should_not_run,
+    )
+    monkeypatch.delitem(sys.modules, "app.services.webpush", raising=False)
+    module = importlib.import_module("app.services.webpush")
+    assert getattr(module, "_Session") is None
+
+
+@pytest.mark.asyncio
+async def test_webpush_operation_ensures_schema(monkeypatch):
+    import app.services.push_schema as push_schema
+
+    ensure_called = False
+
+    def _fake_ensure(engine):
+        nonlocal ensure_called
+        ensure_called = True
+        assert engine is not None
+
+    created_engines: list[object] = []
+
+    def _fake_create_engine(url, *args, **kwargs):
+        created_engines.append((url, args, kwargs))
+
+        class _Engine:
+            pass
+
+        return _Engine()
+
+    sessionmaker_called = False
+
+    class _DummySession:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def execute(self, *args, **kwargs):  # pragma: no cover - defensive
+            return None
+
+        def commit(self):  # pragma: no cover - defensive
+            return None
+
+    def _fake_sessionmaker(*args, **kwargs):
+        nonlocal sessionmaker_called
+        sessionmaker_called = True
+
+        class _Factory:
+            def __call__(self):
+                return _DummySession()
+
+        return _Factory()
+
+    monkeypatch.setattr("sqlalchemy.create_engine", _fake_create_engine)
+    monkeypatch.setattr("sqlalchemy.orm.sessionmaker", _fake_sessionmaker)
+    monkeypatch.setattr(
+        push_schema,
+        "ensure_push_subscription_schema_sync",
+        _fake_ensure,
+    )
+    monkeypatch.delitem(sys.modules, "app.services.webpush", raising=False)
+    webpush = importlib.import_module("app.services.webpush")
+    assert ensure_called is False
+
+    class _FakeResult:
+        def scalars(self):
+            return self
+
+        def all(self):
+            return []
+
+    class _FakeAsyncSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def execute(self, *args, **kwargs):
+            return _FakeResult()
+
+    monkeypatch.setattr(webpush, "async_session", lambda: _FakeAsyncSession())
+
+    results = await webpush.send_to_user(1, None)
+    assert results == []
+    assert ensure_called is True
+    assert len(created_engines) == 1
+    assert sessionmaker_called is True


### PR DESCRIPTION
## Summary
- lazily initialize the webpush sync engine and session factory with thread- and async-safe guards
- ensure push dispatch helpers trigger schema setup only when needed
- add tests covering import-time behaviour and lazy schema creation

## Testing
- pytest root/tests/test_webpush_config.py *(fails: ModuleNotFoundError: No module named 'fakeredis')*

------
https://chatgpt.com/codex/tasks/task_e_68f682a792a88327aeb584c348b303b0