### PR TITLE
Resolve admin avatar URLs using API client origin

### DIFF
--- a/root/frontend/src/pages/AdminUsers.tsx
+++ b/root/frontend/src/pages/AdminUsers.tsx
@@ -25,8 +25,7 @@ import DeleteIcon from "@mui/icons-material/Delete"
 import { useAuth } from "../contexts/AuthContext"
 import useMediaQuery from "@mui/material/useMediaQuery"
 import { useTranslation } from "react-i18next"
-
-const backendBaseUrl = "http://localhost:8000"
+import { buildAvatarUrl } from "../utils/avatar"
 
 type UserRole = "student" | "teacher" | "admin"
 
@@ -45,12 +44,6 @@ type UserFilters = {
   full_name: string
   group_id: string
   role: "" | UserRole
-}
-
-function getAvatar(url: string | null | undefined, id: number) {
-  if (!url) return ""
-  if (url.startsWith("http")) return url
-  return backendBaseUrl + url + "?uid=" + id
 }
 
 export default function AdminUsers() {
@@ -197,7 +190,7 @@ export default function AdminUsers() {
                   }}
                 >
                   <Avatar
-                    src={getAvatar(user.avatar_url, user.id)}
+                    src={buildAvatarUrl(user.avatar_url, user.id)}
                     sx={{ width: 44, height: 44 }}
                   />
                   <Box flex={1}>
@@ -291,7 +284,7 @@ export default function AdminUsers() {
                   {users.map((user) => (
                     <TableRow key={user.id}>
                       <TableCell align="center">
-                        <Avatar src={getAvatar(user.avatar_url, user.id)} />
+                        <Avatar src={buildAvatarUrl(user.avatar_url, user.id)} />
                       </TableCell>
                       <TableCell align="center">{user.full_name}</TableCell>
                       <TableCell align="center">{user.email}</TableCell>

--- a/root/frontend/src/utils/__tests__/avatar.test.ts
+++ b/root/frontend/src/utils/__tests__/avatar.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest"
+import { buildAvatarUrl } from "@/utils/avatar"
+
+describe("buildAvatarUrl", () => {
+  it("resolves relative avatar URLs against the dev origin", () => {
+    const result = buildAvatarUrl("/static/avatars/user.webp", 42, {
+      baseURL: "/api",
+      locationOrigin: "http://localhost:5173",
+    })
+
+    expect(result).toBe("http://localhost:5173/static/avatars/user.webp?uid=42")
+  })
+
+  it("resolves relative avatar URLs against the production backend origin", () => {
+    const result = buildAvatarUrl("/static/avatars/user.webp", 99, {
+      baseURL: "https://api.example.com",
+    })
+
+    expect(result).toBe("https://api.example.com/static/avatars/user.webp?uid=99")
+  })
+
+  it("returns absolute avatar URLs as-is", () => {
+    const absolute = "https://cdn.example.com/avatars/user.webp"
+    const result = buildAvatarUrl(absolute, 77, {
+      baseURL: "https://api.example.com",
+    })
+
+    expect(result).toBe(absolute)
+  })
+})

--- a/root/frontend/src/utils/avatar.ts
+++ b/root/frontend/src/utils/avatar.ts
@@ -1,0 +1,67 @@
+import api from "@/api/client"
+
+const DUMMY_ORIGIN = "http://__avatar__"
+const ABSOLUTE_URL_PATTERN = /^(?:https?:)?\/\//i
+
+const getLocationOrigin = (): string | undefined => {
+  if (typeof window === "undefined") return undefined
+  try {
+    return window.location?.origin
+  } catch {
+    return undefined
+  }
+}
+
+type ResolveOptions = {
+  baseURL?: string
+  locationOrigin?: string
+}
+
+export function resolveBackendOrigin({
+  baseURL = api.defaults.baseURL,
+  locationOrigin = getLocationOrigin(),
+}: ResolveOptions = {}): string | undefined {
+  const fallback = locationOrigin
+  if (!baseURL) {
+    return fallback
+  }
+
+  try {
+    const resolved = new URL(baseURL, fallback ?? DUMMY_ORIGIN)
+    return resolved.origin
+  } catch {
+    return fallback
+  }
+}
+
+const appendUid = (relativeUrl: string, uid: number) => {
+  try {
+    const parsed = new URL(relativeUrl, DUMMY_ORIGIN)
+    parsed.searchParams.set("uid", String(uid))
+    return parsed.toString().replace(DUMMY_ORIGIN, "")
+  } catch {
+    const separator = relativeUrl.includes("?") ? "&" : "?"
+    return `${relativeUrl}${separator}uid=${encodeURIComponent(String(uid))}`
+  }
+}
+
+type AvatarUrlOptions = ResolveOptions
+
+export function buildAvatarUrl(
+  rawUrl: string | null | undefined,
+  uid: number,
+  options: AvatarUrlOptions = {}
+): string {
+  if (!rawUrl) return ""
+  const trimmed = String(rawUrl).trim()
+  if (!trimmed) return ""
+
+  if (ABSOLUTE_URL_PATTERN.test(trimmed)) {
+    return trimmed
+  }
+
+  const withLeadingSlash = trimmed.startsWith("/") ? trimmed : `/${trimmed}`
+  const relativeWithUid = appendUid(withLeadingSlash, uid)
+  const origin = resolveBackendOrigin(options)
+  return origin ? `${origin}${relativeWithUid}` : relativeWithUid
+}


### PR DESCRIPTION
## Summary
- update the admin users page to build avatar URLs from the Axios client origin instead of a hard-coded backend host
- add a reusable helper that appends the uid cache buster while handling relative and absolute URLs
- cover dev and production avatar URL resolution with new Vitest unit tests

## Testing
- npm run test -- src/utils/__tests__/avatar.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68f697f9a6f88327b824943f70aeee37