### PR TITLE
Ensure Accept-Language uses shared fallback locale

### DIFF
--- a/root/frontend/src/api/__tests__/client.language.test.ts
+++ b/root/frontend/src/api/__tests__/client.language.test.ts
@@ -116,4 +116,23 @@ describe("API language interceptor", () => {
 
     expect(response.data[0].title).toBe("ru")
   })
+
+  it("falls back to the default locale for unsupported languages", async () => {
+    const observedLanguages: string[] = []
+
+    server.use(
+      http.get("*/news", ({ request }) => {
+        observedLanguages.push(request.headers.get("accept-language") ?? "")
+        return HttpResponse.json(englishNews)
+      })
+    )
+
+    await i18n.changeLanguage("kk")
+    await api.get<NewsPayload[]>("/news")
+
+    await i18n.changeLanguage("de")
+    await api.get<NewsPayload[]>("/news")
+
+    expect(observedLanguages).toEqual(["en", "en"])
+  })
 })

--- a/root/frontend/src/api/client.ts
+++ b/root/frontend/src/api/client.ts
@@ -4,7 +4,7 @@ import axios, {
   type AxiosRequestConfig,
   type AxiosResponse,
 } from "axios"
-import i18n from "@/i18n/config"
+import i18n, { fallbackLng, supportedLngs } from "@/i18n/config"
 
 export const API_UNAUTHORIZED_EVENT = "auth:unauthorized"
 export const SKIP_UNAUTHORIZED_HEADER = "X-Client-Skip-Unauthorized"
@@ -57,16 +57,29 @@ const api: ApiInstance = axios.create({
 
 const acceptLanguageHeader = "Accept-Language"
 
+const normalizeLanguageCandidate = (candidate: string) =>
+  candidate.toLowerCase().replace(/_/g, "-").split(",", 1)[0]?.trim() ?? ""
+
 const resolveAcceptLanguage = (language?: string) => {
-  if (!language) return "ru"
-  const normalized = language.toLowerCase()
-  if (normalized.startsWith("en")) return "en"
-  if (normalized.startsWith("ru")) return "ru"
-  return "ru"
+  const fallbackLanguage = fallbackLng
+  if (!language) return fallbackLanguage
+
+  const normalized = normalizeLanguageCandidate(language)
+  if (!normalized) return fallbackLanguage
+
+  const supportedMatch = supportedLngs.find((locale) => {
+    const normalizedLocale = locale.toLowerCase()
+    return (
+      normalized === normalizedLocale ||
+      normalized.startsWith(`${normalizedLocale}-`)
+    )
+  })
+
+  return supportedMatch ?? fallbackLanguage
 }
 
 api.interceptors.request.use((config) => {
-  const currentLanguage = i18n.language || i18n.resolvedLanguage || "ru"
+  const currentLanguage = i18n.language || i18n.resolvedLanguage || fallbackLng
   const headerValue = resolveAcceptLanguage(currentLanguage)
 
   const headers = AxiosHeaders.from(config.headers ?? {})

--- a/root/frontend/src/api/client.ts
+++ b/root/frontend/src/api/client.ts
@@ -69,10 +69,7 @@ const resolveAcceptLanguage = (language?: string) => {
 
   const supportedMatch = supportedLngs.find((locale) => {
     const normalizedLocale = locale.toLowerCase()
-    return (
-      normalized === normalizedLocale ||
-      normalized.startsWith(`${normalizedLocale}-`)
-    )
+    return normalized === normalizedLocale || normalized.startsWith(`${normalizedLocale}-`)
   })
 
   return supportedMatch ?? fallbackLanguage

--- a/root/frontend/src/i18n/config.ts
+++ b/root/frontend/src/i18n/config.ts
@@ -63,13 +63,15 @@ export const resources = {
   },
 } as const
 
-const fallbackLng = "en"
+export const supportedLngs = ["en", "ru"] as const
+
+export const fallbackLng = "en"
 
 void i18n.use(initReactI18next).init({
   resources,
   defaultNS,
   fallbackLng,
-  supportedLngs: ["en", "ru"],
+  supportedLngs: [...supportedLngs],
   lng: "ru",
   interpolation: {
     escapeValue: false,


### PR DESCRIPTION
## Summary
- align the API client's Accept-Language resolver with the shared fallback language and supported locale list
- export the frontend i18n fallback and supported locale metadata for reuse
- add tests verifying unsupported languages fall back to the neutral default instead of Russian

## Testing
- npm run test -- src/api/__tests__/client.language.test.ts
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68f6a46112f48327b9927af0d098b3ac