### PR TITLE
Harden metrics endpoint credential handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,11 @@ Key settings you may want to adjust for local development:
 
 Refer to [`root/app/core/config.py`](root/app/core/config.py) for the complete configuration model and validation logic. The `.env` file is loaded automatically when you start the backend or worker.
 
+> **Security note:** When exposing the metrics endpoint, set `METRICS_BASIC_AUTH_USERNAME` and
+> `METRICS_BASIC_AUTH_PASSWORD` in your `.env` file (or Compose override) to unique, strong values.
+> The backend refuses to serve `/metrics` when `METRICS_BASIC_AUTH_PASSWORD` uses a known placeholder
+> to prevent deployments with weak credentials.
+
 ## Image uploads
 
 Uploaded profile photos and news images are limited to **5&nbsp;MB**. The backend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,6 @@ services:
       FRONTEND_ORIGINS: http://localhost:8080
       NOTIFICATIONS_SCHEDULER_INLINE_ENABLED: "false"
       ENABLE_METRICS_ENDPOINT: "true"
-      METRICS_BASIC_AUTH_USERNAME: metrics
-      METRICS_BASIC_AUTH_PASSWORD: changeme
       METRICS_ALLOWLIST: 127.0.0.1,::1
     depends_on:
       postgres:

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -7,6 +7,7 @@
 - Для включения клиентского мониторинга ошибок задайте `VITE_SENTRY_DSN` и, при необходимости, `VITE_ENVIRONMENT`. В дев-сборке SDK автоматически не активируется.
 - Backend и фронтенд должны работать по HTTPS, иначе браузер заблокирует загрузку `/media` и `/static`.
 - Для лимитирования запросов настройте backend с помощью `RATE_LIMIT_STORAGE_BACKEND` и `RATE_LIMIT_STORAGE_URI`. Значение `redis` + Redis URL (например, `redis://user:pass@host:6379/0`) включает общий сторедж для middleware и чувствительных эндпоинтов. Установите `memory` или `memory://` для простого однопроцессного режима без внешнего Redis.
+- Для экспонирования Prometheus-метрик установите `ENABLE_METRICS_ENDPOINT=true` и задайте собственные, стойкие значения `METRICS_BASIC_AUTH_USERNAME` и `METRICS_BASIC_AUTH_PASSWORD` (docker-compose больше не подставляет плейсхолдеры). Backend откажется отдавать `/metrics`, если пароль равен известному плейсхолдеру вроде `changeme`.
 
 ```bash
 # пример

--- a/root/app/core/metrics.py
+++ b/root/app/core/metrics.py
@@ -175,7 +175,11 @@ def configure_metrics(app: FastAPI) -> None:
     if getattr(app.state, _CONFIGURED_ATTR, False):
         return
 
-    if settings.enable_metrics_endpoint and settings.metrics_basic_auth_password.strip().lower() in _PLACEHOLDER_PASSWORDS:
+    if (
+        settings.enable_metrics_endpoint
+        and settings.metrics_basic_auth_password.strip().lower()
+        in _PLACEHOLDER_PASSWORDS
+    ):
         logger.warning(
             "Metrics endpoint is enabled but METRICS_BASIC_AUTH_PASSWORD uses a placeholder "
             "value; refusing to expose /metrics until strong credentials are configured."

--- a/root/app/core/metrics.py
+++ b/root/app/core/metrics.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import hmac
+import logging
 import time
 from ipaddress import ip_address, ip_network
 from typing import Iterable
@@ -53,6 +54,8 @@ _REQUEST_DURATION = (
 )
 
 _CONFIGURED_ATTR = "_metrics_configured"
+_PLACEHOLDER_PASSWORDS = {"changeme"}
+logger = logging.getLogger(__name__)
 
 
 class PrometheusRequestMetricsMiddleware(BaseHTTPMiddleware):
@@ -170,6 +173,13 @@ async def metrics_endpoint(request: Request) -> Response:
 
 def configure_metrics(app: FastAPI) -> None:
     if getattr(app.state, _CONFIGURED_ATTR, False):
+        return
+
+    if settings.enable_metrics_endpoint and settings.metrics_basic_auth_password.strip().lower() in _PLACEHOLDER_PASSWORDS:
+        logger.warning(
+            "Metrics endpoint is enabled but METRICS_BASIC_AUTH_PASSWORD uses a placeholder "
+            "value; refusing to expose /metrics until strong credentials are configured."
+        )
         return
 
     app.add_middleware(PrometheusRequestMetricsMiddleware)


### PR DESCRIPTION
## Summary
- stop docker-compose from injecting placeholder Prometheus basic-auth credentials
- document the requirement to configure strong metrics credentials before enabling the endpoint
- warn and refuse to expose /metrics when a known placeholder password is configured

## Testing
- pytest tests/test_metrics_endpoint.py -q *(fails: ModuleNotFoundError: No module named 'fakeredis')*


------
https://chatgpt.com/codex/tasks/task_e_68f6ba99395c8327bb38677b0f1d195f