### PR TITLE
Consolidate password reset email helper

### DIFF
--- a/root/app/api/users.py
+++ b/root/app/api/users.py
@@ -2,10 +2,7 @@ import hashlib
 import json
 import logging
 import secrets
-import smtplib
-import ssl
 from datetime import datetime, timedelta, timezone
-from email.message import EmailMessage
 from typing import List, Optional
 
 import anyio
@@ -34,7 +31,7 @@ from app.core.observability import get_request_id
 from app.localization import resolve_locale, translate
 from app.models import models
 from app.schemas import schemas
-from app.utils.email import RESET_TOKEN_EXPIRY_MINUTES, build_reset_email_content
+from app.utils.email import RESET_TOKEN_EXPIRY_MINUTES, send_reset_email
 from app.utils.files import delete_static_file
 from app.utils.ratelimit import sensitive_route_limit
 
@@ -52,77 +49,10 @@ def _hash_token(token: str) -> str:
     return hashlib.sha256(token.encode()).hexdigest()
 
 
-def _redact_sensitive_query(url: str) -> str:
-    from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
-
-    try:
-        parts = urlsplit(url)
-    except ValueError:
-        return "[redacted]"
-    redacted_items = []
-    for key, value in parse_qsl(parts.query, keep_blank_values=True):
-        if key.lower() in {"token", "code"}:
-            redacted_items.append((key, "***redacted***"))
-        else:
-            redacted_items.append((key, value))
-    sanitized_query = urlencode(redacted_items, doseq=True)
-    sanitized = parts._replace(query=sanitized_query)
-    result = urlunsplit(sanitized)
-    return result or "[redacted]"
-
-
 def _send_reset_email_blocking(
     to_email: str, link: str, full_name: str = "", locale: str | None = None
 ) -> None:
-    host = settings.smtp_host or ""
-    port = int(settings.smtp_port or 0)
-    user = settings.smtp_user or ""
-    password = settings.smtp_password or ""
-    mail_from = settings.mail_from or "no-reply@example.com"
-    security = (
-        settings.smtp_security or ("starttls" if settings.smtp_starttls else "none")
-    ).lower()
-    subject, plain, html = build_reset_email_content(link, full_name, locale=locale)
-    msg = EmailMessage()
-    msg["Subject"] = subject
-    msg["From"] = mail_from
-    msg["To"] = to_email
-    msg.set_content(plain)
-    msg.add_alternative(html, subtype="html")
-    try:
-        if not host or not port:
-            safe_link = _redact_sensitive_query(link)
-            logger.warning(
-                "password.reset_email.fallback",
-                extra={"email": to_email, "link": safe_link},
-            )
-            return
-        ctx = ssl.create_default_context()
-        if security == "ssl":
-            with smtplib.SMTP_SSL(host, port, context=ctx, timeout=10) as s:
-                if user:
-                    s.login(user, password)
-                s.send_message(msg)
-        elif security == "starttls":
-            with smtplib.SMTP(host, port, timeout=10) as s:
-                s.ehlo()
-                s.starttls(context=ctx)
-                s.ehlo()
-                if user:
-                    s.login(user, password)
-                s.send_message(msg)
-        else:
-            with smtplib.SMTP(host, port, timeout=10) as s:
-                if user:
-                    s.login(user, password)
-                s.send_message(msg)
-    except Exception:
-        safe_link = _redact_sensitive_query(link)
-        logger.error(
-            "password.reset_email.error",
-            extra={"email": to_email, "link": safe_link},
-            exc_info=True,
-        )
+    send_reset_email(to_email, link, full_name, locale=locale)
 
 
 async def _send_reset_email(

--- a/root/app/utils/email.py
+++ b/root/app/utils/email.py
@@ -1,9 +1,13 @@
+import logging
 import smtplib
 import ssl
 from email.message import EmailMessage
 
 from app.core.config import settings
 from app.localization import resolve_locale, translate
+
+
+logger = logging.getLogger(__name__)
 
 RESET_TOKEN_EXPIRY_MINUTES = 45
 
@@ -43,15 +47,36 @@ def build_reset_email_content(
     return subject, plain, html
 
 
+def _redact_sensitive_query(url: str) -> str:
+    from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+    try:
+        parts = urlsplit(url)
+    except ValueError:
+        return "[redacted]"
+    redacted_items = []
+    for key, value in parse_qsl(parts.query, keep_blank_values=True):
+        if key.lower() in {"token", "code"}:
+            redacted_items.append((key, "***redacted***"))
+        else:
+            redacted_items.append((key, value))
+    sanitized_query = urlencode(redacted_items, doseq=True)
+    sanitized = parts._replace(query=sanitized_query)
+    result = urlunsplit(sanitized)
+    return result or "[redacted]"
+
+
 def send_reset_email(
     to_email: str, link: str, full_name: str = "", *, locale: str | None = None
 ) -> None:
-    host = settings.smtp_host
-    port = settings.smtp_port
-    user = settings.smtp_user
-    password = settings.smtp_password
-    starttls = settings.smtp_starttls
-    mail_from = settings.mail_from
+    host = settings.smtp_host or ""
+    port = int(settings.smtp_port or 0)
+    user = settings.smtp_user or ""
+    password = settings.smtp_password or ""
+    mail_from = settings.mail_from or "no-reply@example.com"
+    security = (
+        settings.smtp_security or ("starttls" if settings.smtp_starttls else "none")
+    ).lower()
 
     msg = EmailMessage()
     subject, plain, html = build_reset_email_content(link, full_name, locale=locale)
@@ -61,15 +86,38 @@ def send_reset_email(
     msg.set_content(plain)
     msg.add_alternative(html, subtype="html")
 
-    context = ssl.create_default_context()
-    if starttls:
-        with smtplib.SMTP(host, port) as s:
-            s.starttls(context=context)
-            if user:
-                s.login(user, password)
-            s.send_message(msg)
-    else:
-        with smtplib.SMTP_SSL(host, port, context=context) as s:
-            if user:
-                s.login(user, password)
-            s.send_message(msg)
+    try:
+        if not host or not port:
+            safe_link = _redact_sensitive_query(link)
+            logger.warning(
+                "password.reset_email.fallback",
+                extra={"email": to_email, "link": safe_link},
+            )
+            return
+
+        context = ssl.create_default_context()
+        if security == "ssl":
+            with smtplib.SMTP_SSL(host, port, context=context, timeout=10) as s:
+                if user:
+                    s.login(user, password)
+                s.send_message(msg)
+        elif security == "starttls":
+            with smtplib.SMTP(host, port, timeout=10) as s:
+                s.ehlo()
+                s.starttls(context=context)
+                s.ehlo()
+                if user:
+                    s.login(user, password)
+                s.send_message(msg)
+        else:
+            with smtplib.SMTP(host, port, timeout=10) as s:
+                if user:
+                    s.login(user, password)
+                s.send_message(msg)
+    except Exception:
+        safe_link = _redact_sensitive_query(link)
+        logger.error(
+            "password.reset_email.error",
+            extra={"email": to_email, "link": safe_link},
+            exc_info=True,
+        )

--- a/root/app/utils/email.py
+++ b/root/app/utils/email.py
@@ -6,7 +6,6 @@ from email.message import EmailMessage
 from app.core.config import settings
 from app.localization import resolve_locale, translate
 
-
 logger = logging.getLogger(__name__)
 
 RESET_TOKEN_EXPIRY_MINUTES = 45

--- a/root/tests/test_utils_email.py
+++ b/root/tests/test_utils_email.py
@@ -1,0 +1,98 @@
+import logging
+from email.message import EmailMessage
+
+import pytest
+
+from app.utils import email as email_utils
+
+
+@pytest.fixture(autouse=True)
+def reset_email_settings(monkeypatch):
+    """Reset settings that the email helper relies on for each test."""
+    monkeypatch.setattr(email_utils.settings, "smtp_host", "")
+    monkeypatch.setattr(email_utils.settings, "smtp_port", 0)
+    monkeypatch.setattr(email_utils.settings, "smtp_user", "")
+    monkeypatch.setattr(email_utils.settings, "smtp_password", "")
+    monkeypatch.setattr(email_utils.settings, "smtp_security", "none")
+    monkeypatch.setattr(email_utils.settings, "smtp_starttls", False)
+    monkeypatch.setattr(email_utils.settings, "mail_from", "no-reply@example.com")
+    yield
+
+
+def test_send_reset_email_logs_fallback_when_missing_server(monkeypatch, caplog):
+    monkeypatch.setattr(
+        email_utils,
+        "build_reset_email_content",
+        lambda *args, **kwargs: ("Subject", "Plain", "<p>html</p>"),
+    )
+
+    with caplog.at_level(logging.WARNING):
+        email_utils.send_reset_email(
+            "student@example.com",
+            "https://example.com/reset?token=super-secret",
+            "Student Name",
+        )
+
+    messages = [record.message for record in caplog.records]
+    assert "password.reset_email.fallback" in messages
+
+
+def test_send_reset_email_uses_starttls(monkeypatch):
+    sent_messages: list[EmailMessage] = []
+    calls: list[str] = []
+
+    class DummySMTP:
+        def __init__(self, host: str, port: int, timeout: int = 0):
+            self.host = host
+            self.port = port
+            self.timeout = timeout
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def ehlo(self):
+            calls.append("ehlo")
+
+        def starttls(self, *, context):
+            assert context is not None
+            calls.append("starttls")
+
+        def login(self, user, password):
+            calls.append("login")
+            assert user == "smtp-user"
+            assert password == "smtp-pass"
+
+        def send_message(self, msg):
+            calls.append("send_message")
+            sent_messages.append(msg)
+
+    monkeypatch.setattr(email_utils.smtplib, "SMTP", DummySMTP)
+    monkeypatch.setattr(
+        email_utils,
+        "build_reset_email_content",
+        lambda *args, **kwargs: ("Subject", "Plain", "<p>html</p>"),
+    )
+
+    monkeypatch.setattr(email_utils.settings, "smtp_host", "smtp.example.com")
+    monkeypatch.setattr(email_utils.settings, "smtp_port", 587)
+    monkeypatch.setattr(email_utils.settings, "smtp_user", "smtp-user")
+    monkeypatch.setattr(email_utils.settings, "smtp_password", "smtp-pass")
+    monkeypatch.setattr(email_utils.settings, "smtp_security", "starttls")
+
+    email_utils.send_reset_email(
+        "student@example.com",
+        "https://example.com/reset?token=super-secret",
+        "Student Name",
+    )
+
+    assert sent_messages, "Expected send_message to be invoked"
+    msg = sent_messages[0]
+    assert isinstance(msg, EmailMessage)
+    assert msg["To"] == "student@example.com"
+    assert msg["Subject"] == "Subject"
+    assert "Plain" in msg.get_body(preferencelist=("plain",)).get_content()
+    assert "starttls" in calls
+    assert "send_message" in calls


### PR DESCRIPTION
## Summary
- consolidate password reset email sending into app.utils.email
- update the users API to call the shared helper
- cover the helper with unit tests for fallback and starttls behaviour

## Testing
- pytest tests/test_utils_email.py

------
https://chatgpt.com/codex/tasks/task_e_68f6cf0b77b88327ac628be3941b7de2