### PR TITLE
Add durable notification queue backend

### DIFF
--- a/root/alembic/versions/202506150001_add_notification_queue_jobs_table.py
+++ b/root/alembic/versions/202506150001_add_notification_queue_jobs_table.py
@@ -3,6 +3,7 @@
 from typing import Sequence, Union
 
 import sqlalchemy as sa
+
 from alembic import op
 
 # revision identifiers, used by Alembic.

--- a/root/alembic/versions/202506150001_add_notification_queue_jobs_table.py
+++ b/root/alembic/versions/202506150001_add_notification_queue_jobs_table.py
@@ -1,0 +1,60 @@
+"""Create durable notification queue table."""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "202506150001"
+down_revision: Union[str, None] = "202506010001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_TABLE_NAME = "notification_queue_jobs"
+_KIND_CHECK = "ck_notification_queue_jobs_kind"
+_UNIQUE_NAME = "uq_notification_queue_jobs_kind_record"
+_INDEX_NAME = "ix_notification_queue_jobs_kind_record"
+
+
+def upgrade() -> None:
+    """Create durable notification queue backing table."""
+
+    op.create_table(
+        _TABLE_NAME,
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("kind", sa.String(length=16), nullable=False),
+        sa.Column("record_id", sa.Integer(), nullable=False),
+        sa.Column("locale", sa.String(length=16), nullable=True),
+        sa.Column(
+            "enqueued_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("claimed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "attempts", sa.Integer(), nullable=False, server_default=sa.text("0")
+        ),
+        sa.CheckConstraint("kind IN ('event', 'news')", name=_KIND_CHECK),
+        sa.UniqueConstraint("kind", "record_id", name=_UNIQUE_NAME),
+    )
+    op.create_index(
+        _INDEX_NAME,
+        _TABLE_NAME,
+        ["kind", "record_id"],
+    )
+    op.create_index(
+        "ix_notification_queue_jobs_claimed_at",
+        _TABLE_NAME,
+        ["claimed_at"],
+    )
+
+
+def downgrade() -> None:
+    """Drop durable notification queue backing table."""
+
+    op.drop_index("ix_notification_queue_jobs_claimed_at", table_name=_TABLE_NAME)
+    op.drop_index(_INDEX_NAME, table_name=_TABLE_NAME)
+    op.drop_table(_TABLE_NAME)

--- a/root/app/core/config.py
+++ b/root/app/core/config.py
@@ -153,6 +153,7 @@ class Settings(BaseSettings):
     notifications_retention_cleanup_interval_seconds: int = 86_400
     notifications_queue_max_size: int = 1024
     notifications_queue_enqueue_timeout_seconds: float = 0.5
+    notifications_queue_in_memory_only: bool = False
     session_cleanup_interval_seconds: int = 900
     event_file_allowed_mime_types: str | list[str] = (
         "application/pdf,"

--- a/root/app/core/observability.py
+++ b/root/app/core/observability.py
@@ -550,7 +550,7 @@ def get_notification_queue_metrics() -> NotificationQueueMetrics:
         _notification_queue_metrics = NotificationQueueMetrics(
             queue_size=Gauge(
                 "notification_queue_size",
-                "Number of pending notification jobs in the in-process queue",
+                "Number of pending notification jobs awaiting processing",
             ),
             dropped_jobs_total=Counter(
                 "notification_queue_dropped_jobs_total",

--- a/root/app/models/models.py
+++ b/root/app/models/models.py
@@ -312,7 +312,9 @@ class NotificationQueueJob(Base):
     kind = Column(String(16), nullable=False, index=True)
     record_id = Column(Integer, nullable=False)
     locale = Column(String(16))
-    enqueued_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    enqueued_at = Column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
     claimed_at = Column(DateTime(timezone=True), index=True)
     attempts = Column(Integer, nullable=False, server_default=text("0"))
 

--- a/root/app/models/models.py
+++ b/root/app/models/models.py
@@ -14,6 +14,7 @@ from sqlalchemy import (
     Time,
     UniqueConstraint,
     func,
+    text,
 )
 from sqlalchemy.orm import relationship
 
@@ -301,6 +302,29 @@ class Notification(Base):
         Index("ix_notifications_user_created", "user_id", "created_at"),
         Index("ix_notifications_dupe_check", "user_id", "title", "url", "created_at"),
         Index("ix_notifications_user_dedupe", "user_id", "dedupe_key"),
+    )
+
+
+class NotificationQueueJob(Base):
+    __tablename__ = "notification_queue_jobs"
+
+    id = Column(Integer, primary_key=True)
+    kind = Column(String(16), nullable=False, index=True)
+    record_id = Column(Integer, nullable=False)
+    locale = Column(String(16))
+    enqueued_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    claimed_at = Column(DateTime(timezone=True), index=True)
+    attempts = Column(Integer, nullable=False, server_default=text("0"))
+
+    __table_args__ = (
+        CheckConstraint(
+            "kind IN ('event', 'news')",
+            name="ck_notification_queue_jobs_kind",
+        ),
+        UniqueConstraint(
+            "kind", "record_id", name="uq_notification_queue_jobs_kind_record"
+        ),
+        Index("ix_notification_queue_jobs_kind_record", "kind", "record_id"),
     )
 
 

--- a/root/app/services/notification_queue.py
+++ b/root/app/services/notification_queue.py
@@ -389,9 +389,9 @@ async def _refresh_persistent_queue_size(metrics: NotificationQueueMetrics) -> N
     try:
         async with async_session() as session:
             result = await session.execute(
-                select(func.count()).select_from(NotificationQueueJob).where(
-                    NotificationQueueJob.claimed_at.is_(None)
-                )
+                select(func.count())
+                .select_from(NotificationQueueJob)
+                .where(NotificationQueueJob.claimed_at.is_(None))
             )
             metrics.queue_size.set(int(result.scalar_one()))
     except Exception:  # pragma: no cover - defensive guard
@@ -401,9 +401,9 @@ async def _refresh_persistent_queue_size(metrics: NotificationQueueMetrics) -> N
 async def _pending_persistent_jobs() -> int:
     async with async_session() as session:
         result = await session.execute(
-            select(func.count()).select_from(NotificationQueueJob).where(
-                NotificationQueueJob.claimed_at.is_(None)
-            )
+            select(func.count())
+            .select_from(NotificationQueueJob)
+            .where(NotificationQueueJob.claimed_at.is_(None))
         )
         return int(result.scalar_one())
 

--- a/root/app/services/notification_queue.py
+++ b/root/app/services/notification_queue.py
@@ -1,4 +1,4 @@
-"""In-process queue for dispatching notification jobs asynchronously."""
+"""Hybrid queue for dispatching notification jobs asynchronously."""
 
 from __future__ import annotations
 
@@ -6,10 +6,12 @@ import asyncio
 import logging
 import time
 from dataclasses import dataclass
-from typing import Literal
+from datetime import datetime, timezone
+from typing import Literal, cast
 from weakref import WeakKeyDictionary
 
-from sqlalchemy import select
+from sqlalchemy import delete, func, select, update
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
@@ -18,7 +20,7 @@ from app.core.observability import (
     NotificationQueueMetrics,
     get_notification_queue_metrics,
 )
-from app.models.models import Event, News, Notification
+from app.models.models import Event, News, Notification, NotificationQueueJob
 from app.services.notifications import notify_about_event, notify_about_news
 
 logger = logging.getLogger(__name__)
@@ -34,6 +36,7 @@ class NotificationJob:
     kind: JobKind
     record_id: int
     locale: str | None
+    queue_id: int | None = None
 
 
 @dataclass(slots=True)
@@ -43,6 +46,8 @@ class _LoopState:
     queue: asyncio.Queue[NotificationJob]
     worker_task: asyncio.Task[None] | None
     worker_lock: asyncio.Lock
+    job_event: asyncio.Event
+    active_jobs: int = 0
 
 
 _loop_states: "WeakKeyDictionary[asyncio.AbstractEventLoop, _LoopState]" = (
@@ -63,6 +68,10 @@ def _get_metrics() -> NotificationQueueMetrics | None:
     return _queue_metrics
 
 
+def _use_persistent_backend() -> bool:
+    return not getattr(settings, "notifications_queue_in_memory_only", False)
+
+
 def _get_loop_state() -> _LoopState:
     loop = asyncio.get_running_loop()
     state = _loop_states.get(loop)
@@ -71,11 +80,15 @@ def _get_loop_state() -> _LoopState:
             queue=asyncio.Queue(maxsize=max(0, settings.notifications_queue_max_size)),
             worker_task=None,
             worker_lock=asyncio.Lock(),
+            job_event=asyncio.Event(),
         )
         _loop_states[loop] = state
     metrics = _get_metrics()
     if metrics is not None:
-        metrics.queue_size.set(state.queue.qsize())
+        if _use_persistent_backend():
+            loop.create_task(_refresh_persistent_queue_size(metrics))
+        else:
+            metrics.queue_size.set(state.queue.qsize())
     return state
 
 
@@ -95,22 +108,28 @@ async def _ensure_worker() -> None:
             return
         loop = asyncio.get_running_loop()
         state.worker_task = loop.create_task(
-            _worker_loop(state.queue), name=_WORKER_TASK_NAME
+            _worker_loop(state), name=_WORKER_TASK_NAME
         )
 
 
-async def _worker_loop(queue: asyncio.Queue[NotificationJob]) -> None:
+async def _worker_loop(state: _LoopState) -> None:
     """Continuously process notification jobs from the queue."""
 
     metrics = _get_metrics()
     try:
         while True:
-            job = await queue.get()
-            if metrics is not None:
-                metrics.queue_size.set(queue.qsize())
+            if _use_persistent_backend():
+                job = await _dequeue_persistent_job(state)
+            else:
+                job = await state.queue.get()
+                if metrics is not None:
+                    metrics.queue_size.set(state.queue.qsize())
+            state.active_jobs += 1
             started = time.perf_counter()
+            success = False
             try:
                 await _process_job(job)
+                success = True
             except asyncio.CancelledError:  # pragma: no cover - cooperative shutdown
                 raise
             except Exception:  # pragma: no cover - defensive guard
@@ -121,7 +140,13 @@ async def _worker_loop(queue: asyncio.Queue[NotificationJob]) -> None:
                 if metrics is not None:
                     elapsed = max(time.perf_counter() - started, 0.0)
                     metrics.processing_latency_seconds.observe(elapsed)
-                queue.task_done()
+                if _use_persistent_backend():
+                    await _acknowledge_persistent_job(
+                        job, success=success, state=state, metrics=metrics
+                    )
+                else:
+                    state.queue.task_done()
+                state.active_jobs = max(state.active_jobs - 1, 0)
     except asyncio.CancelledError:  # pragma: no cover - cooperative shutdown
         raise
 
@@ -137,6 +162,13 @@ def _evict_oldest(queue: asyncio.Queue[NotificationJob]) -> NotificationJob | No
 
 
 async def _enqueue_job(job: NotificationJob) -> None:
+    if _use_persistent_backend():
+        await _enqueue_persistent_job(job)
+    else:
+        await _enqueue_in_memory_job(job)
+
+
+async def _enqueue_in_memory_job(job: NotificationJob) -> None:
     state = _get_loop_state()
     queue = state.queue
     metrics = _get_metrics()
@@ -181,6 +213,26 @@ async def _enqueue_job(job: NotificationJob) -> None:
         metrics.queue_size.set(queue.qsize())
     if enqueued:
         await _ensure_worker()
+
+
+async def _enqueue_persistent_job(job: NotificationJob) -> None:
+    metrics = _get_metrics()
+    state = _get_loop_state()
+    try:
+        async with async_session() as session:
+            async with session.begin():
+                record = NotificationQueueJob(
+                    kind=job.kind,
+                    record_id=job.record_id,
+                    locale=job.locale,
+                )
+                session.add(record)
+    except IntegrityError:
+        logger.debug("Skipping duplicate notification job", extra={"job": job})
+    await _ensure_worker()
+    state.job_event.set()
+    if metrics is not None:
+        await _refresh_persistent_queue_size(metrics)
 
 
 async def _notification_exists(
@@ -255,18 +307,29 @@ async def enqueue_news_notification(news_id: int, *, locale: str | None = None) 
 async def wait_for_all_jobs(timeout: float | None = None) -> None:
     """Wait until the queue is empty. Intended for tests."""
 
-    queue = _get_loop_state().queue
+    state = _get_loop_state()
+
+    async def _wait() -> None:
+        if _use_persistent_backend():
+            while True:
+                pending = await _pending_persistent_jobs()
+                if pending == 0 and state.active_jobs == 0:
+                    return
+                await asyncio.sleep(0.01)
+        else:
+            await state.queue.join()
 
     if timeout is None:
-        await queue.join()
+        await _wait()
         return
-    await asyncio.wait_for(queue.join(), timeout=timeout)
+    await asyncio.wait_for(_wait(), timeout=timeout)
 
 
 async def reset_testing_state() -> None:
     """Best-effort helper to clear pending jobs between tests."""
 
-    queue = _get_loop_state().queue
+    state = _get_loop_state()
+    queue = state.queue
     metrics = _get_metrics()
 
     while not queue.empty():
@@ -276,8 +339,14 @@ async def reset_testing_state() -> None:
             break
         else:
             queue.task_done()
+    state.active_jobs = 0
+    state.job_event.clear()
+    await _clear_persistent_jobs()
     if metrics is not None:
-        metrics.queue_size.set(queue.qsize())
+        if _use_persistent_backend():
+            await _refresh_persistent_queue_size(metrics)
+        else:
+            metrics.queue_size.set(queue.qsize())
 
 
 async def shutdown_notification_queue() -> None:
@@ -304,5 +373,114 @@ async def shutdown_notification_queue() -> None:
             break
         else:
             queue.task_done()
+    state.active_jobs = 0
+    state.job_event.clear()
+    await _clear_persistent_jobs()
     if metrics is not None:
-        metrics.queue_size.set(queue.qsize())
+        if _use_persistent_backend():
+            await _refresh_persistent_queue_size(metrics)
+        else:
+            metrics.queue_size.set(queue.qsize())
+
+
+async def _refresh_persistent_queue_size(metrics: NotificationQueueMetrics) -> None:
+    """Update queue size metric based on durable backlog."""
+
+    try:
+        async with async_session() as session:
+            result = await session.execute(
+                select(func.count()).select_from(NotificationQueueJob).where(
+                    NotificationQueueJob.claimed_at.is_(None)
+                )
+            )
+            metrics.queue_size.set(int(result.scalar_one()))
+    except Exception:  # pragma: no cover - defensive guard
+        logger.exception("Failed to refresh persistent queue size metric")
+
+
+async def _pending_persistent_jobs() -> int:
+    async with async_session() as session:
+        result = await session.execute(
+            select(func.count()).select_from(NotificationQueueJob).where(
+                NotificationQueueJob.claimed_at.is_(None)
+            )
+        )
+        return int(result.scalar_one())
+
+
+async def _clear_persistent_jobs() -> None:
+    async with async_session() as session:
+        async with session.begin():
+            await session.execute(delete(NotificationQueueJob))
+
+
+async def _dequeue_persistent_job(state: _LoopState) -> NotificationJob:
+    while True:
+        job = await _claim_next_persistent_job()
+        if job is not None:
+            return job
+        state.job_event.clear()
+        await state.job_event.wait()
+
+
+async def _claim_next_persistent_job() -> NotificationJob | None:
+    async with async_session() as session:
+        async with session.begin():
+            result = await session.execute(
+                select(NotificationQueueJob)
+                .where(NotificationQueueJob.claimed_at.is_(None))
+                .order_by(NotificationQueueJob.enqueued_at, NotificationQueueJob.id)
+                .with_for_update(skip_locked=True)
+                .limit(1)
+            )
+            row = result.scalar_one_or_none()
+            if row is None:
+                return None
+            row.claimed_at = datetime.now(timezone.utc)
+            row.attempts = (row.attempts or 0) + 1
+            job = NotificationJob(
+                kind=cast(JobKind, row.kind),
+                record_id=row.record_id,
+                locale=row.locale,
+                queue_id=row.id,
+            )
+    metrics = _get_metrics()
+    if metrics is not None:
+        await _refresh_persistent_queue_size(metrics)
+    return job
+
+
+async def _acknowledge_persistent_job(
+    job: NotificationJob,
+    *,
+    success: bool,
+    state: _LoopState,
+    metrics: NotificationQueueMetrics | None,
+) -> None:
+    if job.queue_id is None:
+        return
+    try:
+        async with async_session() as session:
+            async with session.begin():
+                if success:
+                    await session.execute(
+                        delete(NotificationQueueJob).where(
+                            NotificationQueueJob.id == job.queue_id
+                        )
+                    )
+                else:
+                    await session.execute(
+                        update(NotificationQueueJob)
+                        .where(NotificationQueueJob.id == job.queue_id)
+                        .values(claimed_at=None)
+                    )
+    except Exception:
+        logger.exception(
+            "Failed to acknowledge persistent notification job",
+            extra={"job": job, "success": success},
+        )
+    else:
+        if not success:
+            state.job_event.set()
+    if metrics is not None:
+        await _refresh_persistent_queue_size(metrics)

--- a/root/tests/test_notification_queue_worker.py
+++ b/root/tests/test_notification_queue_worker.py
@@ -2,9 +2,22 @@ import asyncio
 
 import pytest
 from prometheus_client import REGISTRY
+from sqlalchemy import select
 
 from app.core import observability
+from app.core.database import async_session
+from app.models.models import NotificationQueueJob
 from app.services import notification_queue
+
+
+@pytest.fixture(autouse=True)
+def _force_persistent_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        notification_queue.settings,
+        "notifications_queue_in_memory_only",
+        False,
+        raising=False,
+    )
 
 
 @pytest.mark.anyio
@@ -77,6 +90,12 @@ async def test_notification_queue_records_drops_when_saturated(
     notification_queue._loop_states.clear()
     monkeypatch.setattr(
         notification_queue.settings,
+        "notifications_queue_in_memory_only",
+        True,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        notification_queue.settings,
         "notifications_queue_max_size",
         1,
         raising=False,
@@ -125,5 +144,88 @@ async def test_notification_queue_records_processing_latency(
     assert count == pytest.approx(1.0)
     assert total is not None and total > 0
     assert _metric_value("notification_queue_size") == pytest.approx(0.0)
+
+    notification_queue._loop_states.clear()
+
+
+@pytest.mark.anyio
+async def test_persistent_queue_persists_and_clears_jobs(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    metrics = observability.get_notification_queue_metrics()
+    metrics.reset()
+    notification_queue._loop_states.clear()
+
+    processed_event = asyncio.Event()
+
+    async def _fake_process(job):
+        assert job.queue_id is not None
+        async with async_session() as session:
+            record = await session.get(NotificationQueueJob, job.queue_id)
+            assert record is not None
+            assert record.claimed_at is not None
+        processed_event.set()
+
+    monkeypatch.setattr(notification_queue, "_process_job", _fake_process)
+
+    await notification_queue.enqueue_event_notification(101)
+
+    await asyncio.wait_for(processed_event.wait(), timeout=1.0)
+    await notification_queue.wait_for_all_jobs(timeout=1.0)
+
+    async with async_session() as session:
+        result = await session.execute(select(NotificationQueueJob.id))
+        assert result.first() is None
+
+    assert _metric_value("notification_queue_size") == pytest.approx(0.0)
+
+    notification_queue._loop_states.clear()
+
+
+@pytest.mark.anyio
+async def test_persistent_queue_deduplicates_jobs(monkeypatch: pytest.MonkeyPatch):
+    metrics = observability.get_notification_queue_metrics()
+    metrics.reset()
+    notification_queue._loop_states.clear()
+
+    async def _noop_worker() -> None:
+        return None
+
+    monkeypatch.setattr(notification_queue, "_ensure_worker", _noop_worker)
+
+    await notification_queue.enqueue_news_notification(202)
+    await notification_queue.enqueue_news_notification(202)
+
+    async with async_session() as session:
+        result = await session.execute(select(NotificationQueueJob.record_id))
+        rows = result.fetchall()
+    assert [row[0] for row in rows] == [202]
+
+    notification_queue._loop_states.clear()
+
+
+@pytest.mark.anyio
+async def test_persistent_queue_retries_failed_jobs(monkeypatch: pytest.MonkeyPatch):
+    metrics = observability.get_notification_queue_metrics()
+    metrics.reset()
+    notification_queue._loop_states.clear()
+
+    attempts: list[int] = []
+    processed_event = asyncio.Event()
+
+    async def _process(job):
+        attempts.append(job.record_id)
+        if len(attempts) == 1:
+            raise RuntimeError("boom")
+        processed_event.set()
+
+    monkeypatch.setattr(notification_queue, "_process_job", _process)
+
+    await notification_queue.enqueue_news_notification(303)
+
+    await asyncio.wait_for(processed_event.wait(), timeout=1.0)
+    await notification_queue.wait_for_all_jobs(timeout=1.0)
+
+    assert attempts == [303, 303]
 
     notification_queue._loop_states.clear()


### PR DESCRIPTION
## Summary
- add a persistent `notification_queue_jobs` table and SQLAlchemy model to back notification dispatch
- rework the notification queue service to favor the durable backend while keeping an opt-in in-memory fallback and refreshed metrics
- extend worker tests to validate persistence, deduplication, and retry behavior

## Testing
- pytest root/tests/test_notification_queue_worker.py *(fails: ModuleNotFoundError: fakeredis)*

------
https://chatgpt.com/codex/tasks/task_e_68f6d6841d908327bfb3fd8daaf8a1f0