### PR TITLE
Adjust rate limit exclusions for static assets

### DIFF
--- a/root/app/core/rate_limit.py
+++ b/root/app/core/rate_limit.py
@@ -235,11 +235,16 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         """Return ``True`` when the request should bypass rate limiting."""
 
         method = request.method.upper()
-        if method == "OPTIONS":
+        if method in {"OPTIONS", "HEAD"}:
             return True
 
         path = request.url.path or ""
+
         if path == "/static" or path.startswith("/static/"):
+            return True
+
+        static_like_prefixes = ("/media/", "/storage/", "/assets/")
+        if method == "GET" and any(path.startswith(prefix) for prefix in static_like_prefixes):
             return True
 
         return False

--- a/root/app/core/rate_limit.py
+++ b/root/app/core/rate_limit.py
@@ -244,7 +244,9 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
             return True
 
         static_like_prefixes = ("/media/", "/storage/", "/assets/")
-        if method == "GET" and any(path.startswith(prefix) for prefix in static_like_prefixes):
+        if method == "GET" and any(
+            path.startswith(prefix) for prefix in static_like_prefixes
+        ):
             return True
 
         return False

--- a/root/tests/test_rate_limit.py
+++ b/root/tests/test_rate_limit.py
@@ -52,6 +52,18 @@ async def test_rate_limit_skips_static_paths():
     async def _static() -> Response:  # pragma: no cover - simple passthrough
         return Response(content=b"", media_type="image/png")
 
+    @app.get("/media/example.png")
+    async def _media() -> Response:  # pragma: no cover - simple passthrough
+        return Response(content=b"", media_type="image/png")
+
+    @app.get("/storage/example.png")
+    async def _storage() -> Response:  # pragma: no cover - simple passthrough
+        return Response(content=b"", media_type="image/png")
+
+    @app.get("/assets/app.js")
+    async def _assets() -> Response:  # pragma: no cover - simple passthrough
+        return Response(content=b"console.log('hi');", media_type="text/javascript")
+
     @app.get("/limited")
     async def _limited():  # pragma: no cover - simple passthrough
         return {"ok": True}
@@ -60,9 +72,18 @@ async def test_rate_limit_skips_static_paths():
     async with httpx.AsyncClient(
         transport=transport, base_url="http://testserver"
     ) as client:
-        for _ in range(5):
-            static_response = await client.get("/static/example.png")
-            assert static_response.status_code == status.HTTP_200_OK
+        for path in [
+            "/static/example.png",
+            "/media/example.png",
+            "/storage/example.png",
+            "/assets/app.js",
+        ]:
+            for _ in range(3):
+                static_response = await client.get(path)
+                assert static_response.status_code == status.HTTP_200_OK
+
+        head_response = await client.head("/media/example.png")
+        assert head_response.status_code == status.HTTP_200_OK
 
         first = await client.get("/limited")
         second = await client.get("/limited")


### PR DESCRIPTION
## Summary
- avoid applying the rate limit middleware to HEAD requests and GET requests for static-like paths so asset fetches no longer count toward API limits
- extend the rate limit test fixture to cover media, storage and assets paths plus HEAD handling

## Testing
- pytest tests/test_rate_limit.py *(fails: ModuleNotFoundError: No module named 'fakeredis')*

------
https://chatgpt.com/codex/tasks/task_e_68f6e625697483278019492a80fa7d45