### PR TITLE
Fix rate limiting for cookie-authenticated sessions

### DIFF
--- a/root/app/core/rate_limit.py
+++ b/root/app/core/rate_limit.py
@@ -5,6 +5,7 @@ import math
 import time
 import uuid
 from dataclasses import dataclass
+from hashlib import sha256
 from typing import Callable, Optional
 
 from fastapi import Request
@@ -227,15 +228,39 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         return info
 
     def _build_identifier(self, request: Request) -> str:
-        auth_header = request.headers.get("authorization")
-        if auth_header:
-            parts = auth_header.strip().split()
-            if len(parts) == 2 and parts[0].lower() == "bearer" and parts[1]:
-                return f"token:{parts[1]}"
+        token = self._extract_bearer_token(request.headers.get("authorization"))
+        if token:
+            return f"token:{token}"
+
+        cookie_token = self._fingerprint_token(request.cookies.get("access_token"))
+        if cookie_token:
+            return f"token:{cookie_token}"
         client = request.client
         if client and client.host:
             return f"ip:{client.host}"
         return "ip:unknown"
+
+    @staticmethod
+    def _extract_bearer_token(header_value: str | None) -> str | None:
+        if not header_value:
+            return None
+        parts = header_value.strip().split()
+        if len(parts) != 2:
+            return None
+        scheme, token = parts[0].lower(), parts[1].strip()
+        if scheme != "bearer" or not token:
+            return None
+        return RateLimitMiddleware._fingerprint_token(token)
+
+    @staticmethod
+    def _fingerprint_token(token: str | None) -> str | None:
+        if not token:
+            return None
+        normalized = token.strip()
+        if not normalized:
+            return None
+        digest = sha256(normalized.encode("utf-8", "ignore")).hexdigest()
+        return digest
 
     def _should_skip(self, method: str, path: str) -> bool:
         """Return ``True`` when the request should bypass rate limiting."""

--- a/root/tests/test_rate_limit.py
+++ b/root/tests/test_rate_limit.py
@@ -38,6 +38,23 @@ async def test_rate_limit_per_token(async_client):
 
 
 @pytest.mark.anyio
+async def test_rate_limit_per_cookie(async_client):
+    async_client.cookies.set("access_token", "cookie-token-a", path="/")
+
+    for _ in range(5):
+        response = await async_client.get("/healthz")
+        assert response.status_code == 200
+
+    blocked = await async_client.get("/healthz")
+    assert blocked.status_code == 429
+
+    async_client.cookies.set("access_token", "cookie-token-b", path="/")
+
+    other = await async_client.get("/healthz")
+    assert other.status_code == 200
+
+
+@pytest.mark.anyio
 async def test_rate_limit_skips_static_paths():
     app = FastAPI()
     app.add_middleware(


### PR DESCRIPTION
## Summary
- fingerprint bearer tokens before using them as rate-limit identifiers
- include the `access_token` session cookie in rate limit identification to avoid IP-wide throttling
- cover cookie-based limits with a regression test

## Testing
- pytest tests/test_rate_limit.py

------
https://chatgpt.com/codex/tasks/task_e_68f774d4c4d08327b8932ba419bd3bb2