### PR TITLE
Handle API rate limits and replace deprecated color helper

### DIFF
--- a/root/frontend/src/api/client.ts
+++ b/root/frontend/src/api/client.ts
@@ -98,14 +98,17 @@ const scheduleRateLimitWindow = (delayMs: number) => {
     rateLimitTimer = null
   }
 
-  rateLimitTimer = setTimeout(() => {
-    rateLimitTimer = null
-    rateLimitResetAt = 0
-    while (rateLimitWaiters.length > 0) {
-      const resolve = rateLimitWaiters.shift()
-      resolve?.()
-    }
-  }, Math.max(0, target - Date.now()))
+  rateLimitTimer = setTimeout(
+    () => {
+      rateLimitTimer = null
+      rateLimitResetAt = 0
+      while (rateLimitWaiters.length > 0) {
+        const resolve = rateLimitWaiters.shift()
+        resolve?.()
+      }
+    },
+    Math.max(0, target - Date.now())
+  )
 }
 
 const waitForRateLimitWindow = async () => {

--- a/root/frontend/src/api/client.ts
+++ b/root/frontend/src/api/client.ts
@@ -14,6 +14,15 @@ const prodBase = import.meta.env.VITE_BACKEND_ORIGIN || "/api"
 
 export type ApiRequestConfig<D = unknown> = AxiosRequestConfig<D> & {
   signal?: AbortSignal
+  /**
+   * Skip the client-side rate-limit queue. Only use for requests that must not
+   * be throttled.
+   */
+  skipRateLimitQueue?: boolean
+  /**
+   * Internal retry counter used by the rate-limit middleware.
+   */
+  __rateLimitRetryCount?: number
 }
 
 type ApiInstance = Omit<AxiosInstance, "get" | "delete" | "post" | "patch" | "put"> & {
@@ -57,6 +66,86 @@ const api: ApiInstance = axios.create({
 
 const acceptLanguageHeader = "Accept-Language"
 
+const RATE_LIMIT_DEFAULT_DELAY_MS = 2000
+const RATE_LIMIT_MAX_RETRY = 2
+
+let rateLimitResetAt = 0
+let rateLimitTimer: ReturnType<typeof setTimeout> | null = null
+const rateLimitWaiters: Array<() => void> = []
+
+const isAbortError = (error: unknown) => {
+  if (!error) return false
+  if (error instanceof DOMException) {
+    return error.name === "AbortError"
+  }
+  if (typeof error === "object" && "name" in error) {
+    const name = (error as { name?: string }).name
+    return name === "CanceledError" || name === "AbortError"
+  }
+  return false
+}
+
+const scheduleRateLimitWindow = (delayMs: number) => {
+  const target = Date.now() + Math.max(delayMs, 0)
+  if (rateLimitTimer && target <= rateLimitResetAt) {
+    return
+  }
+
+  rateLimitResetAt = target
+
+  if (rateLimitTimer) {
+    clearTimeout(rateLimitTimer)
+    rateLimitTimer = null
+  }
+
+  rateLimitTimer = setTimeout(() => {
+    rateLimitTimer = null
+    rateLimitResetAt = 0
+    while (rateLimitWaiters.length > 0) {
+      const resolve = rateLimitWaiters.shift()
+      resolve?.()
+    }
+  }, Math.max(0, target - Date.now()))
+}
+
+const waitForRateLimitWindow = async () => {
+  if (rateLimitResetAt <= Date.now()) {
+    return
+  }
+
+  await new Promise<void>((resolve) => {
+    rateLimitWaiters.push(resolve)
+  })
+}
+
+const parseRetryAfterHeader = (raw: unknown): number | null => {
+  if (typeof raw !== "string") return null
+  const trimmed = raw.trim()
+  if (!trimmed) return null
+
+  const numeric = Number.parseFloat(trimmed)
+  if (Number.isFinite(numeric) && numeric >= 0) {
+    return Math.max(0, numeric * 1000)
+  }
+
+  const parsedDate = Date.parse(trimmed)
+  if (!Number.isNaN(parsedDate)) {
+    const diff = parsedDate - Date.now()
+    if (diff > 0) {
+      return diff
+    }
+  }
+
+  return null
+}
+
+const getRetryDelay = (headers: Record<string, unknown> | undefined) => {
+  if (!headers) return RATE_LIMIT_DEFAULT_DELAY_MS
+  const header = headers["retry-after"] ?? headers["Retry-After"]
+  const parsed = parseRetryAfterHeader(header)
+  return parsed ?? RATE_LIMIT_DEFAULT_DELAY_MS
+}
+
 const normalizeLanguageCandidate = (candidate: string) =>
   candidate.toLowerCase().replace(/_/g, "-").split(",", 1)[0]?.trim() ?? ""
 
@@ -76,6 +165,11 @@ const resolveAcceptLanguage = (language?: string) => {
 }
 
 api.interceptors.request.use((config) => {
+  const candidate = config as ApiRequestConfig
+  if (!candidate.skipRateLimitQueue && rateLimitResetAt > Date.now()) {
+    return waitForRateLimitWindow().then(() => config)
+  }
+
   const currentLanguage = i18n.language || i18n.resolvedLanguage || fallbackLng
   const headerValue = resolveAcceptLanguage(currentLanguage)
 
@@ -92,7 +186,22 @@ api.interceptors.request.use((config) => {
 
 api.interceptors.response.use(
   (r) => r,
-  (err) => {
+  async (err) => {
+    if (err?.response?.status === 429 && err.config) {
+      const config = err.config as ApiRequestConfig
+      if (!config.skipRateLimitQueue) {
+        const delay = getRetryDelay(err.response?.headers)
+        scheduleRateLimitWindow(delay)
+
+        const retryCount = config.__rateLimitRetryCount ?? 0
+        if (retryCount < RATE_LIMIT_MAX_RETRY && !config.signal?.aborted && !isAbortError(err)) {
+          config.__rateLimitRetryCount = retryCount + 1
+          await waitForRateLimitWindow()
+          return api.request(config)
+        }
+      }
+    }
+
     if (err?.response?.status === 401) {
       const headers = (err.config?.headers ?? {}) as Record<string, unknown>
       if (headers[SKIP_UNAUTHORIZED_HEADER]) {

--- a/root/frontend/src/pages/Activity.tsx
+++ b/root/frontend/src/pages/Activity.tsx
@@ -24,7 +24,7 @@ import {
   Divider,
   useMediaQuery,
 } from "@mui/material"
-import { alpha, useTheme, lighten } from "@mui/material/styles"
+import { alpha, useTheme } from "@mui/material/styles"
 import {
   motion,
   AnimatePresence,
@@ -41,6 +41,7 @@ import SchoolIcon from "@mui/icons-material/School"
 import EmojiEventsIcon from "@mui/icons-material/EmojiEvents"
 import { useTranslation } from "react-i18next"
 import { getLocaleForLanguage, useLanguage } from "@/contexts/LanguageContext"
+import { lightenColor } from "@/utils/color"
 
 const toNumber = (value: unknown, fallback = 0) => {
   const num = Number(value)
@@ -296,7 +297,7 @@ export default function Activity() {
   const darkToggleBase = alpha(theme.palette.common.white, 0.9)
   const darkToggleHover = alpha(theme.palette.common.white, 0.96)
   const darkToggleBorder = alpha(theme.palette.common.white, 0.24)
-  const darkToggleSelected = lighten(theme.palette.primary.main, 0.6)
+  const darkToggleSelected = lightenColor(theme.palette.primary.main, 0.6)
 
   const [period, setPeriod] = useState<PeriodKey>("90d")
   const [attendance, setAttendance] = useState<AttendanceStats | null>(null)
@@ -785,7 +786,7 @@ export default function Activity() {
                   "& .Mui-selected": {
                     background: isDark
                       ? darkToggleSelected
-                      : lighten(theme.palette.primary.main, 0.35),
+                      : lightenColor(theme.palette.primary.main, 0.35),
                     color: theme.palette.common.white,
                     boxShadow: isDark
                       ? `0 8px 24px ${alpha(theme.palette.primary.main, 0.45)}`
@@ -793,8 +794,8 @@ export default function Activity() {
                   },
                   "& .Mui-selected:hover": {
                     background: isDark
-                      ? lighten(darkToggleSelected, 0.12)
-                      : lighten(theme.palette.primary.main, 0.3),
+                      ? lightenColor(darkToggleSelected, 0.12)
+                      : lightenColor(theme.palette.primary.main, 0.3),
                   },
                 }}
               >

--- a/root/frontend/src/pages/Settings.tsx
+++ b/root/frontend/src/pages/Settings.tsx
@@ -38,7 +38,7 @@ import {
   CircularProgress,
 } from "@mui/material"
 import dayjs from "dayjs"
-import { useColorScheme, styled, alpha, darken, lighten } from "@mui/material/styles"
+import { useColorScheme, styled, alpha, darken } from "@mui/material/styles"
 import SettingsIcon from "@mui/icons-material/Settings"
 import DarkModeIcon from "@mui/icons-material/DarkMode"
 import LightModeIcon from "@mui/icons-material/LightMode"

--- a/root/frontend/src/utils/color.ts
+++ b/root/frontend/src/utils/color.ts
@@ -1,0 +1,43 @@
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max)
+
+const toHex = (value: number) => value.toString(16).padStart(2, "0")
+
+const expandHex = (hex: string) =>
+  hex.length === 3 ? hex.split("").map((char) => char + char).join("") : hex
+
+const mixChannelWithWhite = (channel: number, coefficient: number) =>
+  Math.round(channel + (255 - channel) * coefficient)
+
+const fromHex = (hex: string) => Number.parseInt(hex, 16)
+
+const tryMixHexWithWhite = (color: string, coefficient: number): string | null => {
+  const hexMatch = /^#?([\da-f]{3}|[\da-f]{6})$/i.exec(color)
+  if (!hexMatch) return null
+  const normalized = expandHex(hexMatch[1])
+  const r = mixChannelWithWhite(fromHex(normalized.slice(0, 2)), coefficient)
+  const g = mixChannelWithWhite(fromHex(normalized.slice(2, 4)), coefficient)
+  const b = mixChannelWithWhite(fromHex(normalized.slice(4, 6)), coefficient)
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`
+}
+
+const buildColorMixExpression = (color: string, coefficient: number) => {
+  const percentage = Math.round(coefficient * 1000) / 10
+  const base = Math.max(0, 100 - percentage)
+  return `color-mix(in srgb, ${color} ${base}%, white ${percentage}%)`
+}
+
+export const mixColorWithWhite = (color: string, coefficient: number) => {
+  const clamped = clamp(coefficient, 0, 1)
+  const trimmed = color.trim()
+
+  if (typeof CSS !== "undefined" && typeof CSS.supports === "function") {
+    const expression = buildColorMixExpression(trimmed, clamped)
+    if (CSS.supports("color", expression)) {
+      return expression
+    }
+  }
+
+  return tryMixHexWithWhite(trimmed, clamped) ?? trimmed
+}
+
+export const lightenColor = mixColorWithWhite

--- a/root/frontend/src/utils/color.ts
+++ b/root/frontend/src/utils/color.ts
@@ -3,7 +3,12 @@ const clamp = (value: number, min: number, max: number) => Math.min(Math.max(val
 const toHex = (value: number) => value.toString(16).padStart(2, "0")
 
 const expandHex = (hex: string) =>
-  hex.length === 3 ? hex.split("").map((char) => char + char).join("") : hex
+  hex.length === 3
+    ? hex
+        .split("")
+        .map((char) => char + char)
+        .join("")
+    : hex
 
 const mixChannelWithWhite = (channel: number, coefficient: number) =>
   Math.round(channel + (255 - channel) * coefficient)


### PR DESCRIPTION
## Summary
- add a client-side rate-limit queue for axios requests so repeated calls honour Retry-After headers and avoid flooding the API
- introduce a reusable `lightenColor` helper based on modern CSS color-mix fallbacks and apply it to the activity page styles
- clean up Settings page imports to remove the deprecated `lighten` helper

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68f7a6acf6ac8327a91ac1878c1bc2b8