### PR TITLE
Cache events responses for 304 tab reloads

### DIFF
--- a/root/frontend/src/pages/Events.tsx
+++ b/root/frontend/src/pages/Events.tsx
@@ -121,6 +121,9 @@ const Events = () => {
   const filtersOpen = Boolean(filterAnchor)
   const filtersActive = Boolean(type?.trim() || location?.trim())
   const etagCacheRef = useRef<Record<string, string>>({})
+  const eventsCacheRef = useRef<
+    Record<string, { events: Event[]; pagination: PaginatedResponse<Event> | null }>
+  >({})
 
   useEffect(() => {
     const t = (searchParams.get("tab") as typeof tab) || "active"
@@ -146,6 +149,14 @@ const Events = () => {
   const dType = useDebounced(type, 350)
   const dLocation = useDebounced(location, 350)
 
+  const cacheKey = useMemo(() => {
+    if (tab === "my") {
+      return `my:${language}`
+    }
+    const isActiveFilter = tab === "active" ? true : tab === "archive" ? false : undefined
+    return `${tab}:${language}:${String(isActiveFilter)}:${dSearch}:${dType}:${dLocation}:limit:${PAGE_SIZE}`
+  }, [tab, language, dSearch, dType, dLocation])
+
   const fetchEvents = useCallback(
     async (signal?: AbortSignal) => {
       setLoading(true)
@@ -166,10 +177,7 @@ const Events = () => {
                 cursor: 0,
               }
 
-        const keyBase =
-          tab === "my"
-            ? `my:${language}`
-            : `${tab}:${language}:${String(isActiveFilter)}:${dSearch}:${dType}:${dLocation}:limit:${PAGE_SIZE}`
+        const keyBase = cacheKey
         const headers = etagCacheRef.current[keyBase]
           ? { "If-None-Match": etagCacheRef.current[keyBase] }
           : undefined
@@ -189,9 +197,16 @@ const Events = () => {
             delete etagCacheRef.current[keyBase]
           }
           if (res.status === 304) {
+            const cached = eventsCacheRef.current[keyBase]
+            if (cached) {
+              setEvents(cached.events)
+            }
+            setPagination(null)
             return
           }
-          setEvents(Array.isArray(res.data) ? res.data : [])
+          const nextEvents = Array.isArray(res.data) ? res.data : []
+          eventsCacheRef.current[keyBase] = { events: nextEvents, pagination: null }
+          setEvents(nextEvents)
           setPagination(null)
           return
         }
@@ -204,12 +219,20 @@ const Events = () => {
           delete etagCacheRef.current[keyBase]
         }
         if (res.status === 304) {
+          const cached = eventsCacheRef.current[keyBase]
+          if (cached) {
+            setEvents(cached.events)
+            setPagination(cached.pagination)
+          }
           return
         }
 
         const data = res.data
-        setEvents(Array.isArray(data?.items) ? data.items : [])
-        setPagination(data ?? null)
+        const nextEvents = Array.isArray(data?.items) ? data.items : []
+        const nextPagination = data ?? null
+        eventsCacheRef.current[keyBase] = { events: nextEvents, pagination: nextPagination }
+        setEvents(nextEvents)
+        setPagination(nextPagination)
       } catch (err: any) {
         if (err?.name !== "CanceledError" && err?.code !== "ERR_CANCELED") {
           setEvents([])
@@ -219,7 +242,7 @@ const Events = () => {
         setLoading(false)
       }
     },
-    [tab, dSearch, dType, dLocation, language]
+    [tab, dSearch, dType, dLocation, language, cacheKey]
   )
 
   useEffect(() => {
@@ -248,6 +271,7 @@ const Events = () => {
       })
       const data = res.data
       const newItems = Array.isArray(data?.items) ? data.items : []
+      let mergedEvents: Event[] = []
       setEvents((prev) => {
         const existing = Array.isArray(prev) ? [...prev] : []
         const seen = new Set(existing.map((item) => item.id))
@@ -260,15 +284,31 @@ const Events = () => {
             seen.add(item.id)
           }
         })
+        mergedEvents = existing
         return existing
       })
       setPagination((prev) => {
-        if (!data) return prev
-        if (!prev) return data
-        return {
+        if (!data) {
+          const cached = eventsCacheRef.current[cacheKey]
+          eventsCacheRef.current[cacheKey] = {
+            events: mergedEvents,
+            pagination: prev ?? null,
+          }
+          return prev
+        }
+        if (!prev) {
+          eventsCacheRef.current[cacheKey] = { events: mergedEvents, pagination: data }
+          return data
+        }
+        const nextPagination = {
           ...prev,
           ...data,
         }
+        eventsCacheRef.current[cacheKey] = {
+          events: mergedEvents,
+          pagination: nextPagination,
+        }
+        return nextPagination
       })
     } catch (err: any) {
       if (err?.name !== "CanceledError" && err?.code !== "ERR_CANCELED") {
@@ -277,7 +317,7 @@ const Events = () => {
     } finally {
       setLoadingMore(false)
     }
-  }, [tab, loadingMore, pagination?.next_cursor, dSearch, dType, dLocation])
+  }, [tab, loadingMore, pagination?.next_cursor, dSearch, dType, dLocation, cacheKey])
 
   const handleTabChange = (_event: SyntheticEvent, newValue: EventTabKey) => setTab(newValue)
 

--- a/root/frontend/src/tests/pages/EventsCache.test.tsx
+++ b/root/frontend/src/tests/pages/EventsCache.test.tsx
@@ -1,0 +1,159 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { MemoryRouter } from "react-router-dom"
+import { describe, expect, it, vi } from "vitest"
+import { HttpResponse, http } from "msw"
+
+import Events from "@/pages/Events"
+import { AuthContext } from "@/contexts/AuthContext"
+import type { Event } from "@/types/Event"
+import { server } from "../mocks/server"
+
+const buildEvent = (id: number, title: string, isActive: boolean): Event => {
+  const start = new Date(Date.now() + id * 60 * 60 * 1000)
+  const end = new Date(start.getTime() + 60 * 60 * 1000)
+  return {
+    id,
+    title,
+    description: `${title} description`,
+    title_en: title,
+    description_en: `${title} description`,
+    location: `Hall ${id}`,
+    location_en: `Hall ${id}`,
+    event_type: null,
+    event_type_en: null,
+    starts_at: start.toISOString(),
+    ends_at: end.toISOString(),
+    created_by: 1,
+    created_at: new Date().toISOString(),
+    is_active: isActive,
+    speaker: null,
+    image_url: null,
+    about: null,
+    about_en: null,
+    files: [],
+    participant_count: 0,
+    is_registered: null,
+    my_qr_code: null,
+  }
+}
+
+const authValue = {
+  isAuth: true,
+  login: vi.fn(),
+  logout: vi.fn(),
+  user: {
+    id: 1,
+    email: "user@example.com",
+    full_name: "Test User",
+    role: "student",
+    group_id: null,
+    avatar_url: null,
+    cover_url: null,
+    about: null,
+    record_book_number: null,
+    status: null,
+    institute: null,
+    course: null,
+    education_level: null,
+    track: null,
+    program: null,
+    telegram: null,
+    achievements: null,
+    department: null,
+    position: null,
+    spotify_connected: false,
+    spotify_display_name: null,
+    spotify_is_connected: null,
+    dnd_enabled: false,
+    dnd_start: null,
+    dnd_end: null,
+    is_active: true,
+  },
+  loading: false,
+  setUser: vi.fn(),
+  refresh: vi.fn(),
+}
+
+describe("Events caching", () => {
+  it("restores cached data when a 304 response is received after switching tabs", async () => {
+    const user = userEvent.setup()
+    const activeEvents = [buildEvent(1, "Active event 1", true)]
+    const archiveEvents = [buildEvent(2, "Archived event 1", false)]
+    let activeRequestCount = 0
+
+    server.use(
+      http.get("*/events", ({ request }) => {
+        const url = new URL(request.url)
+        const isActive = url.searchParams.get("is_active")
+        if (isActive === "true") {
+          const ifNoneMatch = request.headers.get("if-none-match")
+          if (ifNoneMatch === '"active-tag"') {
+            activeRequestCount += 1
+            return new HttpResponse(null, {
+              status: 304,
+              headers: { ETag: '"active-tag"' },
+            })
+          }
+          activeRequestCount += 1
+          return HttpResponse.json(
+            {
+              items: activeEvents,
+              total: activeEvents.length,
+              limit: 12,
+              cursor: 0,
+              next_cursor: null,
+              has_more: false,
+            },
+            { headers: { ETag: '"active-tag"' } }
+          )
+        }
+        if (isActive === "false") {
+          return HttpResponse.json(
+            {
+              items: archiveEvents,
+              total: archiveEvents.length,
+              limit: 12,
+              cursor: 0,
+              next_cursor: null,
+              has_more: false,
+            },
+            { headers: { ETag: '"archive-tag"' } }
+          )
+        }
+        return HttpResponse.json({
+          items: [],
+          total: 0,
+          limit: 12,
+          cursor: 0,
+          next_cursor: null,
+          has_more: false,
+        })
+      })
+    )
+
+    render(
+      <AuthContext.Provider value={authValue}>
+        <MemoryRouter>
+          <Events />
+        </MemoryRouter>
+      </AuthContext.Provider>
+    )
+
+    expect(await screen.findByText("Active event 1")).toBeInTheDocument()
+    expect(activeRequestCount).toBe(1)
+
+    const archiveTab = await screen.findByRole("tab", { name: /past events/i })
+    await user.click(archiveTab)
+
+    expect(await screen.findByText("Archived event 1")).toBeInTheDocument()
+    expect(screen.queryByText("Active event 1")).not.toBeInTheDocument()
+
+    const activeTab = await screen.findByRole("tab", { name: /upcoming/i })
+    await user.click(activeTab)
+
+    await waitFor(() => expect(activeRequestCount).toBe(2))
+    expect(await screen.findByText("Active event 1")).toBeInTheDocument()
+    expect(screen.queryByText("Archived event 1")).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- add a dedicated cache to store event payloads per tab/filter combination
- reuse cached data on 304 responses and keep pagination state in sync when loading more
- cover the behaviour with a new Events caching test that simulates a 304 response

## Testing
- npm test -- EventsCache.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68f8159809548327aff23e4d3e454ea3