### PR TITLE
Validate attendance registration requirements

### DIFF
--- a/root/app/api/events.py
+++ b/root/app/api/events.py
@@ -2,6 +2,7 @@ import hashlib
 import json
 import logging
 import uuid
+from datetime import datetime, timezone
 from functools import lru_cache
 from typing import Any, List, Tuple
 
@@ -147,7 +148,29 @@ async def attend(
             status_code=403,
             detail=translate("errors.events.registration_forbidden", locale=locale),
         )
-    return await crud.register_attendance(db, data, user_id=user.id)
+    event = await db.get(models.Event, data.event_id)
+    if not event:
+        raise HTTPException(
+            status_code=404,
+            detail=translate("errors.events.not_found", locale=locale),
+        )
+    if not event.is_active or event.ends_at <= datetime.now(timezone.utc):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=translate("errors.events.registration_closed", locale=locale),
+        )
+    try:
+        return await crud.register_attendance(db, data, user_id=user.id)
+    except LookupError as exc:
+        raise HTTPException(
+            status_code=404,
+            detail=translate("errors.events.not_found", locale=locale),
+        ) from exc
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=translate("errors.events.registration_closed", locale=locale),
+        ) from exc
 
 
 @router.delete("/attendance", response_model=dict)

--- a/root/app/crud/__init__.py
+++ b/root/app/crud/__init__.py
@@ -483,7 +483,10 @@ async def register_attendance(
         await db.rollback()
         exist = (await db.execute(stmt)).scalar_one_or_none()
         if not exist:
-            raise
+            event = await db.get(models.Event, data.event_id)
+            if not event:
+                raise LookupError("event_not_found") from None
+            raise ValueError("attendance_registration_failed") from None
         if not exist.qr_code:
             exist.qr_code = str(uuid.uuid4())
             await db.commit()

--- a/root/app/localization.py
+++ b/root/app/localization.py
@@ -192,6 +192,10 @@ _TRANSLATIONS: Mapping[str, Mapping[str, str]] = {
         "ru": "Событие не найдено",
         "en": "Event not found",
     },
+    "errors.events.registration_closed": {
+        "ru": "Регистрация на событие закрыта",
+        "en": "Event registration is closed",
+    },
     "errors.events.file_not_found": {
         "ru": "Файл не найден",
         "en": "File not found",

--- a/root/tests/test_event_attendance_api.py
+++ b/root/tests/test_event_attendance_api.py
@@ -1,5 +1,6 @@
-import pytest
 from datetime import datetime, timedelta, timezone
+
+import pytest
 from fastapi import status
 
 from app.auth.security import get_password_hash

--- a/root/tests/test_event_attendance_api.py
+++ b/root/tests/test_event_attendance_api.py
@@ -1,0 +1,115 @@
+import pytest
+from datetime import datetime, timedelta, timezone
+from fastapi import status
+
+from app.auth.security import get_password_hash
+from app.localization import translate
+from app.models import models
+
+
+async def _login(async_client, email: str, password: str) -> dict[str, str]:
+    response = await async_client.post(
+        "/auth/login",
+        data={"username": email, "password": password},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert response.status_code == status.HTTP_200_OK
+    token = response.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.mark.anyio
+async def test_attend_registers_event(async_client, db_session, user_factory):
+    password = "AttendSuccess123!"
+    student = await user_factory(
+        hashed_password=get_password_hash(password),
+        is_active=True,
+    )
+    admin = await user_factory(role="admin")
+
+    now = datetime.now(timezone.utc)
+    event = models.Event(
+        title="Register me",
+        starts_at=now + timedelta(hours=1),
+        ends_at=now + timedelta(hours=2),
+        created_by=admin.id,
+        is_active=True,
+    )
+    db_session.add(event)
+    await db_session.commit()
+    await db_session.refresh(event)
+
+    headers = await _login(async_client, student.email, password)
+    base_headers = {**headers, "Accept-Language": "en"}
+
+    response = await async_client.post(
+        "/events/attendance",
+        headers=base_headers,
+        json={"event_id": event.id},
+    )
+    assert response.status_code == status.HTTP_200_OK
+    payload = response.json()
+    assert payload["event_id"] == event.id
+    assert payload["user_id"] == student.id
+    assert payload["qr_code"]
+
+
+@pytest.mark.anyio
+async def test_attend_missing_event_returns_not_found(
+    async_client, db_session, user_factory
+):
+    password = "AttendMissing123!"
+    student = await user_factory(
+        hashed_password=get_password_hash(password),
+        is_active=True,
+    )
+
+    headers = await _login(async_client, student.email, password)
+    base_headers = {**headers, "Accept-Language": "en"}
+
+    response = await async_client.post(
+        "/events/attendance",
+        headers=base_headers,
+        json={"event_id": 999999},
+    )
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json()["detail"] == translate(
+        "errors.events.not_found", locale="en"
+    )
+
+
+@pytest.mark.anyio
+async def test_attend_registration_closed_returns_conflict(
+    async_client, db_session, user_factory
+):
+    password = "AttendClosed123!"
+    student = await user_factory(
+        hashed_password=get_password_hash(password),
+        is_active=True,
+    )
+    admin = await user_factory(role="admin")
+
+    now = datetime.now(timezone.utc)
+    event = models.Event(
+        title="Too late",
+        starts_at=now - timedelta(hours=2),
+        ends_at=now - timedelta(hours=1),
+        created_by=admin.id,
+        is_active=True,
+    )
+    db_session.add(event)
+    await db_session.commit()
+    await db_session.refresh(event)
+
+    headers = await _login(async_client, student.email, password)
+    base_headers = {**headers, "Accept-Language": "en"}
+
+    response = await async_client.post(
+        "/events/attendance",
+        headers=base_headers,
+        json={"event_id": event.id},
+    )
+    assert response.status_code == status.HTTP_409_CONFLICT
+    assert response.json()["detail"] == translate(
+        "errors.events.registration_closed", locale="en"
+    )


### PR DESCRIPTION
## Summary
- ensure the events attendance endpoint verifies that a target event exists and can still accept registrations before delegating to CRUD logic
- surface descriptive exceptions from the attendance registration helper when a foreign key is missing and add a localized "registration closed" string
- cover successful, missing, and closed-registration attendance flows with API tests

## Testing
- pytest root/tests/test_event_attendance_api.py *(fails: ModuleNotFoundError: No module named 'fakeredis')*

------
https://chatgpt.com/codex/tasks/task_e_68f81887cc4483279a2fe9d75404f2b5