### PR TITLE
Add anyio as explicit dependency

### DIFF
--- a/root/requirements.txt
+++ b/root/requirements.txt
@@ -1,5 +1,6 @@
 fastapi>=0.115
 starlette>=0.40
+anyio>=4.0.0
 uvicorn[standard]>=0.23
 pydantic>=2
 pydantic-settings>=2


### PR DESCRIPTION
## Summary
- add anyio to the main requirements list to cover direct imports

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f81bdf15d08327b1ec5a04f3a70d3f