### PR TITLE
Fix event attendance registration timestamp handling

### DIFF
--- a/root/app/crud/__init__.py
+++ b/root/app/crud/__init__.py
@@ -466,15 +466,25 @@ async def register_attendance(
     )
     exist = (await db.execute(stmt)).scalar_one_or_none()
     if exist:
+        updated = False
+        if exist.registered_at is None:
+            exist.registered_at = datetime.now(UTC)
+            updated = True
         if not exist.qr_code:
             exist.qr_code = str(uuid.uuid4())
+            updated = True
+        if updated:
+            db.add(exist)
             await db.commit()
             await db.refresh(exist)
         return exist
 
     qr_code = str(uuid.uuid4())
     record = models.EventAttendance(
-        user_id=user_id, event_id=data.event_id, qr_code=qr_code
+        user_id=user_id,
+        event_id=data.event_id,
+        qr_code=qr_code,
+        registered_at=datetime.now(UTC),
     )
     db.add(record)
     try:
@@ -487,8 +497,15 @@ async def register_attendance(
             if not event:
                 raise LookupError("event_not_found") from None
             raise ValueError("attendance_registration_failed") from None
+        updated = False
+        if exist.registered_at is None:
+            exist.registered_at = datetime.now(UTC)
+            updated = True
         if not exist.qr_code:
             exist.qr_code = str(uuid.uuid4())
+            updated = True
+        if updated:
+            db.add(exist)
             await db.commit()
             await db.refresh(exist)
         return exist

--- a/root/tests/test_event_attendance_api.py
+++ b/root/tests/test_event_attendance_api.py
@@ -114,3 +114,56 @@ async def test_attend_registration_closed_returns_conflict(
     assert response.json()["detail"] == translate(
         "errors.events.registration_closed", locale="en"
     )
+
+
+@pytest.mark.anyio
+async def test_attend_restores_missing_registration_timestamp(
+    async_client, db_session, user_factory
+):
+    password = "AttendRestore123!"
+    student = await user_factory(
+        hashed_password=get_password_hash(password),
+        is_active=True,
+    )
+    admin = await user_factory(role="admin")
+
+    now = datetime.now(timezone.utc)
+    event = models.Event(
+        title="Restore timestamp",
+        starts_at=now + timedelta(hours=1),
+        ends_at=now + timedelta(hours=2),
+        created_by=admin.id,
+        is_active=True,
+    )
+    db_session.add(event)
+    await db_session.commit()
+    await db_session.refresh(event)
+
+    attendance = models.EventAttendance(
+        user_id=student.id,
+        event_id=event.id,
+        registered_at=None,
+        qr_code=None,
+    )
+    db_session.add(attendance)
+    await db_session.commit()
+    await db_session.refresh(attendance)
+
+    headers = await _login(async_client, student.email, password)
+    base_headers = {**headers, "Accept-Language": "en"}
+
+    response = await async_client.post(
+        "/events/attendance",
+        headers=base_headers,
+        json={"event_id": event.id},
+    )
+    assert response.status_code == status.HTTP_200_OK
+    payload = response.json()
+    assert payload["event_id"] == event.id
+    assert payload["user_id"] == student.id
+    assert payload["qr_code"]
+    assert payload["registered_at"] is not None
+
+    await db_session.refresh(attendance)
+    assert attendance.registered_at is not None
+    assert attendance.qr_code is not None


### PR DESCRIPTION
## Summary
- ensure event attendance registration always persists a timestamp and QR code before returning the record
- add a regression test covering restoration of missing registration metadata

## Testing
- pytest tests/test_event_attendance_api.py -k attend -q

------
https://chatgpt.com/codex/tasks/task_e_68f822be1fe48327a5577bc4817ab778