### PR TITLE
Add stories model and API

### DIFF
--- a/root/alembic/versions/202506200001_add_stories_table.py
+++ b/root/alembic/versions/202506200001_add_stories_table.py
@@ -1,0 +1,65 @@
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "202506200001"
+down_revision: Union[str, None] = "202506150001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "stories",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("title", sa.String(), nullable=False),
+        sa.Column("title_en", sa.String(), nullable=True),
+        sa.Column("short_text", sa.Text(), nullable=False),
+        sa.Column("short_text_en", sa.Text(), nullable=True),
+        sa.Column("cover_url", sa.String(), nullable=True),
+        sa.Column("cta_url", sa.String(), nullable=True),
+        sa.Column(
+            "published_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column(
+            "is_active",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.true(),
+        ),
+        sa.Column("created_by", sa.Integer(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(
+            ["created_by"],
+            ["users.id"],
+            name="fk_stories_created_by_users",
+            ondelete="SET NULL",
+        ),
+    )
+    op.create_index(
+        "ix_stories_expires_at_is_active",
+        "stories",
+        ["expires_at", "is_active"],
+    )
+    op.create_index("ix_stories_is_active", "stories", ["is_active"])
+    op.create_index("ix_stories_created_by", "stories", ["created_by"])
+    op.create_index("ix_stories_created_at", "stories", ["created_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_stories_created_at", table_name="stories")
+    op.drop_index("ix_stories_created_by", table_name="stories")
+    op.drop_index("ix_stories_is_active", table_name="stories")
+    op.drop_index("ix_stories_expires_at_is_active", table_name="stories")
+    op.drop_table("stories")

--- a/root/alembic/versions/202506200001_add_stories_table.py
+++ b/root/alembic/versions/202506200001_add_stories_table.py
@@ -1,8 +1,8 @@
 from typing import Sequence, Union
 
 import sqlalchemy as sa
-from alembic import op
 
+from alembic import op
 
 revision: str = "202506200001"
 down_revision: Union[str, None] = "202506150001"

--- a/root/app/api/stories.py
+++ b/root/app/api/stories.py
@@ -1,0 +1,218 @@
+import logging
+from typing import Any, List
+
+from fastapi import (
+    APIRouter,
+    Body,
+    Depends,
+    File,
+    Header,
+    HTTPException,
+    Request,
+    Response,
+    UploadFile,
+    status,
+)
+from fastapi.encoders import jsonable_encoder
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app import crud
+from app.api.deps import get_current_user
+from app.api.utils import save_upload
+from app.core.database import get_db
+from app.deps.cache import etag_matches, format_etag, get_cache
+from app.localization import (
+    DEFAULT_LOCALE,
+    SUPPORTED_LOCALES,
+    resolve_locale,
+    translate,
+)
+from app.models import models
+from app.schemas import schemas
+from app.utils.files import delete_static_file
+
+logger = logging.getLogger(__name__)
+
+
+router = APIRouter(prefix="/stories", tags=["stories"])
+
+_STORIES_LIST_CACHE_KEY = "stories:list"
+_CACHE_LOCALES: tuple[str, ...] = tuple(sorted({DEFAULT_LOCALE, *SUPPORTED_LOCALES}))
+
+
+def _normalized_cache_locale(locale: str | None) -> str:
+    candidate = (locale or "").strip().lower()
+    if candidate in SUPPORTED_LOCALES:
+        return candidate
+    return DEFAULT_LOCALE
+
+
+def _stories_list_cache_key(locale: str | None) -> str:
+    normalized = _normalized_cache_locale(locale)
+    return f"stories:list:{normalized}"
+
+
+def _stories_cache_keys() -> list[str]:
+    keys: list[str] = [_STORIES_LIST_CACHE_KEY]
+    keys.extend(_stories_list_cache_key(locale) for locale in _CACHE_LOCALES)
+    return keys
+
+
+def _set_language_headers(response: Response, locale: str) -> None:
+    from app.main import _ensure_vary_header as ensure_vary_header
+
+    response.headers["Content-Language"] = locale
+    ensure_vary_header(response, "Accept-Language")
+
+
+def _serialize_story(record: models.Story | schemas.StoryOut, locale: str) -> dict[str, Any]:
+    story = crud.serialize_story(record, locale)
+    return story.model_dump()
+
+
+@router.get("", response_model=List[schemas.StoryOut])
+async def list_stories(
+    request: Request,
+    response: Response,
+    if_none_match: str | None = Header(default=None),
+    db: AsyncSession = Depends(get_db),
+):
+    locale = resolve_locale(request=request)
+    normalized_locale = _normalized_cache_locale(locale)
+    cache = get_cache()
+    cache_key = _stories_list_cache_key(locale)
+    legacy_key = _STORIES_LIST_CACHE_KEY if normalized_locale == DEFAULT_LOCALE else None
+
+    if cache.enabled:
+        cached = await cache.get(cache_key)
+        if not cached and legacy_key:
+            cached = await cache.get(legacy_key)
+        if cached:
+            etag_header = format_etag(cached.etag)
+            if etag_matches(cached.etag, if_none_match):
+                not_modified = Response(
+                    status_code=status.HTTP_304_NOT_MODIFIED,
+                    headers={"ETag": etag_header},
+                )
+                _set_language_headers(not_modified, normalized_locale)
+                return not_modified
+            response.headers["ETag"] = etag_header
+            _set_language_headers(response, normalized_locale)
+            return cached.payload
+
+    rows = await crud.list_active_stories(db)
+    serialized = [_serialize_story(item, locale) for item in rows]
+    encoded = jsonable_encoder(serialized)
+
+    if cache.enabled:
+        entry = await cache.set(cache_key, encoded)
+        response.headers["ETag"] = format_etag(entry.etag)
+    _set_language_headers(response, normalized_locale)
+    return encoded
+
+
+@router.post("", response_model=schemas.StoryOut)
+async def create_story(
+    data: schemas.StoryCreate,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    user: models.User = Depends(get_current_user),
+):
+    locale = resolve_locale(request=request, user=user)
+    if user.role != "admin":
+        raise HTTPException(
+            status_code=403,
+            detail=translate("errors.forbidden", locale=locale),
+        )
+    record = await crud.create_story(db, data, created_by=user.id)
+    cache = get_cache()
+    await cache.invalidate(*_stories_cache_keys())
+    serialized = crud.serialize_story(record, locale)
+    return serialized
+
+
+@router.patch("/{story_id}", response_model=schemas.StoryOut)
+async def update_story(
+    story_id: int,
+    request: Request,
+    data: schemas.StoryUpdate | None = Body(default=None),
+    db: AsyncSession = Depends(get_db),
+    user: models.User = Depends(get_current_user),
+):
+    locale = resolve_locale(request=request, user=user)
+    story = await db.get(models.Story, story_id)
+    if not story:
+        raise HTTPException(
+            status_code=404,
+            detail=translate("errors.stories.not_found", locale=locale),
+        )
+    if user.role != "admin":
+        raise HTTPException(
+            status_code=403,
+            detail=translate("errors.forbidden", locale=locale),
+        )
+    old_cover = story.cover_url
+    updated = await crud.update_story(db, story, data)
+    if old_cover and updated.cover_url != old_cover:
+        try:
+            await delete_static_file(old_cover)
+        except Exception:  # pragma: no cover - cleanup best effort
+            logger.warning(
+                "Failed to delete old story cover", extra={"story_id": story_id}, exc_info=True
+            )
+    cache = get_cache()
+    await cache.invalidate(*_stories_cache_keys())
+    return crud.serialize_story(updated, locale)
+
+
+@router.delete("/{story_id}", response_model=dict)
+async def delete_story(
+    story_id: int,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    user: models.User = Depends(get_current_user),
+):
+    locale = resolve_locale(request=request, user=user)
+    story = await db.get(models.Story, story_id)
+    if not story:
+        raise HTTPException(
+            status_code=404,
+            detail=translate("errors.stories.not_found", locale=locale),
+        )
+    if user.role != "admin":
+        raise HTTPException(
+            status_code=403,
+            detail=translate("errors.forbidden", locale=locale),
+        )
+    cover_url = story.cover_url
+    await crud.delete_story(db, story)
+    if cover_url:
+        try:
+            await delete_static_file(cover_url)
+        except Exception:  # pragma: no cover - cleanup best effort
+            logger.warning(
+                "Failed to delete story cover", extra={"story_id": story_id}, exc_info=True
+            )
+    cache = get_cache()
+    await cache.invalidate(*_stories_cache_keys())
+    return {"ok": True}
+
+
+@router.post("/upload_cover")
+async def upload_story_cover(
+    file: UploadFile = File(...),
+    *,
+    request: Request,
+    user: models.User = Depends(get_current_user),
+):
+    locale = resolve_locale(request=request, user=user)
+    if user.role != "admin":
+        raise HTTPException(
+            status_code=403,
+            detail=translate("errors.forbidden", locale=locale),
+        )
+    url = await save_upload(file, "story_covers", "stories", locale=locale)
+    return {"url": url}
+
+
+__all__ = ["router"]

--- a/root/app/api/stories.py
+++ b/root/app/api/stories.py
@@ -65,7 +65,9 @@ def _set_language_headers(response: Response, locale: str) -> None:
     ensure_vary_header(response, "Accept-Language")
 
 
-def _serialize_story(record: models.Story | schemas.StoryOut, locale: str) -> dict[str, Any]:
+def _serialize_story(
+    record: models.Story | schemas.StoryOut, locale: str
+) -> dict[str, Any]:
     story = crud.serialize_story(record, locale)
     return story.model_dump()
 
@@ -81,7 +83,9 @@ async def list_stories(
     normalized_locale = _normalized_cache_locale(locale)
     cache = get_cache()
     cache_key = _stories_list_cache_key(locale)
-    legacy_key = _STORIES_LIST_CACHE_KEY if normalized_locale == DEFAULT_LOCALE else None
+    legacy_key = (
+        _STORIES_LIST_CACHE_KEY if normalized_locale == DEFAULT_LOCALE else None
+    )
 
     if cache.enabled:
         cached = await cache.get(cache_key)
@@ -158,7 +162,9 @@ async def update_story(
             await delete_static_file(old_cover)
         except Exception:  # pragma: no cover - cleanup best effort
             logger.warning(
-                "Failed to delete old story cover", extra={"story_id": story_id}, exc_info=True
+                "Failed to delete old story cover",
+                extra={"story_id": story_id},
+                exc_info=True,
             )
     cache = get_cache()
     await cache.invalidate(*_stories_cache_keys())
@@ -191,7 +197,9 @@ async def delete_story(
             await delete_static_file(cover_url)
         except Exception:  # pragma: no cover - cleanup best effort
             logger.warning(
-                "Failed to delete story cover", extra={"story_id": story_id}, exc_info=True
+                "Failed to delete story cover",
+                extra={"story_id": story_id},
+                exc_info=True,
             )
     cache = get_cache()
     await cache.invalidate(*_stories_cache_keys())

--- a/root/app/crud/__init__.py
+++ b/root/app/crud/__init__.py
@@ -174,9 +174,7 @@ async def update_story(
     if "title_en" in payload:
         payload["title_en"] = sanitize_optional_text(payload.get("title_en"))
     if "short_text_en" in payload:
-        payload["short_text_en"] = sanitize_optional_text(
-            payload.get("short_text_en")
-        )
+        payload["short_text_en"] = sanitize_optional_text(payload.get("short_text_en"))
     if "cover_url" in payload:
         payload["cover_url"] = sanitize_optional_text(payload.get("cover_url"))
     if "cta_url" in payload:

--- a/root/app/crud/__init__.py
+++ b/root/app/crud/__init__.py
@@ -137,6 +137,112 @@ async def get_news_list(db: AsyncSession, skip: int = 0, limit: int = 10):
     return result.scalars().all()
 
 
+async def create_story(
+    db: AsyncSession,
+    story: schemas.StoryCreate,
+    *,
+    created_by: int | None = None,
+):
+    payload = story.model_dump()
+    payload["title_en"] = sanitize_optional_text(payload.get("title_en"))
+    payload["short_text_en"] = sanitize_optional_text(payload.get("short_text_en"))
+    payload["cover_url"] = sanitize_optional_text(payload.get("cover_url"))
+    payload["cta_url"] = sanitize_optional_text(payload.get("cta_url"))
+
+    published_at = payload.get("published_at")
+    expires_at = payload.get("expires_at")
+    if published_at is not None:
+        payload["published_at"] = _ensure_utc(published_at)
+    if expires_at is not None:
+        payload["expires_at"] = _ensure_utc(expires_at)
+    if created_by is not None:
+        payload["created_by"] = created_by
+
+    record = models.Story(**payload)
+    db.add(record)
+    await db.commit()
+    await db.refresh(record)
+    return record
+
+
+async def update_story(
+    db: AsyncSession,
+    story: models.Story,
+    updates: schemas.StoryUpdate | None,
+) -> models.Story:
+    payload = updates.model_dump(exclude_unset=True) if updates else {}
+    if "title_en" in payload:
+        payload["title_en"] = sanitize_optional_text(payload.get("title_en"))
+    if "short_text_en" in payload:
+        payload["short_text_en"] = sanitize_optional_text(
+            payload.get("short_text_en")
+        )
+    if "cover_url" in payload:
+        payload["cover_url"] = sanitize_optional_text(payload.get("cover_url"))
+    if "cta_url" in payload:
+        payload["cta_url"] = sanitize_optional_text(payload.get("cta_url"))
+    if "published_at" in payload and payload["published_at"] is not None:
+        payload["published_at"] = _ensure_utc(payload["published_at"])
+    if "expires_at" in payload and payload["expires_at"] is not None:
+        payload["expires_at"] = _ensure_utc(payload["expires_at"])
+
+    for field, value in payload.items():
+        setattr(story, field, value)
+
+    await db.commit()
+    await db.refresh(story)
+    return story
+
+
+async def list_active_stories(
+    db: AsyncSession,
+    *,
+    reference_time: datetime | None = None,
+) -> List[models.Story]:
+    now = reference_time or datetime.now(UTC)
+    now_utc = _ensure_utc(now)
+    stmt = (
+        select(models.Story)
+        .where(
+            models.Story.is_active.is_(True),
+            models.Story.published_at <= now_utc,
+            models.Story.expires_at > now_utc,
+        )
+        .order_by(models.Story.published_at.desc(), models.Story.id.desc())
+    )
+    rows = await db.execute(stmt)
+    return list(rows.scalars().all())
+
+
+async def delete_story(db: AsyncSession, story: models.Story) -> None:
+    await db.delete(story)
+    await db.commit()
+
+
+def serialize_story(
+    story: models.Story | schemas.StoryOut,
+    locale: str | None,
+) -> schemas.StoryOut:
+    normalized_locale = normalize_locale(locale)
+    story_out = (
+        story
+        if isinstance(story, schemas.StoryOut)
+        else schemas.StoryOut.model_validate(story)
+    )
+    data = story_out.model_dump()
+    data["title"] = localized_text(
+        normalized_locale,
+        ru=data.get("title"),
+        en=data.get("title_en"),
+    ) or (data.get("title") or "")
+    data["short_text"] = localized_text(
+        normalized_locale,
+        ru=data.get("short_text"),
+        en=data.get("short_text_en"),
+    ) or (data.get("short_text") or "")
+    return schemas.StoryOut.model_validate(data)
+
+
 async def _attendance_counts(db: AsyncSession, event_ids: List[int]) -> Dict[int, int]:
     if not event_ids:
         return {}

--- a/root/app/main.py
+++ b/root/app/main.py
@@ -14,6 +14,7 @@ from app.api.schedule import router as schedule_api_router
 from app.api.sessions import router as sessions_router
 from app.api.spotify import router as spotify_router
 from app.api.stats import router as stats_router
+from app.api.stories import router as stories_router
 from app.api.users import router as users_router
 from app.auth.auth import router as auth_router
 from app.core.config import settings
@@ -210,5 +211,6 @@ app.include_router(schedule_router)
 app.include_router(users_router)
 app.include_router(events_router)
 app.include_router(news_router)
+app.include_router(stories_router)
 app.include_router(schedule_api_router)
 app.include_router(stats_router)

--- a/root/app/models/models.py
+++ b/root/app/models/models.py
@@ -14,10 +14,10 @@ from sqlalchemy import (
     Text,
     Time,
     UniqueConstraint,
+    event,
     func,
     text,
 )
-from sqlalchemy import event
 from sqlalchemy.orm import relationship
 
 from app.core.database import Base

--- a/root/app/models/models.py
+++ b/root/app/models/models.py
@@ -1,4 +1,5 @@
 import secrets
+from datetime import UTC, datetime, timedelta
 
 from sqlalchemy import (
     JSON,
@@ -16,6 +17,7 @@ from sqlalchemy import (
     func,
     text,
 )
+from sqlalchemy import event
 from sqlalchemy.orm import relationship
 
 from app.core.database import Base
@@ -233,6 +235,70 @@ class News(Base):
     content_en = Column(Text)
     image_url = Column(String)
     created_at = Column(DateTime(timezone=True), server_default=func.now(), index=True)
+
+
+def _utcnow() -> datetime:
+    return datetime.now(UTC)
+
+
+class Story(Base):
+    __tablename__ = "stories"
+    __table_args__ = (
+        Index("ix_stories_expires_at_is_active", "expires_at", "is_active"),
+    )
+
+    id = Column(Integer, primary_key=True)
+    title = Column(String, nullable=False)
+    title_en = Column(String)
+    short_text = Column(Text, nullable=False)
+    short_text_en = Column(Text)
+    cover_url = Column(String)
+    cta_url = Column(String)
+    published_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=_utcnow,
+        server_default=func.now(),
+    )
+    expires_at = Column(DateTime(timezone=True), nullable=False)
+    is_active = Column(
+        Boolean,
+        nullable=False,
+        default=True,
+        server_default=text("true"),
+        index=True,
+    )
+    created_by = Column(
+        Integer,
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    created_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=_utcnow,
+        server_default=func.now(),
+        index=True,
+    )
+
+    created_by_user = relationship("User")
+
+
+@event.listens_for(Story, "before_insert")
+def _set_story_expiration(_, __, target: "Story") -> None:
+    if target.published_at is None:
+        target.published_at = _utcnow()
+    if target.expires_at is None and target.published_at is not None:
+        target.expires_at = target.published_at + timedelta(hours=24)
+
+
+@event.listens_for(Story, "before_update")
+def _ensure_story_expiration(_, __, target: "Story") -> None:
+    if target.published_at is None:
+        target.published_at = _utcnow()
+    if target.expires_at is None and target.published_at is not None:
+        target.expires_at = target.published_at + timedelta(hours=24)
 
 
 class InviteCode(Base):

--- a/root/app/schemas/schemas.py
+++ b/root/app/schemas/schemas.py
@@ -197,6 +197,86 @@ class NewsOut(OrmModel, NewsCreate):
     created_at: datetime
 
 
+class StoryCreate(BaseModel):
+    title: str
+    title_en: Optional[str] = None
+    short_text: str
+    short_text_en: Optional[str] = None
+    cover_url: Optional[str] = None
+    cta_url: Optional[str] = None
+    published_at: Optional[datetime] = None
+    expires_at: Optional[datetime] = None
+    is_active: bool = True
+
+    @field_validator("title_en", "short_text_en", "cover_url", "cta_url", mode="before")
+    @classmethod
+    def _strip_optional(cls, value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            text = value.strip()
+            return text or None
+        text = str(value).strip()
+        return text or None
+
+    @model_validator(mode="after")
+    def _validate_expiration(self):  # type: ignore[override]
+        published = self.published_at
+        expires = self.expires_at
+        if expires is not None and published is not None and expires <= published:
+            raise ValueError(translate("validation.stories.expires_after_publish"))
+        return self
+
+
+class StoryUpdate(BaseModel):
+    title: Optional[str] = None
+    title_en: Optional[str] = None
+    short_text: Optional[str] = None
+    short_text_en: Optional[str] = None
+    cover_url: Optional[str] = None
+    cta_url: Optional[str] = None
+    published_at: Optional[datetime] = None
+    expires_at: Optional[datetime] = None
+    is_active: Optional[bool] = None
+
+    @field_validator("title_en", "short_text_en", "cover_url", "cta_url", mode="before")
+    @classmethod
+    def _strip_optional(cls, value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            text = value.strip()
+            return text or None
+        text = str(value).strip()
+        return text or None
+
+    @model_validator(mode="after")
+    def _validate_expiration(self):  # type: ignore[override]
+        provided = self.model_fields_set
+        if "published_at" in provided and "expires_at" in provided:
+            if self.published_at is not None and self.expires_at is not None:
+                if self.expires_at <= self.published_at:
+                    raise ValueError(
+                        translate("validation.stories.expires_after_publish")
+                    )
+        return self
+
+
+class StoryOut(OrmModel):
+    id: int
+    title: str
+    title_en: Optional[str] = None
+    short_text: str
+    short_text_en: Optional[str] = None
+    cover_url: Optional[str] = None
+    cta_url: Optional[str] = None
+    published_at: datetime
+    expires_at: datetime
+    is_active: bool
+    created_by: Optional[int] = None
+    created_at: datetime
+
+
 class EventFileOut(OrmModel):
     id: int
     event_id: int


### PR DESCRIPTION
## Summary
- add the Story ORM model with automatic expiration defaults and create an Alembic migration for the stories table
- extend the schemas and CRUD helpers to support creating, updating, listing, deleting, and serializing stories
- introduce the stories API with localized, cached listings, admin-only mutations, optional cover uploads, and register the router in the main app

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'fakeredis')*

------
https://chatgpt.com/codex/tasks/task_e_68f8ab3a90148327b5ba488cbfa73786