### PR TITLE
Add scheduled cleanup for expired stories

### DIFF
--- a/root/alembic/versions/202506200001_add_stories_table.py
+++ b/root/alembic/versions/202506200001_add_stories_table.py
@@ -10,51 +10,73 @@ branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
 
+def _table_exists(inspector: sa.Inspector, table_name: str) -> bool:
+    return table_name in inspector.get_table_names()
+
+
 def upgrade() -> None:
-    op.create_table(
-        "stories",
-        sa.Column("id", sa.Integer(), primary_key=True),
-        sa.Column("title", sa.String(), nullable=False),
-        sa.Column("title_en", sa.String(), nullable=True),
-        sa.Column("short_text", sa.Text(), nullable=False),
-        sa.Column("short_text_en", sa.Text(), nullable=True),
-        sa.Column("cover_url", sa.String(), nullable=True),
-        sa.Column("cta_url", sa.String(), nullable=True),
-        sa.Column(
-            "published_at",
-            sa.DateTime(timezone=True),
-            nullable=False,
-            server_default=sa.func.now(),
-        ),
-        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
-        sa.Column(
-            "is_active",
-            sa.Boolean(),
-            nullable=False,
-            server_default=sa.true(),
-        ),
-        sa.Column("created_by", sa.Integer(), nullable=True),
-        sa.Column(
-            "created_at",
-            sa.DateTime(timezone=True),
-            nullable=False,
-            server_default=sa.func.now(),
-        ),
-        sa.ForeignKeyConstraint(
-            ["created_by"],
-            ["users.id"],
-            name="fk_stories_created_by_users",
-            ondelete="SET NULL",
-        ),
-    )
-    op.create_index(
-        "ix_stories_expires_at_is_active",
-        "stories",
-        ["expires_at", "is_active"],
-    )
-    op.create_index("ix_stories_is_active", "stories", ["is_active"])
-    op.create_index("ix_stories_created_by", "stories", ["created_by"])
-    op.create_index("ix_stories_created_at", "stories", ["created_at"])
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    table_name = "stories"
+
+    table_exists = _table_exists(inspector, table_name)
+
+    if not table_exists:
+        op.create_table(
+            table_name,
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("title", sa.String(), nullable=False),
+            sa.Column("title_en", sa.String(), nullable=True),
+            sa.Column("short_text", sa.Text(), nullable=False),
+            sa.Column("short_text_en", sa.Text(), nullable=True),
+            sa.Column("cover_url", sa.String(), nullable=True),
+            sa.Column("cta_url", sa.String(), nullable=True),
+            sa.Column(
+                "published_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+            sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column(
+                "is_active",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.true(),
+            ),
+            sa.Column("created_by", sa.Integer(), nullable=True),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+            sa.ForeignKeyConstraint(
+                ["created_by"],
+                ["users.id"],
+                name="fk_stories_created_by_users",
+                ondelete="SET NULL",
+            ),
+        )
+
+    inspector = sa.inspect(bind)
+    if _table_exists(inspector, table_name):
+        existing_indexes = {index["name"] for index in inspector.get_indexes(table_name)}
+    else:
+        existing_indexes = set()
+
+    if "ix_stories_expires_at_is_active" not in existing_indexes:
+        op.create_index(
+            "ix_stories_expires_at_is_active",
+            table_name,
+            ["expires_at", "is_active"],
+        )
+    if "ix_stories_is_active" not in existing_indexes:
+        op.create_index("ix_stories_is_active", table_name, ["is_active"])
+    if "ix_stories_created_by" not in existing_indexes:
+        op.create_index("ix_stories_created_by", table_name, ["created_by"])
+    if "ix_stories_created_at" not in existing_indexes:
+        op.create_index("ix_stories_created_at", table_name, ["created_at"])
 
 
 def downgrade() -> None:

--- a/root/alembic/versions/202506200001_add_stories_table.py
+++ b/root/alembic/versions/202506200001_add_stories_table.py
@@ -61,7 +61,9 @@ def upgrade() -> None:
 
     inspector = sa.inspect(bind)
     if _table_exists(inspector, table_name):
-        existing_indexes = {index["name"] for index in inspector.get_indexes(table_name)}
+        existing_indexes = {
+            index["name"] for index in inspector.get_indexes(table_name)
+        }
     else:
         existing_indexes = set()
 

--- a/root/app/core/config.py
+++ b/root/app/core/config.py
@@ -155,6 +155,8 @@ class Settings(BaseSettings):
     notifications_queue_enqueue_timeout_seconds: float = 0.5
     notifications_queue_in_memory_only: bool = False
     session_cleanup_interval_seconds: int = 900
+    stories_cleanup_enabled: bool = True
+    stories_retention_cleanup_interval_seconds: int = 86_400
     event_file_allowed_mime_types: str | list[str] = (
         "application/pdf,"
         "text/plain,"

--- a/root/app/main.py
+++ b/root/app/main.py
@@ -41,6 +41,11 @@ from app.services.session_cleanup import (
     cleanup_expired_sessions,
     start_session_cleanup_scheduler,
 )
+from app.services.story_cleanup import (
+    StoryCleanupConfig,
+    cleanup_expired_stories,
+    start_story_cleanup_scheduler,
+)
 
 try:
     from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
@@ -57,6 +62,7 @@ async def lifespan(app: FastAPI):
     stop_scheduler = None
     stop_notifications_retention = None
     stop_session_cleanup = None
+    stop_story_cleanup = None
     if settings.is_development and settings.notifications_scheduler_inline_enabled:
         stop_scheduler = await start_notifications_scheduler(
             poll_seconds=settings.notifications_scheduler_poll_seconds,
@@ -67,6 +73,7 @@ async def lifespan(app: FastAPI):
         retention_days=settings.notifications_retention_days
     )
     await cleanup_expired_sessions()
+    await cleanup_expired_stories()
     if (
         settings.notifications_retention_days > 0
         and settings.notifications_retention_cleanup_interval_seconds > 0
@@ -83,6 +90,15 @@ async def lifespan(app: FastAPI):
                 interval_seconds=settings.session_cleanup_interval_seconds
             )
         )
+    if (
+        settings.stories_cleanup_enabled
+        and settings.stories_retention_cleanup_interval_seconds > 0
+    ):
+        stop_story_cleanup = await start_story_cleanup_scheduler(
+            config=StoryCleanupConfig(
+                interval_seconds=settings.stories_retention_cleanup_interval_seconds
+            )
+        )
     try:
         yield
     finally:
@@ -92,6 +108,8 @@ async def lifespan(app: FastAPI):
             await stop_notifications_retention()
         if stop_session_cleanup is not None:
             await stop_session_cleanup()
+        if stop_story_cleanup is not None:
+            await stop_story_cleanup()
         await notification_queue.shutdown_notification_queue()
         webpush.cleanup()
         await shutdown_cache()

--- a/root/app/management/stories_cleanup.py
+++ b/root/app/management/stories_cleanup.py
@@ -1,0 +1,16 @@
+"""Manual entrypoint for running story cleanup."""
+
+from __future__ import annotations
+
+import asyncio
+
+from app.services.story_cleanup import cleanup_expired_stories
+
+
+def main() -> None:
+    removed = asyncio.run(cleanup_expired_stories())
+    print(f"Removed {removed} expired stories")
+
+
+if __name__ == "__main__":
+    main()

--- a/root/app/services/story_cleanup.py
+++ b/root/app/services/story_cleanup.py
@@ -1,0 +1,92 @@
+"""Utilities for removing expired stories from the database."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from contextlib import suppress
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Awaitable, Callable
+
+from sqlalchemy import delete
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import async_session
+from app.models.models import Story
+
+logger = logging.getLogger(__name__)
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+async def cleanup_expired_stories(
+    *, db: AsyncSession | None = None, now: datetime | None = None
+) -> int:
+    """Remove stories whose expiration timestamp has already passed."""
+
+    owns_session = db is None
+    if now is None:
+        now = _now()
+    if owns_session:
+        async with async_session() as session:
+            return await cleanup_expired_stories(db=session, now=now)
+
+    stmt = delete(Story).where(Story.expires_at <= now)
+    result = await db.execute(stmt)
+    await db.commit()
+    deleted = int(result.rowcount or 0)
+    if deleted:
+        logger.info("Removed %s expired stories", deleted)
+    return deleted
+
+
+@dataclass(slots=True)
+class StoryCleanupConfig:
+    interval_seconds: int = 86_400
+
+    def normalized_interval(self) -> int:
+        return max(60, int(self.interval_seconds))
+
+
+async def start_story_cleanup_scheduler(
+    *, config: StoryCleanupConfig | None = None
+) -> Callable[[], Awaitable[None]]:
+    """Start a background task that periodically removes expired stories."""
+
+    cfg = config or StoryCleanupConfig()
+    interval = cfg.normalized_interval()
+
+    async def _loop() -> None:
+        try:
+            while True:
+                try:
+                    await cleanup_expired_stories()
+                except asyncio.CancelledError:
+                    raise
+                except Exception:  # pragma: no cover - defensive logging
+                    logger.exception("Failed to cleanup expired stories")
+                await asyncio.sleep(interval)
+        except asyncio.CancelledError:
+            logger.info("Story cleanup loop cancelled")
+            raise
+
+    loop = asyncio.get_running_loop()
+    task = loop.create_task(_loop())
+
+    async def _stop() -> None:
+        if task.done():
+            with suppress(Exception):
+                task.result()
+            return
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+
+    return _stop
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience entrypoint
+    asyncio.run(cleanup_expired_stories())

--- a/root/app/services/story_cleanup.py
+++ b/root/app/services/story_cleanup.py
@@ -39,9 +39,7 @@ async def cleanup_expired_stories(
             return await cleanup_expired_stories(db=session, now=now)
 
     stmt = delete(Story).where(Story.expires_at <= now)
-    result = await db.execute(
-        stmt.execution_options(synchronize_session=False)
-    )
+    result = await db.execute(stmt.execution_options(synchronize_session=False))
     await db.commit()
     deleted = int(result.rowcount or 0)
     if deleted:

--- a/root/app/services/story_cleanup.py
+++ b/root/app/services/story_cleanup.py
@@ -30,12 +30,18 @@ async def cleanup_expired_stories(
     owns_session = db is None
     if now is None:
         now = _now()
+    elif now.tzinfo is None:
+        now = now.replace(tzinfo=UTC)
+    else:
+        now = now.astimezone(UTC)
     if owns_session:
         async with async_session() as session:
             return await cleanup_expired_stories(db=session, now=now)
 
     stmt = delete(Story).where(Story.expires_at <= now)
-    result = await db.execute(stmt)
+    result = await db.execute(
+        stmt.execution_options(synchronize_session=False)
+    )
     await db.commit()
     deleted = int(result.rowcount or 0)
     if deleted:

--- a/root/tests/conftest.py
+++ b/root/tests/conftest.py
@@ -1,4 +1,5 @@
 import asyncio
+import datetime as dt
 import os
 import sys
 import uuid
@@ -196,6 +197,18 @@ async def async_client(
         main, "start_session_cleanup_scheduler", _start_session_cleanup_scheduler
     )
 
+    async def _start_story_cleanup_scheduler(
+        *args, **kwargs
+    ) -> Callable[[], Awaitable[None]]:
+        async def _stop() -> None:
+            return None
+
+        return _stop
+
+    monkeypatch.setattr(
+        main, "start_story_cleanup_scheduler", _start_story_cleanup_scheduler
+    )
+
     transport = httpx.ASGITransport(app=main.app)
     async with LifespanManager(main.app):
         async with httpx.AsyncClient(
@@ -252,6 +265,27 @@ async def user_factory(db_session) -> Callable[..., Awaitable[models.User]]:
         await db_session.commit()
         await db_session.refresh(user)
         return user
+
+    return _factory
+
+
+@pytest.fixture
+async def story_factory(db_session) -> Callable[..., Awaitable[models.Story]]:
+    async def _factory(**kwargs) -> models.Story:
+        now = dt.datetime.now(dt.UTC)
+        defaults = {
+            "title": f"Story {uuid.uuid4().hex[:8]}",
+            "short_text": "Story body",
+            "expires_at": now + dt.timedelta(hours=24),
+            "published_at": now,
+            "is_active": True,
+        }
+        defaults.update(kwargs)
+        story = models.Story(**defaults)
+        db_session.add(story)
+        await db_session.commit()
+        await db_session.refresh(story)
+        return story
 
     return _factory
 

--- a/root/tests/test_story_cleanup.py
+++ b/root/tests/test_story_cleanup.py
@@ -1,0 +1,37 @@
+import datetime as dt
+
+import pytest
+from sqlalchemy import select
+
+from app.models.models import Story
+from app.services.story_cleanup import cleanup_expired_stories
+
+
+@pytest.mark.asyncio
+async def test_cleanup_expired_stories_removes_expired(db_session, story_factory):
+    now = dt.datetime.now(dt.UTC)
+
+    expired = await story_factory(
+        title="Expired",
+        expires_at=now - dt.timedelta(minutes=10),
+        published_at=now - dt.timedelta(hours=1),
+    )
+    boundary = await story_factory(
+        title="Boundary",
+        expires_at=now,
+        published_at=now - dt.timedelta(hours=2),
+    )
+    active = await story_factory(
+        title="Active",
+        expires_at=now + dt.timedelta(hours=1),
+        published_at=now - dt.timedelta(minutes=30),
+    )
+
+    removed = await cleanup_expired_stories(db=db_session, now=now)
+    assert removed == 2
+
+    result = await db_session.execute(select(Story.id))
+    remaining = set(result.scalars().all())
+    assert remaining == {active.id}
+    assert expired.id not in remaining
+    assert boundary.id not in remaining


### PR DESCRIPTION
## Summary
- add a story cleanup service with a scheduler and manual CLI entrypoint
- expose configuration for controlling story cleanup interval and enablement
- invoke story cleanup during application lifespan and extend tests/fixtures

## Testing
- pytest root/tests/test_story_cleanup.py root/tests/test_session_cleanup.py *(fails: ModuleNotFoundError: No module named 'fakeredis')*

------
https://chatgpt.com/codex/tasks/task_e_68f8af090d588327b3c0bfe561095d85