### PR TITLE
Simplify dashboard stories presentation

### DIFF
--- a/root/frontend/src/app/__tests__/a11y.test.tsx
+++ b/root/frontend/src/app/__tests__/a11y.test.tsx
@@ -171,14 +171,12 @@ describe("Accessibility checks", () => {
       },
     ]
 
-    const getSpy = vi
-      .spyOn(api, "get")
-      .mockImplementation(async (url: string) => {
-        if (url === "/stories") {
-          return { data: stories, status: 200, headers: {} } as any
-        }
-        return { data: [], status: 200, headers: {} } as any
-      })
+    const getSpy = vi.spyOn(api, "get").mockImplementation(async (url: string) => {
+      if (url === "/stories") {
+        return { data: stories, status: 200, headers: {} } as any
+      }
+      return { data: [], status: 200, headers: {} } as any
+    })
 
     const { Wrapper } = createWrapper("/dashboard")
     const { container } = render(<Dashboard />, { wrapper: Wrapper })

--- a/root/frontend/src/components/DashboardStories.tsx
+++ b/root/frontend/src/components/DashboardStories.tsx
@@ -311,6 +311,9 @@ export default function DashboardStories({
       onPointerEnter={onPrefetch}
       onFocusCapture={onPrefetch}
     >
+      <Typography component="h2" variant="h6" sx={{ ...visuallyHidden }}>
+        {t("stories.heading")}
+      </Typography>
       {loading && (
         <Stack direction="row" spacing={1.6} sx={{ flexWrap: "wrap", rowGap: 1.6 }}>
           {Array.from({ length: SKELETON_COUNT }).map((_, index) => (

--- a/root/frontend/src/components/DashboardStories.tsx
+++ b/root/frontend/src/components/DashboardStories.tsx
@@ -17,7 +17,6 @@ import {
   Button,
   ButtonBase,
   Dialog,
-  Divider,
   IconButton,
   LinearProgress,
   Skeleton,
@@ -30,7 +29,6 @@ import { visuallyHidden } from "@mui/utils"
 import CloseRoundedIcon from "@mui/icons-material/CloseRounded"
 import ArrowBackIosNewRoundedIcon from "@mui/icons-material/ArrowBackIosNewRounded"
 import ArrowForwardIosRoundedIcon from "@mui/icons-material/ArrowForwardIosRounded"
-import { cardHoverSx } from "@/constants/cardHover"
 import { useTranslation } from "react-i18next"
 import { Link } from "react-router-dom"
 
@@ -60,7 +58,6 @@ export default function DashboardStories({
   const listLabel = t("aria.storiesList")
   const emptyLabel = t("stories.empty")
   const emptyDescription = t("stories.emptyDescription")
-  const subheading = t("stories.subheading")
 
   const displayStories = useMemo(() => {
     const filtered = Array.isArray(stories) ? stories.filter(Boolean) : []
@@ -279,7 +276,6 @@ export default function DashboardStories({
     return hints
   }, [autoHint, isMobile, keyboardHint, swipeHint, tapHint])
 
-  const hasSubheading = subheading && subheading !== "stories.subheading"
   const hasEmptyDescription =
     emptyDescription && emptyDescription !== "stories.emptyDescription"
   const hasViewerInstructions =
@@ -312,61 +308,17 @@ export default function DashboardStories({
   return (
     <Box
       data-fade
-      style={{ "--fade-delay": "120ms" } as CSSProperties}
-      sx={{
-        ...cardHoverSx({ hoverTransform: null, hoverBoxShadow: null }),
-        background: "var(--card-bg)",
-        borderRadius: "2rem",
-        border: {
-          xs: "1px solid color-mix(in srgb, var(--page-text) 12%, transparent)",
-          md: "1px solid transparent",
-        },
-        p: { xs: 2, md: 2.5 },
-        boxShadow: {
-          xs: "0 16px 40px rgba(0,0,0,.22), 0 6px 16px rgba(0,0,0,.12)",
-          md: "var(--shadow-1)",
-        },
-        backdropFilter: { xs: "saturate(110%)", md: "none" },
-        mt: 3,
-        mb: 3,
-      }}
+      style={{ "--fade-delay": "120ms" } as CSSProperties }
+      sx={{ mt: 3, mb: 3, display: "flex", flexDirection: "column", gap: 2 }}
       aria-busy={loading}
       onPointerEnter={onPrefetch}
       onFocusCapture={onPrefetch}
     >
-      <Stack spacing={0.75} sx={{ mb: 0.5 }}>
-        <Stack direction="row" alignItems="center" justifyContent="space-between">
-          <Typography
-            component="h2"
-            sx={{ fontWeight: 800, fontSize: "clamp(1.05rem, 2vw, 1.4rem)" }}
-          >
-            {t("stories.heading")}
-          </Typography>
-          {viewerStory && viewerStory.cta_url && (
-            <Button
-              size="small"
-              variant="contained"
-              color="primary"
-              {...(linkPropsFor(viewerStory.cta_url) ?? {})}
-              sx={{ textTransform: "none" }}
-            >
-              {t("stories.viewer.openLink")}
-            </Button>
-          )}
-        </Stack>
-        {hasSubheading && (
-          <Typography variant="body2" color="text.secondary">
-            {subheading}
-          </Typography>
-        )}
-      </Stack>
-      <Divider sx={{ my: 1.5 }} />
       {loading && (
         <Stack direction="row" spacing={1.6} sx={{ flexWrap: "wrap", rowGap: 1.6 }}>
           {Array.from({ length: SKELETON_COUNT }).map((_, index) => (
-            <Stack key={index} spacing={0.9} alignItems="center" sx={{ width: 92 }}>
+            <Stack key={index} alignItems="center" sx={{ width: 92 }}>
               <Skeleton variant="circular" width={76} height={76} />
-              <Skeleton width={70} height={18} />
             </Stack>
           ))}
         </Stack>
@@ -410,7 +362,6 @@ export default function DashboardStories({
               <Stack
                 key={story.id}
                 component="li"
-                spacing={0.9}
                 alignItems="center"
                 sx={{ width: 92, flex: { xs: "0 0 auto", sm: "0 0 92px" } }}
               >
@@ -420,6 +371,7 @@ export default function DashboardStories({
                   onFocus={onPrefetch}
                   onMouseEnter={onPrefetch}
                   aria-label={label}
+                  title={tooltip}
                   sx={{
                     ...storyCircleSx(),
                     cursor: "pointer",
@@ -435,21 +387,6 @@ export default function DashboardStories({
                 >
                   {renderAvatar(story)}
                 </ButtonBase>
-                <Typography
-                  component="span"
-                  align="center"
-                  title={tooltip}
-                  sx={{
-                    maxWidth: 84,
-                    fontWeight: 600,
-                    fontSize: ".85rem",
-                    whiteSpace: "nowrap",
-                    overflow: "hidden",
-                    textOverflow: "ellipsis",
-                  }}
-                >
-                  {story.title}
-                </Typography>
               </Stack>
             )
           })}

--- a/root/frontend/src/components/DashboardStories.tsx
+++ b/root/frontend/src/components/DashboardStories.tsx
@@ -264,9 +264,7 @@ export default function DashboardStories({
       hints.push(autoHint)
     }
     const navigationHint = isMobile ? swipeHint : keyboardHint
-    const navigationKey = isMobile
-      ? "stories.viewer.hints.swipe"
-      : "stories.viewer.hints.keyboard"
+    const navigationKey = isMobile ? "stories.viewer.hints.swipe" : "stories.viewer.hints.keyboard"
     if (navigationHint && navigationHint !== navigationKey) {
       hints.push(navigationHint)
     }
@@ -276,8 +274,7 @@ export default function DashboardStories({
     return hints
   }, [autoHint, isMobile, keyboardHint, swipeHint, tapHint])
 
-  const hasEmptyDescription =
-    emptyDescription && emptyDescription !== "stories.emptyDescription"
+  const hasEmptyDescription = emptyDescription && emptyDescription !== "stories.emptyDescription"
   const hasViewerInstructions =
     viewerInstructions && viewerInstructions !== "stories.viewer.aria.instructions"
 
@@ -308,7 +305,7 @@ export default function DashboardStories({
   return (
     <Box
       data-fade
-      style={{ "--fade-delay": "120ms" } as CSSProperties }
+      style={{ "--fade-delay": "120ms" } as CSSProperties}
       sx={{ mt: 3, mb: 3, display: "flex", flexDirection: "column", gap: 2 }}
       aria-busy={loading}
       onPointerEnter={onPrefetch}
@@ -518,45 +515,38 @@ export default function DashboardStories({
                 )}
               </Box>
 
-            <Stack spacing={1.5} sx={{ maxWidth: 480 }}>
-              <Typography id={dialogTitleId} variant="h4" component="h2" sx={{ fontWeight: 800 }}>
-                {viewerStory.title}
-              </Typography>
-              {viewerStory.short_text && (
-                <Typography component="p" sx={{ opacity: 0.9, fontSize: "1.05rem" }}>
-                  {viewerStory.short_text}
+              <Stack spacing={1.5} sx={{ maxWidth: 480 }}>
+                <Typography id={dialogTitleId} variant="h4" component="h2" sx={{ fontWeight: 800 }}>
+                  {viewerStory.title}
                 </Typography>
-              )}
-              {viewerStory.cta_url && (
-                <Button
-                  variant="contained"
-                  color="secondary"
-                  {...(linkPropsFor(viewerStory.cta_url) ?? {})}
-                  sx={{ alignSelf: "center", textTransform: "none" }}
-                >
-                  {t("stories.viewer.openLink")}
-                </Button>
-              )}
-              {(hasViewerInstructions || normalizedHints.length > 0) && (
-                <Stack spacing={0.5} id={dialogHintsId}>
-                  {hasViewerInstructions && (
-                    <Typography sx={{ ...visuallyHidden }}>
-                      {viewerInstructions}
-                    </Typography>
-                  )}
-                  {normalizedHints.map((hint, index) => (
-                    <Typography
-                      key={index}
-                      component="p"
-                      variant="body2"
-                      sx={{ opacity: 0.85 }}
-                    >
-                      {hint}
-                    </Typography>
-                  ))}
-                </Stack>
-              )}
-            </Stack>
+                {viewerStory.short_text && (
+                  <Typography component="p" sx={{ opacity: 0.9, fontSize: "1.05rem" }}>
+                    {viewerStory.short_text}
+                  </Typography>
+                )}
+                {viewerStory.cta_url && (
+                  <Button
+                    variant="contained"
+                    color="secondary"
+                    {...(linkPropsFor(viewerStory.cta_url) ?? {})}
+                    sx={{ alignSelf: "center", textTransform: "none" }}
+                  >
+                    {t("stories.viewer.openLink")}
+                  </Button>
+                )}
+                {(hasViewerInstructions || normalizedHints.length > 0) && (
+                  <Stack spacing={0.5} id={dialogHintsId}>
+                    {hasViewerInstructions && (
+                      <Typography sx={{ ...visuallyHidden }}>{viewerInstructions}</Typography>
+                    )}
+                    {normalizedHints.map((hint, index) => (
+                      <Typography key={index} component="p" variant="body2" sx={{ opacity: 0.85 }}>
+                        {hint}
+                      </Typography>
+                    ))}
+                  </Stack>
+                )}
+              </Stack>
             </Box>
 
             <Box

--- a/root/frontend/src/components/__tests__/DashboardStories.test.tsx
+++ b/root/frontend/src/components/__tests__/DashboardStories.test.tsx
@@ -26,11 +26,13 @@ const translations: Record<string, string> = {
   "dashboard:stories.viewer.aria.next": "Next story",
   "dashboard:stories.viewer.aria.prev": "Previous story",
   "dashboard:stories.viewer.aria.progress": "Progress for {{title}}",
-  "dashboard:stories.viewer.aria.instructions": "Use the arrow keys or swipe to move between stories.",
+  "dashboard:stories.viewer.aria.instructions":
+    "Use the arrow keys or swipe to move between stories.",
   "dashboard:stories.viewer.hints.auto": "Stories advance automatically.",
   "dashboard:stories.viewer.hints.keyboard": "Use the left and right arrow keys to navigate.",
   "dashboard:stories.viewer.hints.swipe": "Swipe left or right to switch stories.",
-  "dashboard:stories.viewer.hints.tap": "Tap the right side to skip ahead and the left side to go back.",
+  "dashboard:stories.viewer.hints.tap":
+    "Tap the right side to skip ahead and the left side to go back.",
 }
 
 vi.mock("react-i18next", () => ({
@@ -111,7 +113,11 @@ function setupMatchMedia({ mobile = false, reducedMotion = false } = {}) {
   vi.spyOn(window, "matchMedia").mockImplementation(
     (query: string) =>
       ({
-        matches: query.includes("max-width") ? mobile : query.includes("prefers-reduced-motion") ? reducedMotion : false,
+        matches: query.includes("max-width")
+          ? mobile
+          : query.includes("prefers-reduced-motion")
+            ? reducedMotion
+            : false,
         media: query,
         onchange: null,
         addEventListener: vi.fn(),
@@ -158,10 +164,12 @@ describe("DashboardStories", () => {
     vi.spyOn(performance, "now").mockImplementation(() => now)
 
     let frameCallback: FrameRequestCallback | null = null
-    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback: FrameRequestCallback) => {
-      frameCallback = callback
-      return 1
-    })
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation(
+      (callback: FrameRequestCallback) => {
+        frameCallback = callback
+        return 1
+      }
+    )
     vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {
       frameCallback = null
     })

--- a/root/frontend/src/tests/pageTranslations.test.tsx
+++ b/root/frontend/src/tests/pageTranslations.test.tsx
@@ -495,25 +495,19 @@ describe("page translations", () => {
     const { user } = renderWithProviders(<Dashboard />, { initialPath: "/dashboard" })
 
     expect(await screen.findByText("Today's schedule")).toBeInTheDocument()
-    expect(
-      await screen.findByRole("heading", { name: "Stories" })
-    ).toBeInTheDocument()
+    expect(await screen.findByRole("heading", { name: "Stories" })).toBeInTheDocument()
     const storyButton = await screen.findByRole("button", {
       name: "Story: Campus orientation",
     })
 
     await user.click(storyButton)
 
-    expect(
-      await screen.findByText("Stories advance automatically.")
-    ).toBeInTheDocument()
+    expect(await screen.findByText("Stories advance automatically.")).toBeInTheDocument()
 
     await user.click(screen.getByTestId("lang-toggle"))
 
     expect(await screen.findByText("Расписание на сегодня")).toBeInTheDocument()
-    expect(
-      await screen.findByText("Истории переключаются автоматически.")
-    ).toBeInTheDocument()
+    expect(await screen.findByText("Истории переключаются автоматически.")).toBeInTheDocument()
   })
 
   it("switches news page translations", async () => {


### PR DESCRIPTION
## Summary
- remove the dashboard stories card container and headings so only the avatar circles remain visible
- streamline the loading state to only render circular skeletons that match the circles
- preserve accessibility by keeping aria labels and adding tooltip titles on each story circle

## Testing
- npm --prefix root/frontend run lint

------
https://chatgpt.com/codex/tasks/task_e_68f8d1ecb61c8327a68058c9cc2b00ca