### PR TITLE
Refine dashboard story viewer styling

### DIFF
--- a/root/frontend/src/components/DashboardStories.tsx
+++ b/root/frontend/src/components/DashboardStories.tsx
@@ -349,13 +349,15 @@ export default function DashboardStories({
                   sx={{
                     ...storyCircleSx(),
                     cursor: "pointer",
+                    outline: "none",
                     "&:hover": {
-                      transform: "translateY(-2px)",
-                      boxShadow: "0 18px 40px rgba(37,99,235,0.28)",
+                      boxShadow:
+                        "0 0 0 4px rgba(125,172,255,0.32), 0 14px 40px rgba(37,99,235,0.32)",
                     },
                     "&:focus-visible": {
                       outline: "none",
-                      boxShadow: "0 0 0 4px #1d4ed81f, 0 0 0 6px #1d4ed880",
+                      boxShadow:
+                        "0 0 0 4px rgba(125,172,255,0.42), 0 0 0 7px rgba(37,99,235,0.32)",
                     },
                   }}
                 >
@@ -383,8 +385,9 @@ export default function DashboardStories({
         }}
         BackdropProps={{
           sx: {
-            backgroundColor: "rgba(9, 14, 28, 0.55)",
-            backdropFilter: "blur(20px)",
+            backgroundColor: "rgba(9, 14, 28, 0.4)",
+            backdropFilter: "blur(28px) saturate(150%)",
+            WebkitBackdropFilter: "blur(28px) saturate(150%)",
           },
         }}
       >
@@ -545,7 +548,7 @@ export default function DashboardStories({
                 aria-label={t("stories.viewer.aria.close")}
                 sx={{
                   position: "absolute",
-                  top: 16,
+                  top: 36,
                   right: 16,
                   color: "inherit",
                   backgroundColor: "rgba(8,11,21,0.55)",

--- a/root/frontend/src/components/DashboardStories.tsx
+++ b/root/frontend/src/components/DashboardStories.tsx
@@ -356,8 +356,7 @@ export default function DashboardStories({
                     },
                     "&:focus-visible": {
                       outline: "none",
-                      boxShadow:
-                        "0 0 0 4px rgba(125,172,255,0.42), 0 0 0 7px rgba(37,99,235,0.32)",
+                      boxShadow: "0 0 0 4px rgba(125,172,255,0.42), 0 0 0 7px rgba(37,99,235,0.32)",
                     },
                   }}
                 >

--- a/root/frontend/src/constants/storyCircle.ts
+++ b/root/frontend/src/constants/storyCircle.ts
@@ -24,8 +24,8 @@ export const storyCircleSx = ({
   textDecoration: "none",
   border: `${borderWidth}px solid color-mix(in srgb, var(--page-text) 16%, transparent)`,
   background: "linear-gradient(135deg,#1d4ed8,#60a5fa)",
-  boxShadow: "0 14px 38px rgba(37,99,235,0.18)",
-  transition: "transform 0.18s ease, box-shadow 0.18s ease",
+  boxShadow: "0 10px 28px rgba(37,99,235,0.18)",
+  transition: "box-shadow 0.18s ease",
   "@media (prefers-reduced-motion: reduce)": {
     transition: "box-shadow 0.18s ease",
   },


### PR DESCRIPTION
## Summary
- adjust dashboard story hover styles to remove scaling and provide a rounded glow
- update story viewer backdrop blur and reposition the close button away from the progress bar
- tweak shared story circle styles to keep consistent shadows without transform transitions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f8f4a9fb208327a22662fa79a5f842