### PR TITLE
Fix stories circle highlight clipping and viewer backdrop

### DIFF
--- a/root/frontend/src/components/DashboardStories.tsx
+++ b/root/frontend/src/components/DashboardStories.tsx
@@ -196,7 +196,7 @@ export default function DashboardStories({
         <SmartImage
           srcRaw={story.cover_url}
           alt={story.title}
-          style={{ width: "100%", height: "100%" }}
+          style={{ width: "100%", height: "100%", borderRadius: "inherit" }}
         />
       )
     }
@@ -337,7 +337,11 @@ export default function DashboardStories({
                 key={story.id}
                 component="li"
                 alignItems="center"
-                sx={{ width: 92, flex: { xs: "0 0 auto", sm: "0 0 92px" } }}
+                sx={{
+                  width: 92,
+                  flex: { xs: "0 0 auto", sm: "0 0 92px" },
+                  overflow: "visible",
+                }}
               >
                 <ButtonBase
                   focusRipple
@@ -360,7 +364,21 @@ export default function DashboardStories({
                     },
                   }}
                 >
-                  {renderAvatar(story)}
+                  <Box
+                    aria-hidden="true"
+                    sx={{
+                      position: "relative",
+                      width: "100%",
+                      height: "100%",
+                      borderRadius: "50%",
+                      overflow: "hidden",
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                    }}
+                  >
+                    {renderAvatar(story)}
+                  </Box>
                 </ButtonBase>
               </Stack>
             )
@@ -384,9 +402,9 @@ export default function DashboardStories({
         }}
         BackdropProps={{
           sx: {
-            backgroundColor: "rgba(9, 14, 28, 0.4)",
-            backdropFilter: "blur(28px) saturate(150%)",
-            WebkitBackdropFilter: "blur(28px) saturate(150%)",
+            backgroundColor: "rgba(9, 14, 28, 0.25)",
+            backdropFilter: "blur(22px) saturate(160%)",
+            WebkitBackdropFilter: "blur(22px) saturate(160%)",
           },
         }}
       >

--- a/root/frontend/src/constants/storyCircle.ts
+++ b/root/frontend/src/constants/storyCircle.ts
@@ -16,7 +16,6 @@ export const storyCircleSx = ({
   minHeight: size,
   borderRadius: "50%",
   position: "relative",
-  overflow: "hidden",
   display: "flex",
   alignItems: "center",
   justifyContent: "center",


### PR DESCRIPTION
## Summary
- stop clipping story circle shadows so the hover/focus glow stays circular
- ensure story avatars remain circular within the new masking wrapper
- adjust the story viewer backdrop to show the page with a translucent blur instead of a flat color

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f8fc4c38008327ab1cec60d06bbfcc