### PR TITLE
Fix story highlight ring and blur the viewer backdrop

### DIFF
--- a/root/frontend/src/components/DashboardStories.tsx
+++ b/root/frontend/src/components/DashboardStories.tsx
@@ -398,6 +398,8 @@ export default function DashboardStories({
             background: "transparent",
             boxShadow: "none",
             color: "#fff",
+            position: "relative",
+            overflow: "hidden",
           },
         }}
         BackdropProps={{
@@ -408,10 +410,23 @@ export default function DashboardStories({
           },
         }}
       >
+        <Box
+          aria-hidden
+          sx={{
+            position: "absolute",
+            inset: 0,
+            zIndex: 0,
+            pointerEvents: "none",
+            background: "radial-gradient(circle at top, rgba(9, 14, 28, 0.32), rgba(9, 14, 28, 0.62))",
+            backdropFilter: "blur(28px) saturate(160%)",
+            WebkitBackdropFilter: "blur(28px) saturate(160%)",
+          }}
+        />
         {viewerStory && (
           <Box
             sx={{
               position: "relative",
+              zIndex: 1,
               width: "100%",
               height: "100%",
               display: "flex",

--- a/root/frontend/src/components/DashboardStories.tsx
+++ b/root/frontend/src/components/DashboardStories.tsx
@@ -417,7 +417,8 @@ export default function DashboardStories({
             inset: 0,
             zIndex: 0,
             pointerEvents: "none",
-            background: "radial-gradient(circle at top, rgba(9, 14, 28, 0.32), rgba(9, 14, 28, 0.62))",
+            background:
+              "radial-gradient(circle at top, rgba(9, 14, 28, 0.32), rgba(9, 14, 28, 0.62))",
             backdropFilter: "blur(28px) saturate(160%)",
             WebkitBackdropFilter: "blur(28px) saturate(160%)",
           }}

--- a/root/frontend/src/constants/storyCircle.ts
+++ b/root/frontend/src/constants/storyCircle.ts
@@ -15,6 +15,7 @@ export const storyCircleSx = ({
   minWidth: size,
   minHeight: size,
   borderRadius: "50%",
+  overflow: "visible",
   position: "relative",
   display: "flex",
   alignItems: "center",
@@ -25,6 +26,10 @@ export const storyCircleSx = ({
   background: "linear-gradient(135deg,#1d4ed8,#60a5fa)",
   boxShadow: "0 10px 28px rgba(37,99,235,0.18)",
   transition: "box-shadow 0.18s ease",
+  "& .MuiTouchRipple-root": {
+    borderRadius: "50%",
+    overflow: "hidden",
+  },
   "@media (prefers-reduced-motion: reduce)": {
     transition: "box-shadow 0.18s ease",
   },


### PR DESCRIPTION
## Summary
- keep the dashboard story ring circular and let the glow render fully
- add a dedicated blurred overlay behind the full-screen story viewer

## Testing
- npm --prefix root/frontend run lint

------
https://chatgpt.com/codex/tasks/task_e_68f9037b656c83278f11acd8326c53aa