### PR TITLE
Fix story highlight shape and viewer backdrop blur

### DIFF
--- a/root/frontend/src/components/DashboardStories.tsx
+++ b/root/frontend/src/components/DashboardStories.tsx
@@ -431,8 +431,7 @@ export default function DashboardStories({
             inset: 0,
             zIndex: 0,
             pointerEvents: "none",
-            background:
-              "linear-gradient(180deg, rgba(9,14,28,0.12) 0%, rgba(9,14,28,0.32) 100%)",
+            background: "linear-gradient(180deg, rgba(9,14,28,0.12) 0%, rgba(9,14,28,0.32) 100%)",
             backdropFilter: "blur(36px) saturate(160%)",
             WebkitBackdropFilter: "blur(36px) saturate(160%)",
           }}

--- a/root/frontend/src/components/DashboardStories.tsx
+++ b/root/frontend/src/components/DashboardStories.tsx
@@ -350,17 +350,31 @@ export default function DashboardStories({
                   onMouseEnter={onPrefetch}
                   aria-label={label}
                   title={tooltip}
+                  data-active={viewerStory?.id === story.id || undefined}
                   sx={{
                     ...storyCircleSx(),
                     cursor: "pointer",
                     outline: "none",
                     "&:hover": {
                       boxShadow:
-                        "0 0 0 4px rgba(125,172,255,0.32), 0 14px 40px rgba(37,99,235,0.32)",
+                        "0 10px 28px rgba(37,99,235,0.28), 0 18px 48px rgba(37,99,235,0.28)",
+                    },
+                    "&:hover::after": {
+                      opacity: 1,
+                      transform: "scale(1)",
                     },
                     "&:focus-visible": {
                       outline: "none",
-                      boxShadow: "0 0 0 4px rgba(125,172,255,0.42), 0 0 0 7px rgba(37,99,235,0.32)",
+                      boxShadow:
+                        "0 10px 28px rgba(37,99,235,0.32), 0 0 0 6px rgba(125,172,255,0.42)",
+                    },
+                    "&:focus-visible::after": {
+                      opacity: 1,
+                      transform: "scale(1)",
+                    },
+                    "&[data-active='true']::after": {
+                      opacity: 1,
+                      transform: "scale(1)",
                     },
                   }}
                 >
@@ -404,9 +418,9 @@ export default function DashboardStories({
         }}
         BackdropProps={{
           sx: {
-            backgroundColor: "rgba(9, 14, 28, 0.25)",
-            backdropFilter: "blur(22px) saturate(160%)",
-            WebkitBackdropFilter: "blur(22px) saturate(160%)",
+            backgroundColor: "rgba(9, 14, 28, 0.18)",
+            backdropFilter: "blur(28px) saturate(160%)",
+            WebkitBackdropFilter: "blur(28px) saturate(160%)",
           },
         }}
       >
@@ -418,9 +432,9 @@ export default function DashboardStories({
             zIndex: 0,
             pointerEvents: "none",
             background:
-              "radial-gradient(circle at top, rgba(9, 14, 28, 0.32), rgba(9, 14, 28, 0.62))",
-            backdropFilter: "blur(28px) saturate(160%)",
-            WebkitBackdropFilter: "blur(28px) saturate(160%)",
+              "linear-gradient(180deg, rgba(9,14,28,0.12) 0%, rgba(9,14,28,0.32) 100%)",
+            backdropFilter: "blur(36px) saturate(160%)",
+            WebkitBackdropFilter: "blur(36px) saturate(160%)",
           }}
         />
         {viewerStory && (

--- a/root/frontend/src/constants/storyCircle.ts
+++ b/root/frontend/src/constants/storyCircle.ts
@@ -26,9 +26,24 @@ export const storyCircleSx = ({
   background: "linear-gradient(135deg,#1d4ed8,#60a5fa)",
   boxShadow: "0 10px 28px rgba(37,99,235,0.18)",
   transition: "box-shadow 0.18s ease",
+  "&::after": {
+    content: "''",
+    position: "absolute",
+    inset: -6,
+    borderRadius: "inherit",
+    border: "2px solid rgba(125,172,255,0.48)",
+    boxShadow: "0 14px 44px rgba(37,99,235,0.38)",
+    opacity: 0,
+    transform: "scale(0.94)",
+    transition: "opacity 0.2s ease, transform 0.2s ease",
+    pointerEvents: "none",
+  },
   "& .MuiTouchRipple-root": {
     borderRadius: "50%",
     overflow: "hidden",
+  },
+  "& .MuiTouchRipple-root, & .MuiTouchRipple-ripple, & .MuiTouchRipple-child": {
+    borderRadius: "50%",
   },
   "@media (prefers-reduced-motion: reduce)": {
     transition: "box-shadow 0.18s ease",


### PR DESCRIPTION
## Summary
- ensure story circle interactions use a circular halo and ripple that is not clipped
- keep the active story button highlighted while the viewer is open
- lighten the story viewer backdrop so the underlying page remains visible through the blur

## Testing
- npm run lint -- --max-warnings=0

------
https://chatgpt.com/codex/tasks/task_e_68f90d2494d88327af786871080b6cbf