### PR TITLE
Fix Stories admin local date parsing

### DIFF
--- a/root/frontend/src/pages/StoriesAdmin.tsx
+++ b/root/frontend/src/pages/StoriesAdmin.tsx
@@ -1,5 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent } from "react"
 import dayjs from "dayjs"
+import utc from "dayjs/plugin/utc"
+
+dayjs.extend(utc)
 import {
   Alert,
   Box,


### PR DESCRIPTION
## Summary
- extend Day.js with the UTC plugin on the Stories admin page so local() works when formatting dates

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f951da5a448327b8da72c558807c31