### PR TITLE
Fix Spotify connect button width on desktop

### DIFF
--- a/root/frontend/src/pages/Settings.tsx
+++ b/root/frontend/src/pages/Settings.tsx
@@ -1223,7 +1223,7 @@ export default function Settings() {
                 <Button
                   variant="contained"
                   onClick={connectSpotify}
-                  sx={{ alignSelf: "lex-start" }}
+                  sx={{ alignSelf: "flex-start" }}
                 >
                   {t("settings:integrations.spotify.connect")}
                 </Button>


### PR DESCRIPTION
## Summary
- correct the Spotify connect button alignment style so it matches the disconnect button on desktop

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68f97ad765cc8327bc458d28ab97e1a3