### PR TITLE
Retry Spotify now-playing when access token is rejected

### DIFF
--- a/root/app/api/spotify.py
+++ b/root/app/api/spotify.py
@@ -272,14 +272,40 @@ async def now_playing(
             return data
         return Response(status_code=204)
 
+    async def _request(access_token: str) -> httpx.Response:
+        async with httpx.AsyncClient(timeout=15) as client:
+            return await client.get(
+                "https://api.spotify.com/v1/me/player/currently-playing",
+                headers={"Authorization": f"Bearer {access_token}"},
+            )
+
     token = await _ensure_access_token(db, user, locale=locale)
     if not token:
         return _as_response(_fallback_now_playing(user))
-    async with httpx.AsyncClient(timeout=15) as client:
-        r = await client.get(
-            "https://api.spotify.com/v1/me/player/currently-playing",
-            headers={"Authorization": f"Bearer {token}"},
-        )
+
+    r = await _request(token)
+    if r.status_code == 401:
+        # Access tokens occasionally expire slightly earlier than advertised or
+        # get invalidated server-side. Instead of forcing the user to reconnect
+        # immediately, attempt a single refresh and retry before giving up.
+        user.spotify_access_token = None
+        user.spotify_token_expires_at = _now_utc() - timedelta(seconds=30)
+        try:
+            refreshed = await _ensure_access_token(db, user, locale=locale)
+        except HTTPException:
+            # ``_ensure_access_token`` already disconnected the user and raised
+            # an appropriate error; propagate it unchanged.
+            raise
+        if not refreshed:
+            return _as_response(_fallback_now_playing(user))
+        r = await _request(refreshed)
+        if r.status_code == 401:
+            _disconnect_user(user, clear_refresh=True)
+            await db.commit()
+            raise HTTPException(
+                status_code=401,
+                detail=translate("errors.spotify.reconnect_required", locale=locale),
+            )
     if r.status_code == 204:
         user.spotify_is_playing = False
         user.spotify_last_checked_at = _now_utc()

--- a/root/tests/test_spotify_fallback.py
+++ b/root/tests/test_spotify_fallback.py
@@ -249,6 +249,85 @@ async def test_now_playing_refreshes_when_access_token_missing(
     assert user.spotify_is_connected is True
 
 
+async def test_now_playing_retries_after_unauthorized_response(
+    async_client: AsyncClient, user_factory, db_session, monkeypatch
+) -> None:
+    password = "SpotifyP@ss4b"
+    hashed = get_password_hash(password)
+    user = await user_factory(hashed_password=hashed, is_active=True)
+
+    user.spotify_access_token = "valid"
+    user.spotify_refresh_token = "refresh"
+    user.spotify_token_expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
+    user.spotify_is_connected = True
+    await db_session.commit()
+    await db_session.refresh(user)
+
+    class UnauthorizedResponse:
+        status_code = 401
+        headers: dict[str, str] = {}
+
+        def json(self) -> dict[str, str]:
+            return {"error": {"status": 401, "message": "The access token expired"}}
+
+    class EmptyResponse:
+        status_code = 204
+        headers: dict[str, str] = {}
+
+        def json(self) -> dict[str, str]:
+            return {}
+
+    class RefreshResponse:
+        status_code = 200
+        headers: dict[str, str] = {}
+
+        def json(self) -> dict[str, str]:
+            return {
+                "access_token": "fresh",
+                "refresh_token": "refresh-new",
+                "expires_in": 1800,
+            }
+
+    refresh_called = False
+    get_calls = 0
+
+    original_get = httpx.AsyncClient.get
+    original_post = httpx.AsyncClient.post
+
+    async def fake_get(self, url, *args, **kwargs):
+        nonlocal get_calls
+        if str(url) == "https://api.spotify.com/v1/me/player/currently-playing":
+            get_calls += 1
+            if get_calls == 1:
+                return UnauthorizedResponse()
+            return EmptyResponse()
+        return await original_get(self, url, *args, **kwargs)
+
+    async def fake_post(self, url, *args, **kwargs):
+        nonlocal refresh_called
+        if str(url) == "https://accounts.spotify.com/api/token":
+            refresh_called = True
+            return RefreshResponse()
+        return await original_post(self, url, *args, **kwargs)
+
+    monkeypatch.setattr("httpx.AsyncClient.get", fake_get)
+    monkeypatch.setattr("httpx.AsyncClient.post", fake_post)
+
+    headers = await _login(async_client, user, password)
+    headers["Accept-Language"] = "ru"
+
+    response = await async_client.get("/spotify/now-playing", headers=headers)
+
+    assert response.status_code == 204
+    assert refresh_called is True
+    assert get_calls == 2
+
+    await db_session.refresh(user)
+    assert user.spotify_access_token == "fresh"
+    assert user.spotify_refresh_token == "refresh-new"
+    assert user.spotify_is_connected is True
+
+
 async def test_now_playing_disconnects_on_unauthorized_response(
     async_client: AsyncClient, user_factory, db_session, monkeypatch
 ) -> None:
@@ -270,14 +349,39 @@ async def test_now_playing_disconnects_on_unauthorized_response(
         def json(self) -> dict[str, str]:
             return {"error": {"status": 401, "message": "The access token expired"}}
 
+    class RefreshResponse:
+        status_code = 200
+        headers: dict[str, str] = {}
+
+        def json(self) -> dict[str, str]:
+            return {
+                "access_token": "another-token",
+                "refresh_token": "another-refresh",
+                "expires_in": 1200,
+            }
+
     original_get = httpx.AsyncClient.get
+    original_post = httpx.AsyncClient.post
+
+    get_calls = 0
+    refresh_called = False
 
     async def fake_get(self, url, *args, **kwargs):
+        nonlocal get_calls
         if str(url) == "https://api.spotify.com/v1/me/player/currently-playing":
+            get_calls += 1
             return UnauthorizedResponse()
         return await original_get(self, url, *args, **kwargs)
 
+    async def fake_post(self, url, *args, **kwargs):
+        nonlocal refresh_called
+        if str(url) == "https://accounts.spotify.com/api/token":
+            refresh_called = True
+            return RefreshResponse()
+        return await original_post(self, url, *args, **kwargs)
+
     monkeypatch.setattr("httpx.AsyncClient.get", fake_get)
+    monkeypatch.setattr("httpx.AsyncClient.post", fake_post)
 
     headers = await _login(async_client, user, password)
     headers["Accept-Language"] = "ru"
@@ -286,6 +390,8 @@ async def test_now_playing_disconnects_on_unauthorized_response(
 
     assert response.status_code == 401
     assert response.json()["detail"] == "Требуется переподключить Spotify"
+    assert get_calls == 2
+    assert refresh_called is True
 
     await db_session.refresh(user)
     assert user.spotify_is_connected is False


### PR DESCRIPTION
## Summary
- retry the Spotify now-playing request once after a 401 by forcing a token refresh before disconnecting the integration
- cover the refreshed retry path and double-401 fallback with new API tests

## Testing
- pytest tests/test_spotify_fallback.py

------
https://chatgpt.com/codex/tasks/task_e_68f97eb64eb48327abf350f77c44f7e5