### PR TITLE
Refine account settings layout

### DIFF
--- a/root/frontend/src/pages/Settings.tsx
+++ b/root/frontend/src/pages/Settings.tsx
@@ -906,7 +906,11 @@ export default function Settings() {
                 const disableRevoke =
                   session.is_current || isRevoked || revokeSessionMutation.isPending
                 return (
-                  <Stack key={session.id} spacing={0.75} opacity={isRevoked ? 0.65 : 1}>
+                  <Stack
+                    key={session.id}
+                    spacing={0.75}
+                    sx={{ opacity: isRevoked ? 0.65 : 1 }}
+                  >
                     <Stack direction="row" justifyContent="space-between" alignItems="baseline">
                       <Typography variant="body1" fontWeight={session.is_current ? 600 : 500}>
                         {session.user_agent || t("settings:sessions.unknownDevice")}

--- a/root/frontend/src/pages/Settings.tsx
+++ b/root/frontend/src/pages/Settings.tsx
@@ -146,16 +146,14 @@ export default function Settings() {
     staleTime: 30_000,
   })
 
-  const sessionList = useMemo(
-    () => (Array.isArray(sessions) ? sessions.filter((session) => !session.revoked_at) : []),
-    [sessions]
-  )
-
-  useEffect(() => {
-    if (!Array.isArray(sessions)) return
-    if (sessions.length === sessionList.length) return
-    queryClient.setQueryData(sessionsKey, sessionList)
-  }, [queryClient, sessionList, sessions, sessionsKey])
+  const visibleSessions = useMemo(() => {
+    if (!Array.isArray(sessions)) return []
+    const cutoff = dayjs().subtract(1, "hour")
+    return sessions.filter((session) => {
+      if (!session.revoked_at) return true
+      return cutoff.isBefore(dayjs(session.revoked_at))
+    })
+  }, [sessions])
 
   const revokeSessionMutation = useMutation({
     mutationFn: async (sessionId: number) => {
@@ -717,11 +715,18 @@ export default function Settings() {
   const accountTab = (
     <Stack spacing={3}>
       <SectionCard>
-        <Stack spacing={2.5} divider={<Divider />}>
+        <Stack
+          component="ul"
+          spacing={2.5}
+          divider={<Divider />}
+          sx={{ listStyle: "none", p: 0, m: 0 }}
+        >
           <Stack
+            component="li"
             direction={{ xs: "column", sm: "row" }}
             spacing={2}
             alignItems={{ xs: "flex-start", sm: "center" }}
+            sx={{ listStyle: "none", width: "100%" }}
           >
             <Avatar
               src={avatarSrc}
@@ -766,9 +771,11 @@ export default function Settings() {
           </Stack>
 
           <Stack
+            component="li"
             direction={{ xs: "column", sm: "row" }}
             spacing={2}
             alignItems={{ xs: "flex-start", sm: "center" }}
+            sx={{ listStyle: "none", width: "100%" }}
           >
             <Box
               data-testid="settings-cover-preview"
@@ -804,10 +811,12 @@ export default function Settings() {
           </Stack>
 
           <Stack
+            component="li"
             direction={{ xs: "column", sm: "row" }}
             spacing={1.5}
             alignItems={{ xs: "flex-start", sm: "center" }}
             justifyContent="space-between"
+            sx={{ listStyle: "none", width: "100%" }}
           >
             <Stack spacing={0.5} sx={{ flexGrow: 1 }}>
               <Typography variant="subtitle1" fontWeight={600}>
@@ -867,28 +876,35 @@ export default function Settings() {
             <Alert severity="error" variant="outlined">
               {sessionsErrorMessage}
             </Alert>
-          ) : sessionList.length === 0 ? (
+          ) : visibleSessions.length === 0 ? (
             <Typography variant="body2" color="text.secondary">
               {t("settings:sessions.empty")}
             </Typography>
           ) : (
             <Stack spacing={1.5} divider={<Divider />}>
-              {sessionList.map((session) => {
-                const lastSeen = session.last_seen_at ?? session.created_at
+              {visibleSessions.map((session) => {
+                const isRevoked = Boolean(session.revoked_at)
+                const lastRelevantMoment = session.revoked_at ?? session.last_seen_at ?? session.created_at
                 const lastSeenText = t("settings:sessions.lastSeen.value", {
-                  value: formatSessionTimestamp(lastSeen),
+                  value: formatSessionTimestamp(lastRelevantMoment),
                 })
                 const ipLabel = session.ip_address
                   ? t("settings:sessions.ipAddress", { ip: session.ip_address })
                   : t("settings:sessions.ipUnknown")
                 const details = `${ipLabel} • ${lastSeenText}`
-                const statusLabel = session.is_current
-                  ? t("settings:sessions.status.current")
-                  : t("settings:sessions.status.active")
-                const statusColor = session.is_current ? accentColor : mutedTextColor
-                const disableRevoke = session.is_current || revokeSessionMutation.isPending
+                const statusLabel = isRevoked
+                  ? t("settings:sessions.status.revoked")
+                  : session.is_current
+                    ? t("settings:sessions.status.current")
+                    : t("settings:sessions.status.active")
+                const statusColor = isRevoked
+                  ? muiTheme.palette.text.disabled
+                  : session.is_current
+                    ? accentColor
+                    : mutedTextColor
+                const disableRevoke = session.is_current || isRevoked || revokeSessionMutation.isPending
                 return (
-                  <Stack key={session.id} spacing={0.75}>
+                  <Stack key={session.id} spacing={0.75} opacity={isRevoked ? 0.65 : 1}>
                     <Stack direction="row" justifyContent="space-between" alignItems="baseline">
                       <Typography variant="body1" fontWeight={session.is_current ? 600 : 500}>
                         {session.user_agent || t("settings:sessions.unknownDevice")}
@@ -900,7 +916,7 @@ export default function Settings() {
                     <Typography variant="body2" color="text.secondary">
                       {details}
                     </Typography>
-                    {!session.is_current && (
+                    {!session.is_current && !isRevoked && (
                       <Button
                         size="small"
                         variant="text"

--- a/root/frontend/src/pages/Settings.tsx
+++ b/root/frontend/src/pages/Settings.tsx
@@ -11,8 +11,9 @@ import type { User } from "@/types/User"
 import type { ActiveSession } from "@/types/Session"
 import { useTranslation } from "react-i18next"
 import {
-  Box,
+  Container,
   Paper,
+  Box,
   Tabs,
   Tab,
   Stack,
@@ -32,9 +33,10 @@ import {
   DialogActions,
   TextField,
   CircularProgress,
+  Switch,
 } from "@mui/material"
 import dayjs from "dayjs"
-import { useColorScheme, styled, alpha } from "@mui/material/styles"
+import { useColorScheme, styled, useTheme } from "@mui/material/styles"
 import SettingsIcon from "@mui/icons-material/Settings"
 import DarkModeIcon from "@mui/icons-material/DarkMode"
 import LightModeIcon from "@mui/icons-material/LightMode"
@@ -49,8 +51,6 @@ type ThemeMode = "system" | "light" | "dark"
 
 const DEFAULT_DND_START = "22:00"
 const DEFAULT_DND_END = "07:00"
-const MUTED_TEXT_COLOR = "color-mix(in srgb, var(--page-text) 68%, transparent)"
-
 const toInputTime = (value: unknown): string => {
   if (!value) return ""
   const str = String(value)
@@ -67,140 +67,13 @@ const toServerTime = (value: string | null): string | null => {
   return trimmed
 }
 
-const ModernSwitch = styled("span")(({ theme }) => {
-  const on = theme.palette.primary.main
-  const trackBg = theme.palette.mode === "dark" ? alpha("#fff", 0.12) : alpha("#000", 0.08)
-  const trackBorder = theme.palette.mode === "dark" ? alpha("#fff", 0.24) : alpha("#000", 0.12)
-  const ring = alpha(on, 0.35)
-
-  return {
-    position: "relative",
-    display: "inline-flex",
-    alignItems: "center",
-    width: 52,
-    height: 28,
-    padding: 2,
-    borderRadius: 999,
-    cursor: "pointer",
-    touchAction: "manipulation",
-    WebkitTapHighlightColor: "transparent",
-    "& input": {
-      opacity: 0,
-      width: 0,
-      height: 0,
-      position: "absolute",
-    },
-    "& .ms-track": {
-      position: "absolute",
-      inset: 0,
-      borderRadius: 999,
-      background: trackBg,
-      border: `1px solid ${trackBorder}`,
-      transition: "background-color .2s ease, border-color .2s ease",
-      boxSizing: "border-box",
-    },
-    "& .ms-thumb": {
-      position: "relative",
-      zIndex: 1,
-      width: 22,
-      height: 22,
-      borderRadius: "50%",
-      background: theme.palette.common.white,
-      boxShadow:
-        theme.palette.mode === "dark"
-          ? "0 1px 2px rgba(0,0,0,.6), 0 0 0 1px rgba(255,255,255,.08) inset"
-          : "0 1px 2px rgba(0,0,0,.25), 0 0 0 1px rgba(0,0,0,.06) inset",
-      transform: "translateX(0)",
-      transition: "transform .18s cubic-bezier(.2,.9,.22,1), box-shadow .18s ease",
-    },
-    "&.ms-checked .ms-track": {
-      background: alpha(on, theme.palette.mode === "dark" ? 0.55 : 0.2),
-      borderColor: alpha(on, 0.6),
-    },
-    "&.ms-checked .ms-thumb": {
-      transform: "translateX(24px)",
-      boxShadow:
-        theme.palette.mode === "dark"
-          ? "0 1px 2px rgba(0,0,0,.6), 0 0 0 1px rgba(255,255,255,.08) inset"
-          : "0 1px 2px rgba(0,0,0,.25), 0 0 0 1px rgba(0,0,0,.06) inset",
-    },
-    "&.ms-hover .ms-track": {
-      background: theme.palette.mode === "dark" ? alpha("#fff", 0.16) : alpha("#000", 0.1),
-    },
-    "&.ms-focus .ms-ring": {
-      boxShadow: `0 0 0 3px ${ring}`,
-      opacity: 1,
-      transform: "scale(1)",
-    },
-    "& .ms-ring": {
-      position: "absolute",
-      inset: -2,
-      borderRadius: 999,
-      boxShadow: "0 0 0 0px transparent",
-      transition: "box-shadow .18s ease, transform .18s ease, opacity .18s ease",
-      pointerEvents: "none",
-      opacity: 0,
-      transform: "scale(.98)",
-    },
-    "&.ms-disabled": {
-      cursor: "not-allowed",
-      opacity: 0.6,
-    },
-  }
-})
-
 const SectionCard = styled(Paper)(({ theme }) => ({
-  padding: theme.spacing(2.5, 3),
-  borderRadius: 16,
-  border: "1px solid var(--glass-border)",
-  backgroundColor: "color-mix(in srgb, var(--card-bg) 96%, transparent)",
+  padding: theme.spacing(3),
+  borderRadius: theme.shape.borderRadius * 2,
+  border: `1px solid ${theme.palette.divider}`,
+  backgroundColor: theme.palette.background.paper,
   boxShadow: "none",
 }))
-
-function SwitchControl({
-  checked,
-  disabled,
-  onChange,
-  inputId,
-  "aria-label": ariaLabel,
-}: {
-  checked: boolean
-  disabled?: boolean
-  onChange: (e: ChangeEvent<HTMLInputElement>, checked: boolean) => void
-  inputId?: string
-  "aria-label"?: string
-}) {
-  const [hover, setHover] = useState(false)
-  const [focus, setFocus] = useState(false)
-  return (
-    <ModernSwitch
-      className={[
-        checked ? "ms-checked" : "",
-        disabled ? "ms-disabled" : "",
-        hover ? "ms-hover" : "",
-        focus ? "ms-focus" : "",
-      ]
-        .filter(Boolean)
-        .join(" ")}
-      onMouseEnter={() => setHover(true)}
-      onMouseLeave={() => setHover(false)}
-    >
-      <span className="ms-ring" />
-      <span className="ms-track" />
-      <span className="ms-thumb" />
-      <input
-        id={inputId}
-        type="checkbox"
-        checked={checked}
-        disabled={disabled}
-        aria-label={ariaLabel}
-        onChange={(e) => onChange(e, e.target.checked)}
-        onFocus={() => setFocus(true)}
-        onBlur={() => setFocus(false)}
-      />
-    </ModernSwitch>
-  )
-}
 
 export default function Settings() {
   const navigate = useNavigate()
@@ -215,46 +88,23 @@ export default function Settings() {
   const { t } = useTranslation(["settings", "common", "notifications", "profile"])
 
   const { mode: storedMode, setMode } = useColorScheme()
-  const theme = (storedMode ?? "system") as ThemeMode
+  const themeMode = (storedMode ?? "system") as ThemeMode
+  const muiTheme = useTheme()
+  const mutedTextColor = muiTheme.palette.text.secondary
+  const accentColor = muiTheme.palette.primary.main
 
   const timeFieldSx = useMemo(
     () => ({
       maxWidth: { xs: "100%", sm: 200 },
       "& .MuiOutlinedInput-root": {
-        borderRadius: 2.5,
-        overflow: "hidden",
-        backgroundColor: "var(--card-bg)",
-        "& fieldset": {
-          borderColor: "color-mix(in srgb, var(--page-text) 24%, transparent)",
-          borderWidth: 1,
-        },
-        "&:hover fieldset": {
-          borderColor: "color-mix(in srgb, var(--page-text) 32%, transparent)",
-        },
-        "&.Mui-focused": {
-          boxShadow: "0 0 0 3px color-mix(in srgb, var(--link-color) 22%, transparent)",
-        },
-        "&.Mui-focused fieldset": {
-          borderColor: "var(--link-color)",
-        },
-        "&.Mui-disabled": {
-          backgroundColor: "color-mix(in srgb, var(--page-text) 6%, transparent)",
-        },
-        "&.Mui-disabled fieldset": {
-          borderColor: "color-mix(in srgb, var(--page-text) 18%, transparent)",
-        },
+        borderRadius: muiTheme.shape.borderRadius,
       },
       "& .MuiInputBase-input": {
         textAlign: "center",
         fontVariantNumeric: "tabular-nums",
       },
-      "& .MuiInputLabel-root": {
-        px: 0.75,
-        backgroundColor: "var(--card-bg)",
-        color: "var(--page-text)",
-      },
     }),
-    []
+    [muiTheme]
   )
 
   const {
@@ -673,45 +523,496 @@ export default function Settings() {
 
   const [confirmLogout, setConfirmLogout] = useState(false)
 
+  const generalTab = (
+    <Stack spacing={3}>
+      <SectionCard>
+        <Stack spacing={2}>
+          <Typography variant="h6">{t("settings:appearance.theme.title")}</Typography>
+          <RadioGroup row value={themeMode} onChange={handleThemeChange}>
+            <FormControlLabel
+              value="system"
+              control={<Radio />}
+              label={
+                <Stack direction="row" alignItems="center" spacing={1}>
+                  <DesktopWindowsIcon fontSize="small" />
+                  <Typography variant="body2">
+                    {t("settings:appearance.theme.options.system")}
+                  </Typography>
+                </Stack>
+              }
+            />
+            <FormControlLabel
+              value="light"
+              control={<Radio />}
+              label={
+                <Stack direction="row" alignItems="center" spacing={1}>
+                  <LightModeIcon fontSize="small" />
+                  <Typography variant="body2">
+                    {t("settings:appearance.theme.options.light")}
+                  </Typography>
+                </Stack>
+              }
+            />
+            <FormControlLabel
+              value="dark"
+              control={<Radio />}
+              label={
+                <Stack direction="row" alignItems="center" spacing={1}>
+                  <DarkModeIcon fontSize="small" />
+                  <Typography variant="body2">
+                    {t("settings:appearance.theme.options.dark")}
+                  </Typography>
+                </Stack>
+              }
+            />
+          </RadioGroup>
+        </Stack>
+      </SectionCard>
+
+      <SectionCard>
+        <Stack spacing={1.5}>
+          <Typography variant="h6">{t("settings:language.title")}</Typography>
+          <RadioGroup
+            row
+            value={language}
+            onChange={(_, value) => setLanguage(value as SupportedLanguage)}
+            aria-label={t("settings:language.aria")}
+          >
+            {availableLanguages.map((code) => (
+              <FormControlLabel
+                key={code}
+                value={code}
+                control={<Radio />}
+                label={t(`settings:language.options.${code}`)}
+              />
+            ))}
+          </RadioGroup>
+          <Typography variant="body2" color="text.secondary">
+            {t("settings:language.description")}
+          </Typography>
+        </Stack>
+      </SectionCard>
+
+      <SectionCard>
+        <Stack spacing={2}>
+          <Typography variant="h6">{t("settings:notifications.title")}</Typography>
+          {!pushSupported ? (
+            <Alert severity="warning" variant="outlined">
+              {t("settings:notifications.unsupported")}
+            </Alert>
+          ) : notificationPermission === "denied" ? (
+            <Stack spacing={1.5}>
+              <Alert severity="error" variant="outlined">
+                {t("settings:notifications.blocked.description")}
+              </Alert>
+              <Typography variant="body2" color="text.secondary">
+                {t("settings:notifications.blocked.hint")}
+              </Typography>
+              <Stack
+                direction={{ xs: "column", sm: "row" }}
+                spacing={1.2}
+                alignItems={{ sm: "center" }}
+              >
+                <Button
+                  variant="contained"
+                  onClick={() => void enableNotifications()}
+                  disabled={pushBusy}
+                  startIcon={pushBusy ? <CircularProgress size={18} color="inherit" /> : undefined}
+                >
+                  {t("settings:notifications.cta.checkPermission")}
+                </Button>
+                <Typography variant="body2" color="text.secondary">
+                  {t("settings:notifications.status", { status: permissionText })}
+                </Typography>
+              </Stack>
+            </Stack>
+          ) : notificationPermission === "default" ? (
+            <Stack spacing={1.5}>
+              <Typography variant="body2" color="text.secondary">
+                {t("settings:notifications.cta.prompt")}
+              </Typography>
+              <Stack
+                direction={{ xs: "column", sm: "row" }}
+                spacing={1.2}
+                alignItems={{ sm: "center" }}
+              >
+                <Button
+                  variant="contained"
+                  onClick={() => void enableNotifications()}
+                  disabled={pushBusy || pushInitializing}
+                  startIcon={
+                    pushBusy || pushInitializing ? (
+                      <CircularProgress size={18} color="inherit" />
+                    ) : undefined
+                  }
+                >
+                  {t("settings:notifications.cta.allow")}
+                </Button>
+                <Typography variant="body2" color="text.secondary">
+                  {t("settings:notifications.status", { status: permissionText })}
+                </Typography>
+              </Stack>
+            </Stack>
+          ) : (
+            <Stack spacing={1.5}>
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={notificationsEnabled}
+                    onChange={handleNotificationsToggle}
+                    disabled={pushBusy || pushInitializing}
+                    inputProps={{
+                      "aria-label": t("settings:notifications.toggles.notifications.aria"),
+                    }}
+                  />
+                }
+                label={t("settings:notifications.toggles.notifications.label")}
+              />
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={dndEnabled}
+                    onChange={handleDndToggle}
+                    disabled={dndSaving}
+                    inputProps={{ "aria-label": t("settings:notifications.toggles.dnd.aria") }}
+                  />
+                }
+                label={t("settings:notifications.toggles.dnd.label")}
+              />
+              <Stack
+                direction={{ xs: "column", sm: "row" }}
+                spacing={1.5}
+                alignItems={{ sm: "center" }}
+              >
+                <TextField
+                  type="time"
+                  label={t("settings:dnd.start")}
+                  value={dndStart}
+                  onChange={handleDndStartChange}
+                  onBlur={handleDndStartBlur}
+                  disabled={!dndEnabled || dndSaving}
+                  size="small"
+                  InputLabelProps={{ shrink: true }}
+                  sx={timeFieldSx}
+                />
+                <TextField
+                  type="time"
+                  label={t("settings:dnd.end")}
+                  value={dndEnd}
+                  onChange={handleDndEndChange}
+                  onBlur={handleDndEndBlur}
+                  disabled={!dndEnabled || dndSaving}
+                  size="small"
+                  InputLabelProps={{ shrink: true }}
+                  sx={timeFieldSx}
+                />
+              </Stack>
+            </Stack>
+          )}
+        </Stack>
+      </SectionCard>
+    </Stack>
+  )
+
+  const accountTab = (
+    <Stack spacing={3}>
+      <SectionCard>
+        <Stack spacing={2.5} divider={<Divider />}>
+          <Stack
+            direction={{ xs: "column", sm: "row" }}
+            spacing={2}
+            alignItems={{ xs: "flex-start", sm: "center" }}
+          >
+            <Avatar
+              src={avatarSrc}
+              alt={user?.full_name || "avatar"}
+              sx={{ width: 56, height: 56 }}
+              imgProps={{
+                onError: handleAvatarError,
+                loading: "lazy",
+                decoding: "async",
+                referrerPolicy: "no-referrer",
+              }}
+            />
+            <Stack spacing={1} sx={{ width: "100%" }}>
+              <Typography variant="subtitle1" fontWeight={600}>
+                {t("settings:media.avatar.title")}
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                {t("settings:media.avatar.subtitle")}
+              </Typography>
+              <Stack direction="row" spacing={1.5} flexWrap="wrap">
+                <Button
+                  variant="outlined"
+                  size="small"
+                  onClick={triggerAvatarPick}
+                  disabled={avatarBusy}
+                >
+                  {t("settings:media.avatar.change")}
+                </Button>
+                {avatarUrl && (
+                  <Button
+                    variant="text"
+                    size="small"
+                    color="error"
+                    onClick={removeAvatar}
+                    disabled={avatarBusy}
+                  >
+                    {t("settings:media.avatar.delete")}
+                  </Button>
+                )}
+              </Stack>
+            </Stack>
+          </Stack>
+
+          <Stack
+            direction={{ xs: "column", sm: "row" }}
+            spacing={2}
+            alignItems={{ xs: "flex-start", sm: "center" }}
+          >
+            <Box
+              data-testid="settings-cover-preview"
+              sx={{
+                width: { xs: "100%", sm: 160 },
+                maxWidth: 240,
+                height: 72,
+                borderRadius: 2,
+                border: `1px solid ${muiTheme.palette.divider}`,
+                backgroundColor: coverSrc ? undefined : muiTheme.palette.action.hover,
+                backgroundImage: coverSrc ? `url(${coverSrc})` : undefined,
+                backgroundSize: "cover",
+                backgroundPosition: "center",
+              }}
+            />
+            <Stack spacing={1} sx={{ width: "100%" }}>
+              <Typography variant="subtitle1" fontWeight={600}>
+                {t("settings:media.cover.title")}
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                {t("settings:media.cover.recommendation")}
+              </Typography>
+              <Button
+                variant="outlined"
+                size="small"
+                onClick={triggerCoverPick}
+                disabled={coverBusy}
+                sx={{ alignSelf: "flex-start" }}
+              >
+                {t("settings:media.cover.change")}
+              </Button>
+            </Stack>
+          </Stack>
+
+          <Stack
+            direction={{ xs: "column", sm: "row" }}
+            spacing={1.5}
+            alignItems={{ xs: "flex-start", sm: "center" }}
+            justifyContent="space-between"
+          >
+            <Stack spacing={0.5} sx={{ flexGrow: 1 }}>
+              <Typography variant="subtitle1" fontWeight={600}>
+                {t("settings:account.profile.title")}
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                {t("settings:account.profile.subtitle")}
+              </Typography>
+            </Stack>
+            <Button
+              variant="outlined"
+              size="small"
+              onClick={() => navigate({ pathname: "/profile", search: "?edit=1" })}
+            >
+              {t("common:buttons.edit")}
+            </Button>
+          </Stack>
+        </Stack>
+        <input
+          ref={avatarInputRef}
+          type="file"
+          accept="image/*"
+          hidden
+          onChange={(e) => {
+            const f = e.currentTarget.files?.[0]
+            if (f) uploadAvatar(f)
+          }}
+        />
+        <input
+          ref={coverInputRef}
+          type="file"
+          accept="image/*"
+          hidden
+          onChange={(e) => {
+            const f = e.currentTarget.files?.[0]
+            if (f) uploadCover(f)
+          }}
+        />
+      </SectionCard>
+
+      <SectionCard>
+        <Stack spacing={2}>
+          <Stack spacing={0.75}>
+            <Typography variant="h6">{t("settings:sessions.title")}</Typography>
+            <Typography variant="body2" color="text.secondary">
+              {t("settings:sessions.subtitle")}
+            </Typography>
+          </Stack>
+          {sessionsFetching ? (
+            <Stack direction="row" spacing={1} alignItems="center">
+              <CircularProgress size={18} />
+              <Typography variant="body2" color="text.secondary">
+                {t("settings:sessions.loading")}
+              </Typography>
+            </Stack>
+          ) : sessionsErrorMessage ? (
+            <Alert severity="error" variant="outlined">
+              {sessionsErrorMessage}
+            </Alert>
+          ) : sessionList.length === 0 ? (
+            <Typography variant="body2" color="text.secondary">
+              {t("settings:sessions.empty")}
+            </Typography>
+          ) : (
+            <Stack spacing={1.5} divider={<Divider />}>
+              {sessionList.map((session) => {
+                const lastSeen = session.last_seen_at ?? session.created_at
+                const lastSeenText = t("settings:sessions.lastSeen.value", {
+                  value: formatSessionTimestamp(lastSeen),
+                })
+                const ipLabel = session.ip_address
+                  ? t("settings:sessions.ipAddress", { ip: session.ip_address })
+                  : t("settings:sessions.ipUnknown")
+                const details = `${ipLabel} • ${lastSeenText}`
+                const statusLabel = session.is_current
+                  ? t("settings:sessions.status.current")
+                  : t("settings:sessions.status.active")
+                const statusColor = session.is_current ? accentColor : mutedTextColor
+                const disableRevoke = session.is_current || revokeSessionMutation.isPending
+                return (
+                  <Stack key={session.id} spacing={0.75}>
+                    <Stack direction="row" justifyContent="space-between" alignItems="baseline">
+                      <Typography variant="body1" fontWeight={session.is_current ? 600 : 500}>
+                        {session.user_agent || t("settings:sessions.unknownDevice")}
+                      </Typography>
+                      <Typography variant="caption" sx={{ color: statusColor, fontWeight: 600 }}>
+                        {statusLabel}
+                      </Typography>
+                    </Stack>
+                    <Typography variant="body2" color="text.secondary">
+                      {details}
+                    </Typography>
+                    {!session.is_current && (
+                      <Button
+                        size="small"
+                        variant="text"
+                        color="error"
+                        disabled={disableRevoke}
+                        onClick={() => void handleRevokeSession(session.id)}
+                        sx={{ alignSelf: { xs: "flex-start", sm: "flex-end" }, px: 0 }}
+                      >
+                        {t("settings:sessions.revoke")}
+                      </Button>
+                    )}
+                  </Stack>
+                )
+              })}
+            </Stack>
+          )}
+        </Stack>
+      </SectionCard>
+
+      <SectionCard>
+        <Stack
+          direction={{ xs: "column", sm: "row" }}
+          spacing={1}
+          alignItems={{ xs: "flex-start", sm: "center" }}
+          justifyContent="space-between"
+        >
+          <Stack spacing={0.5} sx={{ maxWidth: { xs: "100%", sm: 360 } }}>
+            <Typography variant="subtitle1" fontWeight={600}>
+              {t("settings:account.logout.dialogTitle")}
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              {t("settings:account.logout.dialogDescription")}
+            </Typography>
+          </Stack>
+          <Button
+            variant="outlined"
+            color="error"
+            size="small"
+            onClick={() => setConfirmLogout(true)}
+          >
+            {t("settings:account.logout.button")}
+          </Button>
+        </Stack>
+      </SectionCard>
+    </Stack>
+  )
+
+  const integrationsTab = (
+    <SectionCard>
+      <Stack spacing={2}>
+        <Stack direction="row" alignItems="center" spacing={1}>
+          <img
+            src={spotifyLogo}
+            alt={t("settings:integrations.spotify.alt")}
+            width={22}
+            height={22}
+            style={{ display: "block", borderRadius: "50%" }}
+            loading="lazy"
+            decoding="async"
+          />
+          <Typography variant="h6">{t("settings:integrations.spotify.title")}</Typography>
+        </Stack>
+        <Stack direction="row" alignItems="center" spacing={1.2} flexWrap="wrap">
+          <Chip
+            size="small"
+            label={
+              spotifyConnected
+                ? t("settings:integrations.spotify.status.connected")
+                : t("settings:integrations.spotify.status.disconnected")
+            }
+            color={spotifyConnected ? "success" : "default"}
+            variant="outlined"
+          />
+          {spotifyConnected && !!spotifyName && (
+            <Chip size="small" variant="outlined" label={spotifyName} />
+          )}
+        </Stack>
+        {!spotifyConnected ? (
+          <Button variant="contained" onClick={connectSpotify} sx={{ alignSelf: "flex-start" }}>
+            {t("settings:integrations.spotify.connect")}
+          </Button>
+        ) : (
+          <Button
+            variant="outlined"
+            color="error"
+            onClick={disconnectSpotify}
+            sx={{ alignSelf: "flex-start" }}
+          >
+            {t("settings:integrations.spotify.disconnect")}
+          </Button>
+        )}
+      </Stack>
+    </SectionCard>
+  )
+
   return (
-    <Box maxWidth="100vw" mx={0} mt={0} width="100vw" minHeight="100svh" px={0}>
-      <Paper
-        className="glass glass--panel"
-        sx={{
-          p: { xs: 2, md: 4, lg: 6 },
-          borderRadius: 0,
-          width: "100%",
-          minHeight: "100svh",
-          color: "var(--page-text)",
-          bgcolor: "var(--card-bg)",
-        }}
-      >
-        <Stack direction="row" alignItems="center" spacing={1.5} sx={{ mb: { xs: 1.5, md: 2 } }}>
-          <SettingsIcon />
-          <Typography variant="h4" fontWeight={800} sx={{ color: "var(--page-text)" }}>
+    <Container component="main" maxWidth="md" sx={{ py: { xs: 3, md: 6 } }}>
+      <Stack spacing={3}>
+        <Stack direction="row" alignItems="center" spacing={1.5}>
+          <SettingsIcon color="primary" />
+          <Typography variant="h4" fontWeight={700}>
             {t("settings:page.title")}
           </Typography>
         </Stack>
 
-        <Paper
-          variant="outlined"
-          className="glass--segmented"
-          sx={{ mb: 3, bgcolor: "var(--card-bg)" }}
-        >
+        <Paper variant="outlined" sx={{ borderRadius: 3, px: { xs: 1, sm: 2 } }}>
           <Tabs
             value={tab}
             onChange={(_, v) => setTab(v)}
             variant="scrollable"
             scrollButtons="auto"
-            sx={{
-              "& .MuiTab-root": {
-                color: "var(--page-text)",
-                textTransform: "none",
-                fontWeight: 700,
-                minHeight: 42,
-              },
-              "& .Mui-selected": { color: "var(--link-color)" },
-            }}
+            sx={{ "& .MuiTab-root": { textTransform: "none", fontWeight: 600 } }}
           >
             <Tab label={t("settings:tabs.general")} />
             <Tab label={t("settings:tabs.account")} />
@@ -719,544 +1020,10 @@ export default function Settings() {
           </Tabs>
         </Paper>
 
-        {tab === 0 && (
-          <Stack spacing={3}>
-            <Box>
-              <Typography variant="h6" sx={{ mb: 1.2, color: "var(--page-text)" }}>
-                {t("settings:appearance.theme.title")}
-              </Typography>
-              <RadioGroup row value={theme} onChange={handleThemeChange}>
-                <FormControlLabel
-                  value="system"
-                  control={<Radio />}
-                  label={
-                    <Stack
-                      direction="row"
-                      alignItems="center"
-                      spacing={1}
-                      sx={{ color: "var(--page-text)" }}
-                    >
-                      <DesktopWindowsIcon />{" "}
-                      <span>{t("settings:appearance.theme.options.system")}</span>
-                    </Stack>
-                  }
-                  sx={{ "& .MuiFormControlLabel-label": { color: "var(--page-text)" } }}
-                />
-                <FormControlLabel
-                  value="light"
-                  control={<Radio />}
-                  label={
-                    <Stack
-                      direction="row"
-                      alignItems="center"
-                      spacing={1}
-                      sx={{ color: "var(--page-text)" }}
-                    >
-                      <LightModeIcon /> <span>{t("settings:appearance.theme.options.light")}</span>
-                    </Stack>
-                  }
-                  sx={{ "& .MuiFormControlLabel-label": { color: "var(--page-text)" } }}
-                />
-                <FormControlLabel
-                  value="dark"
-                  control={<Radio />}
-                  label={
-                    <Stack
-                      direction="row"
-                      alignItems="center"
-                      spacing={1}
-                      sx={{ color: "var(--page-text)" }}
-                    >
-                      <DarkModeIcon /> <span>{t("settings:appearance.theme.options.dark")}</span>
-                    </Stack>
-                  }
-                  sx={{ "& .MuiFormControlLabel-label": { color: "var(--page-text)" } }}
-                />
-              </RadioGroup>
-            </Box>
-
-            <Box>
-              <Typography variant="h6" sx={{ mb: 1.2, color: "var(--page-text)" }}>
-                {t("settings:language.title")}
-              </Typography>
-              <RadioGroup
-                row
-                value={language}
-                onChange={(_, value) => setLanguage(value as SupportedLanguage)}
-                aria-label={t("settings:language.aria")}
-              >
-                {availableLanguages.map((code) => (
-                  <FormControlLabel
-                    key={code}
-                    value={code}
-                    control={<Radio />}
-                    label={t(`settings:language.options.${code}`)}
-                    sx={{ "& .MuiFormControlLabel-label": { color: "var(--page-text)" } }}
-                  />
-                ))}
-              </RadioGroup>
-              <Typography variant="body2" sx={{ mt: 0.5, color: "var(--page-text)" }}>
-                {t("settings:language.description")}
-              </Typography>
-            </Box>
-
-            <Divider />
-
-            <Box>
-              <Typography variant="h6" sx={{ mb: 1.2, color: "var(--page-text)" }}>
-                {t("settings:notifications.title")}
-              </Typography>
-              {!pushSupported ? (
-                <Alert severity="warning" variant="outlined">
-                  {t("settings:notifications.unsupported")}
-                </Alert>
-              ) : (
-                <Stack spacing={1.8}>
-                  {notificationPermission === "denied" ? (
-                    <Stack spacing={1.5}>
-                      <Alert severity="error" variant="outlined">
-                        {t("settings:notifications.blocked.description")}
-                      </Alert>
-                      <Typography variant="body2" sx={{ color: "var(--page-text)" }}>
-                        {t("settings:notifications.blocked.hint")}
-                      </Typography>
-                      <Stack
-                        direction={{ xs: "column", sm: "row" }}
-                        spacing={1.2}
-                        alignItems={{ sm: "center" }}
-                      >
-                        <Button
-                          variant="contained"
-                          onClick={() => void enableNotifications()}
-                          disabled={pushBusy}
-                          startIcon={
-                            pushBusy ? <CircularProgress size={18} color="inherit" /> : undefined
-                          }
-                        >
-                          {t("settings:notifications.cta.checkPermission")}
-                        </Button>
-                        <Typography variant="body2" sx={{ color: "var(--page-text)" }}>
-                          {t("settings:notifications.status", { status: permissionText })}
-                        </Typography>
-                      </Stack>
-                    </Stack>
-                  ) : notificationPermission === "default" ? (
-                    <Stack spacing={1.5}>
-                      <Typography variant="body2" sx={{ color: "var(--page-text)" }}>
-                        {t("settings:notifications.cta.prompt")}
-                      </Typography>
-                      <Stack
-                        direction={{ xs: "column", sm: "row" }}
-                        spacing={1.2}
-                        alignItems={{ sm: "center" }}
-                      >
-                        <Button
-                          variant="contained"
-                          onClick={() => void enableNotifications()}
-                          disabled={pushBusy || pushInitializing}
-                          startIcon={
-                            pushBusy || pushInitializing ? (
-                              <CircularProgress size={18} color="inherit" />
-                            ) : undefined
-                          }
-                        >
-                          {t("settings:notifications.cta.allow")}
-                        </Button>
-                        <Typography variant="body2" sx={{ color: "var(--page-text)" }}>
-                          {t("settings:notifications.status", { status: permissionText })}
-                        </Typography>
-                      </Stack>
-                    </Stack>
-                  ) : (
-                    <>
-                      <FormControlLabel
-                        sx={{
-                          minHeight: 44,
-                          alignItems: "center",
-                          columnGap: 1.25,
-                          m: 0,
-                        }}
-                        control={
-                          <SwitchControl
-                            checked={notificationsEnabled}
-                            onChange={handleNotificationsToggle}
-                            disabled={pushBusy || pushInitializing}
-                            aria-label={t("settings:notifications.toggles.notifications.aria")}
-                          />
-                        }
-                        label={
-                          <span style={{ color: "var(--page-text)", fontWeight: 700 }}>
-                            {t("settings:notifications.toggles.notifications.label")}
-                          </span>
-                        }
-                      />
-
-                      <FormControlLabel
-                        sx={{
-                          minHeight: 44,
-                          alignItems: "center",
-                          columnGap: 1.25,
-                          m: 0,
-                        }}
-                        control={
-                          <SwitchControl
-                            checked={dndEnabled}
-                            onChange={handleDndToggle}
-                            disabled={dndSaving}
-                            aria-label={t("settings:notifications.toggles.dnd.aria")}
-                          />
-                        }
-                        label={
-                          <span style={{ color: "var(--page-text)", fontWeight: 700 }}>
-                            {t("settings:notifications.toggles.dnd.label")}
-                          </span>
-                        }
-                      />
-
-                      <Stack
-                        direction={{ xs: "column", sm: "row" }}
-                        spacing={1.5}
-                        alignItems={{ sm: "center" }}
-                      >
-                        <TextField
-                          type="time"
-                          label={t("settings:dnd.start")}
-                          value={dndStart}
-                          onChange={handleDndStartChange}
-                          onBlur={handleDndStartBlur}
-                          disabled={!dndEnabled || dndSaving}
-                          size="small"
-                          InputLabelProps={{ shrink: true }}
-                          sx={timeFieldSx}
-                        />
-                        <TextField
-                          type="time"
-                          label={t("settings:dnd.end")}
-                          value={dndEnd}
-                          onChange={handleDndEndChange}
-                          onBlur={handleDndEndBlur}
-                          disabled={!dndEnabled || dndSaving}
-                          size="small"
-                          InputLabelProps={{ shrink: true }}
-                          sx={timeFieldSx}
-                        />
-                      </Stack>
-                    </>
-                  )}
-                </Stack>
-              )}
-            </Box>
-          </Stack>
-        )}
-
-        {tab === 1 && (
-          <Stack spacing={3} sx={{ width: "100%", maxWidth: { xs: "100%", sm: 640, md: 760, lg: 880 } }}>
-            <SectionCard variant="outlined">
-              <Stack
-                spacing={2.5}
-                divider={<Divider sx={{ borderColor: "var(--glass-border)" }} />}
-              >
-                <Stack
-                  direction={{ xs: "column", sm: "row" }}
-                  spacing={2}
-                  alignItems={{ xs: "flex-start", sm: "center" }}
-                >
-                  <Avatar
-                    src={avatarSrc}
-                    alt={user?.full_name || "avatar"}
-                    sx={{ width: 56, height: 56 }}
-                    imgProps={{
-                      onError: handleAvatarError,
-                      loading: "lazy",
-                      decoding: "async",
-                      referrerPolicy: "no-referrer",
-                    }}
-                  />
-                  <Stack spacing={1} sx={{ width: "100%" }}>
-                    <Typography variant="subtitle1" sx={{ fontWeight: 600, color: "var(--page-text)" }}>
-                      {t("settings:media.avatar.title")}
-                    </Typography>
-                    <Typography variant="body2" sx={{ color: MUTED_TEXT_COLOR }}>
-                      {t("settings:media.avatar.subtitle")}
-                    </Typography>
-                    <Stack direction="row" spacing={1.5} flexWrap="wrap">
-                      <Button
-                        variant="outlined"
-                        size="small"
-                        onClick={triggerAvatarPick}
-                        disabled={avatarBusy}
-                      >
-                        {t("settings:media.avatar.change")}
-                      </Button>
-                      {avatarUrl && (
-                        <Button
-                          variant="text"
-                          size="small"
-                          color="error"
-                          onClick={removeAvatar}
-                          disabled={avatarBusy}
-                        >
-                          {t("settings:media.avatar.delete")}
-                        </Button>
-                      )}
-                    </Stack>
-                  </Stack>
-                </Stack>
-
-                <Stack
-                  direction={{ xs: "column", sm: "row" }}
-                  spacing={2}
-                  alignItems={{ xs: "flex-start", sm: "center" }}
-                >
-                  <Box
-                    data-testid="settings-cover-preview"
-                    sx={{
-                      width: { xs: "100%", sm: 160 },
-                      maxWidth: 240,
-                      height: 72,
-                      borderRadius: 2,
-                      border: "1px solid var(--glass-border)",
-                      background: coverSrc
-                        ? `url(${coverSrc}) center/cover no-repeat`
-                        : "color-mix(in srgb, var(--card-bg) 88%, transparent)",
-                    }}
-                  />
-                  <Stack spacing={1} sx={{ width: "100%" }}>
-                    <Typography variant="subtitle1" sx={{ fontWeight: 600, color: "var(--page-text)" }}>
-                      {t("settings:media.cover.title")}
-                    </Typography>
-                    <Typography variant="body2" sx={{ color: MUTED_TEXT_COLOR }}>
-                      {t("settings:media.cover.recommendation")}
-                    </Typography>
-                    <Button
-                      variant="outlined"
-                      size="small"
-                      onClick={triggerCoverPick}
-                      disabled={coverBusy}
-                      sx={{ alignSelf: "flex-start" }}
-                    >
-                      {t("settings:media.cover.change")}
-                    </Button>
-                  </Stack>
-                </Stack>
-
-                <Stack
-                  direction={{ xs: "column", sm: "row" }}
-                  spacing={1.5}
-                  alignItems={{ xs: "flex-start", sm: "center" }}
-                  justifyContent="space-between"
-                >
-                  <Stack spacing={0.5} sx={{ flexGrow: 1 }}>
-                    <Typography variant="subtitle1" sx={{ fontWeight: 600, color: "var(--page-text)" }}>
-                      {t("settings:account.profile.title")}
-                    </Typography>
-                    <Typography variant="body2" sx={{ color: MUTED_TEXT_COLOR }}>
-                      {t("settings:account.profile.subtitle")}
-                    </Typography>
-                  </Stack>
-                  <Button
-                    variant="outlined"
-                    size="small"
-                    onClick={() => navigate({ pathname: "/profile", search: "?edit=1" })}
-                  >
-                    {t("common:buttons.edit")}
-                  </Button>
-                </Stack>
-              </Stack>
-              <input
-                ref={avatarInputRef}
-                type="file"
-                accept="image/*"
-                hidden
-                onChange={(e) => {
-                  const f = e.currentTarget.files?.[0]
-                  if (f) uploadAvatar(f)
-                }}
-              />
-              <input
-                ref={coverInputRef}
-                type="file"
-                accept="image/*"
-                hidden
-                onChange={(e) => {
-                  const f = e.currentTarget.files?.[0]
-                  if (f) uploadCover(f)
-                }}
-              />
-            </SectionCard>
-
-            <SectionCard variant="outlined">
-              <Stack spacing={2}>
-                <Stack spacing={0.75}>
-                  <Typography variant="subtitle1" sx={{ fontWeight: 600, color: "var(--page-text)" }}>
-                    {t("settings:sessions.title")}
-                  </Typography>
-                  <Typography variant="body2" sx={{ color: MUTED_TEXT_COLOR }}>
-                    {t("settings:sessions.subtitle")}
-                  </Typography>
-                </Stack>
-
-                {sessionsFetching ? (
-                  <Stack direction="row" spacing={1} alignItems="center">
-                    <CircularProgress size={18} />
-                    <Typography variant="body2" sx={{ color: "var(--page-text)" }}>
-                      {t("settings:sessions.loading")}
-                    </Typography>
-                  </Stack>
-                ) : sessionsErrorMessage ? (
-                  <Alert severity="error" variant="outlined">
-                    {sessionsErrorMessage}
-                  </Alert>
-                ) : sessionList.length === 0 ? (
-                  <Typography variant="body2" sx={{ color: MUTED_TEXT_COLOR }}>
-                    {t("settings:sessions.empty")}
-                  </Typography>
-                ) : (
-                  <Stack
-                    spacing={1.5}
-                    divider={<Divider sx={{ borderColor: "var(--glass-border)" }} />}
-                  >
-                    {sessionList.map((session) => {
-                      const lastSeen = session.last_seen_at ?? session.created_at
-                      const lastSeenText = t("settings:sessions.lastSeen.value", {
-                        value: formatSessionTimestamp(lastSeen),
-                      })
-                      const ipLabel = session.ip_address
-                        ? t("settings:sessions.ipAddress", { ip: session.ip_address })
-                        : t("settings:sessions.ipUnknown")
-                      const details = `${ipLabel} • ${lastSeenText}`
-                      const statusLabel = session.is_current
-                        ? t("settings:sessions.status.current")
-                        : t("settings:sessions.status.active")
-                      const statusColor = session.is_current
-                        ? "var(--link-color)"
-                        : MUTED_TEXT_COLOR
-                      const disableRevoke = session.is_current || revokeSessionMutation.isPending
-                      return (
-                        <Stack key={session.id} spacing={0.75}>
-                          <Stack direction="row" justifyContent="space-between" alignItems="baseline">
-                            <Typography
-                              variant="body1"
-                              sx={{
-                                color: "var(--page-text)",
-                                fontWeight: session.is_current ? 600 : 500,
-                              }}
-                            >
-                              {session.user_agent || t("settings:sessions.unknownDevice")}
-                            </Typography>
-                            <Typography
-                              variant="caption"
-                              sx={{ color: statusColor, fontWeight: 600 }}
-                            >
-                              {statusLabel}
-                            </Typography>
-                          </Stack>
-                          <Typography variant="body2" sx={{ color: MUTED_TEXT_COLOR }}>
-                            {details}
-                          </Typography>
-                          {!session.is_current && (
-                            <Button
-                              size="small"
-                              variant="text"
-                              color="error"
-                              disabled={disableRevoke}
-                              onClick={() => void handleRevokeSession(session.id)}
-                              sx={{ alignSelf: { xs: "flex-start", sm: "flex-end" }, px: 0 }}
-                            >
-                              {t("settings:sessions.revoke")}
-                            </Button>
-                          )}
-                        </Stack>
-                      )
-                    })}
-                  </Stack>
-                )}
-              </Stack>
-            </SectionCard>
-
-            <SectionCard variant="outlined">
-              <Stack
-                direction={{ xs: "column", sm: "row" }}
-                spacing={1}
-                alignItems={{ xs: "flex-start", sm: "center" }}
-                justifyContent="space-between"
-              >
-                <Stack spacing={0.5} sx={{ maxWidth: { xs: "100%", sm: 360 } }}>
-                  <Typography variant="subtitle1" sx={{ fontWeight: 600, color: "var(--page-text)" }}>
-                    {t("settings:account.logout.dialogTitle")}
-                  </Typography>
-                  <Typography variant="body2" sx={{ color: MUTED_TEXT_COLOR }}>
-                    {t("settings:account.logout.dialogDescription")}
-                  </Typography>
-                </Stack>
-                <Button
-                  variant="outlined"
-                  color="error"
-                  size="small"
-                  onClick={() => setConfirmLogout(true)}
-                >
-                  {t("settings:account.logout.button")}
-                </Button>
-              </Stack>
-            </SectionCard>
-          </Stack>
-        )}
-
-        {tab === 2 && (
-          <Stack spacing={3}>
-            <Stack spacing={2}>
-              <Stack direction="row" alignItems="center" spacing={1}>
-                <img
-                  src={spotifyLogo}
-                  alt={t("settings:integrations.spotify.alt")}
-                  width={22}
-                  height={22}
-                  style={{ display: "block", borderRadius: "50%" }}
-                  loading="lazy"
-                  decoding="async"
-                />
-                <Typography variant="h6" sx={{ color: "var(--page-text)" }}>
-                  {t("settings:integrations.spotify.title")}
-                </Typography>
-              </Stack>
-              <Stack direction="row" alignItems="center" spacing={1.2} flexWrap="wrap">
-                <Chip
-                  size="small"
-                  className="glass--chip"
-                  label={
-                    spotifyConnected
-                      ? t("settings:integrations.spotify.status.connected")
-                      : t("settings:integrations.spotify.status.disconnected")
-                  }
-                  color={spotifyConnected ? "success" : "default"}
-                  variant="outlined"
-                />
-                {spotifyConnected && !!spotifyName && (
-                  <Chip size="small" variant="outlined" label={spotifyName} />
-                )}
-              </Stack>
-              {!spotifyConnected ? (
-                <Button
-                  variant="contained"
-                  onClick={connectSpotify}
-                  sx={{ alignSelf: "flex-start" }}
-                >
-                  {t("settings:integrations.spotify.connect")}
-                </Button>
-              ) : (
-                <Button
-                  variant="outlined"
-                  color="error"
-                  onClick={disconnectSpotify}
-                  sx={{ alignSelf: "flex-start" }}
-                >
-                  {t("settings:integrations.spotify.disconnect")}
-                </Button>
-              )}
-            </Stack>
-          </Stack>
-        )}
-      </Paper>
+        {tab === 0 && generalTab}
+        {tab === 1 && accountTab}
+        {tab === 2 && integrationsTab}
+      </Stack>
 
       <Dialog open={confirmLogout} onClose={() => setConfirmLogout(false)} maxWidth="xs" fullWidth>
         <DialogTitle>{t("settings:account.logout.dialogTitle")}</DialogTitle>
@@ -1292,6 +1059,6 @@ export default function Settings() {
           {snack?.text}
         </Alert>
       </Snackbar>
-    </Box>
+    </Container>
   )
 }

--- a/root/frontend/src/pages/Settings.tsx
+++ b/root/frontend/src/pages/Settings.tsx
@@ -906,11 +906,7 @@ export default function Settings() {
                 const disableRevoke =
                   session.is_current || isRevoked || revokeSessionMutation.isPending
                 return (
-                  <Stack
-                    key={session.id}
-                    spacing={0.75}
-                    sx={{ opacity: isRevoked ? 0.65 : 1 }}
-                  >
+                  <Stack key={session.id} spacing={0.75} sx={{ opacity: isRevoked ? 0.65 : 1 }}>
                     <Stack direction="row" justifyContent="space-between" alignItems="baseline">
                       <Typography variant="body1" fontWeight={session.is_current ? 600 : 500}>
                         {session.user_agent || t("settings:sessions.unknownDevice")}

--- a/root/frontend/src/pages/Settings.tsx
+++ b/root/frontend/src/pages/Settings.tsx
@@ -884,7 +884,8 @@ export default function Settings() {
             <Stack spacing={1.5} divider={<Divider />}>
               {visibleSessions.map((session) => {
                 const isRevoked = Boolean(session.revoked_at)
-                const lastRelevantMoment = session.revoked_at ?? session.last_seen_at ?? session.created_at
+                const lastRelevantMoment =
+                  session.revoked_at ?? session.last_seen_at ?? session.created_at
                 const lastSeenText = t("settings:sessions.lastSeen.value", {
                   value: formatSessionTimestamp(lastRelevantMoment),
                 })
@@ -902,7 +903,8 @@ export default function Settings() {
                   : session.is_current
                     ? accentColor
                     : mutedTextColor
-                const disableRevoke = session.is_current || isRevoked || revokeSessionMutation.isPending
+                const disableRevoke =
+                  session.is_current || isRevoked || revokeSessionMutation.isPending
                 return (
                   <Stack key={session.id} spacing={0.75} opacity={isRevoked ? 0.65 : 1}>
                     <Stack direction="row" justifyContent="space-between" alignItems="baseline">

--- a/root/frontend/src/pages/Settings.tsx
+++ b/root/frontend/src/pages/Settings.tsx
@@ -26,10 +26,6 @@ import {
   Radio,
   Divider,
   Avatar,
-  List,
-  ListItem,
-  ListItemText,
-  ListItemAvatar,
   Dialog,
   DialogTitle,
   DialogContent,
@@ -38,15 +34,11 @@ import {
   CircularProgress,
 } from "@mui/material"
 import dayjs from "dayjs"
-import { useColorScheme, styled, alpha, darken } from "@mui/material/styles"
+import { useColorScheme, styled, alpha } from "@mui/material/styles"
 import SettingsIcon from "@mui/icons-material/Settings"
 import DarkModeIcon from "@mui/icons-material/DarkMode"
 import LightModeIcon from "@mui/icons-material/LightMode"
 import DesktopWindowsIcon from "@mui/icons-material/DesktopWindows"
-import LogoutIcon from "@mui/icons-material/Logout"
-import PhotoCameraIcon from "@mui/icons-material/PhotoCamera"
-import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline"
-import ImageIcon from "@mui/icons-material/Image"
 import { AVATAR_PLACEHOLDER_URL } from "@/constants/placeholders"
 const DEFAULT_AVATAR = AVATAR_PLACEHOLDER_URL
 import spotifyLogo from "@/assets/spotify_icon.png"
@@ -57,6 +49,7 @@ type ThemeMode = "system" | "light" | "dark"
 
 const DEFAULT_DND_START = "22:00"
 const DEFAULT_DND_END = "07:00"
+const MUTED_TEXT_COLOR = "color-mix(in srgb, var(--page-text) 68%, transparent)"
 
 const toInputTime = (value: unknown): string => {
   if (!value) return ""
@@ -155,6 +148,14 @@ const ModernSwitch = styled("span")(({ theme }) => {
     },
   }
 })
+
+const SectionCard = styled(Paper)(({ theme }) => ({
+  padding: theme.spacing(2.5, 3),
+  borderRadius: 16,
+  border: "1px solid var(--glass-border)",
+  backgroundColor: "color-mix(in srgb, var(--card-bg) 96%, transparent)",
+  boxShadow: "none",
+}))
 
 function SwitchControl({
   checked,
@@ -295,7 +296,16 @@ export default function Settings() {
     staleTime: 30_000,
   })
 
-  const sessionList = useMemo(() => (Array.isArray(sessions) ? sessions : []), [sessions])
+  const sessionList = useMemo(
+    () => (Array.isArray(sessions) ? sessions.filter((session) => !session.revoked_at) : []),
+    [sessions]
+  )
+
+  useEffect(() => {
+    if (!Array.isArray(sessions)) return
+    if (sessions.length === sessionList.length) return
+    queryClient.setQueryData(sessionsKey, sessionList)
+  }, [queryClient, sessionList, sessions, sessionsKey])
 
   const revokeSessionMutation = useMutation({
     mutationFn: async (sessionId: number) => {
@@ -940,39 +950,21 @@ export default function Settings() {
         )}
 
         {tab === 1 && (
-          <Box sx={{ width: "100%", maxWidth: { xs: "100%", sm: 640, md: 760, lg: 880 } }}>
-            <List dense disablePadding>
-              <ListItem
-                divider
-                secondaryAction={
-                  <Stack direction="row" spacing={1}>
-                    <Button
-                      size="small"
-                      variant="text"
-                      startIcon={<PhotoCameraIcon />}
-                      onClick={triggerAvatarPick}
-                      disabled={avatarBusy}
-                    >
-                      {t("settings:media.avatar.change")}
-                    </Button>
-                    <Button
-                      size="small"
-                      variant="text"
-                      color="error"
-                      startIcon={<DeleteOutlineIcon />}
-                      onClick={removeAvatar}
-                      disabled={avatarBusy}
-                    >
-                      {t("settings:media.avatar.delete")}
-                    </Button>
-                  </Stack>
-                }
+          <Stack spacing={3} sx={{ width: "100%", maxWidth: { xs: "100%", sm: 640, md: 760, lg: 880 } }}>
+            <SectionCard variant="outlined">
+              <Stack
+                spacing={2.5}
+                divider={<Divider sx={{ borderColor: "var(--glass-border)" }} />}
               >
-                <ListItemAvatar>
+                <Stack
+                  direction={{ xs: "column", sm: "row" }}
+                  spacing={2}
+                  alignItems={{ xs: "flex-start", sm: "center" }}
+                >
                   <Avatar
                     src={avatarSrc}
                     alt={user?.full_name || "avatar"}
-                    sx={{ width: 48, height: 48 }}
+                    sx={{ width: 56, height: 56 }}
                     imgProps={{
                       onError: handleAvatarError,
                       loading: "lazy",
@@ -980,210 +972,234 @@ export default function Settings() {
                       referrerPolicy: "no-referrer",
                     }}
                   />
-                </ListItemAvatar>
-                <ListItemText
-                  primary={t("settings:media.avatar.title")}
-                  secondary={t("settings:media.avatar.subtitle")}
-                />
-                <input
-                  ref={avatarInputRef}
-                  type="file"
-                  accept="image/*"
-                  hidden
-                  onChange={(e) => {
-                    const f = e.currentTarget.files?.[0]
-                    if (f) uploadAvatar(f)
-                  }}
-                />
-              </ListItem>
+                  <Stack spacing={1} sx={{ width: "100%" }}>
+                    <Typography variant="subtitle1" sx={{ fontWeight: 600, color: "var(--page-text)" }}>
+                      {t("settings:media.avatar.title")}
+                    </Typography>
+                    <Typography variant="body2" sx={{ color: MUTED_TEXT_COLOR }}>
+                      {t("settings:media.avatar.subtitle")}
+                    </Typography>
+                    <Stack direction="row" spacing={1.5} flexWrap="wrap">
+                      <Button
+                        variant="outlined"
+                        size="small"
+                        onClick={triggerAvatarPick}
+                        disabled={avatarBusy}
+                      >
+                        {t("settings:media.avatar.change")}
+                      </Button>
+                      {avatarUrl && (
+                        <Button
+                          variant="text"
+                          size="small"
+                          color="error"
+                          onClick={removeAvatar}
+                          disabled={avatarBusy}
+                        >
+                          {t("settings:media.avatar.delete")}
+                        </Button>
+                      )}
+                    </Stack>
+                  </Stack>
+                </Stack>
 
-              <ListItem
-                divider
-                secondaryAction={
-                  <Button
-                    size="small"
-                    variant="text"
-                    startIcon={<ImageIcon />}
-                    onClick={triggerCoverPick}
-                    disabled={coverBusy}
-                  >
-                    {t("settings:media.cover.change")}
-                  </Button>
-                }
-              >
-                <ListItemAvatar sx={{ mr: 1.25 }}>
+                <Stack
+                  direction={{ xs: "column", sm: "row" }}
+                  spacing={2}
+                  alignItems={{ xs: "flex-start", sm: "center" }}
+                >
                   <Box
                     data-testid="settings-cover-preview"
                     sx={{
-                      width: 120,
-                      height: 52,
-                      borderRadius: 1.5,
+                      width: { xs: "100%", sm: 160 },
+                      maxWidth: 240,
+                      height: 72,
+                      borderRadius: 2,
                       border: "1px solid var(--glass-border)",
                       background: coverSrc
                         ? `url(${coverSrc}) center/cover no-repeat`
-                        : "var(--card-bg)",
+                        : "color-mix(in srgb, var(--card-bg) 88%, transparent)",
                     }}
                   />
-                </ListItemAvatar>
-                <ListItemText
-                  primary={t("settings:media.cover.title")}
-                  secondary={t("settings:media.cover.recommendation")}
-                />
-                <input
-                  ref={coverInputRef}
-                  type="file"
-                  accept="image/*"
-                  hidden
-                  onChange={(e) => {
-                    const f = e.currentTarget.files?.[0]
-                    if (f) uploadCover(f)
-                  }}
-                />
-              </ListItem>
+                  <Stack spacing={1} sx={{ width: "100%" }}>
+                    <Typography variant="subtitle1" sx={{ fontWeight: 600, color: "var(--page-text)" }}>
+                      {t("settings:media.cover.title")}
+                    </Typography>
+                    <Typography variant="body2" sx={{ color: MUTED_TEXT_COLOR }}>
+                      {t("settings:media.cover.recommendation")}
+                    </Typography>
+                    <Button
+                      variant="outlined"
+                      size="small"
+                      onClick={triggerCoverPick}
+                      disabled={coverBusy}
+                      sx={{ alignSelf: "flex-start" }}
+                    >
+                      {t("settings:media.cover.change")}
+                    </Button>
+                  </Stack>
+                </Stack>
 
-              <ListItem
-                divider
-                secondaryAction={
+                <Stack
+                  direction={{ xs: "column", sm: "row" }}
+                  spacing={1.5}
+                  alignItems={{ xs: "flex-start", sm: "center" }}
+                  justifyContent="space-between"
+                >
+                  <Stack spacing={0.5} sx={{ flexGrow: 1 }}>
+                    <Typography variant="subtitle1" sx={{ fontWeight: 600, color: "var(--page-text)" }}>
+                      {t("settings:account.profile.title")}
+                    </Typography>
+                    <Typography variant="body2" sx={{ color: MUTED_TEXT_COLOR }}>
+                      {t("settings:account.profile.subtitle")}
+                    </Typography>
+                  </Stack>
                   <Button
+                    variant="outlined"
                     size="small"
-                    variant="text"
                     onClick={() => navigate({ pathname: "/profile", search: "?edit=1" })}
                   >
                     {t("common:buttons.edit")}
                   </Button>
-                }
-              >
-                <ListItemText
-                  primary={t("settings:account.profile.title")}
-                  secondary={t("settings:account.profile.subtitle")}
-                />
-              </ListItem>
-            </List>
+                </Stack>
+              </Stack>
+              <input
+                ref={avatarInputRef}
+                type="file"
+                accept="image/*"
+                hidden
+                onChange={(e) => {
+                  const f = e.currentTarget.files?.[0]
+                  if (f) uploadAvatar(f)
+                }}
+              />
+              <input
+                ref={coverInputRef}
+                type="file"
+                accept="image/*"
+                hidden
+                onChange={(e) => {
+                  const f = e.currentTarget.files?.[0]
+                  if (f) uploadCover(f)
+                }}
+              />
+            </SectionCard>
 
-            <Divider sx={{ my: 2 }} />
-
-            <Box>
-              <Typography variant="h6" sx={{ color: "var(--page-text)", mb: 0.5 }}>
-                {t("settings:sessions.title")}
-              </Typography>
-              <Typography
-                variant="body2"
-                sx={{ color: "color-mix(in srgb, var(--page-text) 72%, transparent)" }}
-              >
-                {t("settings:sessions.subtitle")}
-              </Typography>
-
-              {sessionsFetching ? (
-                <Stack direction="row" spacing={1} alignItems="center" sx={{ mt: 2 }}>
-                  <CircularProgress size={18} />
-                  <Typography variant="body2" sx={{ color: "var(--page-text)" }}>
-                    {t("settings:sessions.loading")}
+            <SectionCard variant="outlined">
+              <Stack spacing={2}>
+                <Stack spacing={0.75}>
+                  <Typography variant="subtitle1" sx={{ fontWeight: 600, color: "var(--page-text)" }}>
+                    {t("settings:sessions.title")}
+                  </Typography>
+                  <Typography variant="body2" sx={{ color: MUTED_TEXT_COLOR }}>
+                    {t("settings:sessions.subtitle")}
                   </Typography>
                 </Stack>
-              ) : sessionsErrorMessage ? (
-                <Alert severity="error" variant="outlined" sx={{ mt: 2 }}>
-                  {sessionsErrorMessage}
-                </Alert>
-              ) : sessionList.length === 0 ? (
-                <Typography variant="body2" sx={{ mt: 2, color: "var(--page-text)" }}>
-                  {t("settings:sessions.empty")}
-                </Typography>
-              ) : (
-                <List disablePadding sx={{ mt: 1 }}>
-                  {sessionList.map((session) => {
-                    const lastSeen = session.last_seen_at ?? session.created_at
-                    const lastSeenText = t("settings:sessions.lastSeen.value", {
-                      value: formatSessionTimestamp(lastSeen),
-                    })
-                    const ipLabel = session.ip_address
-                      ? t("settings:sessions.ipAddress", { ip: session.ip_address })
-                      : t("settings:sessions.ipUnknown")
-                    const details = `${ipLabel} • ${lastSeenText}`
-                    const revoked = Boolean(session.revoked_at)
-                    const statusLabel = revoked
-                      ? t("settings:sessions.status.revoked")
-                      : session.is_current
+
+                {sessionsFetching ? (
+                  <Stack direction="row" spacing={1} alignItems="center">
+                    <CircularProgress size={18} />
+                    <Typography variant="body2" sx={{ color: "var(--page-text)" }}>
+                      {t("settings:sessions.loading")}
+                    </Typography>
+                  </Stack>
+                ) : sessionsErrorMessage ? (
+                  <Alert severity="error" variant="outlined">
+                    {sessionsErrorMessage}
+                  </Alert>
+                ) : sessionList.length === 0 ? (
+                  <Typography variant="body2" sx={{ color: MUTED_TEXT_COLOR }}>
+                    {t("settings:sessions.empty")}
+                  </Typography>
+                ) : (
+                  <Stack
+                    spacing={1.5}
+                    divider={<Divider sx={{ borderColor: "var(--glass-border)" }} />}
+                  >
+                    {sessionList.map((session) => {
+                      const lastSeen = session.last_seen_at ?? session.created_at
+                      const lastSeenText = t("settings:sessions.lastSeen.value", {
+                        value: formatSessionTimestamp(lastSeen),
+                      })
+                      const ipLabel = session.ip_address
+                        ? t("settings:sessions.ipAddress", { ip: session.ip_address })
+                        : t("settings:sessions.ipUnknown")
+                      const details = `${ipLabel} • ${lastSeenText}`
+                      const statusLabel = session.is_current
                         ? t("settings:sessions.status.current")
                         : t("settings:sessions.status.active")
-                    const statusColor: "default" | "primary" | "success" = revoked
-                      ? "default"
-                      : session.is_current
-                        ? "primary"
-                        : "success"
-                    const disableRevoke =
-                      revoked || session.is_current || revokeSessionMutation.isPending
-                    return (
-                      <ListItem
-                        key={session.id}
-                        alignItems="flex-start"
-                        divider
-                        sx={{
-                          opacity: revoked ? 0.6 : 1,
-                        }}
-                        secondaryAction={
-                          <Stack direction="row" spacing={1} alignItems="center">
-                            <Chip
-                              size="small"
-                              color={statusColor}
-                              label={statusLabel}
-                              variant={revoked ? "outlined" : "filled"}
-                            />
-                            {!revoked && (
-                              <Button
-                                size="small"
-                                variant="text"
-                                color="error"
-                                disabled={disableRevoke}
-                                onClick={() => void handleRevokeSession(session.id)}
-                              >
-                                {t("settings:sessions.revoke")}
-                              </Button>
-                            )}
+                      const statusColor = session.is_current
+                        ? "var(--link-color)"
+                        : MUTED_TEXT_COLOR
+                      const disableRevoke = session.is_current || revokeSessionMutation.isPending
+                      return (
+                        <Stack key={session.id} spacing={0.75}>
+                          <Stack direction="row" justifyContent="space-between" alignItems="baseline">
+                            <Typography
+                              variant="body1"
+                              sx={{
+                                color: "var(--page-text)",
+                                fontWeight: session.is_current ? 600 : 500,
+                              }}
+                            >
+                              {session.user_agent || t("settings:sessions.unknownDevice")}
+                            </Typography>
+                            <Typography
+                              variant="caption"
+                              sx={{ color: statusColor, fontWeight: 600 }}
+                            >
+                              {statusLabel}
+                            </Typography>
                           </Stack>
-                        }
-                      >
-                        <ListItemText
-                          primary={session.user_agent || t("settings:sessions.unknownDevice")}
-                          secondary={details}
-                          primaryTypographyProps={{
-                            sx: {
-                              color: "var(--page-text)",
-                              fontWeight: session.is_current ? 600 : 500,
-                            },
-                          }}
-                          secondaryTypographyProps={{
-                            sx: {
-                              color: "color-mix(in srgb, var(--page-text) 68%, transparent)",
-                            },
-                          }}
-                        />
-                      </ListItem>
-                    )
-                  })}
-                </List>
-              )}
-            </Box>
+                          <Typography variant="body2" sx={{ color: MUTED_TEXT_COLOR }}>
+                            {details}
+                          </Typography>
+                          {!session.is_current && (
+                            <Button
+                              size="small"
+                              variant="text"
+                              color="error"
+                              disabled={disableRevoke}
+                              onClick={() => void handleRevokeSession(session.id)}
+                              sx={{ alignSelf: { xs: "flex-start", sm: "flex-end" }, px: 0 }}
+                            >
+                              {t("settings:sessions.revoke")}
+                            </Button>
+                          )}
+                        </Stack>
+                      )
+                    })}
+                  </Stack>
+                )}
+              </Stack>
+            </SectionCard>
 
-            <Box sx={{ pt: 1.5, mt: 2, borderTop: "1px solid var(--glass-border)" }}>
-              <List dense disablePadding>
-                <ListItem>
-                  <Button
-                    size="small"
-                    variant="text"
-                    color="error"
-                    startIcon={<LogoutIcon />}
-                    onClick={async () => {
-                      setConfirmLogout(false)
-                      await logout()
-                    }}
-                    sx={{ px: 0 }}
-                  >
-                    {t("settings:account.logout.button")}
-                  </Button>
-                </ListItem>
-              </List>
-            </Box>
-          </Box>
+            <SectionCard variant="outlined">
+              <Stack
+                direction={{ xs: "column", sm: "row" }}
+                spacing={1}
+                alignItems={{ xs: "flex-start", sm: "center" }}
+                justifyContent="space-between"
+              >
+                <Stack spacing={0.5} sx={{ maxWidth: { xs: "100%", sm: 360 } }}>
+                  <Typography variant="subtitle1" sx={{ fontWeight: 600, color: "var(--page-text)" }}>
+                    {t("settings:account.logout.dialogTitle")}
+                  </Typography>
+                  <Typography variant="body2" sx={{ color: MUTED_TEXT_COLOR }}>
+                    {t("settings:account.logout.dialogDescription")}
+                  </Typography>
+                </Stack>
+                <Button
+                  variant="outlined"
+                  color="error"
+                  size="small"
+                  onClick={() => setConfirmLogout(true)}
+                >
+                  {t("settings:account.logout.button")}
+                </Button>
+              </Stack>
+            </SectionCard>
+          </Stack>
         )}
 
         {tab === 2 && (


### PR DESCRIPTION
## Summary
- streamline the account tab layout with calmer section cards and simplified actions
- automatically filter revoked sessions out of the cached list so the interface stays clean

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f9862949c883279c52ae314204e2c7