### PR TITLE
Fix desktop layout for settings media actions

### DIFF
--- a/root/frontend/src/pages/Settings.tsx
+++ b/root/frontend/src/pages/Settings.tsx
@@ -1083,9 +1083,9 @@ export default function Settings() {
                     direction={{ xs: "column", sm: "row" }}
                     spacing={1}
                     alignItems={{ sm: "center" }}
-                    justifyContent={{ xs: "flex-start", sm: "flex-start" }}
+                    justifyContent={{ xs: "flex-start", sm: "flex-end" }}
                     flexWrap="wrap"
-                    sx={{ width: "100%" }}
+                    sx={{ width: { xs: "100%", sm: "auto" } }}
                   >
                     <Button
                       size="small"
@@ -1155,9 +1155,9 @@ export default function Settings() {
                     direction={{ xs: "column", sm: "row" }}
                     spacing={1}
                     alignItems={{ sm: "center" }}
-                    justifyContent={{ xs: "flex-start", sm: "flex-start" }}
+                    justifyContent={{ xs: "flex-start", sm: "flex-end" }}
                     flexWrap="wrap"
-                    sx={{ width: "100%" }}
+                    sx={{ width: { xs: "100%", sm: "auto" } }}
                   >
                     <Button
                       size="small"


### PR DESCRIPTION
## Summary
- adjust button stack width and alignment in the settings media section for desktop view
- ensure media action buttons no longer overlap previews on larger screens

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fab25408808327a30dd35351851bef