### PR TITLE
Add persistent login lockouts and surface messaging

### DIFF
--- a/root/alembic/versions/202507010001_add_failed_login_attempts_table.py
+++ b/root/alembic/versions/202507010001_add_failed_login_attempts_table.py
@@ -1,8 +1,8 @@
 from typing import Sequence, Union
 
 import sqlalchemy as sa
-from alembic import op
 
+from alembic import op
 
 revision: str = "202507010001"
 down_revision: Union[str, None] = "202506200001"
@@ -47,8 +47,11 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     op.drop_index(
-        "ix_failed_login_attempts_email_attempted_at", table_name="failed_login_attempts"
+        "ix_failed_login_attempts_email_attempted_at",
+        table_name="failed_login_attempts",
     )
-    op.drop_index("ix_failed_login_attempts_attempted_at", table_name="failed_login_attempts")
+    op.drop_index(
+        "ix_failed_login_attempts_attempted_at", table_name="failed_login_attempts"
+    )
     op.drop_index("ix_failed_login_attempts_email", table_name="failed_login_attempts")
     op.drop_table("failed_login_attempts")

--- a/root/alembic/versions/202507010001_add_failed_login_attempts_table.py
+++ b/root/alembic/versions/202507010001_add_failed_login_attempts_table.py
@@ -1,0 +1,54 @@
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "202507010001"
+down_revision: Union[str, None] = "202506200001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "failed_login_attempts",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "user_id",
+            sa.Integer(),
+            sa.ForeignKey("users.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("email", sa.String(), nullable=False),
+        sa.Column(
+            "attempted_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_index(
+        "ix_failed_login_attempts_email",
+        "failed_login_attempts",
+        ["email"],
+    )
+    op.create_index(
+        "ix_failed_login_attempts_attempted_at",
+        "failed_login_attempts",
+        ["attempted_at"],
+    )
+    op.create_index(
+        "ix_failed_login_attempts_email_attempted_at",
+        "failed_login_attempts",
+        ["email", "attempted_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_failed_login_attempts_email_attempted_at", table_name="failed_login_attempts"
+    )
+    op.drop_index("ix_failed_login_attempts_attempted_at", table_name="failed_login_attempts")
+    op.drop_index("ix_failed_login_attempts_email", table_name="failed_login_attempts")
+    op.drop_table("failed_login_attempts")

--- a/root/app/auth/auth.py
+++ b/root/app/auth/auth.py
@@ -154,7 +154,9 @@ def _calculate_lock_until(
             attempt_time = _normalize_timestamp(attempts[-1].attempted_at)
             candidate = attempt_time + timedelta(seconds=seconds)
             if candidate > now:
-                lock_until = candidate if lock_until is None else max(lock_until, candidate)
+                lock_until = (
+                    candidate if lock_until is None else max(lock_until, candidate)
+                )
     return lock_until
 
 
@@ -184,7 +186,9 @@ async def _register_failed_attempt(
     lock_until = _calculate_lock_until(updated, now)
     await db.commit()
     triggered = bool(
-        lock_until and (previous_lock is None or previous_lock <= now) and lock_until > now
+        lock_until
+        and (previous_lock is None or previous_lock <= now)
+        and lock_until > now
     )
     return lock_until, triggered, len(updated)
 

--- a/root/app/auth/auth.py
+++ b/root/app/auth/auth.py
@@ -1,11 +1,13 @@
 import json
 import logging
+import math
 from datetime import UTC, datetime, timedelta
+from typing import Any, Mapping, Sequence
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from fastapi.security import OAuth2PasswordRequestForm
 from pydantic import BaseModel, EmailStr
-from sqlalchemy import select
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth.security import (
@@ -18,7 +20,7 @@ from app.core.config import settings
 from app.core.database import get_db
 from app.core.observability import get_request_id
 from app.localization import resolve_locale, translate
-from app.models.models import ActiveSession, User
+from app.models.models import ActiveSession, FailedLoginAttempt, User
 from app.schemas.schemas import Token, UserCreate
 from app.utils.ratelimit import sensitive_route_limit
 
@@ -68,40 +70,269 @@ def _clear_access_token_cookie(response: Response) -> None:
     )
 
 
-@router.post(
-    "/login",
-    response_model=Token,
-    dependencies=[Depends(sensitive_route_limit())],
-)
-async def login(
-    response: Response,
+def _lockout_rules() -> list[tuple[int, int]]:
+    raw = settings.auth_lockout_thresholds
+    tokens: Sequence[str]
+    if isinstance(raw, str):
+        tokens = [token.strip() for token in raw.split(",")]
+    else:
+        tokens = [str(token).strip() for token in raw]
+
+    rules: list[tuple[int, int]] = []
+    for token in tokens:
+        if not token:
+            continue
+        threshold_str, _, duration_str = token.partition(":")
+        if not threshold_str or not duration_str:
+            continue
+        try:
+            threshold = int(threshold_str)
+            duration = int(duration_str)
+        except ValueError:
+            continue
+        if threshold > 0 and duration > 0:
+            rules.append((threshold, duration))
+    rules.sort(key=lambda item: item[0])
+    return rules
+
+
+def _max_lockout_threshold() -> int:
+    rules = _lockout_rules()
+    if not rules:
+        return 0
+    return max(threshold for threshold, _ in rules)
+
+
+async def _prune_stale_attempts(db: AsyncSession, email: str) -> None:
+    history_minutes = getattr(settings, "auth_lockout_history_minutes", 0)
+    if history_minutes <= 0:
+        return
+    cutoff = datetime.now(UTC) - timedelta(minutes=history_minutes)
+    await db.execute(
+        delete(FailedLoginAttempt)
+        .where(FailedLoginAttempt.email == email)
+        .where(FailedLoginAttempt.attempted_at < cutoff)
+    )
+    await db.flush()
+
+
+async def _fetch_recent_attempts(
+    db: AsyncSession, email: str, limit: int, *, for_update: bool = False
+) -> list[FailedLoginAttempt]:
+    if limit <= 0:
+        limit = 1
+    stmt = (
+        select(FailedLoginAttempt)
+        .where(FailedLoginAttempt.email == email)
+        .order_by(FailedLoginAttempt.attempted_at.desc())
+        .limit(limit)
+    )
+    if for_update:
+        stmt = stmt.with_for_update()
+    result = await db.execute(stmt)
+    attempts = list(result.scalars().all())
+    attempts.reverse()
+    return attempts
+
+
+def _normalize_timestamp(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def _calculate_lock_until(
+    attempts: Sequence[FailedLoginAttempt], now: datetime
+) -> datetime | None:
+    rules = _lockout_rules()
+    if not attempts or not rules:
+        return None
+    total = len(attempts)
+    lock_until: datetime | None = None
+    for threshold, seconds in rules:
+        if total >= threshold:
+            attempt_time = _normalize_timestamp(attempts[-1].attempted_at)
+            candidate = attempt_time + timedelta(seconds=seconds)
+            if candidate > now:
+                lock_until = candidate if lock_until is None else max(lock_until, candidate)
+    return lock_until
+
+
+async def _active_lockout(db: AsyncSession, email: str) -> datetime | None:
+    if not _lockout_rules():
+        return None
+    await _prune_stale_attempts(db, email)
+    limit = max(_max_lockout_threshold(), 1)
+    attempts = await _fetch_recent_attempts(db, email, limit)
+    lock_until = _calculate_lock_until(attempts, datetime.now(UTC))
+    await db.commit()
+    return lock_until
+
+
+async def _register_failed_attempt(
+    db: AsyncSession, email: str, user_id: int | None
+) -> tuple[datetime | None, bool, int]:
+    limit = max(_max_lockout_threshold(), 1)
+    await _prune_stale_attempts(db, email)
+    existing = await _fetch_recent_attempts(db, email, limit, for_update=True)
+    now = datetime.now(UTC)
+    previous_lock = _calculate_lock_until(existing, now)
+    attempt = FailedLoginAttempt(email=email, user_id=user_id, attempted_at=now)
+    db.add(attempt)
+    await db.flush()
+    updated = (existing + [attempt])[-limit:]
+    lock_until = _calculate_lock_until(updated, now)
+    await db.commit()
+    triggered = bool(
+        lock_until and (previous_lock is None or previous_lock <= now) and lock_until > now
+    )
+    return lock_until, triggered, len(updated)
+
+
+async def _clear_failed_attempts(db: AsyncSession, email: str) -> int:
+    result = await db.execute(
+        delete(FailedLoginAttempt).where(FailedLoginAttempt.email == email)
+    )
+    await db.commit()
+    return int(result.rowcount or 0)
+
+
+def _pluralize_en(value: int, unit: str) -> str:
+    forms = {
+        "seconds": "second",
+        "minutes": "minute",
+        "hours": "hour",
+    }
+    singular = forms.get(unit, unit)
+    if value == 1:
+        return singular
+    return f"{singular}s"
+
+
+def _pluralize_ru(value: int, unit: str) -> str:
+    forms = {
+        "seconds": ("секунду", "секунды", "секунд"),
+        "minutes": ("минуту", "минуты", "минут"),
+        "hours": ("час", "часа", "часов"),
+    }
+    singular, few, many = forms.get(unit, (unit, unit, unit))
+    value_mod = value % 100
+    if 11 <= value_mod <= 14:
+        return many
+    remainder = value % 10
+    if remainder == 1:
+        return singular
+    if 2 <= remainder <= 4:
+        return few
+    return many
+
+
+def _format_duration(locale: str, seconds: int) -> str:
+    clamped = max(seconds, 0)
+    if clamped < 60:
+        value = max(clamped, 1)
+        unit = "seconds"
+    elif clamped < 3600:
+        value = max(1, math.ceil(clamped / 60))
+        unit = "minutes"
+    else:
+        value = max(1, math.ceil(clamped / 3600))
+        unit = "hours"
+
+    if locale == "ru":
+        unit_text = _pluralize_ru(value, unit)
+    else:
+        unit_text = _pluralize_en(value, unit)
+    return f"{value} {unit_text}"
+
+
+def _lockout_message(locale: str, lock_until: datetime) -> tuple[str, int]:
+    base = translate("errors.auth.account_locked", locale=locale)
+    now = datetime.now(UTC)
+    remaining_seconds = max(0, int(math.ceil((lock_until - now).total_seconds())))
+    if remaining_seconds <= 0:
+        return base, 0
+    duration_text = _format_duration(locale, remaining_seconds)
+    retry_text = translate(
+        "errors.auth.account_locked_retry",
+        locale=locale,
+        duration=duration_text,
+    )
+    detail = f"{base} {retry_text}".strip()
+    retry_after = max(1, remaining_seconds)
+    return detail, retry_after
+
+
+async def _perform_login(
+    email: str,
+    password: str,
     request: Request,
-    form_data: OAuth2PasswordRequestForm = Depends(OAuth2PasswordRequestForm),
-    db: AsyncSession = Depends(get_db),
-):
-    locale = resolve_locale(request=request)
-    email = form_data.username.strip().lower()
-    res = await db.execute(select(User).where(User.email == email))
+    response: Response,
+    db: AsyncSession,
+) -> dict[str, str]:
+    normalized_email = email.strip().lower()
+    base_locale = resolve_locale(request=request)
+
+    res = await db.execute(select(User).where(User.email == normalized_email))
     user = res.scalars().first()
+    locale = resolve_locale(request=request, user=user) if user else base_locale
+
+    lock_until = await _active_lockout(db, normalized_email)
+    if lock_until:
+        detail, retry_after = _lockout_message(locale, lock_until)
+        _audit_log(
+            "auth.login.failure",
+            request,
+            level=logging.WARNING,
+            user_id=user.id if user else None,
+            reason="locked",
+            extra={"lock_until": lock_until.isoformat()},
+        )
+        raise HTTPException(
+            status_code=status.HTTP_423_LOCKED,
+            detail=detail,
+            headers={"Retry-After": str(retry_after)},
+        )
+
     if not user:
+        lock_until, triggered, attempts = await _register_failed_attempt(
+            db, normalized_email, None
+        )
         _audit_log(
             "auth.login.failure",
             request,
             level=logging.WARNING,
             reason="invalid_credentials",
         )
-        message = translate("errors.auth.credentials_invalid", locale=locale)
+        if triggered and lock_until:
+            detail, retry_after = _lockout_message(base_locale, lock_until)
+            _audit_log(
+                "auth.login.locked",
+                request,
+                level=logging.WARNING,
+                reason="lockout",
+                extra={
+                    "lock_until": lock_until.isoformat(),
+                    "attempts": attempts,
+                },
+            )
+            raise HTTPException(
+                status_code=status.HTTP_423_LOCKED,
+                detail=detail,
+                headers={"Retry-After": str(retry_after)},
+            )
+        message = translate("errors.auth.credentials_invalid", locale=base_locale)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=message,
             headers={"WWW-Authenticate": "Bearer"},
         )
 
-    locale = resolve_locale(request=request, user=user)
-    verified, new_hash = verify_and_update_password(
-        form_data.password, user.hashed_password
-    )
+    verified, new_hash = verify_and_update_password(password, user.hashed_password)
     if not verified:
+        lock_until, triggered, attempts = await _register_failed_attempt(
+            db, normalized_email, user.id
+        )
         _audit_log(
             "auth.login.failure",
             request,
@@ -109,12 +340,31 @@ async def login(
             user_id=user.id,
             reason="invalid_credentials",
         )
+        if triggered and lock_until:
+            detail, retry_after = _lockout_message(locale, lock_until)
+            _audit_log(
+                "auth.login.locked",
+                request,
+                level=logging.WARNING,
+                user_id=user.id,
+                reason="lockout",
+                extra={
+                    "lock_until": lock_until.isoformat(),
+                    "attempts": attempts,
+                },
+            )
+            raise HTTPException(
+                status_code=status.HTTP_423_LOCKED,
+                detail=detail,
+                headers={"Retry-After": str(retry_after)},
+            )
         message = translate("errors.auth.credentials_invalid", locale=locale)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=message,
             headers={"WWW-Authenticate": "Bearer"},
         )
+
     if not user.is_active:
         _audit_log(
             "auth.login.failure",
@@ -129,11 +379,22 @@ async def login(
             detail=message,
             headers={"WWW-Authenticate": "Bearer"},
         )
-    user_id = user.id
+
     if new_hash:
         user.hashed_password = new_hash
-        await db.commit()
+
+    cleared = await _clear_failed_attempts(db, normalized_email)
+    if cleared:
+        _audit_log(
+            "auth.login.unlocked",
+            request,
+            user_id=user.id,
+            reason="successful_login",
+            extra={"cleared_attempts": cleared},
+        )
+    if new_hash:
         await db.refresh(user)
+
     forwarded_for = request.headers.get("x-forwarded-for")
     if forwarded_for:
         client_ip = forwarded_for.split(",")[0].strip()
@@ -142,7 +403,7 @@ async def login(
     user_agent = request.headers.get("user-agent")
     now = datetime.now(UTC)
     token = await create_access_token(
-        str(user_id),
+        str(user.id),
         db=db,
         session_metadata={
             "ip_address": client_ip,
@@ -154,10 +415,30 @@ async def login(
     _audit_log(
         "auth.login.success",
         request,
-        user_id=user_id,
+        user_id=user.id,
         reason="authenticated",
     )
     return {"access_token": token, "token_type": "bearer"}
+
+
+@router.post(
+    "/login",
+    response_model=Token,
+    dependencies=[Depends(sensitive_route_limit())],
+)
+async def login(
+    response: Response,
+    request: Request,
+    form_data: OAuth2PasswordRequestForm = Depends(OAuth2PasswordRequestForm),
+    db: AsyncSession = Depends(get_db),
+):
+    return await _perform_login(
+        form_data.username,
+        form_data.password,
+        request,
+        response,
+        db,
+    )
 
 
 @router.post(
@@ -171,85 +452,13 @@ async def login_json(
     request: Request,
     db: AsyncSession = Depends(get_db),
 ):
-    locale = resolve_locale(request=request)
-    email = payload.email.strip().lower()
-    res = await db.execute(select(User).where(User.email == email))
-    user = res.scalars().first()
-    if not user:
-        _audit_log(
-            "auth.login.failure",
-            request,
-            level=logging.WARNING,
-            reason="invalid_credentials",
-        )
-        message = translate("errors.auth.credentials_invalid", locale=locale)
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail=message,
-            headers={"WWW-Authenticate": "Bearer"},
-        )
-
-    locale = resolve_locale(request=request, user=user)
-    verified, new_hash = verify_and_update_password(
-        payload.password, user.hashed_password
-    )
-    if not verified:
-        _audit_log(
-            "auth.login.failure",
-            request,
-            level=logging.WARNING,
-            user_id=user.id,
-            reason="invalid_credentials",
-        )
-        message = translate("errors.auth.credentials_invalid", locale=locale)
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail=message,
-            headers={"WWW-Authenticate": "Bearer"},
-        )
-    if not user.is_active:
-        _audit_log(
-            "auth.login.failure",
-            request,
-            level=logging.WARNING,
-            user_id=user.id,
-            reason="inactive_user",
-        )
-        message = translate("errors.auth.user_deactivated", locale=locale)
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail=message,
-            headers={"WWW-Authenticate": "Bearer"},
-        )
-    user_id = user.id
-    if new_hash:
-        user.hashed_password = new_hash
-        await db.commit()
-        await db.refresh(user)
-    forwarded_for = request.headers.get("x-forwarded-for")
-    if forwarded_for:
-        client_ip = forwarded_for.split(",")[0].strip()
-    else:
-        client_ip = request.client.host if request.client else None
-    user_agent = request.headers.get("user-agent")
-    now = datetime.now(UTC)
-    token = await create_access_token(
-        str(user_id),
-        db=db,
-        session_metadata={
-            "ip_address": client_ip,
-            "user_agent": user_agent,
-            "last_seen_at": now,
-        },
-    )
-    _set_access_token_cookie(response, token)
-    _audit_log(
-        "auth.login.success",
+    return await _perform_login(
+        payload.email,
+        payload.password,
         request,
-        user_id=user_id,
-        reason="authenticated",
+        response,
+        db,
     )
-    return {"access_token": token, "token_type": "bearer"}
 
 
 @router.post("/register", dependencies=[Depends(sensitive_route_limit())])
@@ -326,10 +535,11 @@ def _audit_log(
     level: int = logging.INFO,
     user_id: int | str | None = None,
     reason: str | None = None,
+    extra: Mapping[str, Any] | None = None,
 ) -> None:
     request_id = get_request_id() or request.headers.get("x-request-id")
     client_ip = request.client.host if request.client else None
-    payload: dict[str, str] = {"event": event}
+    payload: dict[str, Any] = {"event": event}
     if user_id is not None:
         payload["user_id"] = str(user_id)
     if request_id:
@@ -338,4 +548,14 @@ def _audit_log(
         payload["ip"] = client_ip
     if reason:
         payload["reason"] = reason
+    if extra:
+        for key, value in extra.items():
+            if value is None:
+                continue
+            if isinstance(value, datetime):
+                payload[key] = value.isoformat()
+            elif isinstance(value, (str, int, float, bool)):
+                payload[key] = value
+            else:
+                payload[key] = str(value)
     logger.log(level, json.dumps(payload, ensure_ascii=False))

--- a/root/app/core/config.py
+++ b/root/app/core/config.py
@@ -111,6 +111,8 @@ class Settings(BaseSettings):
     rate_limit_storage_backend: str = "memory"
     rate_limit_storage_uri: str = "memory://"
     rate_limit_headers_enabled: bool = True
+    auth_lockout_thresholds: str | list[str] = "5:30,8:300,10:3600"
+    auth_lockout_history_minutes: int = 1_440
     security_csp: str = ""
     # Extra hosts for connect-src; merged with defaults dynamically.
     security_connect_src_extra: str | list[str] = (

--- a/root/app/localization.py
+++ b/root/app/localization.py
@@ -148,6 +148,14 @@ _TRANSLATIONS: Mapping[str, Mapping[str, str]] = {
         "ru": "Не удалось подтвердить учётные данные",
         "en": "Could not validate credentials",
     },
+    "errors.auth.account_locked": {
+        "ru": "Слишком много неудачных попыток входа. Аккаунт временно заблокирован.",
+        "en": "Too many failed attempts. Your account is temporarily locked.",
+    },
+    "errors.auth.account_locked_retry": {
+        "ru": "Повторите попытку через {duration}.",
+        "en": "Try again in {duration}.",
+    },
     "errors.auth.user_deactivated": {
         "ru": "Пользователь деактивирован",
         "en": "User account is deactivated",

--- a/root/app/models/models.py
+++ b/root/app/models/models.py
@@ -190,6 +190,33 @@ class ActiveSession(Base):
     user = relationship("User", back_populates="sessions")
 
 
+class FailedLoginAttempt(Base):
+    __tablename__ = "failed_login_attempts"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(
+        Integer,
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    email = Column(String, nullable=False, index=True)
+    attempted_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        index=True,
+    )
+
+    __table_args__ = (
+        Index(
+            "ix_failed_login_attempts_email_attempted_at",
+            "email",
+            "attempted_at",
+        ),
+    )
+
+
 class EventAttendance(Base):
     __tablename__ = "event_attendance"
 

--- a/root/frontend/src/contexts/AuthContext.tsx
+++ b/root/frontend/src/contexts/AuthContext.tsx
@@ -13,6 +13,7 @@ import {
 import { useQueryClient } from "@tanstack/react-query"
 import { isAxiosError } from "axios"
 import { useTranslation } from "react-i18next"
+import type { TFunction } from "i18next"
 import { hasPushConsent, softSyncPushSubscription, unsubscribePush } from "@/push/subscribe"
 import api, { API_UNAUTHORIZED_EVENT } from "../api/client"
 import { SPOTIFY_REAUTH_EVENT } from "@/hooks/useNowPlaying"
@@ -77,6 +78,28 @@ type ProfileBroadcastMessage = { type: "unauthorized" }
 type HandleUnauthorizedOptions = {
   broadcast?: boolean
   persist?: boolean
+}
+
+const formatLockoutDuration = (
+  seconds: number | null | undefined,
+  t: TFunction<"auth">
+): string | null => {
+  if (typeof seconds !== "number" || !Number.isFinite(seconds) || seconds <= 0) {
+    return null
+  }
+
+  if (seconds < 60) {
+    const value = Math.max(1, Math.ceil(seconds))
+    return t("login.duration.seconds", { count: value })
+  }
+
+  if (seconds < 3600) {
+    const value = Math.max(1, Math.ceil(seconds / 60))
+    return t("login.duration.minutes", { count: value })
+  }
+
+  const value = Math.max(1, Math.ceil(seconds / 3600))
+  return t("login.duration.hours", { count: value })
 }
 
 const encodeBase64 = (value: string): string => {
@@ -488,6 +511,31 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         }
 
         if (isAxiosError(error)) {
+          if (error.response?.status === 423) {
+            const retryAfterHeader = error.response.headers?.["retry-after"]
+            const retryValue = Array.isArray(retryAfterHeader)
+              ? retryAfterHeader[0]
+              : retryAfterHeader
+            const parsedSeconds = typeof retryValue === "string"
+              ? Number.parseInt(retryValue, 10)
+              : Number.NaN
+
+            let detail =
+              typeof error.response.data?.detail === "string"
+                ? error.response.data.detail
+                : t("login.locked")
+
+            const durationText = formatLockoutDuration(parsedSeconds, t)
+            if (durationText) {
+              const retryText = t("login.lockedRetry", { duration: durationText })
+              if (!detail.includes(retryText)) {
+                detail = `${detail} ${retryText}`.trim()
+              }
+            }
+
+            throw new Error(detail)
+          }
+
           const message =
             typeof error.response?.data?.detail === "string"
               ? error.response.data.detail

--- a/root/frontend/src/i18n/locales/en/auth.json
+++ b/root/frontend/src/i18n/locales/en/auth.json
@@ -28,7 +28,17 @@
     "forgot": "Forgot password?",
     "noAccount": "No account?",
     "ctaRegister": "Sign up",
-    "error": "Incorrect email or password"
+    "error": "Incorrect email or password",
+    "locked": "Too many failed attempts. Your account is temporarily locked.",
+    "lockedRetry": "Try again in {{duration}}.",
+    "duration": {
+      "seconds_one": "{{count}} second",
+      "seconds_other": "{{count}} seconds",
+      "minutes_one": "{{count}} minute",
+      "minutes_other": "{{count}} minutes",
+      "hours_one": "{{count}} hour",
+      "hours_other": "{{count}} hours"
+    }
   },
   "register": {
     "title": "Sign up",

--- a/root/frontend/src/i18n/locales/ru/auth.json
+++ b/root/frontend/src/i18n/locales/ru/auth.json
@@ -28,7 +28,23 @@
     "forgot": "Забыли пароль?",
     "noAccount": "Нет аккаунта?",
     "ctaRegister": "Зарегистрироваться",
-    "error": "Неверный email или пароль"
+    "error": "Неверный email или пароль",
+    "locked": "Слишком много неудачных попыток. Аккаунт временно заблокирован.",
+    "lockedRetry": "Попробуйте снова через {{duration}}.",
+    "duration": {
+      "seconds_one": "{{count}} секунду",
+      "seconds_few": "{{count}} секунды",
+      "seconds_many": "{{count}} секунд",
+      "seconds_other": "{{count}} секунды",
+      "minutes_one": "{{count}} минуту",
+      "minutes_few": "{{count}} минуты",
+      "minutes_many": "{{count}} минут",
+      "minutes_other": "{{count}} минуты",
+      "hours_one": "{{count}} час",
+      "hours_few": "{{count}} часа",
+      "hours_many": "{{count}} часов",
+      "hours_other": "{{count}} часа"
+    }
   },
   "register": {
     "title": "Регистрация",

--- a/root/frontend/src/pages/__tests__/Login.test.tsx
+++ b/root/frontend/src/pages/__tests__/Login.test.tsx
@@ -134,6 +134,40 @@ describe("Login page", () => {
     expect(await screen.findByText(tAuth("login.error"))).toBeInTheDocument()
   })
 
+  it("shows lockout messaging with retry information", async () => {
+    server.use(
+      http.post("*/auth/login", () =>
+        HttpResponse.json(
+          {
+            detail: "Too many failed attempts. Your account is temporarily locked.",
+          },
+          { status: 423, headers: { "Retry-After": "120" } }
+        )
+      )
+    )
+
+    const user = userEvent.setup()
+    renderLogin()
+
+    const emailInput = screen.getByLabelText(matchText(tAuth("fields.email")), {
+      selector: 'input[type="email"]',
+    })
+
+    await user.type(emailInput, "user@example.com")
+    await user.type(
+      screen.getByLabelText(matchText(tAuth("fields.password")), {
+        selector: 'input[type="password"]',
+      }),
+      "secret123"
+    )
+    await user.click(screen.getByRole("button", { name: tAuth("actions.signIn") }))
+
+    const message = await screen.findByText((content) =>
+      content.includes("temporarily locked") && content.includes("Try again in 2 minutes")
+    )
+    expect(message).toBeInTheDocument()
+  })
+
   it("meets basic accessibility requirements", async () => {
     const { container } = renderLogin()
     const results = await axe(container)

--- a/root/tests/test_auth_lockout.py
+++ b/root/tests/test_auth_lockout.py
@@ -11,7 +11,6 @@ from app.core.config import settings
 from app.localization import translate
 from app.models.models import FailedLoginAttempt
 
-
 pytestmark = pytest.mark.anyio("asyncio")
 
 _HEADERS = {"Content-Type": "application/x-www-form-urlencoded"}

--- a/root/tests/test_auth_lockout.py
+++ b/root/tests/test_auth_lockout.py
@@ -1,0 +1,130 @@
+import asyncio
+import json
+import logging
+
+import pytest
+from fastapi import status
+from sqlalchemy import select
+
+from app.auth.security import get_password_hash
+from app.core.config import settings
+from app.localization import translate
+from app.models.models import FailedLoginAttempt
+
+
+pytestmark = pytest.mark.anyio("asyncio")
+
+_HEADERS = {"Content-Type": "application/x-www-form-urlencoded"}
+
+
+def _find_event(caplog, event: str) -> dict | None:
+    for record in reversed(caplog.records):
+        if record.name != "app.auth":
+            continue
+        try:
+            payload = json.loads(record.message)
+        except json.JSONDecodeError:  # pragma: no cover - defensive guard
+            continue
+        if payload.get("event") == event:
+            return payload
+    return None
+
+
+async def _login(async_client, email: str, password: str):
+    return await async_client.post(
+        "/auth/login",
+        data={"username": email, "password": password},
+        headers=_HEADERS,
+    )
+
+
+async def test_login_lockout_enforced(
+    async_client, user_factory, db_session, monkeypatch, caplog
+):
+    monkeypatch.setattr(settings, "auth_lockout_thresholds", "2:3")
+    monkeypatch.setattr(settings, "auth_lockout_history_minutes", 5)
+    caplog.set_level(logging.INFO)
+    caplog.clear()
+
+    hashed = get_password_hash("ValidPass123!")
+    user = await user_factory(hashed_password=hashed, is_active=True)
+
+    first = await _login(async_client, user.email, "WrongPass!1")
+    assert first.status_code == status.HTTP_401_UNAUTHORIZED
+
+    second = await _login(async_client, user.email, "WrongPass!1")
+    assert second.status_code == status.HTTP_423_LOCKED
+    detail = second.json()["detail"]
+    assert translate("errors.auth.account_locked", locale="en") in detail
+    retry_after = int(second.headers["Retry-After"])
+    assert retry_after >= 1
+
+    result = await db_session.execute(
+        select(FailedLoginAttempt).where(FailedLoginAttempt.email == user.email)
+    )
+    attempts = result.scalars().all()
+    assert len(attempts) == 2
+
+    locked_event = _find_event(caplog, "auth.login.locked")
+    assert locked_event is not None
+    assert locked_event.get("reason") == "lockout"
+
+
+async def test_login_lockout_clears_after_success(
+    async_client, user_factory, db_session, monkeypatch, caplog
+):
+    monkeypatch.setattr(settings, "auth_lockout_thresholds", "2:1")
+    monkeypatch.setattr(settings, "auth_lockout_history_minutes", 5)
+    caplog.set_level(logging.INFO)
+    caplog.clear()
+
+    password = "ValidPass123!"
+    hashed = get_password_hash(password)
+    user = await user_factory(hashed_password=hashed, is_active=True)
+
+    await _login(async_client, user.email, "WrongPass!1")
+    await _login(async_client, user.email, "WrongPass!1")
+
+    locked = await _login(async_client, user.email, "WrongPass!1")
+    assert locked.status_code == status.HTTP_423_LOCKED
+
+    await asyncio.sleep(1.2)
+
+    success = await _login(async_client, user.email, password)
+    assert success.status_code == status.HTTP_200_OK
+
+    result = await db_session.execute(
+        select(FailedLoginAttempt).where(FailedLoginAttempt.email == user.email)
+    )
+    assert not result.scalars().all()
+
+    unlocked_event = _find_event(caplog, "auth.login.unlocked")
+    assert unlocked_event is not None
+    assert unlocked_event.get("reason") == "successful_login"
+
+
+async def test_login_lockout_race_condition(
+    async_client, user_factory, db_session, monkeypatch
+):
+    monkeypatch.setattr(settings, "auth_lockout_thresholds", "2:5")
+    monkeypatch.setattr(settings, "auth_lockout_history_minutes", 5)
+
+    hashed = get_password_hash("RacePass123!")
+    user = await user_factory(hashed_password=hashed, is_active=True)
+
+    async def attempt():
+        return await _login(async_client, user.email, "WrongPass!1")
+
+    first, second = await asyncio.gather(attempt(), attempt())
+    assert {first.status_code, second.status_code} <= {
+        status.HTTP_401_UNAUTHORIZED,
+        status.HTTP_423_LOCKED,
+    }
+
+    third = await _login(async_client, user.email, "WrongPass!1")
+    assert third.status_code == status.HTTP_423_LOCKED
+
+    result = await db_session.execute(
+        select(FailedLoginAttempt).where(FailedLoginAttempt.email == user.email)
+    )
+    assert len(result.scalars().all()) >= 2


### PR DESCRIPTION
## Summary
- add a failed_login_attempts table and SQLAlchemy model to persist recent login failures with timestamps
- enforce configurable exponential lockouts during authentication, log lock/unlock audit events, and reset counters on success
- expose lockout settings, add focused backend tests, and surface lockout messaging with retry hints in the frontend

## Testing
- cd root && pytest tests/test_auth_lockout.py tests/test_auth_security.py tests/test_auth_cookie_flow.py
- cd root/frontend && npm test -- src/pages/__tests__/Login.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68fab9c5d1548327bb5be601afb0eef1