### PR TITLE
Add retry handling to notification queue

### DIFF
--- a/root/alembic/versions/202507100001_add_retry_fields_to_notification_queue_jobs.py
+++ b/root/alembic/versions/202507100001_add_retry_fields_to_notification_queue_jobs.py
@@ -3,8 +3,8 @@
 from typing import Sequence, Union
 
 import sqlalchemy as sa
-from alembic import op
 
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "202507100001"

--- a/root/alembic/versions/202507100001_add_retry_fields_to_notification_queue_jobs.py
+++ b/root/alembic/versions/202507100001_add_retry_fields_to_notification_queue_jobs.py
@@ -1,0 +1,59 @@
+"""Add retry metadata to notification queue jobs."""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "202507100001"
+down_revision: Union[str, None] = "202506150001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "notification_queue_jobs",
+        sa.Column("last_error", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "notification_queue_jobs",
+        sa.Column("next_retry_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "notification_queue_jobs",
+        sa.Column(
+            "dead_lettered",
+            sa.Boolean(),
+            server_default=sa.text("0"),
+            nullable=False,
+        ),
+    )
+    op.create_index(
+        "ix_notification_queue_jobs_dead_lettered",
+        "notification_queue_jobs",
+        ["dead_lettered"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_notification_queue_jobs_next_retry_at",
+        "notification_queue_jobs",
+        ["next_retry_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_notification_queue_jobs_next_retry_at",
+        table_name="notification_queue_jobs",
+    )
+    op.drop_index(
+        "ix_notification_queue_jobs_dead_lettered",
+        table_name="notification_queue_jobs",
+    )
+    op.drop_column("notification_queue_jobs", "dead_lettered")
+    op.drop_column("notification_queue_jobs", "next_retry_at")
+    op.drop_column("notification_queue_jobs", "last_error")

--- a/root/app/core/config.py
+++ b/root/app/core/config.py
@@ -156,6 +156,8 @@ class Settings(BaseSettings):
     notifications_queue_max_size: int = 1024
     notifications_queue_enqueue_timeout_seconds: float = 0.5
     notifications_queue_in_memory_only: bool = False
+    notifications_queue_retry_base_seconds: float = 1.0
+    notifications_queue_max_attempts: int = 5
     session_cleanup_interval_seconds: int = 900
     password_reset_cleanup_interval_seconds: int = 3_600
     password_reset_cleanup_retention_minutes: int = 45

--- a/root/app/core/observability.py
+++ b/root/app/core/observability.py
@@ -523,6 +523,7 @@ class NotificationQueueMetrics:
 
     queue_size: Gauge
     dropped_jobs_total: Counter
+    failed_jobs_total: Counter
     processing_latency_seconds: Histogram
 
     def reset(self) -> None:
@@ -532,6 +533,7 @@ class NotificationQueueMetrics:
         # The internals below are implementation details of prometheus_client,
         # hence the type: ignore annotations.
         self.dropped_jobs_total._value.set(0)  # type: ignore[attr-defined]
+        self.failed_jobs_total._value.set(0)  # type: ignore[attr-defined]
         self.processing_latency_seconds._sum.set(0)  # type: ignore[attr-defined]
         for bucket in getattr(self.processing_latency_seconds, "_buckets", []):  # type: ignore[attr-defined]
             bucket.set(0)
@@ -555,6 +557,10 @@ def get_notification_queue_metrics() -> NotificationQueueMetrics:
             dropped_jobs_total=Counter(
                 "notification_queue_dropped_jobs_total",
                 "Total notification jobs dropped due to queue saturation",
+            ),
+            failed_jobs_total=Counter(
+                "notification_queue_failed_jobs_total",
+                "Total notification jobs permanently failed or dead-lettered",
             ),
             processing_latency_seconds=Histogram(
                 "notification_queue_processing_latency_seconds",

--- a/root/app/models/models.py
+++ b/root/app/models/models.py
@@ -410,6 +410,9 @@ class NotificationQueueJob(Base):
     )
     claimed_at = Column(DateTime(timezone=True), index=True)
     attempts = Column(Integer, nullable=False, server_default=text("0"))
+    last_error = Column(Text)
+    next_retry_at = Column(DateTime(timezone=True), index=True)
+    dead_lettered = Column(Boolean, nullable=False, server_default=text("0"), index=True)
 
     __table_args__ = (
         CheckConstraint(

--- a/root/app/models/models.py
+++ b/root/app/models/models.py
@@ -412,7 +412,9 @@ class NotificationQueueJob(Base):
     attempts = Column(Integer, nullable=False, server_default=text("0"))
     last_error = Column(Text)
     next_retry_at = Column(DateTime(timezone=True), index=True)
-    dead_lettered = Column(Boolean, nullable=False, server_default=text("0"), index=True)
+    dead_lettered = Column(
+        Boolean, nullable=False, server_default=text("0"), index=True
+    )
 
     __table_args__ = (
         CheckConstraint(

--- a/root/app/services/notification_queue.py
+++ b/root/app/services/notification_queue.py
@@ -549,9 +549,7 @@ async def _acknowledge_persistent_job(
                     max_attempts = int(settings.notifications_queue_max_attempts)
                     record.last_error = error_message
                     record.claimed_at = None
-                    should_dead_letter = (
-                        max_attempts > 0 and attempts >= max_attempts
-                    )
+                    should_dead_letter = max_attempts > 0 and attempts >= max_attempts
                     if should_dead_letter:
                         record.dead_lettered = True
                         record.next_retry_at = None
@@ -581,7 +579,9 @@ async def _acknowledge_persistent_job(
                                 "job": job,
                                 "queue_id": job.queue_id,
                                 "attempt": attempts,
-                                "max_attempts": max_attempts if max_attempts > 0 else None,
+                                "max_attempts": (
+                                    max_attempts if max_attempts > 0 else None
+                                ),
                                 "next_retry_at": next_retry.isoformat(),
                                 "error": error_message,
                             },

--- a/root/app/services/notification_queue.py
+++ b/root/app/services/notification_queue.py
@@ -6,11 +6,11 @@ import asyncio
 import logging
 import time
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Literal, cast
 from weakref import WeakKeyDictionary
 
-from sqlalchemy import delete, func, select, update
+from sqlalchemy import delete, func, or_, select
 from sqlalchemy.exc import IntegrityError, OperationalError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -127,12 +127,14 @@ async def _worker_loop(state: _LoopState) -> None:
                     metrics.queue_size.set(state.queue.qsize())
             started = time.perf_counter()
             success = False
+            error: BaseException | None = None
             try:
                 await _process_job(job)
                 success = True
             except asyncio.CancelledError:  # pragma: no cover - cooperative shutdown
                 raise
-            except Exception:  # pragma: no cover - defensive guard
+            except Exception as exc:  # pragma: no cover - defensive guard
+                error = exc
                 logger.exception(
                     "Failed to process notification job", extra={"job": job}
                 )
@@ -142,7 +144,11 @@ async def _worker_loop(state: _LoopState) -> None:
                     metrics.processing_latency_seconds.observe(elapsed)
                 if _use_persistent_backend():
                     await _acknowledge_persistent_job(
-                        job, success=success, state=state, metrics=metrics
+                        job,
+                        success=success,
+                        error=error,
+                        state=state,
+                        metrics=metrics,
                     )
                 else:
                     state.queue.task_done()
@@ -394,7 +400,10 @@ async def _refresh_persistent_queue_size(metrics: NotificationQueueMetrics) -> N
             result = await session.execute(
                 select(func.count())
                 .select_from(NotificationQueueJob)
-                .where(NotificationQueueJob.claimed_at.is_(None))
+                .where(
+                    NotificationQueueJob.claimed_at.is_(None),
+                    NotificationQueueJob.dead_lettered.is_(False),
+                )
             )
             metrics.queue_size.set(int(result.scalar_one()))
     except Exception:  # pragma: no cover - defensive guard
@@ -406,7 +415,10 @@ async def _pending_persistent_jobs() -> int:
         result = await session.execute(
             select(func.count())
             .select_from(NotificationQueueJob)
-            .where(NotificationQueueJob.claimed_at.is_(None))
+            .where(
+                NotificationQueueJob.claimed_at.is_(None),
+                NotificationQueueJob.dead_lettered.is_(False),
+            )
         )
         return int(result.scalar_one())
 
@@ -453,18 +465,34 @@ async def _dequeue_persistent_job(state: _LoopState) -> NotificationJob:
 async def _claim_next_persistent_job() -> NotificationJob | None:
     async with async_session() as session:
         async with session.begin():
+            now = datetime.now(timezone.utc)
             result = await session.execute(
                 select(NotificationQueueJob)
-                .where(NotificationQueueJob.claimed_at.is_(None))
-                .order_by(NotificationQueueJob.enqueued_at, NotificationQueueJob.id)
+                .where(
+                    NotificationQueueJob.claimed_at.is_(None),
+                    NotificationQueueJob.dead_lettered.is_(False),
+                    or_(
+                        NotificationQueueJob.next_retry_at.is_(None),
+                        NotificationQueueJob.next_retry_at <= now,
+                    ),
+                )
+                .order_by(
+                    func.coalesce(
+                        NotificationQueueJob.next_retry_at,
+                        NotificationQueueJob.enqueued_at,
+                    ),
+                    NotificationQueueJob.enqueued_at,
+                    NotificationQueueJob.id,
+                )
                 .with_for_update(skip_locked=True)
                 .limit(1)
             )
             row = result.scalar_one_or_none()
             if row is None:
                 return None
-            row.claimed_at = datetime.now(timezone.utc)
+            row.claimed_at = now
             row.attempts = (row.attempts or 0) + 1
+            row.next_retry_at = None
             job = NotificationJob(
                 kind=cast(JobKind, row.kind),
                 record_id=row.record_id,
@@ -477,30 +505,87 @@ async def _claim_next_persistent_job() -> NotificationJob | None:
     return job
 
 
+def _format_job_error(error: BaseException | None) -> str:
+    if error is None:
+        return "Unknown error"
+    message = str(error).strip()
+    if not message:
+        message = error.__class__.__name__
+    if len(message) > 1024:
+        return f"{message[:1021]}..."
+    return message
+
+
 async def _acknowledge_persistent_job(
     job: NotificationJob,
     *,
     success: bool,
+    error: BaseException | None,
     state: _LoopState,
     metrics: NotificationQueueMetrics | None,
 ) -> None:
     if job.queue_id is None:
         return
+    wake_delay = 0.0
     try:
         async with async_session() as session:
             async with session.begin():
+                result = await session.execute(
+                    select(NotificationQueueJob)
+                    .where(NotificationQueueJob.id == job.queue_id)
+                    .with_for_update()
+                )
+                record = result.scalar_one_or_none()
+                if record is None:
+                    return
                 if success:
-                    await session.execute(
-                        delete(NotificationQueueJob).where(
-                            NotificationQueueJob.id == job.queue_id
-                        )
-                    )
+                    await session.delete(record)
                 else:
-                    await session.execute(
-                        update(NotificationQueueJob)
-                        .where(NotificationQueueJob.id == job.queue_id)
-                        .values(claimed_at=None)
+                    error_message = _format_job_error(error)
+                    attempts = record.attempts or 0
+                    base_delay = max(
+                        float(settings.notifications_queue_retry_base_seconds), 0.0
                     )
+                    max_attempts = int(settings.notifications_queue_max_attempts)
+                    record.last_error = error_message
+                    record.claimed_at = None
+                    should_dead_letter = (
+                        max_attempts > 0 and attempts >= max_attempts
+                    )
+                    if should_dead_letter:
+                        record.dead_lettered = True
+                        record.next_retry_at = None
+                        if metrics is not None:
+                            metrics.failed_jobs_total.inc()
+                        logger.error(
+                            "Notification job exhausted retries; moving to dead-letter queue",
+                            extra={
+                                "job": job,
+                                "queue_id": job.queue_id,
+                                "attempt": attempts,
+                                "max_attempts": max_attempts,
+                                "error": error_message,
+                            },
+                        )
+                    else:
+                        delay_seconds = base_delay * (2 ** max(attempts - 1, 0))
+                        wake_delay = max(delay_seconds, 0.0)
+                        next_retry = datetime.now(timezone.utc) + timedelta(
+                            seconds=wake_delay
+                        )
+                        record.dead_lettered = False
+                        record.next_retry_at = next_retry
+                        logger.warning(
+                            "Notification job failed; scheduling retry",
+                            extra={
+                                "job": job,
+                                "queue_id": job.queue_id,
+                                "attempt": attempts,
+                                "max_attempts": max_attempts if max_attempts > 0 else None,
+                                "next_retry_at": next_retry.isoformat(),
+                                "error": error_message,
+                            },
+                        )
     except Exception:
         logger.exception(
             "Failed to acknowledge persistent notification job",
@@ -508,6 +593,14 @@ async def _acknowledge_persistent_job(
         )
     else:
         if not success:
-            state.job_event.set()
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:  # pragma: no cover - defensive guard
+                state.job_event.set()
+            else:
+                if wake_delay <= 0:
+                    state.job_event.set()
+                else:
+                    loop.call_later(wake_delay, state.job_event.set)
     if metrics is not None:
         await _refresh_persistent_queue_size(metrics)

--- a/root/tests/test_notification_queue_worker.py
+++ b/root/tests/test_notification_queue_worker.py
@@ -1,4 +1,5 @@
 import asyncio
+from datetime import datetime, timezone
 
 import pytest
 from prometheus_client import REGISTRY
@@ -210,6 +211,13 @@ async def test_persistent_queue_retries_failed_jobs(monkeypatch: pytest.MonkeyPa
     metrics.reset()
     notification_queue._loop_states.clear()
 
+    monkeypatch.setattr(
+        notification_queue.settings,
+        "notifications_queue_retry_base_seconds",
+        0.0,
+        raising=False,
+    )
+
     attempts: list[int] = []
     processed_event = asyncio.Event()
 
@@ -227,5 +235,131 @@ async def test_persistent_queue_retries_failed_jobs(monkeypatch: pytest.MonkeyPa
     await notification_queue.wait_for_all_jobs(timeout=1.0)
 
     assert attempts == [303, 303]
+
+    notification_queue._loop_states.clear()
+
+
+@pytest.mark.anyio
+async def test_persistent_queue_applies_exponential_backoff(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    metrics = observability.get_notification_queue_metrics()
+    metrics.reset()
+    notification_queue._loop_states.clear()
+
+    monkeypatch.setattr(
+        notification_queue.settings,
+        "notifications_queue_retry_base_seconds",
+        0.05,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        notification_queue.settings,
+        "notifications_queue_max_attempts",
+        3,
+        raising=False,
+    )
+
+    attempt_times: list[float] = []
+    first_attempt = asyncio.Event()
+    processed_event = asyncio.Event()
+
+    async def _process(job):
+        attempt_times.append(asyncio.get_running_loop().time())
+        if len(attempt_times) == 1:
+            first_attempt.set()
+            raise RuntimeError("boom")
+        processed_event.set()
+
+    monkeypatch.setattr(notification_queue, "_process_job", _process)
+
+    await notification_queue.enqueue_event_notification(404)
+
+    await asyncio.wait_for(first_attempt.wait(), timeout=1.0)
+    await asyncio.sleep(0.01)
+
+    async with async_session() as session:
+        result = await session.execute(
+            select(NotificationQueueJob).where(NotificationQueueJob.record_id == 404)
+        )
+        record = result.scalar_one()
+        assert record.next_retry_at is not None
+        now = datetime.now(timezone.utc)
+        next_retry = record.next_retry_at
+        if next_retry.tzinfo is None:
+            next_retry = next_retry.replace(tzinfo=timezone.utc)
+        assert next_retry > now
+        assert record.last_error == "boom"
+        assert not record.dead_lettered
+
+    await asyncio.wait_for(processed_event.wait(), timeout=1.0)
+    await notification_queue.wait_for_all_jobs(timeout=1.0)
+
+    assert len(attempt_times) == 2
+    interval = attempt_times[1] - attempt_times[0]
+    assert interval >= 0.04
+    assert _metric_value("notification_queue_failed_jobs_total") == pytest.approx(0.0)
+
+    notification_queue._loop_states.clear()
+
+
+@pytest.mark.anyio
+async def test_persistent_queue_dead_letters_poison_jobs(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    metrics = observability.get_notification_queue_metrics()
+    metrics.reset()
+    notification_queue._loop_states.clear()
+
+    monkeypatch.setattr(
+        notification_queue.settings,
+        "notifications_queue_retry_base_seconds",
+        0.01,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        notification_queue.settings,
+        "notifications_queue_max_attempts",
+        3,
+        raising=False,
+    )
+
+    attempts: list[int] = []
+
+    async def _process(job):
+        attempts.append(job.record_id)
+        raise RuntimeError("poison pill")
+
+    monkeypatch.setattr(notification_queue, "_process_job", _process)
+
+    await notification_queue.enqueue_event_notification(505)
+
+    async def _wait_for_dead_lettered() -> NotificationQueueJob:
+        while True:
+            async with async_session() as session:
+                result = await session.execute(
+                    select(NotificationQueueJob).where(
+                        NotificationQueueJob.record_id == 505
+                    )
+                )
+                record = result.scalar_one_or_none()
+            if record and record.dead_lettered:
+                return record
+            await asyncio.sleep(0.01)
+
+    record = await asyncio.wait_for(_wait_for_dead_lettered(), timeout=2.0)
+
+    assert record.dead_lettered is True
+    assert record.attempts == 3
+    assert record.next_retry_at is None
+    assert record.last_error == "poison pill"
+    assert len(attempts) == 3
+
+    await asyncio.sleep(0.05)
+    assert len(attempts) == 3
+
+    assert _metric_value("notification_queue_failed_jobs_total") == pytest.approx(1.0)
+
+    await notification_queue.wait_for_all_jobs(timeout=1.0)
 
     notification_queue._loop_states.clear()


### PR DESCRIPTION
## Summary
- extend the persistent notification queue schema with retry metadata and dead-letter tracking
- implement exponential backoff, structured logging, and Prometheus counters for failed jobs
- add integration coverage for retry scheduling and dead-letter behaviour

## Testing
- pytest root/tests/test_notification_queue_worker.py

------
https://chatgpt.com/codex/tasks/task_e_68fac220bdd08327a0236c6e4eedfc35