### PR TITLE
Add merge migration for divergent alembic heads

### DIFF
--- a/root/alembic/versions/202507010001_add_failed_login_attempts_table.py
+++ b/root/alembic/versions/202507010001_add_failed_login_attempts_table.py
@@ -4,7 +4,6 @@ import sqlalchemy as sa
 
 from alembic import op
 
-
 TABLE_NAME = "failed_login_attempts"
 INDEX_DEFINITIONS = {
     "ix_failed_login_attempts_email": ["email"],
@@ -23,7 +22,9 @@ def upgrade() -> None:
     if bind is not None:
         inspector = sa.inspect(bind)
         if TABLE_NAME in inspector.get_table_names():
-            existing_indexes = {index["name"] for index in inspector.get_indexes(TABLE_NAME)}
+            existing_indexes = {
+                index["name"] for index in inspector.get_indexes(TABLE_NAME)
+            }
             for index_name, columns in INDEX_DEFINITIONS.items():
                 if index_name not in existing_indexes:
                     op.create_index(index_name, TABLE_NAME, columns)
@@ -55,8 +56,6 @@ def downgrade() -> None:
         "ix_failed_login_attempts_email_attempted_at",
         table_name=TABLE_NAME,
     )
-    op.drop_index(
-        "ix_failed_login_attempts_attempted_at", table_name=TABLE_NAME
-    )
+    op.drop_index("ix_failed_login_attempts_attempted_at", table_name=TABLE_NAME)
     op.drop_index("ix_failed_login_attempts_email", table_name=TABLE_NAME)
     op.drop_table(TABLE_NAME)

--- a/root/alembic/versions/8793a392b5a2_merge_failed_login_attempts_and_retry_.py
+++ b/root/alembic/versions/8793a392b5a2_merge_failed_login_attempts_and_retry_.py
@@ -1,0 +1,14 @@
+from typing import Sequence, Union
+
+revision: str = "8793a392b5a2"
+down_revision: Union[str, tuple[str, ...], None] = ("202507010001", "202507100001")
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Summary
- add a merge migration that combines the `202507010001` and `202507100001` heads so Alembic has a single linear history

## Testing
- alembic heads
- alembic upgrade head *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_68fac7cff14c8327bd3a26531b41fb74