### PR TITLE
Fix default for dead_lettered column

### DIFF
--- a/root/alembic/versions/202507100001_add_retry_fields_to_notification_queue_jobs.py
+++ b/root/alembic/versions/202507100001_add_retry_fields_to_notification_queue_jobs.py
@@ -27,7 +27,7 @@ def upgrade() -> None:
         sa.Column(
             "dead_lettered",
             sa.Boolean(),
-            server_default=sa.text("0"),
+            server_default=sa.false(),
             nullable=False,
         ),
     )


### PR DESCRIPTION
## Summary
- update the notification queue jobs migration to use a boolean server default for the new `dead_lettered` column

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68facb1bcd788327a1f08be715fc4162