### PR TITLE
Fix Alembic revision chain after merge

### DIFF
--- a/root/alembic/versions/202507200001_add_session_signing_key.py
+++ b/root/alembic/versions/202507200001_add_session_signing_key.py
@@ -11,7 +11,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "202507200001"
-down_revision: str | None = "202507100001"
+down_revision: str | None = "8793a392b5a2"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 


### PR DESCRIPTION
## Summary
- update the latest Alembic migration to depend on the merge revision so the branch has a single head

## Testing
- `alembic upgrade head` *(fails: ModuleNotFoundError: No module named 'psycopg2')*


------
https://chatgpt.com/codex/tasks/task_e_68fad142a3148327963153e8c3a4af1c