### PR TITLE
Add MFA support scaffolding

### DIFF
--- a/root/alembic/versions/202507300001_add_mfa_tables.py
+++ b/root/alembic/versions/202507300001_add_mfa_tables.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Sequence
 
 import sqlalchemy as sa
+
 from alembic import op
 
 revision: str = "202507300001"
@@ -77,8 +78,9 @@ def upgrade() -> None:
                 ),
             )
 
-        if "ix_users_mfa_required" not in user_indexes and "mfa_required" in _column_names(
-            sa.inspect(bind), _USERS_TABLE
+        if (
+            "ix_users_mfa_required" not in user_indexes
+            and "mfa_required" in _column_names(sa.inspect(bind), _USERS_TABLE)
         ):
             op.create_index("ix_users_mfa_required", _USERS_TABLE, ["mfa_required"])
         if (
@@ -131,8 +133,10 @@ def upgrade() -> None:
                 sa.Column("mfa_method", sa.String(length=64), nullable=True),
             )
 
-        if "ix_active_sessions_mfa_required" not in session_indexes and "mfa_required" in _column_names(
-            sa.inspect(bind), _ACTIVE_SESSIONS_TABLE
+        if (
+            "ix_active_sessions_mfa_required" not in session_indexes
+            and "mfa_required"
+            in _column_names(sa.inspect(bind), _ACTIVE_SESSIONS_TABLE)
         ):
             op.create_index(
                 "ix_active_sessions_mfa_required",
@@ -200,7 +204,9 @@ def upgrade() -> None:
                 sa.ForeignKey(f"{_USERS_TABLE}.id", ondelete="CASCADE"),
                 nullable=False,
             ),
-            sa.Column("credential_id", sa.String(length=255), nullable=False, unique=True),
+            sa.Column(
+                "credential_id", sa.String(length=255), nullable=False, unique=True
+            ),
             sa.Column("public_key", sa.Text(), nullable=False),
             sa.Column(
                 "sign_count",
@@ -241,9 +247,15 @@ def upgrade() -> None:
         op.alter_column(_WEBAUTHN_TABLE, "clone_warning", server_default=None)
         op.alter_column(_WEBAUTHN_TABLE, "is_active", server_default=None)
         op.create_index(f"ix_{_WEBAUTHN_TABLE}_user_id", _WEBAUTHN_TABLE, ["user_id"])
-        op.create_index(f"ix_{_WEBAUTHN_TABLE}_is_active", _WEBAUTHN_TABLE, ["is_active"])
-        op.create_index(f"ix_{_WEBAUTHN_TABLE}_backed_up", _WEBAUTHN_TABLE, ["backed_up"])
-        op.create_index(f"ix_{_WEBAUTHN_TABLE}_last_used_at", _WEBAUTHN_TABLE, ["last_used_at"])
+        op.create_index(
+            f"ix_{_WEBAUTHN_TABLE}_is_active", _WEBAUTHN_TABLE, ["is_active"]
+        )
+        op.create_index(
+            f"ix_{_WEBAUTHN_TABLE}_backed_up", _WEBAUTHN_TABLE, ["backed_up"]
+        )
+        op.create_index(
+            f"ix_{_WEBAUTHN_TABLE}_last_used_at", _WEBAUTHN_TABLE, ["last_used_at"]
+        )
         op.create_index(
             "ix_mfa_webauthn_user_active",
             _WEBAUTHN_TABLE,
@@ -269,7 +281,9 @@ def upgrade() -> None:
                 server_default=sa.func.now(),
             ),
             sa.Column("label", sa.String(length=255), nullable=True),
-            sa.UniqueConstraint("user_id", "code_hash", name="uq_mfa_recovery_codes_hash"),
+            sa.UniqueConstraint(
+                "user_id", "code_hash", name="uq_mfa_recovery_codes_hash"
+            ),
         )
         op.create_index(f"ix_{_RECOVERY_TABLE}_user_id", _RECOVERY_TABLE, ["user_id"])
         op.create_index(f"ix_{_RECOVERY_TABLE}_used_at", _RECOVERY_TABLE, ["used_at"])
@@ -302,16 +316,28 @@ def upgrade() -> None:
             ),
             sa.Column("payload", sa.JSON(), nullable=True),
         )
-        op.create_index(f"ix_{_CHALLENGES_TABLE}_user_id", _CHALLENGES_TABLE, ["user_id"])
-        op.create_index(f"ix_{_CHALLENGES_TABLE}_session_id", _CHALLENGES_TABLE, ["session_id"])
+        op.create_index(
+            f"ix_{_CHALLENGES_TABLE}_user_id", _CHALLENGES_TABLE, ["user_id"]
+        )
+        op.create_index(
+            f"ix_{_CHALLENGES_TABLE}_session_id", _CHALLENGES_TABLE, ["session_id"]
+        )
         op.create_index(
             "ix_mfa_challenges_user_expires",
             _CHALLENGES_TABLE,
             ["user_id", "expires_at"],
         )
-        op.create_index(f"ix_{_CHALLENGES_TABLE}_challenge_type", _CHALLENGES_TABLE, ["challenge_type"])
-        op.create_index(f"ix_{_CHALLENGES_TABLE}_expires_at", _CHALLENGES_TABLE, ["expires_at"])
-        op.create_index(f"ix_{_CHALLENGES_TABLE}_consumed_at", _CHALLENGES_TABLE, ["consumed_at"])
+        op.create_index(
+            f"ix_{_CHALLENGES_TABLE}_challenge_type",
+            _CHALLENGES_TABLE,
+            ["challenge_type"],
+        )
+        op.create_index(
+            f"ix_{_CHALLENGES_TABLE}_expires_at", _CHALLENGES_TABLE, ["expires_at"]
+        )
+        op.create_index(
+            f"ix_{_CHALLENGES_TABLE}_consumed_at", _CHALLENGES_TABLE, ["consumed_at"]
+        )
 
 
 def downgrade() -> None:

--- a/root/alembic/versions/202507300001_add_mfa_tables.py
+++ b/root/alembic/versions/202507300001_add_mfa_tables.py
@@ -1,0 +1,417 @@
+"""Introduce multi-factor authentication tables."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "202507300001"
+down_revision: str | None = "202507200001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+_USERS_TABLE = "users"
+_ACTIVE_SESSIONS_TABLE = "active_sessions"
+_TOTP_TABLE = "mfa_totp_enrollments"
+_WEBAUTHN_TABLE = "mfa_webauthn_credentials"
+_RECOVERY_TABLE = "mfa_recovery_codes"
+_CHALLENGES_TABLE = "mfa_challenges"
+
+
+def _table_names(inspector) -> set[str]:
+    return set(inspector.get_table_names())
+
+
+def _column_names(inspector, table: str) -> set[str]:
+    return {column["name"] for column in inspector.get_columns(table)}
+
+
+def _index_names(inspector, table: str) -> set[str]:
+    return {index["name"] for index in inspector.get_indexes(table)}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    tables = _table_names(inspector)
+
+    if _USERS_TABLE in tables:
+        user_columns = _column_names(inspector, _USERS_TABLE)
+        user_indexes = _index_names(inspector, _USERS_TABLE)
+
+        if "mfa_required" not in user_columns:
+            op.add_column(
+                _USERS_TABLE,
+                sa.Column(
+                    "mfa_required",
+                    sa.Boolean(),
+                    nullable=False,
+                    server_default=sa.false(),
+                ),
+            )
+            op.alter_column(_USERS_TABLE, "mfa_required", server_default=None)
+        if "mfa_default_method" not in user_columns:
+            op.add_column(
+                _USERS_TABLE,
+                sa.Column("mfa_default_method", sa.String(length=64), nullable=True),
+            )
+        if "mfa_last_verified_at" not in user_columns:
+            op.add_column(
+                _USERS_TABLE,
+                sa.Column(
+                    "mfa_last_verified_at",
+                    sa.DateTime(timezone=True),
+                    nullable=True,
+                ),
+            )
+        if "mfa_recovery_codes_generated_at" not in user_columns:
+            op.add_column(
+                _USERS_TABLE,
+                sa.Column(
+                    "mfa_recovery_codes_generated_at",
+                    sa.DateTime(timezone=True),
+                    nullable=True,
+                ),
+            )
+
+        if "ix_users_mfa_required" not in user_indexes and "mfa_required" in _column_names(
+            sa.inspect(bind), _USERS_TABLE
+        ):
+            op.create_index("ix_users_mfa_required", _USERS_TABLE, ["mfa_required"])
+        if (
+            "ix_users_mfa_last_verified_at" not in user_indexes
+            and "mfa_last_verified_at" in _column_names(sa.inspect(bind), _USERS_TABLE)
+        ):
+            op.create_index(
+                "ix_users_mfa_last_verified_at",
+                _USERS_TABLE,
+                ["mfa_last_verified_at"],
+            )
+        if (
+            "ix_users_mfa_recovery_codes_generated_at" not in user_indexes
+            and "mfa_recovery_codes_generated_at"
+            in _column_names(sa.inspect(bind), _USERS_TABLE)
+        ):
+            op.create_index(
+                "ix_users_mfa_recovery_codes_generated_at",
+                _USERS_TABLE,
+                ["mfa_recovery_codes_generated_at"],
+            )
+
+    if _ACTIVE_SESSIONS_TABLE in tables:
+        session_columns = _column_names(inspector, _ACTIVE_SESSIONS_TABLE)
+        session_indexes = _index_names(inspector, _ACTIVE_SESSIONS_TABLE)
+
+        if "mfa_required" not in session_columns:
+            op.add_column(
+                _ACTIVE_SESSIONS_TABLE,
+                sa.Column(
+                    "mfa_required",
+                    sa.Boolean(),
+                    nullable=False,
+                    server_default=sa.false(),
+                ),
+            )
+            op.alter_column(_ACTIVE_SESSIONS_TABLE, "mfa_required", server_default=None)
+        if "mfa_completed_at" not in session_columns:
+            op.add_column(
+                _ACTIVE_SESSIONS_TABLE,
+                sa.Column(
+                    "mfa_completed_at",
+                    sa.DateTime(timezone=True),
+                    nullable=True,
+                ),
+            )
+        if "mfa_method" not in session_columns:
+            op.add_column(
+                _ACTIVE_SESSIONS_TABLE,
+                sa.Column("mfa_method", sa.String(length=64), nullable=True),
+            )
+
+        if "ix_active_sessions_mfa_required" not in session_indexes and "mfa_required" in _column_names(
+            sa.inspect(bind), _ACTIVE_SESSIONS_TABLE
+        ):
+            op.create_index(
+                "ix_active_sessions_mfa_required",
+                _ACTIVE_SESSIONS_TABLE,
+                ["mfa_required"],
+            )
+        if (
+            "ix_active_sessions_mfa_completed_at" not in session_indexes
+            and "mfa_completed_at"
+            in _column_names(sa.inspect(bind), _ACTIVE_SESSIONS_TABLE)
+        ):
+            op.create_index(
+                "ix_active_sessions_mfa_completed_at",
+                _ACTIVE_SESSIONS_TABLE,
+                ["mfa_completed_at"],
+            )
+
+    tables = _table_names(sa.inspect(bind))
+
+    if _TOTP_TABLE not in tables:
+        op.create_table(
+            _TOTP_TABLE,
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column(
+                "user_id",
+                sa.Integer(),
+                sa.ForeignKey(f"{_USERS_TABLE}.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("secret", sa.Text(), nullable=False),
+            sa.Column("label", sa.String(length=255), nullable=True),
+            sa.Column(
+                "is_active",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.true(),
+            ),
+            sa.Column("confirmed_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+        )
+        op.alter_column(_TOTP_TABLE, "is_active", server_default=None)
+        op.create_index(f"ix_{_TOTP_TABLE}_user_id", _TOTP_TABLE, ["user_id"])
+        op.create_index(f"ix_{_TOTP_TABLE}_is_active", _TOTP_TABLE, ["is_active"])
+        op.create_index(f"ix_{_TOTP_TABLE}_confirmed_at", _TOTP_TABLE, ["confirmed_at"])
+        op.create_index(f"ix_{_TOTP_TABLE}_revoked_at", _TOTP_TABLE, ["revoked_at"])
+        op.create_index(
+            "ix_mfa_totp_enrollments_active",
+            _TOTP_TABLE,
+            ["user_id", "is_active"],
+        )
+
+    if _WEBAUTHN_TABLE not in tables:
+        op.create_table(
+            _WEBAUTHN_TABLE,
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column(
+                "user_id",
+                sa.Integer(),
+                sa.ForeignKey(f"{_USERS_TABLE}.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("credential_id", sa.String(length=255), nullable=False, unique=True),
+            sa.Column("public_key", sa.Text(), nullable=False),
+            sa.Column(
+                "sign_count",
+                sa.Integer(),
+                nullable=False,
+                server_default=sa.text("0"),
+            ),
+            sa.Column("transports", sa.JSON(), nullable=True),
+            sa.Column("device_name", sa.String(length=255), nullable=True),
+            sa.Column(
+                "backed_up",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.false(),
+            ),
+            sa.Column(
+                "clone_warning",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.false(),
+            ),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+            sa.Column("last_used_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column(
+                "is_active",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.true(),
+            ),
+        )
+        op.alter_column(_WEBAUTHN_TABLE, "sign_count", server_default=None)
+        op.alter_column(_WEBAUTHN_TABLE, "backed_up", server_default=None)
+        op.alter_column(_WEBAUTHN_TABLE, "clone_warning", server_default=None)
+        op.alter_column(_WEBAUTHN_TABLE, "is_active", server_default=None)
+        op.create_index(f"ix_{_WEBAUTHN_TABLE}_user_id", _WEBAUTHN_TABLE, ["user_id"])
+        op.create_index(f"ix_{_WEBAUTHN_TABLE}_is_active", _WEBAUTHN_TABLE, ["is_active"])
+        op.create_index(f"ix_{_WEBAUTHN_TABLE}_backed_up", _WEBAUTHN_TABLE, ["backed_up"])
+        op.create_index(f"ix_{_WEBAUTHN_TABLE}_last_used_at", _WEBAUTHN_TABLE, ["last_used_at"])
+        op.create_index(
+            "ix_mfa_webauthn_user_active",
+            _WEBAUTHN_TABLE,
+            ["user_id", "is_active"],
+        )
+
+    if _RECOVERY_TABLE not in tables:
+        op.create_table(
+            _RECOVERY_TABLE,
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column(
+                "user_id",
+                sa.Integer(),
+                sa.ForeignKey(f"{_USERS_TABLE}.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("code_hash", sa.String(length=255), nullable=False),
+            sa.Column("used_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+            sa.Column("label", sa.String(length=255), nullable=True),
+            sa.UniqueConstraint("user_id", "code_hash", name="uq_mfa_recovery_codes_hash"),
+        )
+        op.create_index(f"ix_{_RECOVERY_TABLE}_user_id", _RECOVERY_TABLE, ["user_id"])
+        op.create_index(f"ix_{_RECOVERY_TABLE}_used_at", _RECOVERY_TABLE, ["used_at"])
+
+    if _CHALLENGES_TABLE not in tables:
+        op.create_table(
+            _CHALLENGES_TABLE,
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column(
+                "user_id",
+                sa.Integer(),
+                sa.ForeignKey(f"{_USERS_TABLE}.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column(
+                "session_id",
+                sa.Integer(),
+                sa.ForeignKey(f"{_ACTIVE_SESSIONS_TABLE}.id", ondelete="CASCADE"),
+                nullable=True,
+            ),
+            sa.Column("challenge_type", sa.String(length=64), nullable=False),
+            sa.Column("token", sa.String(length=255), nullable=False, unique=True),
+            sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("consumed_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+            sa.Column("payload", sa.JSON(), nullable=True),
+        )
+        op.create_index(f"ix_{_CHALLENGES_TABLE}_user_id", _CHALLENGES_TABLE, ["user_id"])
+        op.create_index(f"ix_{_CHALLENGES_TABLE}_session_id", _CHALLENGES_TABLE, ["session_id"])
+        op.create_index(
+            "ix_mfa_challenges_user_expires",
+            _CHALLENGES_TABLE,
+            ["user_id", "expires_at"],
+        )
+        op.create_index(f"ix_{_CHALLENGES_TABLE}_challenge_type", _CHALLENGES_TABLE, ["challenge_type"])
+        op.create_index(f"ix_{_CHALLENGES_TABLE}_expires_at", _CHALLENGES_TABLE, ["expires_at"])
+        op.create_index(f"ix_{_CHALLENGES_TABLE}_consumed_at", _CHALLENGES_TABLE, ["consumed_at"])
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    tables = _table_names(inspector)
+
+    if _CHALLENGES_TABLE in tables:
+        existing_indexes = _index_names(inspector, _CHALLENGES_TABLE)
+        for index_name in [
+            f"ix_{_CHALLENGES_TABLE}_consumed_at",
+            f"ix_{_CHALLENGES_TABLE}_expires_at",
+            "ix_mfa_challenges_user_expires",
+            f"ix_{_CHALLENGES_TABLE}_challenge_type",
+            f"ix_{_CHALLENGES_TABLE}_session_id",
+            f"ix_{_CHALLENGES_TABLE}_user_id",
+        ]:
+            if index_name in existing_indexes:
+                op.drop_index(index_name, table_name=_CHALLENGES_TABLE)
+        op.drop_table(_CHALLENGES_TABLE)
+
+    if _RECOVERY_TABLE in tables:
+        existing_indexes = _index_names(inspector, _RECOVERY_TABLE)
+        for index_name in [
+            f"ix_{_RECOVERY_TABLE}_used_at",
+            f"ix_{_RECOVERY_TABLE}_user_id",
+        ]:
+            if index_name in existing_indexes:
+                op.drop_index(index_name, table_name=_RECOVERY_TABLE)
+        op.drop_table(_RECOVERY_TABLE)
+
+    if _WEBAUTHN_TABLE in tables:
+        existing_indexes = _index_names(inspector, _WEBAUTHN_TABLE)
+        for index_name in [
+            "ix_mfa_webauthn_user_active",
+            f"ix_{_WEBAUTHN_TABLE}_last_used_at",
+            f"ix_{_WEBAUTHN_TABLE}_backed_up",
+            f"ix_{_WEBAUTHN_TABLE}_is_active",
+            f"ix_{_WEBAUTHN_TABLE}_user_id",
+        ]:
+            if index_name in existing_indexes:
+                op.drop_index(index_name, table_name=_WEBAUTHN_TABLE)
+        op.drop_table(_WEBAUTHN_TABLE)
+
+    if _TOTP_TABLE in tables:
+        existing_indexes = _index_names(inspector, _TOTP_TABLE)
+        for index_name in [
+            "ix_mfa_totp_enrollments_active",
+            f"ix_{_TOTP_TABLE}_revoked_at",
+            f"ix_{_TOTP_TABLE}_confirmed_at",
+            f"ix_{_TOTP_TABLE}_is_active",
+            f"ix_{_TOTP_TABLE}_user_id",
+        ]:
+            if index_name in existing_indexes:
+                op.drop_index(index_name, table_name=_TOTP_TABLE)
+        op.drop_table(_TOTP_TABLE)
+
+    inspector = sa.inspect(bind)
+    tables = _table_names(inspector)
+
+    if _ACTIVE_SESSIONS_TABLE in tables:
+        session_indexes = _index_names(inspector, _ACTIVE_SESSIONS_TABLE)
+        if "ix_active_sessions_mfa_completed_at" in session_indexes:
+            op.drop_index(
+                "ix_active_sessions_mfa_completed_at",
+                table_name=_ACTIVE_SESSIONS_TABLE,
+            )
+        if "ix_active_sessions_mfa_required" in session_indexes:
+            op.drop_index(
+                "ix_active_sessions_mfa_required",
+                table_name=_ACTIVE_SESSIONS_TABLE,
+            )
+        session_columns = _column_names(inspector, _ACTIVE_SESSIONS_TABLE)
+        if "mfa_method" in session_columns:
+            op.drop_column(_ACTIVE_SESSIONS_TABLE, "mfa_method")
+        if "mfa_completed_at" in session_columns:
+            op.drop_column(_ACTIVE_SESSIONS_TABLE, "mfa_completed_at")
+        if "mfa_required" in session_columns:
+            op.drop_column(_ACTIVE_SESSIONS_TABLE, "mfa_required")
+
+    inspector = sa.inspect(bind)
+    tables = _table_names(inspector)
+
+    if _USERS_TABLE in tables:
+        user_indexes = _index_names(inspector, _USERS_TABLE)
+        if "ix_users_mfa_recovery_codes_generated_at" in user_indexes:
+            op.drop_index(
+                "ix_users_mfa_recovery_codes_generated_at",
+                table_name=_USERS_TABLE,
+            )
+        if "ix_users_mfa_last_verified_at" in user_indexes:
+            op.drop_index("ix_users_mfa_last_verified_at", table_name=_USERS_TABLE)
+        if "ix_users_mfa_required" in user_indexes:
+            op.drop_index("ix_users_mfa_required", table_name=_USERS_TABLE)
+        user_columns = _column_names(inspector, _USERS_TABLE)
+        if "mfa_recovery_codes_generated_at" in user_columns:
+            op.drop_column(_USERS_TABLE, "mfa_recovery_codes_generated_at")
+        if "mfa_last_verified_at" in user_columns:
+            op.drop_column(_USERS_TABLE, "mfa_last_verified_at")
+        if "mfa_default_method" in user_columns:
+            op.drop_column(_USERS_TABLE, "mfa_default_method")
+        if "mfa_required" in user_columns:
+            op.drop_column(_USERS_TABLE, "mfa_required")

--- a/root/app/auth/auth.py
+++ b/root/app/auth/auth.py
@@ -415,6 +415,8 @@ async def _perform_login(
             "ip_address": client_ip,
             "user_agent": user_agent,
             "last_seen_at": now,
+            "mfa_required": user.mfa_required,
+            "mfa_method": user.mfa_default_method,
         },
     )
     _set_access_token_cookie(response, token)

--- a/root/app/auth/security.py
+++ b/root/app/auth/security.py
@@ -134,12 +134,22 @@ async def create_access_token(
             ip_address = session_metadata.get("ip_address")
             user_agent = session_metadata.get("user_agent")
             last_seen_at = session_metadata.get("last_seen_at")
+            mfa_required = session_metadata.get("mfa_required")
+            mfa_method = session_metadata.get("mfa_method")
+            mfa_completed_at = session_metadata.get("mfa_completed_at")
             if ip_address:
                 session.ip_address = str(ip_address)[:64]
             if user_agent:
                 session.user_agent = str(user_agent)[:512]
             if last_seen_at is not None:
                 session.last_seen_at = last_seen_at
+            if mfa_required is not None:
+                session.mfa_required = bool(mfa_required)
+            if mfa_method is not None:
+                method_text = str(mfa_method).strip()
+                session.mfa_method = method_text[:64] if method_text else None
+            if mfa_completed_at is not None:
+                session.mfa_completed_at = mfa_completed_at
         db.add(session)
         await db.commit()
     return token

--- a/root/app/core/config.py
+++ b/root/app/core/config.py
@@ -59,6 +59,37 @@ def _validate_webpush_subject(value: str) -> str:
     return normalized
 
 
+def _validate_non_empty(value: str, *, label: str) -> str:
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"{label} must not be empty")
+    return normalized
+
+
+def _validate_positive_int(value: int, *, label: str) -> int:
+    if value <= 0:
+        raise ValueError(f"{label} must be greater than zero")
+    return value
+
+
+def _validate_webauthn_origin(value: str) -> str:
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError("MFA_WEBAUTHN_ORIGIN must not be empty")
+    parsed = urlparse(normalized)
+    if parsed.scheme not in {"https", "http"}:
+        raise ValueError("MFA_WEBAUTHN_ORIGIN must use http or https")
+    if not parsed.netloc:
+        raise ValueError("MFA_WEBAUTHN_ORIGIN must include a host")
+    if parsed.scheme == "http":
+        host = (parsed.hostname or "").lower()
+        if host not in {"localhost", "127.0.0.1"}:
+            raise ValueError(
+                "Insecure MFA_WEBAUTHN_ORIGIN http scheme is only allowed for localhost"
+            )
+    return normalized
+
+
 class Settings(BaseSettings):
     database_url: str
     secret_key: str
@@ -113,6 +144,15 @@ class Settings(BaseSettings):
     rate_limit_headers_enabled: bool = True
     auth_lockout_thresholds: str | list[str] = "5:30,8:300,10:3600"
     auth_lockout_history_minutes: int = 1_440
+    mfa_enabled: bool = False
+    mfa_default_method: str | None = None
+    mfa_totp_issuer: str = "University Ecosystem"
+    mfa_totp_initial_skew_windows: int = 1
+    mfa_challenge_ttl_seconds: int = 300
+    mfa_challenge_max_attempts: int = 5
+    mfa_webauthn_rp_id: str = "localhost"
+    mfa_webauthn_rp_name: str = "University Ecosystem"
+    mfa_webauthn_origin: str = "http://localhost:5173"
     security_csp: str = ""
     # Extra hosts for connect-src; merged with defaults dynamically.
     security_connect_src_extra: str | list[str] = (
@@ -197,6 +237,33 @@ class Settings(BaseSettings):
         if normalized not in {"memory", "redis"}:
             raise ValueError("RATE_LIMIT_STORAGE_BACKEND must be 'memory' or 'redis'")
         return normalized
+
+    @field_validator("mfa_totp_issuer")
+    @classmethod
+    def _validate_mfa_totp_issuer(cls, value: str) -> str:
+        return _validate_non_empty(value, label="MFA_TOTP_ISSUER")
+
+    @field_validator("mfa_webauthn_rp_id")
+    @classmethod
+    def _validate_mfa_webauthn_rp_id(cls, value: str) -> str:
+        return _validate_non_empty(value, label="MFA_WEBAUTHN_RP_ID")
+
+    @field_validator("mfa_webauthn_origin")
+    @classmethod
+    def _validate_mfa_webauthn_origin(cls, value: str) -> str:
+        return _validate_webauthn_origin(value)
+
+    @field_validator("mfa_challenge_ttl_seconds", "mfa_challenge_max_attempts")
+    @classmethod
+    def _validate_positive_mfa_values(cls, value: int, info):
+        return _validate_positive_int(value, label=info.field_name.upper())
+
+    @field_validator("mfa_totp_initial_skew_windows")
+    @classmethod
+    def _validate_totp_skew(cls, value: int) -> int:
+        if value < 0:
+            raise ValueError("MFA_TOTP_INITIAL_SKEW_WINDOWS must be zero or positive")
+        return value
 
     model_config = SettingsConfigDict(
         env_file=str(_ENV_FILE),

--- a/root/app/crud/__init__.py
+++ b/root/app/crud/__init__.py
@@ -8,6 +8,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth.security import get_password_hash
+from app.core.config import settings
 from app.localization import localized_text, normalize_locale, translate
 from app.models import models
 from app.models.enums import UserRole
@@ -94,6 +95,8 @@ async def create_user(db: AsyncSession, user_in: schemas.UserCreate):
         achievements=getattr(user_in, "achievements", None),
         department=getattr(user_in, "department", None),
         position=getattr(user_in, "position", None),
+        mfa_required=settings.mfa_enabled,
+        mfa_default_method=settings.mfa_default_method,
     )
     db.add(db_user)
     try:

--- a/root/app/models/models.py
+++ b/root/app/models/models.py
@@ -44,6 +44,12 @@ class User(Base):
     role = Column(String, nullable=False, default=UserRole.STUDENT.value, index=True)
     group_id = Column(Integer, ForeignKey("groups.id", ondelete="SET NULL"))
     is_active = Column(Boolean, default=True, index=True)
+    mfa_required = Column(Boolean, default=False, nullable=False, index=True)
+    mfa_default_method = Column(String(64))
+    mfa_last_verified_at = Column(DateTime(timezone=True), nullable=True, index=True)
+    mfa_recovery_codes_generated_at = Column(
+        DateTime(timezone=True), nullable=True, index=True
+    )
 
     avatar_url = Column(String)
     cover_url = Column(String)
@@ -95,6 +101,30 @@ class User(Base):
     )
     sessions = relationship(
         "ActiveSession",
+        back_populates="user",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+    )
+    totp_enrollments = relationship(
+        "MfaTotpEnrollment",
+        back_populates="user",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+    )
+    webauthn_credentials = relationship(
+        "MfaWebAuthnCredential",
+        back_populates="user",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+    )
+    recovery_codes = relationship(
+        "MfaRecoveryCode",
+        back_populates="user",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+    )
+    mfa_challenges = relationship(
+        "MfaChallenge",
         back_populates="user",
         cascade="all, delete-orphan",
         passive_deletes=True,
@@ -191,8 +221,107 @@ class ActiveSession(Base):
     user_agent = Column(String(512))
     last_seen_at = Column(DateTime(timezone=True), nullable=True, index=True)
     signing_key = Column(String, nullable=False, default=_generate_session_signing_key)
+    mfa_required = Column(Boolean, default=False, nullable=False, index=True)
+    mfa_completed_at = Column(DateTime(timezone=True), nullable=True, index=True)
+    mfa_method = Column(String(64))
 
     user = relationship("User", back_populates="sessions")
+    challenges = relationship(
+        "MfaChallenge",
+        back_populates="session",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+    )
+
+
+class MfaTotpEnrollment(Base):
+    __tablename__ = "mfa_totp_enrollments"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(
+        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    secret = Column(EncryptedString(), nullable=False)
+    label = Column(String(255))
+    is_active = Column(Boolean, nullable=False, default=True, index=True)
+    confirmed_at = Column(DateTime(timezone=True), nullable=True, index=True)
+    revoked_at = Column(DateTime(timezone=True), nullable=True, index=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+    user = relationship("User", back_populates="totp_enrollments")
+
+    __table_args__ = (
+        Index("ix_mfa_totp_enrollments_active", "user_id", "is_active"),
+    )
+
+
+class MfaWebAuthnCredential(Base):
+    __tablename__ = "mfa_webauthn_credentials"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(
+        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    credential_id = Column(String(255), nullable=False, unique=True)
+    public_key = Column(Text, nullable=False)
+    sign_count = Column(Integer, nullable=False, default=0)
+    transports = Column(JSON, nullable=True)
+    device_name = Column(String(255))
+    backed_up = Column(Boolean, nullable=False, default=False, index=True)
+    clone_warning = Column(Boolean, nullable=False, default=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    last_used_at = Column(DateTime(timezone=True), nullable=True, index=True)
+    is_active = Column(Boolean, nullable=False, default=True, index=True)
+
+    user = relationship("User", back_populates="webauthn_credentials")
+
+    __table_args__ = (
+        Index("ix_mfa_webauthn_user_active", "user_id", "is_active"),
+    )
+
+
+class MfaRecoveryCode(Base):
+    __tablename__ = "mfa_recovery_codes"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(
+        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    code_hash = Column(String(255), nullable=False)
+    used_at = Column(DateTime(timezone=True), nullable=True, index=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    label = Column(String(255))
+
+    user = relationship("User", back_populates="recovery_codes")
+
+    __table_args__ = (
+        UniqueConstraint("user_id", "code_hash", name="uq_mfa_recovery_codes_hash"),
+    )
+
+
+class MfaChallenge(Base):
+    __tablename__ = "mfa_challenges"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(
+        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    session_id = Column(
+        Integer, ForeignKey("active_sessions.id", ondelete="CASCADE"), nullable=True
+    )
+    challenge_type = Column(String(64), nullable=False, index=True)
+    token = Column(String(255), nullable=False, unique=True)
+    expires_at = Column(DateTime(timezone=True), nullable=False, index=True)
+    consumed_at = Column(DateTime(timezone=True), nullable=True, index=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    payload = Column(JSON, nullable=True)
+
+    user = relationship("User", back_populates="mfa_challenges")
+    session = relationship("ActiveSession", back_populates="challenges")
+
+    __table_args__ = (
+        Index("ix_mfa_challenges_user_expires", "user_id", "expires_at"),
+    )
 
 
 class FailedLoginAttempt(Base):

--- a/root/app/models/models.py
+++ b/root/app/models/models.py
@@ -246,13 +246,13 @@ class MfaTotpEnrollment(Base):
     is_active = Column(Boolean, nullable=False, default=True, index=True)
     confirmed_at = Column(DateTime(timezone=True), nullable=True, index=True)
     revoked_at = Column(DateTime(timezone=True), nullable=True, index=True)
-    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    created_at = Column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
 
     user = relationship("User", back_populates="totp_enrollments")
 
-    __table_args__ = (
-        Index("ix_mfa_totp_enrollments_active", "user_id", "is_active"),
-    )
+    __table_args__ = (Index("ix_mfa_totp_enrollments_active", "user_id", "is_active"),)
 
 
 class MfaWebAuthnCredential(Base):
@@ -269,15 +269,15 @@ class MfaWebAuthnCredential(Base):
     device_name = Column(String(255))
     backed_up = Column(Boolean, nullable=False, default=False, index=True)
     clone_warning = Column(Boolean, nullable=False, default=False)
-    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    created_at = Column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
     last_used_at = Column(DateTime(timezone=True), nullable=True, index=True)
     is_active = Column(Boolean, nullable=False, default=True, index=True)
 
     user = relationship("User", back_populates="webauthn_credentials")
 
-    __table_args__ = (
-        Index("ix_mfa_webauthn_user_active", "user_id", "is_active"),
-    )
+    __table_args__ = (Index("ix_mfa_webauthn_user_active", "user_id", "is_active"),)
 
 
 class MfaRecoveryCode(Base):
@@ -289,7 +289,9 @@ class MfaRecoveryCode(Base):
     )
     code_hash = Column(String(255), nullable=False)
     used_at = Column(DateTime(timezone=True), nullable=True, index=True)
-    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    created_at = Column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
     label = Column(String(255))
 
     user = relationship("User", back_populates="recovery_codes")
@@ -313,15 +315,15 @@ class MfaChallenge(Base):
     token = Column(String(255), nullable=False, unique=True)
     expires_at = Column(DateTime(timezone=True), nullable=False, index=True)
     consumed_at = Column(DateTime(timezone=True), nullable=True, index=True)
-    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    created_at = Column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
     payload = Column(JSON, nullable=True)
 
     user = relationship("User", back_populates="mfa_challenges")
     session = relationship("ActiveSession", back_populates="challenges")
 
-    __table_args__ = (
-        Index("ix_mfa_challenges_user_expires", "user_id", "expires_at"),
-    )
+    __table_args__ = (Index("ix_mfa_challenges_user_expires", "user_id", "expires_at"),)
 
 
 class FailedLoginAttempt(Base):

--- a/root/app/schemas/schemas.py
+++ b/root/app/schemas/schemas.py
@@ -65,10 +65,62 @@ class UserCreate(UserBase):
     invite_code: Optional[str] = None
 
 
+class MfaTotpEnrollmentOut(OrmModel):
+    id: int
+    user_id: int
+    label: Optional[str] = None
+    is_active: bool
+    confirmed_at: Optional[datetime] = None
+    revoked_at: Optional[datetime] = None
+    created_at: datetime
+
+
+class MfaWebAuthnCredentialOut(OrmModel):
+    id: int
+    user_id: int
+    credential_id: str
+    device_name: Optional[str] = None
+    sign_count: int
+    transports: Optional[list[str]] = None
+    backed_up: bool
+    clone_warning: bool
+    created_at: datetime
+    last_used_at: Optional[datetime] = None
+    is_active: bool
+
+
+class MfaRecoveryCodeOut(OrmModel):
+    id: int
+    user_id: int
+    used_at: Optional[datetime] = None
+    created_at: datetime
+    label: Optional[str] = None
+
+
+class MfaChallengeOut(OrmModel):
+    id: int
+    user_id: int
+    session_id: Optional[int] = None
+    challenge_type: str
+    token: str
+    expires_at: datetime
+    consumed_at: Optional[datetime] = None
+    created_at: datetime
+    payload: Optional[dict[str, Any]] = None
+
+
 class UserOut(OrmModel, UserBase):
     id: int
     is_active: bool
     spotify_is_connected: Optional[bool] = None
+    mfa_required: bool = False
+    mfa_default_method: Optional[str] = None
+    mfa_last_verified_at: Optional[datetime] = None
+    mfa_recovery_codes_generated_at: Optional[datetime] = None
+    totp_enrollments: List[MfaTotpEnrollmentOut] = Field(default_factory=list)
+    webauthn_credentials: List[MfaWebAuthnCredentialOut] = Field(default_factory=list)
+    recovery_codes: List[MfaRecoveryCodeOut] = Field(default_factory=list)
+    mfa_challenges: List[MfaChallengeOut] = Field(default_factory=list)
 
 
 class UserAdminUpdate(BaseModel):
@@ -404,6 +456,9 @@ class ActiveSessionOut(OrmModel):
     ip_address: str | None = None
     user_agent: str | None = None
     last_seen_at: datetime | None = None
+    mfa_required: bool = False
+    mfa_completed_at: datetime | None = None
+    mfa_method: str | None = None
     is_current: bool = False
 
 

--- a/root/requirements-dev.txt
+++ b/root/requirements-dev.txt
@@ -5,3 +5,5 @@ pytest-cov>=5
 fakeredis>=2
 asgi-lifespan>=2.1.0
 pre-commit>=3.8
+pyotp>=2.9
+webauthn>=1.11

--- a/root/requirements.txt
+++ b/root/requirements.txt
@@ -26,6 +26,8 @@ slowapi>=0.1.9
 redis>=5
 aiosqlite>=0.19
 prometheus-client>=0.20
+pyotp>=2.9
+webauthn>=1.11
 
 opentelemetry-api==1.38.0
 opentelemetry-sdk==1.38.0


### PR DESCRIPTION
## Summary
- add pyotp and webauthn dependencies for MFA features
- introduce MFA settings, persistence models, and Alembic migration
- expose MFA state through schemas and session metadata handling

## Testing
- pytest root/tests/test_sessions_api.py *(fails: ModuleNotFoundError: No module named 'fakeredis')*


------
https://chatgpt.com/codex/tasks/task_e_68fb436403148327974b3f33c4706464