### PR TITLE
Add admin MFA reset tooling and audit coverage

### DIFF
--- a/root/app/api/users.py
+++ b/root/app/api/users.py
@@ -33,6 +33,7 @@ from app.core.observability import get_request_id
 from app.localization import resolve_locale, translate
 from app.models import models
 from app.schemas import schemas
+from app.services.notifications import create_notifications_for_users
 from app.utils.email import RESET_TOKEN_EXPIRY_MINUTES, send_reset_email
 from app.utils.files import delete_static_file
 from app.utils.ratelimit import sensitive_route_limit
@@ -443,7 +444,93 @@ async def update_user_admin(
             status_code=403,
             detail=translate("errors.forbidden", locale=locale),
         )
-    return await crud.admin_update_user(db, user_id, data)
+    updated_user, reset_stats = await crud.admin_update_user(db, user_id, data)
+    _audit_log("users.admin_update", request, user_id=updated_user.id, reason="admin_update")
+    reset_requested = bool(getattr(data, "reset_mfa", False))
+    if reset_stats is not None:
+        if reset_stats.changed:
+            target_locale = resolve_locale(request=request, user=updated_user)
+            title = translate("notifications.mfa.reset.title", locale=target_locale)
+            body = translate("notifications.mfa.reset.body", locale=target_locale)
+            await create_notifications_for_users(
+                db,
+                title=title,
+                body=body,
+                type="security",
+                user_ids=[updated_user.id],
+            )
+            _audit_log(
+                "users.mfa.reset",
+                request,
+                user_id=updated_user.id,
+                reason="admin_reset",
+            )
+        else:
+            _audit_log(
+                "users.mfa.reset",
+                request,
+                user_id=updated_user.id,
+                reason="admin_reset_noop",
+            )
+    elif reset_requested:
+        _audit_log(
+            "users.mfa.reset",
+            request,
+            user_id=updated_user.id,
+            reason="admin_reset_requested_noop",
+        )
+    return updated_user
+
+
+@users_router.get("/{user_id}/mfa", response_model=schemas.UserMfaMethodsOut)
+async def get_user_mfa_methods(
+    user_id: int,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    user: models.User = Depends(get_current_user),
+):
+    locale = resolve_locale(request=request, user=user)
+    if user.role != "admin":
+        raise HTTPException(
+            status_code=403,
+            detail=translate("errors.forbidden", locale=locale),
+        )
+    target_user = await db.get(models.User, user_id)
+    if target_user is None:
+        raise HTTPException(
+            status_code=404,
+            detail=translate("errors.users.not_found", locale=locale),
+        )
+    totp_rows = await db.execute(
+        select(models.MfaTotpEnrollment)
+        .where(models.MfaTotpEnrollment.user_id == user_id)
+        .where(models.MfaTotpEnrollment.is_active.is_(True))
+        .order_by(models.MfaTotpEnrollment.created_at)
+    )
+    webauthn_rows = await db.execute(
+        select(models.MfaWebAuthnCredential)
+        .where(models.MfaWebAuthnCredential.user_id == user_id)
+        .where(models.MfaWebAuthnCredential.is_active.is_(True))
+        .order_by(models.MfaWebAuthnCredential.created_at)
+    )
+    recovery_rows = await db.execute(
+        select(models.MfaRecoveryCode)
+        .where(models.MfaRecoveryCode.user_id == user_id)
+        .order_by(models.MfaRecoveryCode.created_at)
+    )
+    challenge_rows = await db.execute(
+        select(models.MfaChallenge)
+        .where(models.MfaChallenge.user_id == user_id)
+        .where(models.MfaChallenge.consumed_at.is_(None))
+        .order_by(models.MfaChallenge.created_at)
+    )
+    _audit_log("users.mfa.inspect", request, user_id=user_id, reason="admin_view")
+    return schemas.UserMfaMethodsOut(
+        totp_enrollments=list(totp_rows.scalars().all()),
+        webauthn_credentials=list(webauthn_rows.scalars().all()),
+        recovery_codes=list(recovery_rows.scalars().all()),
+        pending_challenges=list(challenge_rows.scalars().all()),
+    )
 
 
 @users_router.delete("/me/avatar", response_model=schemas.UserOut)

--- a/root/app/api/users.py
+++ b/root/app/api/users.py
@@ -445,7 +445,9 @@ async def update_user_admin(
             detail=translate("errors.forbidden", locale=locale),
         )
     updated_user, reset_stats = await crud.admin_update_user(db, user_id, data)
-    _audit_log("users.admin_update", request, user_id=updated_user.id, reason="admin_update")
+    _audit_log(
+        "users.admin_update", request, user_id=updated_user.id, reason="admin_update"
+    )
     reset_requested = bool(getattr(data, "reset_mfa", False))
     if reset_stats is not None:
         if reset_stats.changed:

--- a/root/app/auth/mfa.py
+++ b/root/app/auth/mfa.py
@@ -6,6 +6,7 @@ import base64
 import hashlib
 import secrets
 from collections.abc import Mapping, MutableMapping
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
@@ -67,6 +68,27 @@ CHALLENGE_TYPE_RECOVERY = "recovery-code"
 MFA_METHOD_TOTP = "totp"
 MFA_METHOD_WEBAUTHN = "webauthn"
 MFA_METHOD_RECOVERY = "recovery"
+
+
+@dataclass(slots=True)
+class MfaResetStats:
+    totp_deleted: int = 0
+    webauthn_deleted: int = 0
+    recovery_codes_deleted: int = 0
+    challenges_revoked: int = 0
+    fields_cleared: bool = False
+
+    @property
+    def changed(self) -> bool:
+        return any(
+            (
+                self.totp_deleted,
+                self.webauthn_deleted,
+                self.recovery_codes_deleted,
+                self.challenges_revoked,
+                self.fields_cleared,
+            )
+        )
 
 
 def _utcnow() -> datetime:
@@ -690,6 +712,46 @@ async def disable_webauthn_credential(
             count += 1
     await db.flush()
     return count
+
+
+async def reset_user_mfa(db: AsyncSession, *, user: User) -> MfaResetStats:
+    """Remove MFA factors, revoke challenges, and clear MFA state for a user."""
+
+    stats = MfaResetStats()
+
+    totp_result = await db.execute(
+        delete(MfaTotpEnrollment).where(MfaTotpEnrollment.user_id == user.id)
+    )
+    webauthn_result = await db.execute(
+        delete(MfaWebAuthnCredential).where(MfaWebAuthnCredential.user_id == user.id)
+    )
+    recovery_result = await db.execute(
+        delete(MfaRecoveryCode).where(MfaRecoveryCode.user_id == user.id)
+    )
+    challenge_result = await db.execute(
+        delete(MfaChallenge).where(MfaChallenge.user_id == user.id)
+    )
+
+    stats.totp_deleted = int(totp_result.rowcount or 0)
+    stats.webauthn_deleted = int(webauthn_result.rowcount or 0)
+    stats.recovery_codes_deleted = int(recovery_result.rowcount or 0)
+    stats.challenges_revoked = int(challenge_result.rowcount or 0)
+
+    if user.mfa_required:
+        user.mfa_required = False
+        stats.fields_cleared = True
+    if user.mfa_default_method:
+        user.mfa_default_method = None
+        stats.fields_cleared = True
+    if user.mfa_last_verified_at is not None:
+        user.mfa_last_verified_at = None
+        stats.fields_cleared = True
+    if user.mfa_recovery_codes_generated_at is not None:
+        user.mfa_recovery_codes_generated_at = None
+        stats.fields_cleared = True
+
+    await db.flush()
+    return stats
 
 
 async def record_mfa_success(

--- a/root/app/crud/__init__.py
+++ b/root/app/crud/__init__.py
@@ -7,6 +7,7 @@ from sqlalchemy import and_, func, or_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.auth import mfa
 from app.auth.security import get_password_hash
 from app.core.config import settings
 from app.localization import localized_text, normalize_locale, translate
@@ -738,15 +739,20 @@ async def get_users(
 
 async def admin_update_user(
     db: AsyncSession, user_id: int, data: schemas.UserAdminUpdate
-) -> models.User:
+) -> tuple[models.User, mfa.MfaResetStats | None]:
     user = await db.get(models.User, user_id)
     if not user:
         raise ValueError(translate("errors.users.not_found"))
-    for field, value in data.model_dump(exclude_unset=True).items():
+    payload = data.model_dump(exclude_unset=True)
+    reset_requested = bool(payload.pop("reset_mfa", False))
+    for field, value in payload.items():
         setattr(user, field, value)
+    reset_stats: mfa.MfaResetStats | None = None
+    if reset_requested:
+        reset_stats = await mfa.reset_user_mfa(db, user=user)
     await db.commit()
     await db.refresh(user)
-    return user
+    return user, reset_stats
 
 
 async def delete_user(db: AsyncSession, user_id: int):

--- a/root/app/localization.py
+++ b/root/app/localization.py
@@ -136,6 +136,14 @@ _TRANSLATIONS: Mapping[str, Mapping[str, str]] = {
         "ru": "Системное сообщение",
         "en": "System message",
     },
+    "notifications.mfa.reset.title": {
+        "ru": "Многофакторная аутентификация сброшена",
+        "en": "Multi-factor authentication was reset",
+    },
+    "notifications.mfa.reset.body": {
+        "ru": "Администратор отключил ваши MFA-методы. Настройте защиту повторно при следующем входе.",
+        "en": "An administrator removed your MFA methods. Please set them up again on your next sign-in.",
+    },
     "notifications.actions.open_schedule": {
         "ru": "Открыть расписание",
         "en": "Open schedule",

--- a/root/app/management/reset_mfa.py
+++ b/root/app/management/reset_mfa.py
@@ -1,0 +1,133 @@
+"""Management command to reset MFA factors for a specific user."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+from typing import Any
+
+from sqlalchemy import select
+
+from app.auth import mfa
+from app.core.database import async_session
+from app.localization import resolve_locale, translate
+from app.models import models
+from app.services.notifications import create_notifications_for_users
+
+audit_logger = logging.getLogger("app.users.audit")
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Reset all MFA methods for a specific user",
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--user-id",
+        type=int,
+        help="Reset MFA for the user with the given numeric ID",
+    )
+    group.add_argument(
+        "--email",
+        type=str,
+        help="Reset MFA for the user with the given email address",
+    )
+    parser.add_argument(
+        "--no-notify",
+        action="store_true",
+        help="Skip sending a notification to the affected user",
+    )
+    return parser
+
+
+def _audit_cli(event: str, *, user_id: int, reason: str, extra: dict[str, Any] | None = None) -> None:
+    payload: dict[str, Any] = {"event": event, "user_id": str(user_id), "reason": reason, "source": "management"}
+    if extra:
+        payload.update(extra)
+    audit_logger.info(json.dumps(payload, ensure_ascii=False))
+
+
+async def _load_user(session, *, user_id: int | None, email: str | None) -> models.User | None:
+    if user_id is not None:
+        return await session.get(models.User, user_id)
+    if email is None:
+        return None
+    result = await session.execute(
+        select(models.User).where(models.User.email == email.strip())
+    )
+    return result.scalar_one_or_none()
+
+
+async def _reset_user_mfa(
+    *,
+    user_id: int | None,
+    email: str | None,
+    notify: bool,
+) -> tuple[models.User, mfa.MfaResetStats]:
+    async with async_session() as session:
+        user = await _load_user(session, user_id=user_id, email=email)
+        if user is None:
+            raise ValueError("User not found")
+        stats = await mfa.reset_user_mfa(session, user=user)
+        await session.commit()
+
+        if notify and stats.changed:
+            locale = resolve_locale(user=user)
+            title = translate("notifications.mfa.reset.title", locale=locale)
+            body = translate("notifications.mfa.reset.body", locale=locale)
+            await create_notifications_for_users(
+                session,
+                title=title,
+                body=body,
+                type="security",
+                user_ids=[user.id],
+            )
+        reason = "admin_reset" if stats.changed else "admin_reset_noop"
+        _audit_cli(
+            "users.mfa.reset",
+            user_id=user.id,
+            reason=reason,
+            extra={
+                "notify": "false" if not notify else "true",
+                "totp_deleted": str(stats.totp_deleted),
+                "webauthn_deleted": str(stats.webauthn_deleted),
+                "recovery_deleted": str(stats.recovery_codes_deleted),
+                "challenges_revoked": str(stats.challenges_revoked),
+            },
+        )
+        return user, stats
+
+
+async def _async_main(args: argparse.Namespace) -> None:
+    user, stats = await _reset_user_mfa(
+        user_id=getattr(args, "user_id", None),
+        email=getattr(args, "email", None),
+        notify=not getattr(args, "no_notify", False),
+    )
+    print(
+        "MFA reset completed for user",
+        user.id,
+        {
+            "totp_deleted": stats.totp_deleted,
+            "webauthn_deleted": stats.webauthn_deleted,
+            "recovery_deleted": stats.recovery_codes_deleted,
+            "challenges_revoked": stats.challenges_revoked,
+            "fields_cleared": stats.fields_cleared,
+        },
+    )
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO)
+    parser = _build_arg_parser()
+    args = parser.parse_args()
+    try:
+        asyncio.run(_async_main(args))
+    except ValueError as exc:  # pragma: no cover - CLI feedback
+        parser.error(str(exc))
+
+
+if __name__ == "__main__":
+    main()

--- a/root/app/management/reset_mfa.py
+++ b/root/app/management/reset_mfa.py
@@ -42,14 +42,23 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _audit_cli(event: str, *, user_id: int, reason: str, extra: dict[str, Any] | None = None) -> None:
-    payload: dict[str, Any] = {"event": event, "user_id": str(user_id), "reason": reason, "source": "management"}
+def _audit_cli(
+    event: str, *, user_id: int, reason: str, extra: dict[str, Any] | None = None
+) -> None:
+    payload: dict[str, Any] = {
+        "event": event,
+        "user_id": str(user_id),
+        "reason": reason,
+        "source": "management",
+    }
     if extra:
         payload.update(extra)
     audit_logger.info(json.dumps(payload, ensure_ascii=False))
 
 
-async def _load_user(session, *, user_id: int | None, email: str | None) -> models.User | None:
+async def _load_user(
+    session, *, user_id: int | None, email: str | None
+) -> models.User | None:
     if user_id is not None:
         return await session.get(models.User, user_id)
     if email is None:

--- a/root/app/schemas/schemas.py
+++ b/root/app/schemas/schemas.py
@@ -128,6 +128,14 @@ class UserAdminUpdate(BaseModel):
     email: Optional[EmailStr] = None
     role: Optional[UserRole] = None
     group_id: Optional[int] = None
+    reset_mfa: Optional[bool] = None
+
+
+class UserMfaMethodsOut(BaseModel):
+    totp_enrollments: List[MfaTotpEnrollmentOut] = Field(default_factory=list)
+    webauthn_credentials: List[MfaWebAuthnCredentialOut] = Field(default_factory=list)
+    recovery_codes: List[MfaRecoveryCodeOut] = Field(default_factory=list)
+    pending_challenges: List[MfaChallengeOut] = Field(default_factory=list)
 
 
 class UserProfileUpdate(BaseModel):


### PR DESCRIPTION
## Summary
- allow administrators to request MFA resets through the existing user update endpoint with audit logging, challenge revocation, and user notifications
- add a read-only admin endpoint to inspect a user’s active MFA registrations and outstanding challenges
- introduce a management CLI command to reset MFA for a specific user and localize the corresponding notifications

## Testing
- pytest *(fails: missing fakeredis dependency in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fb5eb9643483278f10ebbd3d5d59eb