### PR TITLE
Add MFA challenge handling to AuthContext

### DIFF
--- a/root/app/api/deps.py
+++ b/root/app/api/deps.py
@@ -11,6 +11,7 @@ from app.core.config import settings
 from app.core.database import get_db
 from app.localization import resolve_locale, translate
 from app.models.models import ActiveSession, User
+from app.models.user_loaders import USER_MFA_LOAD_OPTIONS
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/login", auto_error=False)
 
@@ -38,7 +39,7 @@ async def get_current_user(
         user_id = int(sub)
     except (TypeError, ValueError):
         raise credentials_exception
-    user = await db.get(User, user_id)
+    user = await db.get(User, user_id, options=USER_MFA_LOAD_OPTIONS)
     if not user or not user.is_active:
         raise credentials_exception
     if not jti:

--- a/root/app/api/users.py
+++ b/root/app/api/users.py
@@ -32,6 +32,10 @@ from app.core.database import get_db
 from app.core.observability import get_request_id
 from app.localization import resolve_locale, translate
 from app.models import models
+from app.models.user_loaders import (
+    USER_MFA_LOAD_OPTIONS,
+    ensure_mfa_relationships_loaded,
+)
 from app.schemas import schemas
 from app.services.notifications import create_notifications_for_users
 from app.utils.email import RESET_TOKEN_EXPIRY_MINUTES, send_reset_email
@@ -282,7 +286,7 @@ async def update_me(
     db: AsyncSession = Depends(get_db),
     user: models.User = Depends(get_current_user),
 ):
-    db_user = await db.get(models.User, user.id)
+    db_user = await db.get(models.User, user.id, options=USER_MFA_LOAD_OPTIONS)
     update_fields = data.model_dump(exclude_unset=True)
     locale = resolve_locale(request=request, user=user)
 
@@ -317,6 +321,7 @@ async def update_me(
         setattr(db_user, field, value)
     await db.commit()
     await db.refresh(db_user)
+    await ensure_mfa_relationships_loaded(db, db_user)
     return db_user
 
 
@@ -330,7 +335,7 @@ async def upload_avatar(
 ):
     locale = resolve_locale(request=request, user=user)
     url = await save_upload(file, "avatars", f"user_{user.id}_avatar", locale=locale)
-    db_user = await db.get(models.User, user.id)
+    db_user = await db.get(models.User, user.id, options=USER_MFA_LOAD_OPTIONS)
     previous_url = db_user.avatar_url
     db_user.avatar_url = url
     try:
@@ -342,6 +347,7 @@ async def upload_avatar(
         raise
     try:
         await db.refresh(db_user)
+        await ensure_mfa_relationships_loaded(db, db_user)
     except Exception:
         db_user.avatar_url = previous_url
         await delete_static_file(url)
@@ -359,7 +365,7 @@ async def upload_cover(
 ):
     locale = resolve_locale(request=request, user=user)
     url = await save_upload(file, "covers", f"user_{user.id}_cover", locale=locale)
-    db_user = await db.get(models.User, user.id)
+    db_user = await db.get(models.User, user.id, options=USER_MFA_LOAD_OPTIONS)
     previous_url = db_user.cover_url
     db_user.cover_url = url
     try:
@@ -371,6 +377,7 @@ async def upload_cover(
         raise
     try:
         await db.refresh(db_user)
+        await ensure_mfa_relationships_loaded(db, db_user)
     except Exception:
         db_user.cover_url = previous_url
         await delete_static_file(url)
@@ -539,12 +546,13 @@ async def get_user_mfa_methods(
 async def delete_avatar(
     db: AsyncSession = Depends(get_db), user: models.User = Depends(get_current_user)
 ):
-    db_user = await db.get(models.User, user.id)
+    db_user = await db.get(models.User, user.id, options=USER_MFA_LOAD_OPTIONS)
     if db_user.avatar_url:
         await delete_static_file(db_user.avatar_url)
     db_user.avatar_url = None
     await db.commit()
     await db.refresh(db_user)
+    await ensure_mfa_relationships_loaded(db, db_user)
     return db_user
 
 

--- a/root/app/crud/__init__.py
+++ b/root/app/crud/__init__.py
@@ -12,11 +12,11 @@ from app.auth.security import get_password_hash
 from app.core.config import settings
 from app.localization import localized_text, normalize_locale, translate
 from app.models import models
+from app.models.enums import UserRole
 from app.models.user_loaders import (
     USER_MFA_LOAD_OPTIONS,
     ensure_mfa_relationships_loaded,
 )
-from app.models.enums import UserRole
 from app.schemas import schemas
 
 

--- a/root/app/crud/__init__.py
+++ b/root/app/crud/__init__.py
@@ -12,6 +12,10 @@ from app.auth.security import get_password_hash
 from app.core.config import settings
 from app.localization import localized_text, normalize_locale, translate
 from app.models import models
+from app.models.user_loaders import (
+    USER_MFA_LOAD_OPTIONS,
+    ensure_mfa_relationships_loaded,
+)
 from app.models.enums import UserRole
 from app.schemas import schemas
 
@@ -114,6 +118,8 @@ async def create_user(db: AsyncSession, user_in: schemas.UserCreate):
         code.used_by_user_id = db_user.id
         db.add(code)
         await db.commit()
+
+    await ensure_mfa_relationships_loaded(db, db_user)
 
     return db_user
 
@@ -726,7 +732,7 @@ async def get_users(
     full_name: Optional[str] = None,
     role: Optional[str] = None,
 ) -> List[models.User]:
-    stmt = select(models.User)
+    stmt = select(models.User).options(*USER_MFA_LOAD_OPTIONS)
     if group_id:
         stmt = stmt.where(models.User.group_id == group_id)
     if full_name:
@@ -752,15 +758,7 @@ async def admin_update_user(
         reset_stats = await mfa.reset_user_mfa(db, user=user)
     await db.commit()
     await db.refresh(user)
-    await db.refresh(
-        user,
-        attribute_names=[
-            "totp_enrollments",
-            "webauthn_credentials",
-            "recovery_codes",
-            "mfa_challenges",
-        ],
-    )
+    await ensure_mfa_relationships_loaded(db, user)
     return user, reset_stats
 
 

--- a/root/app/models/user_loaders.py
+++ b/root/app/models/user_loaders.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from .models import User
+
+USER_MFA_RELATIONSHIP_NAMES: tuple[str, ...] = (
+    "totp_enrollments",
+    "webauthn_credentials",
+    "recovery_codes",
+    "mfa_challenges",
+)
+
+USER_MFA_LOAD_OPTIONS: tuple = (
+    selectinload(User.totp_enrollments),
+    selectinload(User.webauthn_credentials),
+    selectinload(User.recovery_codes),
+    selectinload(User.mfa_challenges),
+)
+
+
+async def ensure_mfa_relationships_loaded(
+    db: AsyncSession, user: User | None
+) -> User | None:
+    """Ensure MFA-related relationships are loaded on the given user instance."""
+
+    if user is None:
+        return None
+    await db.refresh(user, attribute_names=list(USER_MFA_RELATIONSHIP_NAMES))
+    return user

--- a/root/frontend/src/api/mfa.ts
+++ b/root/frontend/src/api/mfa.ts
@@ -1,0 +1,45 @@
+import api from "./client"
+import type {
+  MfaTotpEnrollment,
+  MfaWebAuthnCredential,
+  PendingMfaResponse,
+  TotpEnrollmentConfirmPayload,
+  TotpEnrollmentStartPayload,
+  TotpEnrollmentStartResponse,
+  WebAuthnAssertionStartResponse,
+  WebAuthnAttestationFinishPayload,
+  WebAuthnAttestationStartResponse,
+  MfaVerifyPayload,
+} from "@/types/Mfa"
+
+export const startTotpEnrollment = (payload?: TotpEnrollmentStartPayload) =>
+  api.post<TotpEnrollmentStartResponse>("/auth/mfa/totp/start", payload)
+
+export const confirmTotpEnrollment = (payload: TotpEnrollmentConfirmPayload) =>
+  api.post<MfaTotpEnrollment>("/auth/mfa/totp/confirm", payload)
+
+export const listTotpEnrollments = () => api.get<MfaTotpEnrollment[]>("/auth/mfa/totp")
+
+export const deleteTotpEnrollment = (enrollmentId: number) =>
+  api.delete<{ disabled: boolean }>(`/auth/mfa/totp/${enrollmentId}`)
+
+export const listWebAuthnCredentials = () =>
+  api.get<MfaWebAuthnCredential[]>("/auth/mfa/webauthn")
+
+export const deleteWebAuthnCredential = (credentialId: string) =>
+  api.delete<{ disabled: boolean }>(`/auth/mfa/webauthn/${credentialId}`)
+
+export const startWebAuthnAttestation = () =>
+  api.post<WebAuthnAttestationStartResponse>("/auth/mfa/webauthn/attestation/start")
+
+export const finishWebAuthnAttestation = (payload: WebAuthnAttestationFinishPayload) =>
+  api.post<MfaWebAuthnCredential>("/auth/mfa/webauthn/attestation/finish", payload)
+
+export const startWebAuthnAssertion = () =>
+  api.post<WebAuthnAssertionStartResponse>("/auth/mfa/webauthn/assertion/start")
+
+export const verifyMfaChallenge = (payload: MfaVerifyPayload) =>
+  api.post<{ access_token: string; token_type: string }>("/auth/mfa/verify", payload)
+
+export const requestStepUpChallenge = () =>
+  api.post<PendingMfaResponse>("/auth/mfa/step-up")

--- a/root/frontend/src/api/mfa.ts
+++ b/root/frontend/src/api/mfa.ts
@@ -23,8 +23,7 @@ export const listTotpEnrollments = () => api.get<MfaTotpEnrollment[]>("/auth/mfa
 export const deleteTotpEnrollment = (enrollmentId: number) =>
   api.delete<{ disabled: boolean }>(`/auth/mfa/totp/${enrollmentId}`)
 
-export const listWebAuthnCredentials = () =>
-  api.get<MfaWebAuthnCredential[]>("/auth/mfa/webauthn")
+export const listWebAuthnCredentials = () => api.get<MfaWebAuthnCredential[]>("/auth/mfa/webauthn")
 
 export const deleteWebAuthnCredential = (credentialId: string) =>
   api.delete<{ disabled: boolean }>(`/auth/mfa/webauthn/${credentialId}`)
@@ -41,5 +40,4 @@ export const startWebAuthnAssertion = () =>
 export const verifyMfaChallenge = (payload: MfaVerifyPayload) =>
   api.post<{ access_token: string; token_type: string }>("/auth/mfa/verify", payload)
 
-export const requestStepUpChallenge = () =>
-  api.post<PendingMfaResponse>("/auth/mfa/step-up")
+export const requestStepUpChallenge = () => api.post<PendingMfaResponse>("/auth/mfa/step-up")

--- a/root/frontend/src/app/__tests__/a11y.test.tsx
+++ b/root/frontend/src/app/__tests__/a11y.test.tsx
@@ -85,6 +85,14 @@ const baseUser: User = {
   dnd_start: null,
   dnd_end: null,
   is_active: true,
+  mfa_required: false,
+  mfa_default_method: null,
+  mfa_last_verified_at: null,
+  mfa_recovery_codes_generated_at: null,
+  totp_enrollments: [],
+  webauthn_credentials: [],
+  recovery_codes: [],
+  mfa_challenges: [],
 }
 
 const activeClients: QueryClient[] = []
@@ -100,6 +108,9 @@ const createWrapper = (route = "/dashboard") => {
     refresh: vi.fn(),
     loading: false,
     user: { ...baseUser },
+    pendingMfa: null,
+    submitMfaChallenge: vi.fn().mockResolvedValue(undefined),
+    requireMfa: vi.fn().mockResolvedValue(null),
   }
 
   const Wrapper = ({ children }: PropsWithChildren) => (

--- a/root/frontend/src/contexts/AuthContext.tsx
+++ b/root/frontend/src/contexts/AuthContext.tsx
@@ -19,11 +19,26 @@ import { sha256 } from "@noble/hashes/sha256"
 import { hasPushConsent, softSyncPushSubscription, unsubscribePush } from "@/push/subscribe"
 import api, { API_UNAUTHORIZED_EVENT } from "../api/client"
 import { SPOTIFY_REAUTH_EVENT } from "@/hooks/useNowPlaying"
+import type { PendingMfaResponse, MfaMethod, MfaVerifyPayload } from "@/types/Mfa"
 import type { User } from "@/types/User"
 
 type UserState = User | null
 
 type SetUserArg = SetStateAction<UserState>
+
+export type PendingMfaState = PendingMfaResponse & { reason: "login" | "step-up" }
+
+export type SubmitMfaChallengePayload =
+  | {
+      method: Extract<MfaMethod, "totp" | "recovery">
+      code: string
+      challengeToken?: string
+    }
+  | {
+      method: Extract<MfaMethod, "webauthn">
+      credential: Record<string, unknown>
+      challengeToken?: string
+    }
 
 type AuthContextType = {
   isAuth: boolean
@@ -33,6 +48,9 @@ type AuthContextType = {
   loading: boolean
   setUser: Dispatch<SetUserArg>
   refresh: () => Promise<void>
+  pendingMfa: PendingMfaState | null
+  submitMfaChallenge: (payload: SubmitMfaChallengePayload) => Promise<void>
+  requireMfa: () => Promise<PendingMfaState | null>
 }
 
 const noopSetUser: Dispatch<SetUserArg> = (_value) => {
@@ -49,6 +67,9 @@ export const AuthContext = createContext<AuthContextType>({
   loading: false,
   setUser: noopSetUser,
   refresh: async () => {},
+  pendingMfa: null,
+  submitMfaChallenge: async () => {},
+  requireMfa: async () => null,
 })
 
 export const useAuth = () => useContext(AuthContext)
@@ -75,7 +96,17 @@ const isAscii = (value: string) => {
   return true
 }
 
-type CachedUserSnapshot = Pick<User, "id" | "full_name" | "avatar_url">
+type CachedUserSnapshot =
+  Pick<User, "id" | "full_name" | "avatar_url"> &
+  Partial<
+    Pick<
+      User,
+      | "mfa_required"
+      | "mfa_default_method"
+      | "mfa_last_verified_at"
+      | "mfa_recovery_codes_generated_at"
+    >
+  >
 
 type CachedProfileEnvelope = {
   version: number
@@ -90,7 +121,10 @@ type SessionSigningKeyResponse = {
   signing_key: string
 }
 
-type ProfileBroadcastMessage = { type: "unauthorized" }
+type ProfileBroadcastMessage =
+  | { type: "unauthorized" }
+  | { type: "mfa-pending"; payload: PendingMfaState }
+  | { type: "mfa-cleared" }
 
 type HandleUnauthorizedOptions = {
   broadcast?: boolean
@@ -252,6 +286,14 @@ const createOptimisticUser = (snapshot: CachedUserSnapshot): User => ({
   dnd_start: null,
   dnd_end: null,
   is_active: false,
+  mfa_required: Boolean(snapshot.mfa_required),
+  mfa_default_method: snapshot.mfa_default_method ?? null,
+  mfa_last_verified_at: snapshot.mfa_last_verified_at ?? null,
+  mfa_recovery_codes_generated_at: snapshot.mfa_recovery_codes_generated_at ?? null,
+  totp_enrollments: [],
+  webauthn_credentials: [],
+  recovery_codes: [],
+  mfa_challenges: [],
 })
 
 const clearProfileCacheStorage = () => {
@@ -336,6 +378,10 @@ const persistUserToCache = (value: User | null, signingKey: string | null) => {
         id: value.id,
         full_name: value.full_name,
         avatar_url: value.avatar_url,
+        mfa_required: value.mfa_required,
+        mfa_default_method: value.mfa_default_method,
+        mfa_last_verified_at: value.mfa_last_verified_at,
+        mfa_recovery_codes_generated_at: value.mfa_recovery_codes_generated_at,
       }
       const payload: CacheSignaturePayload = {
         version: PROFILE_CACHE_SCHEMA_VERSION,
@@ -402,9 +448,11 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     readStoredSessionSigningKey()
   )
   const [userState, setUserState] = useState<UserState>(initializeCachedUser)
+  const [pendingMfaState, setPendingMfaState] = useState<PendingMfaState | null>(null)
   const cachedUserRef = useRef<UserState>(userState)
   const sessionSigningKeyRef = useRef<string | null>(sessionSigningKey)
   const sessionSigningKeyPromiseRef = useRef<Promise<string | null> | null>(null)
+  const pendingMfaRef = useRef<PendingMfaState | null>(pendingMfaState)
   const [initializing, setInitializing] = useState<boolean>(true)
   const [authOperation, setAuthOperation] = useState(false)
   const activeRequestRef = useRef<AbortController | null>(null)
@@ -449,6 +497,22 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       }
     }
   }, [])
+
+  const updatePendingMfa = useCallback(
+    (value: PendingMfaState | null, { broadcast = true }: { broadcast?: boolean } = {}) => {
+      const previous = pendingMfaRef.current
+      pendingMfaRef.current = value
+      setPendingMfaState(value)
+      if (!broadcast) return
+      if (!previous && !value) return
+      if (value) {
+        broadcastProfileEvent({ type: "mfa-pending", payload: value })
+      } else {
+        broadcastProfileEvent({ type: "mfa-cleared" })
+      }
+    },
+    [broadcastProfileEvent]
+  )
 
   const applyUserState = useCallback(
     (value: SetUserArg, { persist }: { persist: boolean }) => {
@@ -505,13 +569,14 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       sessionSigningKeyPromiseRef.current = null
       updateSessionSigningKey(null)
       clearProfile({ persist })
+      updatePendingMfa(null, { broadcast })
       setAuthOperation(false)
       setInitializing(false)
       if (broadcast) {
         broadcastProfileEvent({ type: "unauthorized" })
       }
     },
-    [broadcastProfileEvent, clearProfile, updateSessionSigningKey]
+    [broadcastProfileEvent, clearProfile, updatePendingMfa, updateSessionSigningKey]
   )
 
   useEffect(() => {
@@ -539,6 +604,16 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 
       if (data.type === "unauthorized") {
         handleUnauthorized({ broadcast: false, persist: false })
+        return
+      }
+
+      if (data.type === "mfa-pending" && data.payload) {
+        updatePendingMfa(data.payload, { broadcast: false })
+        return
+      }
+
+      if (data.type === "mfa-cleared") {
+        updatePendingMfa(null, { broadcast: false })
       }
     }
 
@@ -560,7 +635,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         channel.close()
       }
     }
-  }, [applyUserState, handleUnauthorized])
+  }, [applyUserState, handleUnauthorized, updatePendingMfa])
 
   useEffect(() => {
     if (typeof window === "undefined") {
@@ -606,6 +681,9 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   }, [ensureSessionSigningKey, handleUnauthorized, setUser])
 
   const refresh = useCallback(async () => {
+    if (pendingMfaRef.current) {
+      return
+    }
     const controller = new AbortController()
     activeRequestRef.current?.abort()
     activeRequestRef.current = controller
@@ -636,7 +714,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         setInitializing(false)
       }
     }
-  }, [ensureSessionSigningKey, handleUnauthorized, setUser])
+  }, [ensureSessionSigningKey, handleUnauthorized, pendingMfaRef, setUser])
 
   useEffect(() => {
     if (typeof window === "undefined") return
@@ -664,6 +742,42 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     return () => window.removeEventListener(SPOTIFY_REAUTH_EVENT, onSpotifyReauth as EventListener)
   }, [queryClient, setUser])
 
+  const finalizeAuthenticatedSession = useCallback(
+    async (
+      controller: AbortController,
+      { skipPushSync = false }: { skipPushSync?: boolean } = {}
+    ) => {
+      const signingKeyPromise = ensureSessionSigningKey()
+      const profile = await fetchCurrentUser({ signal: controller.signal })
+      try {
+        await signingKeyPromise
+      } catch (error) {
+        if (!controller.signal.aborted && import.meta.env.DEV) {
+          console.warn("Failed to obtain session signing key", error)
+        }
+      }
+
+      if (controller.signal.aborted) {
+        return
+      }
+
+      setUser(profile)
+
+      if (!skipPushSync && typeof window !== "undefined" && typeof Notification !== "undefined") {
+        if (Notification.permission === "granted" && hasPushConsent()) {
+          void (async () => {
+            try {
+              await softSyncPushSubscription()
+            } catch (error) {
+              console.warn("Failed to sync push subscription", error)
+            }
+          })()
+        }
+      }
+    },
+    [ensureSessionSigningKey, setUser]
+  )
+
   const login = useCallback(
     async (email: string, password: string) => {
       const payload = new URLSearchParams()
@@ -677,35 +791,26 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       try {
         setAuthOperation(true)
         setInitializing(true)
-        await api.post("/auth/login", payload, {
-          headers: { "Content-Type": "application/x-www-form-urlencoded" },
-          signal: controller.signal,
-        })
+        const response = await api.post<PendingMfaResponse | { access_token?: string }>(
+          "/auth/login",
+          payload,
+          {
+            headers: { "Content-Type": "application/x-www-form-urlencoded" },
+            signal: controller.signal,
+          }
+        )
 
         if (controller.signal.aborted) return
 
-        const signingKeyPromise = ensureSessionSigningKey()
-        const profile = await fetchCurrentUser({ signal: controller.signal })
-        try {
-          await signingKeyPromise
-        } catch (error) {
-          if (!controller.signal.aborted && import.meta.env.DEV) {
-            console.warn("Failed to obtain session signing key", error)
-          }
+        if (response.status === 202) {
+          const data = response.data as PendingMfaResponse
+          const challenge: PendingMfaState = { ...data, reason: "login" }
+          updatePendingMfa(challenge)
+          return
         }
-        setUser(profile)
 
-        if (typeof window !== "undefined" && typeof Notification !== "undefined") {
-          if (Notification.permission === "granted" && hasPushConsent()) {
-            void (async () => {
-              try {
-                await softSyncPushSubscription()
-              } catch (error) {
-                console.warn("Failed to sync push subscription", error)
-              }
-            })()
-          }
-        }
+        updatePendingMfa(null)
+        await finalizeAuthenticatedSession(controller)
       } catch (error) {
         if (!controller.signal.aborted) {
           handleUnauthorized()
@@ -758,8 +863,148 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         }
       }
     },
-    [ensureSessionSigningKey, handleUnauthorized, setUser, t]
+    [finalizeAuthenticatedSession, handleUnauthorized, t, updatePendingMfa]
   )
+
+  const submitMfaChallenge = useCallback(
+    async (payload: SubmitMfaChallengePayload) => {
+      const pending = pendingMfaRef.current
+      if (!pending) {
+        throw new Error(t("login.error"))
+      }
+
+      const controller = new AbortController()
+      activeRequestRef.current?.abort()
+      activeRequestRef.current = controller
+
+      const shouldToggleInitializing = pending.reason === "login"
+
+      try {
+        setAuthOperation(true)
+        if (shouldToggleInitializing) {
+          setInitializing(true)
+        }
+
+        const token =
+          payload.challengeToken ??
+          pending.methods.find((entry) => entry.method === (payload.method as MfaMethod))
+            ?.challenge_token
+
+        if (!token) {
+          throw new Error(t("login.error"))
+        }
+
+        let requestPayload: MfaVerifyPayload
+        if (payload.method === "webauthn") {
+          requestPayload = {
+            method: payload.method,
+            challenge_token: token,
+            credential: payload.credential,
+          }
+        } else {
+          requestPayload = {
+            method: payload.method,
+            challenge_token: token,
+            code: payload.code,
+          }
+        }
+
+        const skipPushSync = Boolean(pending.session_id)
+        await api.post("/auth/mfa/verify", requestPayload, { signal: controller.signal })
+
+        if (controller.signal.aborted) {
+          return
+        }
+
+        updatePendingMfa(null)
+        await finalizeAuthenticatedSession(controller, {
+          skipPushSync,
+        })
+      } catch (error) {
+        if (controller.signal.aborted) {
+          return
+        }
+
+        if (isAxiosError(error)) {
+          if (error.response?.status === 401) {
+            handleUnauthorized()
+            return
+          }
+          const message =
+            typeof error.response?.data?.detail === "string"
+              ? error.response.data.detail
+              : t("login.error")
+          throw new Error(message)
+        }
+
+        if (error instanceof Error) {
+          throw error
+        }
+
+        throw new Error(t("login.error"))
+      } finally {
+        if (activeRequestRef.current === controller) {
+          activeRequestRef.current = null
+        }
+        setAuthOperation(false)
+        if (shouldToggleInitializing && !controller.signal.aborted) {
+          setInitializing(false)
+        }
+      }
+    },
+    [finalizeAuthenticatedSession, handleUnauthorized, pendingMfaRef, t, updatePendingMfa]
+  )
+
+  const requireMfa = useCallback(async (): Promise<PendingMfaState | null> => {
+    const controller = new AbortController()
+    activeRequestRef.current?.abort()
+    activeRequestRef.current = controller
+
+    try {
+      const response = await api.post<PendingMfaResponse>("/auth/mfa/step-up", undefined, {
+        signal: controller.signal,
+      })
+
+      if (controller.signal.aborted) {
+        return null
+      }
+
+      if (response.status === 202) {
+        const challenge: PendingMfaState = { ...response.data, reason: "step-up" }
+        updatePendingMfa(challenge)
+        return challenge
+      }
+
+      updatePendingMfa(null)
+      return null
+    } catch (error) {
+      if (controller.signal.aborted) {
+        return null
+      }
+
+      if (isAxiosError(error)) {
+        if (error.response?.status === 401) {
+          handleUnauthorized()
+          return null
+        }
+        const message =
+          typeof error.response?.data?.detail === "string"
+            ? error.response.data.detail
+            : t("login.error")
+        throw new Error(message)
+      }
+
+      if (error instanceof Error) {
+        throw error
+      }
+
+      throw new Error(t("login.error"))
+    } finally {
+      if (activeRequestRef.current === controller) {
+        activeRequestRef.current = null
+      }
+    }
+  }, [handleUnauthorized, t, updatePendingMfa])
 
   const logout = useCallback(async () => {
     activeRequestRef.current?.abort()
@@ -786,10 +1031,33 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const user = userState
   const isAuth = Boolean(user)
   const loading = initializing || authOperation
+  const pendingMfa = pendingMfaState
 
   const value = useMemo(
-    () => ({ isAuth, login, logout, user, loading, setUser, refresh }),
-    [isAuth, login, logout, user, loading, setUser, refresh]
+    () => ({
+      isAuth,
+      login,
+      logout,
+      user,
+      loading,
+      setUser,
+      refresh,
+      pendingMfa,
+      submitMfaChallenge,
+      requireMfa,
+    }),
+    [
+      isAuth,
+      login,
+      logout,
+      user,
+      loading,
+      setUser,
+      refresh,
+      pendingMfa,
+      submitMfaChallenge,
+      requireMfa,
+    ]
   )
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>

--- a/root/frontend/src/contexts/AuthContext.tsx
+++ b/root/frontend/src/contexts/AuthContext.tsx
@@ -96,8 +96,7 @@ const isAscii = (value: string) => {
   return true
 }
 
-type CachedUserSnapshot =
-  Pick<User, "id" | "full_name" | "avatar_url"> &
+type CachedUserSnapshot = Pick<User, "id" | "full_name" | "avatar_url"> &
   Partial<
     Pick<
       User,

--- a/root/frontend/src/pages/__tests__/Schedule.translations.test.tsx
+++ b/root/frontend/src/pages/__tests__/Schedule.translations.test.tsx
@@ -51,6 +51,14 @@ const baseUser: User = {
   dnd_start: null,
   dnd_end: null,
   is_active: true,
+  mfa_required: false,
+  mfa_default_method: null,
+  mfa_last_verified_at: null,
+  mfa_recovery_codes_generated_at: null,
+  totp_enrollments: [],
+  webauthn_credentials: [],
+  recovery_codes: [],
+  mfa_challenges: [],
 }
 
 const authState: AuthState = {

--- a/root/frontend/src/pages/__tests__/Settings.media.test.tsx
+++ b/root/frontend/src/pages/__tests__/Settings.media.test.tsx
@@ -65,6 +65,14 @@ const baseUser: User = {
   dnd_start: null,
   dnd_end: null,
   is_active: true,
+  mfa_required: false,
+  mfa_default_method: null,
+  mfa_last_verified_at: null,
+  mfa_recovery_codes_generated_at: null,
+  totp_enrollments: [],
+  webauthn_credentials: [],
+  recovery_codes: [],
+  mfa_challenges: [],
 }
 
 const renderSettings = () => {
@@ -86,6 +94,9 @@ const renderSettings = () => {
                 refresh: vi.fn(),
                 isAuth: true,
                 loading: false,
+                pendingMfa: null,
+                submitMfaChallenge: vi.fn().mockResolvedValue(undefined),
+                requireMfa: vi.fn().mockResolvedValue(null),
               }}
             >
               <Settings />

--- a/root/frontend/src/pages/__tests__/Settings.sessions.test.tsx
+++ b/root/frontend/src/pages/__tests__/Settings.sessions.test.tsx
@@ -59,6 +59,14 @@ const baseUser: User = {
   dnd_start: null,
   dnd_end: null,
   is_active: true,
+  mfa_required: false,
+  mfa_default_method: null,
+  mfa_last_verified_at: null,
+  mfa_recovery_codes_generated_at: null,
+  totp_enrollments: [],
+  webauthn_credentials: [],
+  recovery_codes: [],
+  mfa_challenges: [],
 }
 
 const renderSettings = () => {
@@ -80,6 +88,9 @@ const renderSettings = () => {
                 refresh: vi.fn(),
                 isAuth: true,
                 loading: false,
+                pendingMfa: null,
+                submitMfaChallenge: vi.fn().mockResolvedValue(undefined),
+                requireMfa: vi.fn().mockResolvedValue(null),
               }}
             >
               <Settings />

--- a/root/frontend/src/tests/mocks/handlers.ts
+++ b/root/frontend/src/tests/mocks/handlers.ts
@@ -40,6 +40,14 @@ export const testUser: User = {
   dnd_start: null,
   dnd_end: null,
   is_active: true,
+  mfa_required: false,
+  mfa_default_method: null,
+  mfa_last_verified_at: null,
+  mfa_recovery_codes_generated_at: null,
+  totp_enrollments: [],
+  webauthn_credentials: [],
+  recovery_codes: [],
+  mfa_challenges: [],
 }
 
 const createBaseSessions = (): ActiveSession[] => {
@@ -56,6 +64,10 @@ const createBaseSessions = (): ActiveSession[] => {
       ip_address: "198.51.100.10",
       user_agent: "Mozilla/5.0 (Macintosh; Intel Mac OS X)",
       last_seen_at: currentIso,
+      mfa_required: false,
+      mfa_completed_at: currentIso,
+      mfa_method: null,
+      mfa_verified_at: currentIso,
       is_current: true,
     },
     {
@@ -68,6 +80,10 @@ const createBaseSessions = (): ActiveSession[] => {
       ip_address: "203.0.113.42",
       user_agent: "Safari/17.3 (iPhone; CPU iPhone OS)",
       last_seen_at: new Date(now - 10 * 60 * 1000).toISOString(),
+      mfa_required: false,
+      mfa_completed_at: currentIso,
+      mfa_method: null,
+      mfa_verified_at: currentIso,
       is_current: false,
     },
   ]

--- a/root/frontend/src/tests/pageTranslations.test.tsx
+++ b/root/frontend/src/tests/pageTranslations.test.tsx
@@ -67,11 +67,19 @@ const {
     spotify_connected: false,
     spotify_display_name: null,
     spotify_is_connected: false,
-    dnd_enabled: false,
-    dnd_start: null,
-    dnd_end: null,
-    is_active: true,
-  }
+  dnd_enabled: false,
+  dnd_start: null,
+  dnd_end: null,
+  is_active: true,
+  mfa_required: false,
+  mfa_default_method: null,
+  mfa_last_verified_at: null,
+  mfa_recovery_codes_generated_at: null,
+  totp_enrollments: [],
+  webauthn_credentials: [],
+  recovery_codes: [],
+  mfa_challenges: [],
+}
 
   const scheduleGroups = [{ id: 1, name: "IU5-21" }]
   const scheduleLessons = [

--- a/root/frontend/src/tests/pageTranslations.test.tsx
+++ b/root/frontend/src/tests/pageTranslations.test.tsx
@@ -67,19 +67,19 @@ const {
     spotify_connected: false,
     spotify_display_name: null,
     spotify_is_connected: false,
-  dnd_enabled: false,
-  dnd_start: null,
-  dnd_end: null,
-  is_active: true,
-  mfa_required: false,
-  mfa_default_method: null,
-  mfa_last_verified_at: null,
-  mfa_recovery_codes_generated_at: null,
-  totp_enrollments: [],
-  webauthn_credentials: [],
-  recovery_codes: [],
-  mfa_challenges: [],
-}
+    dnd_enabled: false,
+    dnd_start: null,
+    dnd_end: null,
+    is_active: true,
+    mfa_required: false,
+    mfa_default_method: null,
+    mfa_last_verified_at: null,
+    mfa_recovery_codes_generated_at: null,
+    totp_enrollments: [],
+    webauthn_credentials: [],
+    recovery_codes: [],
+    mfa_challenges: [],
+  }
 
   const scheduleGroups = [{ id: 1, name: "IU5-21" }]
   const scheduleLessons = [

--- a/root/frontend/src/tests/pages/EventsCache.test.tsx
+++ b/root/frontend/src/tests/pages/EventsCache.test.tsx
@@ -69,10 +69,21 @@ const authValue = {
     dnd_start: null,
     dnd_end: null,
     is_active: true,
+    mfa_required: false,
+    mfa_default_method: null,
+    mfa_last_verified_at: null,
+    mfa_recovery_codes_generated_at: null,
+    totp_enrollments: [],
+    webauthn_credentials: [],
+    recovery_codes: [],
+    mfa_challenges: [],
   },
   loading: false,
   setUser: vi.fn(),
   refresh: vi.fn(),
+  pendingMfa: null,
+  submitMfaChallenge: vi.fn().mockResolvedValue(undefined),
+  requireMfa: vi.fn().mockResolvedValue(null),
 }
 
 describe("Events caching", () => {

--- a/root/frontend/src/tests/pages/EventsPagination.test.tsx
+++ b/root/frontend/src/tests/pages/EventsPagination.test.tsx
@@ -76,10 +76,21 @@ const authValue = {
     dnd_start: null,
     dnd_end: null,
     is_active: true,
+    mfa_required: false,
+    mfa_default_method: null,
+    mfa_last_verified_at: null,
+    mfa_recovery_codes_generated_at: null,
+    totp_enrollments: [],
+    webauthn_credentials: [],
+    recovery_codes: [],
+    mfa_challenges: [],
   },
   loading: false,
   setUser: vi.fn(),
   refresh: vi.fn(),
+  pendingMfa: null,
+  submitMfaChallenge: vi.fn().mockResolvedValue(undefined),
+  requireMfa: vi.fn().mockResolvedValue(null),
 }
 
 describe("Events pagination UI", () => {

--- a/root/frontend/src/types/Mfa.ts
+++ b/root/frontend/src/types/Mfa.ts
@@ -105,4 +105,3 @@ export type MfaVerifyPayload =
       credential: Record<string, unknown>
       code?: never
     }
-

--- a/root/frontend/src/types/Mfa.ts
+++ b/root/frontend/src/types/Mfa.ts
@@ -1,0 +1,108 @@
+export type MfaMethod = "totp" | "webauthn" | "recovery"
+
+export interface MfaMethodChallenge {
+  method: MfaMethod
+  challenge_token: string
+  challenge_expires_at: string
+  options?: Record<string, unknown> | null
+}
+
+export interface PendingMfaResponse {
+  status: "mfa_required"
+  user_id: number
+  session_id: number | null
+  default_method: MfaMethod | null
+  methods: MfaMethodChallenge[]
+}
+
+export interface MfaTotpEnrollment {
+  id: number
+  user_id: number
+  label: string | null
+  is_active: boolean
+  confirmed_at: string | null
+  revoked_at: string | null
+  created_at: string
+}
+
+export interface MfaWebAuthnCredential {
+  id: number
+  user_id: number
+  credential_id: string
+  device_name: string | null
+  sign_count: number
+  transports: string[] | null
+  backed_up: boolean
+  clone_warning: boolean
+  created_at: string
+  last_used_at: string | null
+  is_active: boolean
+}
+
+export interface MfaRecoveryCode {
+  id: number
+  user_id: number
+  used_at: string | null
+  created_at: string
+  label: string | null
+}
+
+export interface MfaChallenge {
+  id: number
+  user_id: number
+  session_id: number | null
+  challenge_type: string
+  token: string
+  expires_at: string
+  consumed_at: string | null
+  created_at: string
+  payload: Record<string, unknown> | null
+}
+
+export interface TotpEnrollmentStartResponse {
+  enrollment: MfaTotpEnrollment
+  secret: string
+  otpauth_url: string
+}
+
+export type TotpEnrollmentStartPayload = {
+  label?: string | null
+}
+
+export interface TotpEnrollmentConfirmPayload {
+  enrollment_id: number
+  code: string
+}
+
+export interface WebAuthnAttestationStartResponse {
+  options: Record<string, unknown>
+  challenge_token: string
+  challenge_expires_at: string
+}
+
+export interface WebAuthnAttestationFinishPayload {
+  challenge_token: string
+  credential: Record<string, unknown>
+  device_name?: string | null
+}
+
+export interface WebAuthnAssertionStartResponse {
+  options: Record<string, unknown>
+  challenge_token: string
+  challenge_expires_at: string
+}
+
+export type MfaVerifyPayload =
+  | {
+      method: "totp" | "recovery"
+      challenge_token: string
+      code: string
+      credential?: never
+    }
+  | {
+      method: "webauthn"
+      challenge_token: string
+      credential: Record<string, unknown>
+      code?: never
+    }
+

--- a/root/frontend/src/types/User.ts
+++ b/root/frontend/src/types/User.ts
@@ -1,3 +1,11 @@
+import type {
+  MfaChallenge,
+  MfaMethod,
+  MfaRecoveryCode,
+  MfaTotpEnrollment,
+  MfaWebAuthnCredential,
+} from "./Mfa"
+
 export interface User {
   id: number
   email: string
@@ -25,4 +33,12 @@ export interface User {
   dnd_start: string | null
   dnd_end: string | null
   is_active: boolean
+  mfa_required: boolean
+  mfa_default_method: MfaMethod | null
+  mfa_last_verified_at: string | null
+  mfa_recovery_codes_generated_at: string | null
+  totp_enrollments: MfaTotpEnrollment[]
+  webauthn_credentials: MfaWebAuthnCredential[]
+  recovery_codes: MfaRecoveryCode[]
+  mfa_challenges: MfaChallenge[]
 }

--- a/root/tests/conftest.py
+++ b/root/tests/conftest.py
@@ -79,6 +79,7 @@ from app.core.database import Base, async_session, engine
 from app.core.rate_limit import set_rate_limit_client_factory
 from app.deps import cache as cache_module
 from app.models import models
+from app.models.user_loaders import ensure_mfa_relationships_loaded
 from app.services import notification_queue
 from app.utils import ratelimit as ratelimit_module
 
@@ -278,6 +279,7 @@ async def user_factory(db_session) -> Callable[..., Awaitable[models.User]]:
         db_session.add(user)
         await db_session.commit()
         await db_session.refresh(user)
+        await ensure_mfa_relationships_loaded(db_session, user)
         return user
 
     return _factory


### PR DESCRIPTION
## Summary
- add strongly typed MFA models and expose MFA metadata on the user shape
- implement dedicated MFA API helpers and teach AuthContext to manage pending challenges, step-up flows, and signed profile caching
- align mocks and tests with the extended MFA-aware contracts

## Testing
- pnpm typecheck

------
https://chatgpt.com/codex/tasks/task_e_68fb690175e88327a4b07bc2b696f421