### PR TITLE
Add MFA testing coverage across unit and e2e suites

### DIFF
--- a/root/frontend/src/contexts/__tests__/AuthContext.mfa.test.tsx
+++ b/root/frontend/src/contexts/__tests__/AuthContext.mfa.test.tsx
@@ -1,0 +1,102 @@
+import type { PropsWithChildren } from "react"
+import { renderHook, act, waitFor } from "@testing-library/react"
+import { QueryClientProvider } from "@tanstack/react-query"
+import { beforeEach, describe, expect, it } from "vitest"
+import { AuthProvider, useAuth } from "@/contexts/AuthContext"
+import { createQueryClient } from "@/app/queryClient"
+
+const createWrapper = () => {
+  const queryClient = createQueryClient()
+  const wrapper = ({ children }: PropsWithChildren) => (
+    <QueryClientProvider client={queryClient}>
+      <AuthProvider>{children}</AuthProvider>
+    </QueryClientProvider>
+  )
+
+  return { wrapper, queryClient }
+}
+
+describe("AuthProvider MFA state machine", () => {
+  beforeEach(() => {
+    localStorage.clear()
+    sessionStorage.clear()
+  })
+
+  it("surfaces login MFA challenges and clears them after successful verification", async () => {
+    const { wrapper, queryClient } = createWrapper()
+    const { result, unmount } = renderHook(() => useAuth(), { wrapper })
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    let challenge = null as Awaited<ReturnType<typeof result.current.login>>
+    await act(async () => {
+      challenge = await result.current.login("mfa@example.com", "Password123")
+    })
+
+    expect(challenge).not.toBeNull()
+    expect(challenge?.reason).toBe("login")
+
+    await waitFor(() => expect(result.current.pendingMfa?.reason).toBe("login"))
+
+    await act(async () => {
+      await result.current.submitMfaChallenge({ method: "totp", code: "123456" })
+    })
+
+    await waitFor(() => expect(result.current.pendingMfa).toBeNull())
+    await waitFor(() => expect(result.current.user).not.toBeNull())
+    expect(result.current.isAuth).toBe(true)
+
+    unmount()
+    queryClient.clear()
+  })
+
+  it("provides step-up challenges and resets state on verification", async () => {
+    const { wrapper, queryClient } = createWrapper()
+    const { result, unmount } = renderHook(() => useAuth(), { wrapper })
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    let challenge = null as Awaited<ReturnType<typeof result.current.requireMfa>>
+    await act(async () => {
+      challenge = await result.current.requireMfa()
+    })
+
+    expect(challenge).not.toBeNull()
+    expect(challenge?.reason).toBe("step-up")
+
+    await waitFor(() => expect(result.current.pendingMfa?.reason).toBe("step-up"))
+
+    await act(async () => {
+      await result.current.submitMfaChallenge({ method: "totp", code: "123456" })
+    })
+
+    await waitFor(() => expect(result.current.pendingMfa).toBeNull())
+
+    unmount()
+    queryClient.clear()
+  })
+
+  it("surfaces verification errors when the wrong OTP is provided", async () => {
+    const { wrapper, queryClient } = createWrapper()
+    const { result, unmount } = renderHook(() => useAuth(), { wrapper })
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    await act(async () => {
+      await result.current.login("mfa@example.com", "Password123")
+    })
+
+    await waitFor(() => expect(result.current.pendingMfa?.reason).toBe("login"))
+
+    await expect(
+      act(async () => {
+        await result.current.submitMfaChallenge({ method: "totp", code: "000000" })
+      })
+    ).rejects.toThrow()
+
+    expect(result.current.pendingMfa?.reason).toBe("login")
+
+    unmount()
+    queryClient.clear()
+  })
+})

--- a/root/frontend/src/pages/__tests__/Login.test.tsx
+++ b/root/frontend/src/pages/__tests__/Login.test.tsx
@@ -169,6 +169,70 @@ describe("Login page", () => {
     expect(message).toBeInTheDocument()
   })
 
+  it("transitions to MFA verification when additional challenges are required", async () => {
+    const user = userEvent.setup()
+    renderLogin()
+
+    await user.type(
+      screen.getByLabelText(matchText(tAuth("fields.email")), {
+        selector: 'input[type="email"]',
+      }),
+      "mfa@example.com"
+    )
+
+    await user.type(
+      screen.getByLabelText(matchText(tAuth("fields.password")), {
+        selector: 'input[type="password"]',
+      }),
+      "Password123"
+    )
+
+    await user.click(screen.getByRole("button", { name: tAuth("actions.signIn") }))
+
+    await screen.findByText(tAuth("mfa.verifyTitle"))
+
+    const otpInput = screen.getByLabelText(/Authenticator code|Код из приложения/i)
+    await user.type(otpInput, "123456")
+    await user.click(screen.getByRole("button", { name: /Verify|Подтвердить/i }))
+
+    await waitFor(() => expect(screen.getByText("Welcome!")).toBeInTheDocument())
+  })
+
+  it("displays errors for invalid OTP attempts and allows retry", async () => {
+    const user = userEvent.setup()
+    renderLogin()
+
+    await user.type(
+      screen.getByLabelText(matchText(tAuth("fields.email")), {
+        selector: 'input[type="email"]',
+      }),
+      "mfa@example.com"
+    )
+
+    await user.type(
+      screen.getByLabelText(matchText(tAuth("fields.password")), {
+        selector: 'input[type="password"]',
+      }),
+      "Password123"
+    )
+
+    await user.click(screen.getByRole("button", { name: tAuth("actions.signIn") }))
+
+    await screen.findByText(tAuth("mfa.verifyTitle"))
+
+    const otpInput = screen.getByLabelText(/Authenticator code|Код из приложения/i)
+    await user.type(otpInput, "000000")
+    await user.click(screen.getByRole("button", { name: /Verify|Подтвердить/i }))
+
+    await screen.findByText(/Invalid verification code|Неверный код/i)
+
+    await user.clear(otpInput)
+    await user.type(otpInput, "123456")
+    await user.click(screen.getByRole("button", { name: /Verify|Подтвердить/i }))
+
+    await waitFor(() => expect(screen.getByText("Welcome!")).toBeInTheDocument())
+  })
+
   it("meets basic accessibility requirements", async () => {
     const { container } = renderLogin()
     const results = await axe(container)

--- a/root/frontend/src/pages/__tests__/Settings.totp.test.tsx
+++ b/root/frontend/src/pages/__tests__/Settings.totp.test.tsx
@@ -1,0 +1,146 @@
+import { useState, type PropsWithChildren } from "react"
+import { MemoryRouter } from "react-router-dom"
+import { QueryClientProvider } from "@tanstack/react-query"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { CssVarsProvider } from "@mui/material/styles"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import Settings from "@/pages/Settings"
+import { LanguageProvider } from "@/contexts/LanguageContext"
+import { AuthContext } from "@/contexts/AuthContext"
+import type { User } from "@/types/User"
+import theme from "@/theme"
+import { createQueryClient } from "@/app/queryClient"
+import { resetTestMfa, testUser } from "@/tests/mocks/handlers"
+import { server } from "@/tests/mocks/server"
+import { http, HttpResponse } from "msw"
+
+vi.mock("@/hooks/usePushPreferences", () => ({
+  usePushPreferences: () => ({
+    topicKeys: [],
+    topicState: {},
+    pushSupported: false,
+    notificationPermission: "default" as NotificationPermission,
+    notificationsEnabled: false,
+    pushBusy: false,
+    pushInitializing: false,
+    permissionText: "",
+    selectedTopicsDescription: "",
+    enableNotifications: vi.fn(),
+    disableNotifications: vi.fn(),
+    handleTopicToggle: () => () => {},
+    safariIOS: false,
+    safariGuideUrl: "#",
+  }),
+}))
+
+const createBaseUser = (): User => ({
+  ...testUser,
+  totp_enrollments: [],
+  webauthn_credentials: [],
+  recovery_codes: [],
+  mfa_default_method: null,
+  mfa_last_verified_at: null,
+})
+
+const renderSettings = () => {
+  const queryClient = createQueryClient()
+  const initialUser = createBaseUser()
+
+  const TestAuthProvider = ({ children }: PropsWithChildren) => {
+    const [user, setUser] = useState<User | null>(initialUser)
+    return (
+      <AuthContext.Provider
+        value={{
+          user,
+          setUser,
+          logout: vi.fn(),
+          login: vi.fn(),
+          refresh: vi.fn(),
+          isAuth: true,
+          loading: false,
+          pendingMfa: null,
+          submitMfaChallenge: vi.fn(),
+          requireMfa: vi.fn(),
+        }}
+      >
+        {children}
+      </AuthContext.Provider>
+    )
+  }
+
+  const result = render(
+    <MemoryRouter initialEntries={["/settings"]}>
+      <QueryClientProvider client={queryClient}>
+        <CssVarsProvider theme={theme}>
+          <LanguageProvider>
+            <TestAuthProvider>
+              <Settings />
+            </TestAuthProvider>
+          </LanguageProvider>
+        </CssVarsProvider>
+      </QueryClientProvider>
+    </MemoryRouter>
+  )
+
+  return { ...result, queryClient }
+}
+
+const matchTotpAddButton = /Set up authenticator app|Настроить приложение/i
+const matchTotpSubmit = /Verify|Подтвердить/i
+const matchAccountTab = /Account|Аккаунт/i
+const matchSecurityHeading = /Security & MFA|Безопасность и MFA/i
+
+describe("Settings TOTP enrollment", () => {
+  beforeEach(() => {
+    resetTestMfa()
+    localStorage.clear()
+    localStorage.setItem("ue:language", "en")
+  })
+
+  it("starts and completes a new TOTP enrollment", async () => {
+    const user = userEvent.setup()
+    renderSettings()
+
+    await user.click(await screen.findByRole("tab", { name: matchAccountTab }))
+    await screen.findByRole("heading", { name: matchSecurityHeading })
+    await user.click(await screen.findByRole("button", { name: matchTotpAddButton }))
+
+    await screen.findByText(/Finish setup|Завершите настройку/i)
+
+    const manualCode = await screen.findByLabelText(/Manual code|Ручной код/i)
+    expect((manualCode as HTMLInputElement).value).toBe("JBSWY3DPEHJK")
+
+    const otpInput = screen.getByLabelText(/Authenticator code|Код из приложения/i)
+    await user.type(otpInput, "123456")
+    await user.click(screen.getByRole("button", { name: matchTotpSubmit }))
+
+    await waitFor(() => expect(screen.getByText(/Authenticator app connected|Приложение-аутентификатор подключено/i)).toBeVisible())
+
+    await waitFor(() =>
+      expect(screen.getByText(/Authenticator 1|Аутентификатор 1/i)).toBeVisible()
+    )
+  })
+
+  it("surfaces server errors when confirmation fails", async () => {
+    server.use(
+      http.post("*/auth/mfa/totp/confirm", () =>
+        HttpResponse.json({ detail: "Invalid verification code" }, { status: 400 })
+      )
+    )
+
+    const user = userEvent.setup()
+    renderSettings()
+
+    await user.click(await screen.findByRole("tab", { name: matchAccountTab }))
+    await screen.findByRole("heading", { name: matchSecurityHeading })
+    await user.click(await screen.findByRole("button", { name: matchTotpAddButton }))
+
+    const otpInput = await screen.findByLabelText(/Authenticator code|Код из приложения/i)
+    await user.type(otpInput, "000000")
+    await user.click(screen.getByRole("button", { name: matchTotpSubmit }))
+
+    await screen.findByText(/Invalid verification code/i)
+    expect(screen.getByText(/Finish setup|Завершите настройку/i)).toBeVisible()
+  })
+})

--- a/root/frontend/src/pages/__tests__/Settings.totp.test.tsx
+++ b/root/frontend/src/pages/__tests__/Settings.totp.test.tsx
@@ -115,11 +115,13 @@ describe("Settings TOTP enrollment", () => {
     await user.type(otpInput, "123456")
     await user.click(screen.getByRole("button", { name: matchTotpSubmit }))
 
-    await waitFor(() => expect(screen.getByText(/Authenticator app connected|Приложение-аутентификатор подключено/i)).toBeVisible())
-
     await waitFor(() =>
-      expect(screen.getByText(/Authenticator 1|Аутентификатор 1/i)).toBeVisible()
+      expect(
+        screen.getByText(/Authenticator app connected|Приложение-аутентификатор подключено/i)
+      ).toBeVisible()
     )
+
+    await waitFor(() => expect(screen.getByText(/Authenticator 1|Аутентификатор 1/i)).toBeVisible())
   })
 
   it("surfaces server errors when confirmation fails", async () => {

--- a/root/frontend/src/setupTests.ts
+++ b/root/frontend/src/setupTests.ts
@@ -5,7 +5,7 @@ import { webcrypto } from "node:crypto"
 import { afterAll, afterEach, beforeAll, expect, vi } from "vitest"
 import { toHaveNoViolations } from "jest-axe"
 import { server } from "./tests/mocks/server"
-import { resetTestEvents, resetTestSessions } from "./tests/mocks/handlers"
+import { resetTestEvents, resetTestMfa, resetTestSessions } from "./tests/mocks/handlers"
 import i18n from "./i18n/config"
 
 expect.extend(toHaveNoViolations)
@@ -19,6 +19,7 @@ afterEach(() => {
   server.resetHandlers()
   resetTestSessions()
   resetTestEvents()
+  resetTestMfa()
 })
 afterAll(() => server.close())
 if (!(globalThis as any).TextEncoder) (globalThis as any).TextEncoder = TextEncoder
@@ -46,4 +47,59 @@ if (!windowWithScroll.scrollTo) {
 }
 vi.mock("qrcode.react", () => ({
   QRCodeSVG: () => null,
+}))
+
+vi.mock("@simplewebauthn/browser", () => ({
+  startAuthentication: vi.fn(async () => ({
+    id: "test-credential",
+    rawId: "dGVzdC1jcmVkZW50aWFs",
+    response: {
+      clientDataJSON: "",
+      authenticatorData: "",
+      signature: "",
+      userHandle: null,
+    },
+    type: "public-key",
+    clientExtensionResults: () => ({}),
+    authenticatorAttachment: "platform",
+    toJSON() {
+      return {
+        id: "test-credential",
+        rawId: "dGVzdC1jcmVkZW50aWFs",
+        response: {
+          clientDataJSON: "",
+          authenticatorData: "",
+          signature: "",
+          userHandle: null,
+        },
+        type: "public-key",
+        clientExtensionResults: {},
+        authenticatorAttachment: "platform",
+      }
+    },
+  })),
+  startRegistration: vi.fn(async () => ({
+    id: "test-registration",
+    rawId: "dGVzdC1yZWc=",
+    response: {
+      clientDataJSON: "",
+      attestationObject: "",
+    },
+    type: "public-key",
+    clientExtensionResults: () => ({}),
+    authenticatorAttachment: "platform",
+    toJSON() {
+      return {
+        id: "test-registration",
+        rawId: "dGVzdC1yZWc=",
+        response: {
+          clientDataJSON: "",
+          attestationObject: "",
+        },
+        type: "public-key",
+        clientExtensionResults: {},
+        authenticatorAttachment: "platform",
+      }
+    },
+  })),
 }))

--- a/root/frontend/src/tests/mocks/handlers.ts
+++ b/root/frontend/src/tests/mocks/handlers.ts
@@ -279,7 +279,9 @@ export const handlers = [
     }
 
     const label =
-      payload && typeof payload === "object" && typeof (payload as { label?: unknown }).label === "string"
+      payload &&
+      typeof payload === "object" &&
+      typeof (payload as { label?: unknown }).label === "string"
         ? ((payload as { label?: string }).label as string)
         : null
 
@@ -298,9 +300,10 @@ export const handlers = [
       return HttpResponse.json({ detail: "No pending enrollment" }, { status: 400 })
     }
 
-    const body = (await request.json().catch(() => null)) as
-      | { enrollment_id?: number; code?: string }
-      | null
+    const body = (await request.json().catch(() => null)) as {
+      enrollment_id?: number
+      code?: string
+    } | null
 
     if (!body || body.enrollment_id !== totpDraft.enrollment.id) {
       return HttpResponse.json({ detail: "Enrollment not found" }, { status: 404 })

--- a/root/frontend/src/tests/mocks/handlers.ts
+++ b/root/frontend/src/tests/mocks/handlers.ts
@@ -2,6 +2,13 @@ import { HttpResponse, http } from "msw"
 import type { User } from "@/types/User"
 import type { ActiveSession } from "@/types/Session"
 import type { Event } from "@/types/Event"
+import type {
+  MfaMethod,
+  MfaTotpEnrollment,
+  MfaVerifyPayload,
+  PendingMfaResponse,
+  TotpEnrollmentStartResponse,
+} from "@/types/Mfa"
 
 type NewUserPayload = {
   email?: string
@@ -48,6 +55,119 @@ export const testUser: User = {
   webauthn_credentials: [],
   recovery_codes: [],
   mfa_challenges: [],
+}
+
+const nowIso = () => new Date().toISOString()
+
+const createTotpEnrollment = (overrides: Partial<MfaTotpEnrollment> = {}): MfaTotpEnrollment => {
+  const createdAt = overrides.created_at ?? nowIso()
+  return {
+    id: overrides.id ?? Math.floor(Math.random() * 10_000) + 1,
+    user_id: overrides.user_id ?? testUser.id,
+    label: overrides.label ?? null,
+    is_active: overrides.is_active ?? false,
+    confirmed_at: overrides.confirmed_at ?? null,
+    revoked_at: overrides.revoked_at ?? null,
+    created_at: createdAt,
+  }
+}
+
+const createChallengeExpiresAt = () => new Date(Date.now() + 5 * 60 * 1000).toISOString()
+
+type ChallengeOptions = {
+  includeTotp?: boolean
+  includeRecovery?: boolean
+  includeWebAuthn?: boolean
+  defaultMethod?: MfaMethod | null
+  sessionId?: number | null
+}
+
+const createMfaChallenge = ({
+  includeTotp = true,
+  includeRecovery = false,
+  includeWebAuthn = false,
+  defaultMethod = includeTotp ? "totp" : includeWebAuthn ? "webauthn" : null,
+  sessionId = 1,
+}: ChallengeOptions = {}): PendingMfaResponse => {
+  const methods: PendingMfaResponse["methods"] = []
+  if (includeTotp) {
+    methods.push({
+      method: "totp",
+      challenge_token: "totp-challenge-token",
+      challenge_expires_at: createChallengeExpiresAt(),
+      options: null,
+    })
+  }
+  if (includeRecovery) {
+    methods.push({
+      method: "recovery",
+      challenge_token: "recovery-challenge-token",
+      challenge_expires_at: createChallengeExpiresAt(),
+      options: null,
+    })
+  }
+  if (includeWebAuthn) {
+    methods.push({
+      method: "webauthn",
+      challenge_token: "webauthn-challenge-token",
+      challenge_expires_at: createChallengeExpiresAt(),
+      options: {
+        challenge: "c2FtcGxlLXdlYmF1dGhuLWNoYWxsZW5nZQ==",
+        timeout: 60_000,
+        rpId: "localhost",
+        allowCredentials: [
+          {
+            type: "public-key",
+            id: "credential-id",
+            transports: ["internal"],
+          },
+        ],
+        userVerification: "preferred",
+      },
+    })
+  }
+
+  return {
+    status: "mfa_required",
+    user_id: testUser.id,
+    session_id: sessionId,
+    default_method: defaultMethod,
+    methods,
+  }
+}
+
+let totpDraft: TotpEnrollmentStartResponse | null = null
+let totpEnrollmentCounter = 1
+let loginChallenge: PendingMfaResponse | null = null
+let stepUpChallenge: PendingMfaResponse | null = createMfaChallenge({
+  includeTotp: true,
+  includeWebAuthn: true,
+  includeRecovery: true,
+  sessionId: 42,
+})
+
+const resetUserEnrollments = () => {
+  testUser.totp_enrollments.splice(0, testUser.totp_enrollments.length)
+  testUser.webauthn_credentials.splice(0, testUser.webauthn_credentials.length)
+  testUser.recovery_codes.splice(0, testUser.recovery_codes.length)
+  testUser.mfa_challenges.splice(0, testUser.mfa_challenges.length)
+}
+
+export const resetTestMfa = () => {
+  totpDraft = null
+  totpEnrollmentCounter = 1
+  loginChallenge = null
+  stepUpChallenge = createMfaChallenge({
+    includeTotp: true,
+    includeWebAuthn: true,
+    includeRecovery: true,
+    sessionId: 42,
+  })
+  testUser.mfa_required = false
+  testUser.mfa_default_method = null
+  testUser.mfa_last_verified_at = null
+  testUser.mfa_recovery_codes_generated_at = null
+  resetUserEnrollments()
 }
 
 const createBaseSessions = (): ActiveSession[] => {
@@ -141,12 +261,146 @@ export const resetTestEvents = () => {
   setTestEvents(createBaseEvents())
 }
 
+resetTestMfa()
+
 export const handlers = [
   http.get("*/auth/session/signing-key", () =>
     HttpResponse.json({ signing_key: "test-session-signing-key" })
   ),
   http.get("*/users/me", () => HttpResponse.json(testUser)),
   http.get("*/auth/sessions", () => HttpResponse.json(testSessions)),
+  http.get("*/auth/mfa/totp", () => HttpResponse.json(testUser.totp_enrollments)),
+  http.post("*/auth/mfa/totp/start", async ({ request }) => {
+    let payload: unknown = {}
+    try {
+      payload = await request.json()
+    } catch {
+      payload = {}
+    }
+
+    const label =
+      payload && typeof payload === "object" && typeof (payload as { label?: unknown }).label === "string"
+        ? ((payload as { label?: string }).label as string)
+        : null
+
+    const enrollment = createTotpEnrollment({
+      id: totpEnrollmentCounter++,
+      label,
+      created_at: nowIso(),
+    })
+    const secret = "JBSW Y3DP EHJK"
+    const otpauthUrl = `otpauth://totp/University:user?secret=${secret.replace(/\s+/g, "")}&issuer=University`
+    totpDraft = { enrollment, secret, otpauth_url: otpauthUrl }
+    return HttpResponse.json(totpDraft)
+  }),
+  http.post("*/auth/mfa/totp/confirm", async ({ request }) => {
+    if (!totpDraft) {
+      return HttpResponse.json({ detail: "No pending enrollment" }, { status: 400 })
+    }
+
+    const body = (await request.json().catch(() => null)) as
+      | { enrollment_id?: number; code?: string }
+      | null
+
+    if (!body || body.enrollment_id !== totpDraft.enrollment.id) {
+      return HttpResponse.json({ detail: "Enrollment not found" }, { status: 404 })
+    }
+
+    const code = (body.code ?? "").toString().replace(/\s+/g, "")
+    if (code !== "123456") {
+      return HttpResponse.json({ detail: "Invalid verification code" }, { status: 400 })
+    }
+
+    const confirmed = {
+      ...totpDraft.enrollment,
+      is_active: true,
+      confirmed_at: nowIso(),
+    }
+    totpDraft = null
+    testUser.mfa_default_method = "totp"
+    testUser.mfa_last_verified_at = nowIso()
+    testUser.mfa_required = false
+    testUser.totp_enrollments.splice(0, testUser.totp_enrollments.length, confirmed)
+    return HttpResponse.json(confirmed)
+  }),
+  http.delete("*/auth/mfa/totp/:id", ({ params }) => {
+    const id = Number(params.id)
+    const index = testUser.totp_enrollments.findIndex((entry) => entry.id === id)
+    if (index === -1) {
+      return HttpResponse.json({ detail: "Enrollment not found" }, { status: 404 })
+    }
+    const entry = testUser.totp_enrollments[index]!
+    entry.is_active = false
+    entry.revoked_at = nowIso()
+    testUser.totp_enrollments.splice(index, 1)
+    if (!testUser.totp_enrollments.length && testUser.mfa_default_method === "totp") {
+      testUser.mfa_default_method = null
+    }
+    return HttpResponse.json({ disabled: true })
+  }),
+  http.post("*/auth/mfa/step-up", () => {
+    if (!stepUpChallenge) {
+      stepUpChallenge = createMfaChallenge({
+        includeTotp: true,
+        includeRecovery: true,
+        includeWebAuthn: true,
+        sessionId: 42,
+      })
+    }
+    return HttpResponse.json(stepUpChallenge, { status: 202 })
+  }),
+  http.post("*/auth/mfa/verify", async ({ request }) => {
+    const body = (await request.json().catch(() => null)) as MfaVerifyPayload | null
+    if (!body || typeof body !== "object") {
+      return HttpResponse.json({ detail: "Invalid payload" }, { status: 400 })
+    }
+
+    const matchChallenge = (challenge: PendingMfaResponse | null) =>
+      Boolean(
+        challenge?.methods.some(
+          (method) =>
+            method.method === body.method && method.challenge_token === body.challenge_token
+        )
+      )
+
+    const matchedLogin = matchChallenge(loginChallenge)
+    const matchedStepUp = matchChallenge(stepUpChallenge)
+
+    if (!matchedLogin && !matchedStepUp) {
+      return HttpResponse.json({ detail: "Challenge expired" }, { status: 400 })
+    }
+
+    if (body.method === "webauthn") {
+      if (!body.credential || typeof body.credential !== "object") {
+        return HttpResponse.json({ detail: "Invalid credential" }, { status: 400 })
+      }
+    } else {
+      const code = body.code?.toString().replace(/\s+/g, "") ?? ""
+      if (code !== "123456" && !(body.method === "recovery" && code === "RECOVERY-1")) {
+        return HttpResponse.json({ detail: "Invalid verification code" }, { status: 400 })
+      }
+    }
+
+    testUser.mfa_last_verified_at = nowIso()
+    if (body.method !== "recovery") {
+      testUser.mfa_default_method = body.method
+    }
+    testUser.mfa_required = false
+
+    if (matchedLogin) {
+      loginChallenge = null
+    }
+    if (matchedStepUp) {
+      stepUpChallenge = createMfaChallenge({
+        includeTotp: true,
+        includeRecovery: true,
+        includeWebAuthn: true,
+        sessionId: 42,
+      })
+    }
+
+    return HttpResponse.json({ access_token: "test-access-token", token_type: "bearer" })
+  }),
   http.delete("*/auth/sessions/:id", ({ params }) => {
     const id = Number(params.id)
     const session = testSessions.find((item) => item.id === id)
@@ -196,6 +450,31 @@ export const handlers = [
 
     if (!username || !password || username === "blocked@example.com") {
       return HttpResponse.json({ detail: "Неверные данные для входа" }, { status: 401 })
+    }
+
+    if (username === "mfa@example.com" && password === "Password123") {
+      loginChallenge = createMfaChallenge({
+        includeTotp: true,
+        includeRecovery: true,
+        defaultMethod: "totp",
+        sessionId: 84,
+      })
+      testUser.mfa_required = true
+      testUser.mfa_default_method = "totp"
+      return HttpResponse.json(loginChallenge, { status: 202 })
+    }
+
+    if (username === "webauthn@example.com" && password === "Password123") {
+      loginChallenge = createMfaChallenge({
+        includeTotp: false,
+        includeRecovery: false,
+        includeWebAuthn: true,
+        defaultMethod: "webauthn",
+        sessionId: 96,
+      })
+      testUser.mfa_required = true
+      testUser.mfa_default_method = "webauthn"
+      return HttpResponse.json(loginChallenge, { status: 202 })
     }
 
     return HttpResponse.json({ access_token: "test-access-token", username })

--- a/root/frontend/src/tests/mocks/simplewebauthn.ts
+++ b/root/frontend/src/tests/mocks/simplewebauthn.ts
@@ -1,0 +1,53 @@
+export const startAuthentication = async () => ({
+  id: "test-credential",
+  rawId: "dGVzdC1jcmVkZW50aWFs",
+  response: {
+    clientDataJSON: "",
+    authenticatorData: "",
+    signature: "",
+    userHandle: null,
+  },
+  type: "public-key",
+  clientExtensionResults: () => ({}),
+  authenticatorAttachment: "platform",
+  toJSON() {
+    return {
+      id: "test-credential",
+      rawId: "dGVzdC1jcmVkZW50aWFs",
+      response: {
+        clientDataJSON: "",
+        authenticatorData: "",
+        signature: "",
+        userHandle: null,
+      },
+      type: "public-key",
+      clientExtensionResults: {},
+      authenticatorAttachment: "platform",
+    }
+  },
+})
+
+export const startRegistration = async () => ({
+  id: "test-registration",
+  rawId: "dGVzdC1yZWc=",
+  response: {
+    clientDataJSON: "",
+    attestationObject: "",
+  },
+  type: "public-key",
+  clientExtensionResults: () => ({}),
+  authenticatorAttachment: "platform",
+  toJSON() {
+    return {
+      id: "test-registration",
+      rawId: "dGVzdC1yZWc=",
+      response: {
+        clientDataJSON: "",
+        attestationObject: "",
+      },
+      type: "public-key",
+      clientExtensionResults: {},
+      authenticatorAttachment: "platform",
+    }
+  },
+})

--- a/root/frontend/src/types/simplewebauthn-browser.d.ts
+++ b/root/frontend/src/types/simplewebauthn-browser.d.ts
@@ -1,0 +1,41 @@
+declare module "@simplewebauthn/browser" {
+  export type AuthenticationResponseJSON = {
+    id: string
+    rawId: string
+    response: Record<string, unknown>
+    type: string
+    authenticatorAttachment?: string | null
+    clientExtensionResults?: Record<string, unknown>
+    userHandle?: string | null
+  }
+
+  export type PublicKeyCredentialRequestOptionsJSON = Record<string, unknown>
+  export type PublicKeyCredentialCreationOptionsJSON = Record<string, unknown>
+
+  export type RegistrationResponseJSON = {
+    id: string
+    rawId: string
+    response: Record<string, unknown>
+    type: string
+    authenticatorAttachment?: string | null
+    clientExtensionResults?: Record<string, unknown>
+  }
+
+  export type StartAuthenticationOptions = {
+    optionsJSON: PublicKeyCredentialRequestOptionsJSON
+    useBrowserAutofill?: boolean
+  }
+
+  export type StartRegistrationOptions = {
+    optionsJSON: PublicKeyCredentialCreationOptionsJSON
+    useBrowserAutofill?: boolean
+  }
+
+  export function startAuthentication(
+    options: StartAuthenticationOptions
+  ): Promise<AuthenticationResponseJSON>
+
+  export function startRegistration(
+    options: StartRegistrationOptions
+  ): Promise<RegistrationResponseJSON>
+}

--- a/root/frontend/tests/e2e/mfa.spec.ts
+++ b/root/frontend/tests/e2e/mfa.spec.ts
@@ -1,0 +1,129 @@
+import { expect, test } from "@playwright/test"
+import { useMockApi } from "./utils/mockApi"
+
+const matchTotpAddButton = /Set up authenticator app|Настроить приложение/i
+const matchTotpVerifyButton = /Verify|Подтвердить/i
+
+test.describe("Multi-factor authentication flows", () => {
+  test("allows enabling TOTP in settings", async ({ page }) => {
+    const mock = await useMockApi(page)
+    await mock.login(page)
+
+    await page.goto("/settings")
+    await page.waitForURL(/\/settings$/)
+
+    await page.getByRole("button", { name: matchTotpAddButton }).click()
+    await expect(page.getByText(/Finish setup|Завершите настройку/i)).toBeVisible()
+
+    await page.getByLabelText(/Authenticator code|Код из приложения/i).fill("123456")
+    await page.getByRole("button", { name: matchTotpVerifyButton }).click()
+
+    await expect(
+      page.getByText(/Authenticator app connected|Приложение-аутентификатор подключено/i)
+    ).toBeVisible()
+    await expect(page.getByText(/Authenticator 1|Аутентификатор 1/i)).toBeVisible()
+  })
+
+  test("completes login when an OTP challenge is returned", async ({ page }) => {
+    await useMockApi(page)
+
+    await page.goto("/login")
+    await page.waitForURL(/\/login$/)
+
+    await page.locator('input[name="username"]').fill("mfa@example.com")
+    await page.locator('input[name="password"]').fill("Password123")
+    await page.getByRole("button", { name: /Sign in|Войти/i }).click()
+
+    await expect(page.getByText(/Verify it's you|Подтвердите свою личность/i)).toBeVisible()
+
+    await page.getByLabelText(/Authenticator code|Код из приложения/i).fill("123456")
+    await page.getByRole("button", { name: matchTotpVerifyButton }).click()
+
+    await expect(page).toHaveURL(/\/dashboard$/)
+  })
+
+  test("shows an error for invalid OTP attempts and allows retry", async ({ page }) => {
+    await useMockApi(page)
+
+    await page.goto("/login")
+    await page.waitForURL(/\/login$/)
+
+    await page.locator('input[name="username"]').fill("mfa@example.com")
+    await page.locator('input[name="password"]').fill("Password123")
+    await page.getByRole("button", { name: /Sign in|Войти/i }).click()
+
+    await expect(page.getByText(/Verify it's you|Подтвердите свою личность/i)).toBeVisible()
+
+    const otpInput = page.getByLabelText(/Authenticator code|Код из приложения/i)
+    await otpInput.fill("000000")
+    await page.getByRole("button", { name: matchTotpVerifyButton }).click()
+
+    await expect(page.getByText(/Invalid verification code|Неверный код/i)).toBeVisible()
+
+    await otpInput.fill("123456")
+    await page.getByRole("button", { name: matchTotpVerifyButton }).click()
+
+    await expect(page).toHaveURL(/\/dashboard$/)
+  })
+
+  test("allows logging in with a WebAuthn challenge", async ({ page }) => {
+    await page.addInitScript(() => {
+      const credentialResponse = {
+        id: "credential-id",
+        rawId: Uint8Array.from([1, 2, 3]).buffer,
+        response: {
+          clientDataJSON: Uint8Array.from([4, 5]).buffer,
+          authenticatorData: Uint8Array.from([6, 7]).buffer,
+          signature: Uint8Array.from([8, 9]).buffer,
+          userHandle: null,
+        },
+        type: "public-key",
+        authenticatorAttachment: "platform",
+        clientExtensionResults: () => ({}),
+        toJSON() {
+          return {
+            id: "credential-id",
+            rawId: "AQID",
+            response: {
+              clientDataJSON: "BAU=",
+              authenticatorData: "Bgc=",
+              signature: "CAk=",
+              userHandle: null,
+            },
+            type: "public-key",
+            clientExtensionResults: {},
+            authenticatorAttachment: "platform",
+          }
+        },
+      }
+
+      Object.defineProperty(window, "PublicKeyCredential", {
+        value: class PublicKeyCredential {
+          static isUserVerifyingPlatformAuthenticatorAvailable() {
+            return Promise.resolve(true)
+          }
+        },
+      })
+
+      Object.defineProperty(navigator, "credentials", {
+        value: {
+          get: async () => credentialResponse,
+        },
+        configurable: true,
+      })
+    })
+
+    await useMockApi(page)
+
+    await page.goto("/login")
+    await page.waitForURL(/\/login$/)
+
+    await page.locator('input[name="username"]').fill("webauthn@example.com")
+    await page.locator('input[name="password"]').fill("Password123")
+    await page.getByRole("button", { name: /Sign in|Войти/i }).click()
+
+    await expect(page.getByText(/Use your security key|Используйте ключ безопасности/i)).toBeVisible()
+
+    await expect(page).toHaveURL(/\/dashboard$/)
+  })
+})

--- a/root/frontend/tests/e2e/mfa.spec.ts
+++ b/root/frontend/tests/e2e/mfa.spec.ts
@@ -15,7 +15,7 @@ test.describe("Multi-factor authentication flows", () => {
     await page.getByRole("button", { name: matchTotpAddButton }).click()
     await expect(page.getByText(/Finish setup|Завершите настройку/i)).toBeVisible()
 
-    await page.getByLabelText(/Authenticator code|Код из приложения/i).fill("123456")
+    await page.getByLabel(/Authenticator code|Код из приложения/i).fill("123456")
     await page.getByRole("button", { name: matchTotpVerifyButton }).click()
 
     await expect(
@@ -36,7 +36,7 @@ test.describe("Multi-factor authentication flows", () => {
 
     await expect(page.getByText(/Verify it's you|Подтвердите свою личность/i)).toBeVisible()
 
-    await page.getByLabelText(/Authenticator code|Код из приложения/i).fill("123456")
+    await page.getByLabel(/Authenticator code|Код из приложения/i).fill("123456")
     await page.getByRole("button", { name: matchTotpVerifyButton }).click()
 
     await expect(page).toHaveURL(/\/dashboard$/)
@@ -54,7 +54,7 @@ test.describe("Multi-factor authentication flows", () => {
 
     await expect(page.getByText(/Verify it's you|Подтвердите свою личность/i)).toBeVisible()
 
-    const otpInput = page.getByLabelText(/Authenticator code|Код из приложения/i)
+    const otpInput = page.getByLabel(/Authenticator code|Код из приложения/i)
     await otpInput.fill("000000")
     await page.getByRole("button", { name: matchTotpVerifyButton }).click()
 

--- a/root/frontend/tests/e2e/mfa.spec.ts
+++ b/root/frontend/tests/e2e/mfa.spec.ts
@@ -122,7 +122,9 @@ test.describe("Multi-factor authentication flows", () => {
     await page.locator('input[name="password"]').fill("Password123")
     await page.getByRole("button", { name: /Sign in|Войти/i }).click()
 
-    await expect(page.getByText(/Use your security key|Используйте ключ безопасности/i)).toBeVisible()
+    await expect(
+      page.getByText(/Use your security key|Используйте ключ безопасности/i)
+    ).toBeVisible()
 
     await expect(page).toHaveURL(/\/dashboard$/)
   })

--- a/root/frontend/tests/e2e/utils/mockApi.ts
+++ b/root/frontend/tests/e2e/utils/mockApi.ts
@@ -3,8 +3,8 @@ import type {
   MfaTotpEnrollment,
   PendingMfaResponse,
   TotpEnrollmentStartResponse,
-} from "../../src/types/Mfa"
-import type { User } from "../../src/types/User"
+} from "@/types/Mfa"
+import type { User } from "@/types/User"
 
 type NewsLogEntry = {
   header: string | undefined
@@ -621,7 +621,8 @@ export async function useMockApi(page: Page) {
       const matches = (challenge: PendingMfaResponse | null) =>
         Boolean(
           challenge?.methods.some(
-            (entry) => entry.method === method && entry.challenge_token === challengeToken
+            (entry: PendingMfaResponse["methods"][number]) =>
+              entry.method === method && entry.challenge_token === challengeToken
           )
         )
 

--- a/root/frontend/tests/e2e/utils/mockApi.ts
+++ b/root/frontend/tests/e2e/utils/mockApi.ts
@@ -578,7 +578,12 @@ export async function useMockApi(page: Page) {
     if (pathname === "api/auth/mfa/step-up") {
       const challenge =
         state.mfa.stepUpChallenge ??
-        createMfaChallenge({ includeTotp: true, includeRecovery: true, includeWebAuthn: true, sessionId: 42 })
+        createMfaChallenge({
+          includeTotp: true,
+          includeRecovery: true,
+          includeWebAuthn: true,
+          sessionId: 42,
+        })
       state.mfa.stepUpChallenge = challenge
       await route.fulfill({
         status: 202,
@@ -614,7 +619,11 @@ export async function useMockApi(page: Page) {
       }
 
       const matches = (challenge: PendingMfaResponse | null) =>
-        Boolean(challenge?.methods.some((entry) => entry.method === method && entry.challenge_token === challengeToken))
+        Boolean(
+          challenge?.methods.some(
+            (entry) => entry.method === method && entry.challenge_token === challengeToken
+          )
+        )
 
       const matchedLogin = matches(state.mfa.loginChallenge)
       const matchedStepUp = matches(state.mfa.stepUpChallenge)

--- a/root/frontend/tests/e2e/utils/mockApi.ts
+++ b/root/frontend/tests/e2e/utils/mockApi.ts
@@ -1,8 +1,25 @@
 import { expect, type Page } from "@playwright/test"
+import type {
+  MfaTotpEnrollment,
+  PendingMfaResponse,
+  TotpEnrollmentStartResponse,
+} from "../../src/types/Mfa"
+import type { User } from "../../src/types/User"
 
 type NewsLogEntry = {
   header: string | undefined
   status: number
+}
+
+type TotpState = {
+  pending: TotpEnrollmentStartResponse | null
+  enrollments: MfaTotpEnrollment[]
+  nextId: number
+}
+
+type MfaState = {
+  loginChallenge: PendingMfaResponse | null
+  stepUpChallenge: PendingMfaResponse | null
 }
 
 type MockState = {
@@ -11,6 +28,9 @@ type MockState = {
   offline: boolean
   newsLog: NewsLogEntry[]
   sessions: SessionMock[]
+  profile: User
+  totp: TotpState
+  mfa: MfaState
 }
 
 type SessionMock = {
@@ -25,12 +45,42 @@ type SessionMock = {
   last_seen_at: string
 }
 
-const mockUser = {
+const createBaseProfile = (): User => ({
   id: 1,
+  email: "student@example.com",
   full_name: "Иван Иванов",
   role: "student",
-  group_id: "iu-21",
-}
+  group_id: null,
+  avatar_url: null,
+  cover_url: null,
+  about: null,
+  record_book_number: "IU-21-123",
+  status: "active",
+  institute: "ИТ",
+  course: "2",
+  education_level: "bachelor",
+  track: null,
+  program: null,
+  telegram: "@ivan",
+  achievements: null,
+  department: "ИТ",
+  position: "Student",
+  spotify_connected: false,
+  spotify_display_name: null,
+  spotify_is_connected: false,
+  dnd_enabled: false,
+  dnd_start: null,
+  dnd_end: null,
+  is_active: true,
+  mfa_required: false,
+  mfa_default_method: null,
+  mfa_last_verified_at: null,
+  mfa_recovery_codes_generated_at: null,
+  totp_enrollments: [],
+  webauthn_credentials: [],
+  recovery_codes: [],
+  mfa_challenges: [],
+})
 
 const mockNews = [
   {
@@ -129,6 +179,68 @@ const createMockSessions = (): SessionMock[] => {
   ]
 }
 
+const challengeExpiresAt = () => new Date(Date.now() + 5 * 60 * 1000).toISOString()
+
+const createMfaChallenge = ({
+  includeTotp = true,
+  includeRecovery = false,
+  includeWebAuthn = false,
+  defaultMethod = includeTotp ? "totp" : includeWebAuthn ? "webauthn" : null,
+  sessionId = 1,
+}: {
+  includeTotp?: boolean
+  includeRecovery?: boolean
+  includeWebAuthn?: boolean
+  defaultMethod?: PendingMfaResponse["default_method"]
+  sessionId?: number
+} = {}): PendingMfaResponse => {
+  const methods: PendingMfaResponse["methods"] = []
+  if (includeTotp) {
+    methods.push({
+      method: "totp",
+      challenge_token: "totp-challenge-token",
+      challenge_expires_at: challengeExpiresAt(),
+      options: null,
+    })
+  }
+  if (includeRecovery) {
+    methods.push({
+      method: "recovery",
+      challenge_token: "recovery-challenge-token",
+      challenge_expires_at: challengeExpiresAt(),
+      options: null,
+    })
+  }
+  if (includeWebAuthn) {
+    methods.push({
+      method: "webauthn",
+      challenge_token: "webauthn-challenge-token",
+      challenge_expires_at: challengeExpiresAt(),
+      options: {
+        challenge: "c2FtcGxlLXdlYmF1dGhu",
+        timeout: 60_000,
+        rpId: "localhost",
+        allowCredentials: [
+          {
+            type: "public-key",
+            id: "credential-id",
+            transports: ["internal"],
+          },
+        ],
+        userVerification: "preferred",
+      },
+    })
+  }
+
+  return {
+    status: "mfa_required",
+    user_id: 1,
+    session_id: sessionId,
+    default_method: defaultMethod,
+    methods,
+  }
+}
+
 export async function useMockApi(page: Page) {
   const state: MockState = {
     loggedIn: false,
@@ -136,6 +248,21 @@ export async function useMockApi(page: Page) {
     offline: false,
     newsLog: [],
     sessions: createMockSessions(),
+    profile: createBaseProfile(),
+    totp: {
+      pending: null,
+      enrollments: [],
+      nextId: 1,
+    },
+    mfa: {
+      loginChallenge: null,
+      stepUpChallenge: createMfaChallenge({
+        includeTotp: true,
+        includeRecovery: true,
+        includeWebAuthn: true,
+        sessionId: 42,
+      }),
+    },
   }
 
   await page.addInitScript(() => {
@@ -198,6 +325,42 @@ export async function useMockApi(page: Page) {
         return
       }
 
+      if (username === "mfa@example.com" && password === "Password123") {
+        const challenge = createMfaChallenge({
+          includeTotp: true,
+          includeRecovery: true,
+          defaultMethod: "totp",
+          sessionId: 84,
+        })
+        state.profile.mfa_required = true
+        state.profile.mfa_default_method = "totp"
+        state.mfa.loginChallenge = challenge
+        await route.fulfill({
+          status: 202,
+          contentType: "application/json",
+          body: JSON.stringify(challenge),
+        })
+        return
+      }
+
+      if (username === "webauthn@example.com" && password === "Password123") {
+        const challenge = createMfaChallenge({
+          includeTotp: false,
+          includeWebAuthn: true,
+          defaultMethod: "webauthn",
+          sessionId: 96,
+        })
+        state.profile.mfa_required = true
+        state.profile.mfa_default_method = "webauthn"
+        state.mfa.loginChallenge = challenge
+        await route.fulfill({
+          status: 202,
+          contentType: "application/json",
+          body: JSON.stringify(challenge),
+        })
+        return
+      }
+
       await route.fulfill({
         status: 401,
         contentType: "application/json",
@@ -223,10 +386,15 @@ export async function useMockApi(page: Page) {
       const auth = route.request().headers()["authorization"]
       console.log(`[mock] /users/me -> loggedIn=${state.loggedIn} auth=${auth ?? "none"}`)
       if (state.loggedIn || auth?.includes("mock-token")) {
+        const profile: User = {
+          ...state.profile,
+          totp_enrollments: state.totp.enrollments.map((entry) => ({ ...entry })),
+        }
+        state.profile.totp_enrollments = profile.totp_enrollments
         await route.fulfill({
           status: 200,
           contentType: "application/json",
-          body: JSON.stringify(mockUser),
+          body: JSON.stringify(profile),
         })
       } else {
         await route.fulfill({
@@ -255,6 +423,255 @@ export async function useMockApi(page: Page) {
         status: 200,
         contentType: "application/json",
         body: JSON.stringify(sessions),
+      })
+      return
+    }
+
+    if (pathname === "api/auth/mfa/totp/start") {
+      if (!state.loggedIn) {
+        await route.fulfill({
+          status: 401,
+          contentType: "application/json",
+          body: JSON.stringify({ detail: "Unauthorized" }),
+        })
+        return
+      }
+
+      let payload: { label?: string } = {}
+      try {
+        payload = JSON.parse(route.request().postData() ?? "{}")
+      } catch {
+        payload = {}
+      }
+
+      const enrollment: MfaTotpEnrollment = {
+        id: state.totp.nextId++,
+        user_id: state.profile.id,
+        label: typeof payload.label === "string" ? payload.label : null,
+        is_active: false,
+        confirmed_at: null,
+        revoked_at: null,
+        created_at: new Date().toISOString(),
+      }
+
+      const secret = "JBSW Y3DP EHJK"
+      state.totp.pending = {
+        enrollment,
+        secret,
+        otpauth_url: `otpauth://totp/University:user?secret=${secret.replace(/\s+/g, "")}&issuer=University`,
+      }
+
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(state.totp.pending),
+      })
+      return
+    }
+
+    if (pathname === "api/auth/mfa/totp/confirm") {
+      if (!state.loggedIn) {
+        await route.fulfill({
+          status: 401,
+          contentType: "application/json",
+          body: JSON.stringify({ detail: "Unauthorized" }),
+        })
+        return
+      }
+
+      const raw = route.request().postData() ?? "{}"
+      let body: { enrollment_id?: number; code?: string }
+      try {
+        body = JSON.parse(raw)
+      } catch {
+        body = {}
+      }
+
+      if (!state.totp.pending || body.enrollment_id !== state.totp.pending.enrollment.id) {
+        await route.fulfill({
+          status: 404,
+          contentType: "application/json",
+          body: JSON.stringify({ detail: "Enrollment not found" }),
+        })
+        return
+      }
+
+      const code = String(body.code ?? "").replace(/\s+/g, "")
+      if (code !== "123456") {
+        await route.fulfill({
+          status: 400,
+          contentType: "application/json",
+          body: JSON.stringify({ detail: "Invalid verification code" }),
+        })
+        return
+      }
+
+      const confirmed: MfaTotpEnrollment = {
+        ...state.totp.pending.enrollment,
+        is_active: true,
+        confirmed_at: new Date().toISOString(),
+      }
+      state.totp.enrollments = [confirmed]
+      state.totp.pending = null
+      state.profile.totp_enrollments = [confirmed]
+      state.profile.mfa_default_method = "totp"
+      state.profile.mfa_last_verified_at = confirmed.confirmed_at
+
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(confirmed),
+      })
+      return
+    }
+
+    if (pathname === "api/auth/mfa/totp") {
+      if (!state.loggedIn) {
+        await route.fulfill({
+          status: 401,
+          contentType: "application/json",
+          body: JSON.stringify({ detail: "Unauthorized" }),
+        })
+        return
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(state.totp.enrollments),
+      })
+      return
+    }
+
+    const totpDeleteMatch = pathname.match(/^api\/auth\/mfa\/totp\/(\d+)$/)
+    if (totpDeleteMatch) {
+      if (!state.loggedIn) {
+        await route.fulfill({
+          status: 401,
+          contentType: "application/json",
+          body: JSON.stringify({ detail: "Unauthorized" }),
+        })
+        return
+      }
+      const id = Number.parseInt(totpDeleteMatch[1] ?? "", 10)
+      const index = state.totp.enrollments.findIndex((entry) => entry.id === id)
+      if (index === -1) {
+        await route.fulfill({
+          status: 404,
+          contentType: "application/json",
+          body: JSON.stringify({ detail: "Enrollment not found" }),
+        })
+        return
+      }
+      state.totp.enrollments.splice(index, 1)
+      state.profile.totp_enrollments = [...state.totp.enrollments]
+      if (!state.totp.enrollments.length && state.profile.mfa_default_method === "totp") {
+        state.profile.mfa_default_method = null
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ disabled: true }),
+      })
+      return
+    }
+
+    if (pathname === "api/auth/mfa/step-up") {
+      const challenge =
+        state.mfa.stepUpChallenge ??
+        createMfaChallenge({ includeTotp: true, includeRecovery: true, includeWebAuthn: true, sessionId: 42 })
+      state.mfa.stepUpChallenge = challenge
+      await route.fulfill({
+        status: 202,
+        contentType: "application/json",
+        body: JSON.stringify(challenge),
+      })
+      return
+    }
+
+    if (pathname === "api/auth/mfa/verify") {
+      const raw = route.request().postData() ?? "{}"
+      let payload: {
+        method?: string
+        code?: string
+        credential?: unknown
+        challenge_token?: string
+      }
+      try {
+        payload = JSON.parse(raw)
+      } catch {
+        payload = {}
+      }
+
+      const challengeToken = payload.challenge_token
+      const method = payload.method as PendingMfaResponse["methods"][number]["method"] | undefined
+      if (!challengeToken || !method) {
+        await route.fulfill({
+          status: 400,
+          contentType: "application/json",
+          body: JSON.stringify({ detail: "Invalid payload" }),
+        })
+        return
+      }
+
+      const matches = (challenge: PendingMfaResponse | null) =>
+        Boolean(challenge?.methods.some((entry) => entry.method === method && entry.challenge_token === challengeToken))
+
+      const matchedLogin = matches(state.mfa.loginChallenge)
+      const matchedStepUp = matches(state.mfa.stepUpChallenge)
+
+      if (!matchedLogin && !matchedStepUp) {
+        await route.fulfill({
+          status: 400,
+          contentType: "application/json",
+          body: JSON.stringify({ detail: "Challenge expired" }),
+        })
+        return
+      }
+
+      if (method === "webauthn") {
+        if (!payload.credential || typeof payload.credential !== "object") {
+          await route.fulfill({
+            status: 400,
+            contentType: "application/json",
+            body: JSON.stringify({ detail: "Invalid credential" }),
+          })
+          return
+        }
+      } else {
+        const code = String(payload.code ?? "").replace(/\s+/g, "")
+        if (code !== "123456" && !(method === "recovery" && code === "RECOVERY-1")) {
+          await route.fulfill({
+            status: 400,
+            contentType: "application/json",
+            body: JSON.stringify({ detail: "Invalid verification code" }),
+          })
+          return
+        }
+      }
+
+      state.profile.mfa_last_verified_at = new Date().toISOString()
+      state.profile.mfa_required = false
+      if (method !== "recovery") {
+        state.profile.mfa_default_method = method
+      }
+
+      if (matchedLogin) {
+        state.loggedIn = true
+        state.mfa.loginChallenge = null
+      }
+      if (matchedStepUp) {
+        state.mfa.stepUpChallenge = createMfaChallenge({
+          includeTotp: true,
+          includeRecovery: true,
+          includeWebAuthn: true,
+          sessionId: 42,
+        })
+      }
+
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ access_token: "mock-token", token_type: "bearer" }),
       })
       return
     }

--- a/root/frontend/vitest.config.ts
+++ b/root/frontend/vitest.config.ts
@@ -8,10 +8,7 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "src"),
-      "@simplewebauthn/browser": path.resolve(
-        __dirname,
-        "src/tests/mocks/simplewebauthn.ts"
-      ),
+      "@simplewebauthn/browser": path.resolve(__dirname, "src/tests/mocks/simplewebauthn.ts"),
     },
   },
   test: {

--- a/root/frontend/vitest.config.ts
+++ b/root/frontend/vitest.config.ts
@@ -8,6 +8,10 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "src"),
+      "@simplewebauthn/browser": path.resolve(
+        __dirname,
+        "src/tests/mocks/simplewebauthn.ts"
+      ),
     },
   },
   test: {


### PR DESCRIPTION
## Summary
- add Vitest coverage for AuthContext MFA state transitions, Settings TOTP enrollment, and login dialog OTP flows
- extend MSW handlers, shared mocks, and Playwright fixtures to simulate MFA/TOTP/WebAuthn API responses
- add Playwright MFA scenarios for TOTP setup, OTP login retries, and WebAuthn challenges

## Testing
- npm test
- npm run test:e2e tests/e2e/mfa.spec.ts *(fails: Playwright browsers not installed in CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68fc062bf0d483278be9c40c26a57802