### PR TITLE
Add accessible shared route guard loading state

### DIFF
--- a/root/frontend/src/components/LoadingState.tsx
+++ b/root/frontend/src/components/LoadingState.tsx
@@ -3,11 +3,15 @@ import { visuallyHidden } from "@mui/utils"
 import { useTranslation } from "react-i18next"
 import Layout from "./Layout"
 
+type LoadingStateProps = {
+  label?: string
+}
+
 const HEADER_SKELETON_RADIUS = "16px"
 
-export default function RouteGuardLoading() {
+export default function LoadingState({ label }: LoadingStateProps) {
   const { t } = useTranslation("common")
-  const loadingLabel = t("statuses.loading")
+  const loadingLabel = label ?? t("statuses.loading")
 
   return (
     <Layout>

--- a/root/frontend/src/components/RouteGuards.tsx
+++ b/root/frontend/src/components/RouteGuards.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from "react"
 import { Navigate } from "react-router-dom"
 import { useAuth } from "@/contexts/AuthContext"
-import RouteGuardLoading from "./RouteGuardLoading"
+import LoadingState from "./LoadingState"
 
 export type RouteGuardProps = { children: ReactElement }
 
@@ -9,7 +9,7 @@ export function PrivateRoute({ children }: RouteGuardProps) {
   const { isAuth, loading } = useAuth()
 
   if (loading) {
-    return <RouteGuardLoading />
+    return <LoadingState />
   }
 
   return isAuth ? children : <Navigate to="/login" />
@@ -19,7 +19,7 @@ export function AdminRoute({ children }: RouteGuardProps) {
   const { isAuth, user, loading } = useAuth()
 
   if (loading) {
-    return <RouteGuardLoading />
+    return <LoadingState />
   }
 
   if (!isAuth) {

--- a/root/frontend/src/components/__tests__/LoadingState.test.tsx
+++ b/root/frontend/src/components/__tests__/LoadingState.test.tsx
@@ -1,0 +1,16 @@
+import { screen } from "@testing-library/react"
+import LoadingState from "@/components/LoadingState"
+import { renderWithA11y } from "@/tests/axeTest"
+
+describe("LoadingState", () => {
+  test("renders an accessible busy status with page landmarks", async () => {
+    const { container } = await renderWithA11y(<LoadingState />)
+
+    const status = screen.getByRole("status")
+    expect(status).toHaveAttribute("aria-busy", "true")
+    expect(status).toHaveAttribute("aria-live", "polite")
+    expect(screen.getAllByText(/loading/i)[0]).toBeInTheDocument()
+    expect(container.querySelector("main#main")).not.toBeNull()
+    expect(container.querySelector("header")).not.toBeNull()
+  })
+})

--- a/root/frontend/src/tests/components/RouteGuards.test.tsx
+++ b/root/frontend/src/tests/components/RouteGuards.test.tsx
@@ -19,7 +19,7 @@ afterEach(() => {
 })
 
 describe("PrivateRoute", () => {
-  test("shows a busy loading fallback while authentication is resolving", async () => {
+  test("shows an accessible loading fallback while authentication is resolving", async () => {
     mockUseAuth.mockReturnValue({ isAuth: false, loading: true, user: null })
 
     const { container } = render(
@@ -30,6 +30,7 @@ describe("PrivateRoute", () => {
 
     const status = screen.getByRole("status")
     expect(status).toHaveAttribute("aria-busy", "true")
+    expect(status).toHaveAttribute("aria-live", "polite")
     expect(screen.getAllByText(/loading/i)[0]).toBeInTheDocument()
     expect(container.querySelector("main#main")).not.toBeNull()
     expect(container.querySelector("header")).not.toBeNull()
@@ -73,10 +74,10 @@ describe("PrivateRoute", () => {
 })
 
 describe("AdminRoute", () => {
-  test("shows the loading indicator while the admin state is resolving", () => {
+  test("shows the loading indicator while the admin state is resolving", async () => {
     mockUseAuth.mockReturnValue({ isAuth: true, loading: true, user: { role: "admin" } })
 
-    render(
+    const { container } = render(
       <AdminRoute>
         <div>Admin content</div>
       </AdminRoute>
@@ -84,6 +85,9 @@ describe("AdminRoute", () => {
 
     const status = screen.getByRole("status")
     expect(status).toHaveAttribute("aria-busy", "true")
+    expect(status).toHaveAttribute("aria-live", "polite")
+
+    await checkA11y(container)
   })
 
   test("redirects non-admin users to the dashboard", () => {


### PR DESCRIPTION
## Summary
- add a reusable LoadingState component that preserves page landmarks while showing a busy indicator
- use the shared loading state in PrivateRoute and AdminRoute guards
- cover the new loading shell with unit tests and jest-axe accessibility assertions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68fc16f0be1c8327980f7532efd87a1b