### PR TITLE
Tokenize event attendance QR codes and issue signed tokens

### DIFF
--- a/root/alembic/versions/202507310001_tokenize_event_attendance.py
+++ b/root/alembic/versions/202507310001_tokenize_event_attendance.py
@@ -1,0 +1,88 @@
+"""tokenize event attendance qr codes
+
+Revision ID: 202507310001
+Revises: 202507300002
+Create Date: 2025-07-31 00:01:00.000000
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import os
+import secrets
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "202507310001"
+down_revision = "202507300002"
+branch_labels = None
+depends_on = None
+
+
+def _server_secret() -> bytes:
+    secret = os.getenv("ATTENDANCE_TOKEN_SECRET") or os.getenv("SECRET_KEY")
+    if not secret:
+        raise RuntimeError(
+            "ATTENDANCE_TOKEN_SECRET or SECRET_KEY must be set during migration"
+        )
+    return secret.strip().encode("utf-8")
+
+
+def _encode_digest(secret: str) -> str:
+    digest = hmac.new(_server_secret(), secret.encode("utf-8"), hashlib.sha256).digest()
+    return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+
+
+def upgrade() -> None:
+    op.add_column("event_attendance", sa.Column("qr_secret", sa.String(), nullable=True))
+    op.add_column("event_attendance", sa.Column("qr_hmac", sa.String(), nullable=True))
+
+    attendance = sa.table(
+        "event_attendance",
+        sa.column("id", sa.Integer()),
+        sa.column("qr_code", sa.String()),
+        sa.column("qr_secret", sa.String()),
+        sa.column("qr_hmac", sa.String()),
+    )
+
+    connection = op.get_bind()
+    rows = connection.execute(sa.select(attendance.c.id, attendance.c.qr_code)).fetchall()
+    for row in rows:
+        secret = row.qr_code or secrets.token_urlsafe(32)
+        connection.execute(
+            attendance.update()
+            .where(attendance.c.id == row.id)
+            .values(qr_secret=secret, qr_hmac=_encode_digest(secret))
+        )
+
+    op.drop_column("event_attendance", "qr_code")
+    op.alter_column("event_attendance", "qr_secret", nullable=False)
+    op.alter_column("event_attendance", "qr_hmac", nullable=False)
+
+
+def downgrade() -> None:
+    op.add_column("event_attendance", sa.Column("qr_code", sa.String(), nullable=True))
+
+    attendance = sa.table(
+        "event_attendance",
+        sa.column("id", sa.Integer()),
+        sa.column("qr_secret", sa.String()),
+        sa.column("qr_code", sa.String()),
+    )
+
+    connection = op.get_bind()
+    rows = connection.execute(sa.select(attendance.c.id, attendance.c.qr_secret)).fetchall()
+    for row in rows:
+        connection.execute(
+            attendance.update()
+            .where(attendance.c.id == row.id)
+            .values(qr_code=row.qr_secret)
+        )
+
+    op.drop_column("event_attendance", "qr_hmac")
+    op.drop_column("event_attendance", "qr_secret")

--- a/root/alembic/versions/202507310001_tokenize_event_attendance.py
+++ b/root/alembic/versions/202507310001_tokenize_event_attendance.py
@@ -14,8 +14,8 @@ import os
 import secrets
 
 import sqlalchemy as sa
-from alembic import op
 
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "202507310001"
@@ -39,7 +39,9 @@ def _encode_digest(secret: str) -> str:
 
 
 def upgrade() -> None:
-    op.add_column("event_attendance", sa.Column("qr_secret", sa.String(), nullable=True))
+    op.add_column(
+        "event_attendance", sa.Column("qr_secret", sa.String(), nullable=True)
+    )
     op.add_column("event_attendance", sa.Column("qr_hmac", sa.String(), nullable=True))
 
     attendance = sa.table(
@@ -51,7 +53,9 @@ def upgrade() -> None:
     )
 
     connection = op.get_bind()
-    rows = connection.execute(sa.select(attendance.c.id, attendance.c.qr_code)).fetchall()
+    rows = connection.execute(
+        sa.select(attendance.c.id, attendance.c.qr_code)
+    ).fetchall()
     for row in rows:
         secret = row.qr_code or secrets.token_urlsafe(32)
         connection.execute(
@@ -76,7 +80,9 @@ def downgrade() -> None:
     )
 
     connection = op.get_bind()
-    rows = connection.execute(sa.select(attendance.c.id, attendance.c.qr_secret)).fetchall()
+    rows = connection.execute(
+        sa.select(attendance.c.id, attendance.c.qr_secret)
+    ).fetchall()
     for row in rows:
         connection.execute(
             attendance.update()

--- a/root/app/api/events.py
+++ b/root/app/api/events.py
@@ -1,7 +1,6 @@
 import hashlib
 import json
 import logging
-import uuid
 from datetime import datetime, timezone
 from functools import lru_cache
 from typing import Any, List, Tuple
@@ -31,7 +30,7 @@ from app.deps.cache import etag_matches, format_etag
 from app.localization import resolve_locale, translate
 from app.models import models
 from app.schemas import schemas
-from app.services import notification_queue
+from app.services import attendance_tokens, notification_queue
 from app.utils.files import delete_static_file, save_attachment
 
 logger = logging.getLogger(__name__)
@@ -406,10 +405,13 @@ async def get_event(
             )
         )
     ).scalar_one_or_none()
-    if attendance and not attendance.qr_code:
-        attendance.qr_code = str(uuid.uuid4())
-        await db.commit()
-        await db.refresh(attendance)
+    attendance_token: str | None = None
+    if attendance:
+        if attendance_tokens.ensure_secret_material(attendance):
+            db.add(attendance)
+            await db.commit()
+            await db.refresh(attendance)
+        attendance_token = attendance_tokens.issue_token(attendance)
     files = (
         (
             await db.execute(
@@ -432,7 +434,7 @@ async def get_event(
         participant_count=participant_count,
         files=files,
         is_registered=attendance is not None,
-        my_qr_code=attendance.qr_code if attendance else None,
+        my_qr_token=attendance_token,
     )
     encoded, digest, weak_header = _encode_payload_with_etag(payload)
     if etag_matches(digest, if_none_match):

--- a/root/app/core/config.py
+++ b/root/app/core/config.py
@@ -198,6 +198,8 @@ class Settings(BaseSettings):
     notifications_queue_enqueue_timeout_seconds: float = 0.5
     notifications_queue_in_memory_only: bool = False
     notifications_queue_retry_base_seconds: float = 1.0
+    attendance_token_secret: str = ""
+    attendance_token_ttl_seconds: int = 300
     notifications_queue_max_attempts: int = 5
     session_cleanup_interval_seconds: int = 900
     password_reset_cleanup_interval_seconds: int = 3_600

--- a/root/app/crud/__init__.py
+++ b/root/app/crud/__init__.py
@@ -18,6 +18,7 @@ from app.models.user_loaders import (
     ensure_mfa_relationships_loaded,
 )
 from app.schemas import schemas
+from app.services import attendance_tokens
 
 
 async def get_user_auth(db: AsyncSession, login: str):
@@ -305,7 +306,7 @@ def serialize_event(
     participant_count: int = 0,
     files: Sequence[models.EventFile | schemas.EventFileOut] = (),
     is_registered: bool | None = None,
-    my_qr_code: str | None = None,
+    my_qr_token: str | None = None,
 ) -> schemas.EventOut:
     normalized_locale = normalize_locale(locale)
     prepared_files: list[schemas.EventFileOut] = []
@@ -360,7 +361,7 @@ def serialize_event(
         "files": prepared_files,
         "participant_count": participant_count,
         "is_registered": is_registered,
-        "my_qr_code": my_qr_code,
+        "my_qr_token": my_qr_token,
     }
 
     return schemas.EventOut.model_validate(data)
@@ -453,15 +454,20 @@ async def get_all_events(
             .scalars()
             .all()
         )
-        missing_qr = [row for row in attendance_rows if not row.qr_code]
-        if missing_qr:
-            for row in missing_qr:
-                row.qr_code = str(uuid.uuid4())
+        updated_rows: list[models.EventAttendance] = []
+        for row in attendance_rows:
+            if attendance_tokens.ensure_secret_material(row):
+                db.add(row)
+                updated_rows.append(row)
+        if updated_rows:
             await db.commit()
-            for row in missing_qr:
+            for row in updated_rows:
                 await db.refresh(row)
         registered_ids = {row.event_id for row in attendance_rows}
-        qr_map = {row.event_id: row.qr_code for row in attendance_rows}
+        qr_map = {
+            row.event_id: attendance_tokens.issue_token(row)
+            for row in attendance_rows
+        }
 
     normalized_locale = normalize_locale(locale)
     result: List[schemas.EventOut] = []
@@ -474,7 +480,7 @@ async def get_all_events(
                 participant_count=counts.get(event.id, 0),
                 files=files,
                 is_registered=event.id in registered_ids,
-                my_qr_code=qr_map.get(event.id),
+                my_qr_token=qr_map.get(event.id),
             )
         )
 
@@ -584,20 +590,21 @@ async def register_attendance(
         if exist.registered_at is None:
             exist.registered_at = datetime.now(UTC)
             updated = True
-        if not exist.qr_code:
-            exist.qr_code = str(uuid.uuid4())
+        if attendance_tokens.ensure_secret_material(exist):
             updated = True
         if updated:
             db.add(exist)
             await db.commit()
             await db.refresh(exist)
+        exist.qr_token = attendance_tokens.issue_token(exist)
         return exist
 
-    qr_code = str(uuid.uuid4())
+    secret = attendance_tokens.generate_secret()
     record = models.EventAttendance(
         user_id=user_id,
         event_id=data.event_id,
-        qr_code=qr_code,
+        qr_secret=secret,
+        qr_hmac=attendance_tokens.compute_secret_hmac(secret),
         registered_at=datetime.now(UTC),
     )
     db.add(record)
@@ -615,15 +622,16 @@ async def register_attendance(
         if exist.registered_at is None:
             exist.registered_at = datetime.now(UTC)
             updated = True
-        if not exist.qr_code:
-            exist.qr_code = str(uuid.uuid4())
+        if attendance_tokens.ensure_secret_material(exist):
             updated = True
         if updated:
             db.add(exist)
             await db.commit()
             await db.refresh(exist)
+        exist.qr_token = attendance_tokens.issue_token(exist)
         return exist
     await db.refresh(record)
+    record.qr_token = attendance_tokens.issue_token(record)
     return record
 
 
@@ -658,15 +666,17 @@ async def get_my_events(db: AsyncSession, user_id: int, *, locale: str | None = 
     )
     if not attendance_rows:
         return []
-    missing_qr = [row for row in attendance_rows if not row.qr_code]
-    if missing_qr:
-        for row in missing_qr:
-            row.qr_code = str(uuid.uuid4())
+    updated_rows: list[models.EventAttendance] = []
+    for row in attendance_rows:
+        if attendance_tokens.ensure_secret_material(row):
+            db.add(row)
+            updated_rows.append(row)
+    if updated_rows:
         await db.commit()
-        for row in missing_qr:
+        for row in updated_rows:
             await db.refresh(row)
     ids = [row.event_id for row in attendance_rows]
-    qr_map = {row.event_id: row.qr_code for row in attendance_rows}
+    qr_map = {row.event_id: attendance_tokens.issue_token(row) for row in attendance_rows}
     q = select(models.Event).where(models.Event.id.in_(ids))
     events = (await db.execute(q)).scalars().all()
     counts = await _attendance_counts(db, ids)
@@ -683,7 +693,7 @@ async def get_my_events(db: AsyncSession, user_id: int, *, locale: str | None = 
                 participant_count=counts.get(event.id, 0),
                 files=files,
                 is_registered=True,
-                my_qr_code=qr_map.get(event.id),
+                my_qr_token=qr_map.get(event.id),
             )
         )
     return result

--- a/root/app/crud/__init__.py
+++ b/root/app/crud/__init__.py
@@ -465,8 +465,7 @@ async def get_all_events(
                 await db.refresh(row)
         registered_ids = {row.event_id for row in attendance_rows}
         qr_map = {
-            row.event_id: attendance_tokens.issue_token(row)
-            for row in attendance_rows
+            row.event_id: attendance_tokens.issue_token(row) for row in attendance_rows
         }
 
     normalized_locale = normalize_locale(locale)
@@ -676,7 +675,9 @@ async def get_my_events(db: AsyncSession, user_id: int, *, locale: str | None = 
         for row in updated_rows:
             await db.refresh(row)
     ids = [row.event_id for row in attendance_rows]
-    qr_map = {row.event_id: attendance_tokens.issue_token(row) for row in attendance_rows}
+    qr_map = {
+        row.event_id: attendance_tokens.issue_token(row) for row in attendance_rows
+    }
     q = select(models.Event).where(models.Event.id.in_(ids))
     events = (await db.execute(q)).scalars().all()
     counts = await _attendance_counts(db, ids)

--- a/root/app/models/models.py
+++ b/root/app/models/models.py
@@ -370,7 +370,8 @@ class EventAttendance(Base):
     registered_at = Column(
         DateTime(timezone=True), server_default=func.now(), index=True
     )
-    qr_code = Column(String)
+    qr_secret = Column(String, nullable=False)
+    qr_hmac = Column(String, nullable=False)
 
     __table_args__ = (
         UniqueConstraint("user_id", "event_id", name="uq_event_attendance_user_event"),

--- a/root/app/schemas/schemas.py
+++ b/root/app/schemas/schemas.py
@@ -421,7 +421,7 @@ class EventOut(OrmModel):
     files: List[EventFileOut] = Field(default_factory=list)
     participant_count: int = 0
     is_registered: Optional[bool] = None
-    my_qr_code: Optional[str] = None
+    my_qr_token: Optional[str] = None
 
 
 class PaginatedEvents(BaseModel):
@@ -442,7 +442,7 @@ class EventAttendanceOut(OrmModel):
     user_id: int
     event_id: int
     registered_at: datetime
-    qr_code: Optional[str] = None
+    qr_token: Optional[str] = None
 
 
 class Token(BaseModel):

--- a/root/app/services/attendance_tokens.py
+++ b/root/app/services/attendance_tokens.py
@@ -94,7 +94,9 @@ class AttendanceTokenPayload:
             "iat": self.issued_at,
             "exp": self.expires_at,
         }
-        return json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+        return json.dumps(payload, separators=(",", ":"), sort_keys=True).encode(
+            "utf-8"
+        )
 
     @classmethod
     def decode(cls, data: bytes) -> "AttendanceTokenPayload":
@@ -109,7 +111,9 @@ class AttendanceTokenPayload:
         )
 
 
-def issue_token(attendance: Any, *, now: datetime | None = None, ttl_seconds: int | None = None) -> str:
+def issue_token(
+    attendance: Any, *, now: datetime | None = None, ttl_seconds: int | None = None
+) -> str:
     secret = getattr(attendance, "qr_secret", None)
     if not isinstance(secret, str) or not secret:
         raise AttendanceTokenError("Attendance record is missing QR secret material")
@@ -143,7 +147,9 @@ def verify_token(
     except ValueError as exc:
         raise AttendanceTokenInvalid("Token structure is invalid") from exc
     payload_bytes = _b64decode(payload_b64)
-    expected_signature = hmac.new(_server_secret(), payload_bytes, hashlib.sha256).digest()
+    expected_signature = hmac.new(
+        _server_secret(), payload_bytes, hashlib.sha256
+    ).digest()
     try:
         provided_signature = _b64decode(signature_b64)
     except (ValueError, binascii.Error) as exc:

--- a/root/app/services/attendance_tokens.py
+++ b/root/app/services/attendance_tokens.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import hmac
+import json
+import secrets
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from app.core.config import settings
+
+
+class AttendanceTokenError(Exception):
+    """Base error for attendance token failures."""
+
+
+class AttendanceTokenInvalid(AttendanceTokenError):
+    """Raised when the token payload or signature is invalid."""
+
+
+class AttendanceTokenExpired(AttendanceTokenError):
+    """Raised when the token has expired."""
+
+
+TOKEN_PURPOSE = "event_attendance"
+
+
+def _server_secret() -> bytes:
+    secret = settings.attendance_token_secret or settings.secret_key
+    normalized = secret.strip()
+    if not normalized:
+        raise AttendanceTokenError("Attendance token secret is not configured")
+    return normalized.encode("utf-8")
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _b64encode(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _b64decode(value: str) -> bytes:
+    padding = "=" * (-len(value) % 4)
+    return base64.urlsafe_b64decode(value + padding)
+
+
+def generate_secret() -> str:
+    return secrets.token_urlsafe(32)
+
+
+def compute_secret_hmac(secret: str) -> str:
+    digest = hmac.new(_server_secret(), secret.encode("utf-8"), hashlib.sha256).digest()
+    return _b64encode(digest)
+
+
+def ensure_secret_material(attendance: Any) -> bool:
+    """Ensure an attendance row has valid secret material.
+
+    Returns ``True`` if the record was modified.
+    """
+
+    secret = getattr(attendance, "qr_secret", None)
+    hmac_value = getattr(attendance, "qr_hmac", None)
+    if secret and hmac_value:
+        expected = compute_secret_hmac(secret)
+        if secrets.compare_digest(expected, hmac_value):
+            return False
+    new_secret = secret or generate_secret()
+    attendance.qr_secret = new_secret
+    attendance.qr_hmac = compute_secret_hmac(new_secret)
+    return True
+
+
+@dataclass(slots=True)
+class AttendanceTokenPayload:
+    purpose: str
+    event_id: int
+    user_id: int
+    secret: str
+    issued_at: int
+    expires_at: int
+
+    def encode(self) -> bytes:
+        payload = {
+            "sub": self.purpose,
+            "eid": self.event_id,
+            "uid": self.user_id,
+            "sec": self.secret,
+            "iat": self.issued_at,
+            "exp": self.expires_at,
+        }
+        return json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+    @classmethod
+    def decode(cls, data: bytes) -> "AttendanceTokenPayload":
+        payload = json.loads(data.decode("utf-8"))
+        return cls(
+            purpose=payload["sub"],
+            event_id=int(payload["eid"]),
+            user_id=int(payload["uid"]),
+            secret=str(payload["sec"]),
+            issued_at=int(payload["iat"]),
+            expires_at=int(payload["exp"]),
+        )
+
+
+def issue_token(attendance: Any, *, now: datetime | None = None, ttl_seconds: int | None = None) -> str:
+    secret = getattr(attendance, "qr_secret", None)
+    if not isinstance(secret, str) or not secret:
+        raise AttendanceTokenError("Attendance record is missing QR secret material")
+    ttl = ttl_seconds or settings.attendance_token_ttl_seconds
+    if ttl <= 0:
+        raise AttendanceTokenError("Attendance token TTL must be positive")
+    moment = now or _now()
+    issued_at = int(moment.timestamp())
+    expires_at = int((moment + timedelta(seconds=ttl)).timestamp())
+    payload = AttendanceTokenPayload(
+        purpose=TOKEN_PURPOSE,
+        event_id=int(getattr(attendance, "event_id")),
+        user_id=int(getattr(attendance, "user_id")),
+        secret=secret,
+        issued_at=issued_at,
+        expires_at=expires_at,
+    )
+    payload_bytes = payload.encode()
+    signature = hmac.new(_server_secret(), payload_bytes, hashlib.sha256).digest()
+    return f"{_b64encode(payload_bytes)}.{_b64encode(signature)}"
+
+
+def verify_token(
+    token: str,
+    attendance: Any,
+    *,
+    now: datetime | None = None,
+) -> AttendanceTokenPayload:
+    try:
+        payload_b64, signature_b64 = token.split(".", 1)
+    except ValueError as exc:
+        raise AttendanceTokenInvalid("Token structure is invalid") from exc
+    payload_bytes = _b64decode(payload_b64)
+    expected_signature = hmac.new(_server_secret(), payload_bytes, hashlib.sha256).digest()
+    try:
+        provided_signature = _b64decode(signature_b64)
+    except (ValueError, binascii.Error) as exc:
+        raise AttendanceTokenInvalid("Token signature encoding is invalid") from exc
+    if not hmac.compare_digest(expected_signature, provided_signature):
+        raise AttendanceTokenInvalid("Token signature mismatch")
+    try:
+        payload = AttendanceTokenPayload.decode(payload_bytes)
+    except (KeyError, ValueError, json.JSONDecodeError) as exc:
+        raise AttendanceTokenInvalid("Token payload is invalid") from exc
+    if payload.purpose != TOKEN_PURPOSE:
+        raise AttendanceTokenInvalid("Token purpose mismatch")
+    if payload.event_id != getattr(attendance, "event_id"):
+        raise AttendanceTokenInvalid("Token event mismatch")
+    if payload.user_id != getattr(attendance, "user_id"):
+        raise AttendanceTokenInvalid("Token user mismatch")
+    expected_hmac = getattr(attendance, "qr_hmac", None)
+    if not expected_hmac:
+        raise AttendanceTokenInvalid("Attendance record missing secret signature")
+    calculated = compute_secret_hmac(payload.secret)
+    if not hmac.compare_digest(calculated, expected_hmac):
+        raise AttendanceTokenInvalid("Token secret is not active")
+    moment = now or _now()
+    if payload.expires_at <= int(moment.timestamp()):
+        raise AttendanceTokenExpired("Token has expired")
+    return payload
+
+
+__all__ = [
+    "AttendanceTokenError",
+    "AttendanceTokenExpired",
+    "AttendanceTokenInvalid",
+    "AttendanceTokenPayload",
+    "TOKEN_PURPOSE",
+    "compute_secret_hmac",
+    "ensure_secret_material",
+    "generate_secret",
+    "issue_token",
+    "verify_token",
+]

--- a/root/tests/conftest.py
+++ b/root/tests/conftest.py
@@ -43,6 +43,7 @@ os.environ.setdefault("RATE_LIMIT_DEFAULT", "5/minute,10/hour")
 os.environ.setdefault("RATE_LIMIT_SENSITIVE", "4/minute")
 os.environ.setdefault("RATE_LIMIT_STORAGE_BACKEND", "redis")
 os.environ.setdefault("RATE_LIMIT_STORAGE_URI", "redis://test")
+os.environ.setdefault("ATTENDANCE_TOKEN_SECRET", "attendance-test-secret")
 Path(os.environ.get("STATIC_DIR", "app/test-static")).mkdir(parents=True, exist_ok=True)
 
 try:

--- a/root/tests/test_event_attendance_api.py
+++ b/root/tests/test_event_attendance_api.py
@@ -247,7 +247,9 @@ async def test_attendance_token_reuse_rejected_after_expiry(
 
 
 @pytest.mark.anyio
-async def test_attendance_token_signature_tampering(async_client, db_session, user_factory):
+async def test_attendance_token_signature_tampering(
+    async_client, db_session, user_factory
+):
     token, attendance, _, _ = await _register_for_event(
         async_client, db_session, user_factory
     )

--- a/root/tests/test_event_attendance_api.py
+++ b/root/tests/test_event_attendance_api.py
@@ -2,10 +2,12 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 from fastapi import status
+from sqlalchemy import select
 
 from app.auth.security import get_password_hash
 from app.localization import translate
 from app.models import models
+from app.services import attendance_tokens
 
 
 async def _login(async_client, email: str, password: str) -> dict[str, str]:
@@ -52,7 +54,7 @@ async def test_attend_registers_event(async_client, db_session, user_factory):
     payload = response.json()
     assert payload["event_id"] == event.id
     assert payload["user_id"] == student.id
-    assert payload["qr_code"]
+    assert payload["qr_token"]
 
 
 @pytest.mark.anyio
@@ -139,11 +141,13 @@ async def test_attend_restores_missing_registration_timestamp(
     await db_session.commit()
     await db_session.refresh(event)
 
+    secret = attendance_tokens.generate_secret()
     attendance = models.EventAttendance(
         user_id=student.id,
         event_id=event.id,
         registered_at=None,
-        qr_code=None,
+        qr_secret=secret,
+        qr_hmac=attendance_tokens.compute_secret_hmac(secret),
     )
     db_session.add(attendance)
     await db_session.commit()
@@ -161,9 +165,92 @@ async def test_attend_restores_missing_registration_timestamp(
     payload = response.json()
     assert payload["event_id"] == event.id
     assert payload["user_id"] == student.id
-    assert payload["qr_code"]
+    assert payload["qr_token"]
     assert payload["registered_at"] is not None
 
     await db_session.refresh(attendance)
     assert attendance.registered_at is not None
-    assert attendance.qr_code is not None
+    assert attendance.qr_secret
+    assert attendance.qr_hmac
+
+
+async def _register_for_event(
+    async_client,
+    db_session,
+    user_factory,
+    *,
+    locale: str = "en",
+):
+    password = "TokenFlow123!"
+    student = await user_factory(
+        hashed_password=get_password_hash(password),
+        is_active=True,
+    )
+    admin = await user_factory(role="admin")
+
+    now = datetime.now(timezone.utc)
+    event = models.Event(
+        title="Token event",
+        starts_at=now + timedelta(hours=1),
+        ends_at=now + timedelta(hours=2),
+        created_by=admin.id,
+        is_active=True,
+    )
+    db_session.add(event)
+    await db_session.commit()
+    await db_session.refresh(event)
+
+    headers = await _login(async_client, student.email, password)
+    base_headers = {**headers, "Accept-Language": locale}
+    response = await async_client.post(
+        "/events/attendance",
+        headers=base_headers,
+        json={"event_id": event.id},
+    )
+    assert response.status_code == status.HTTP_200_OK
+    token = response.json()["qr_token"]
+
+    attendance = (
+        await db_session.execute(
+            select(models.EventAttendance).where(
+                models.EventAttendance.event_id == event.id,
+                models.EventAttendance.user_id == student.id,
+            )
+        )
+    ).scalar_one()
+
+    return token, attendance, event, student
+
+
+@pytest.mark.anyio
+async def test_attendance_token_can_be_verified(async_client, db_session, user_factory):
+    token, attendance, event, student = await _register_for_event(
+        async_client, db_session, user_factory
+    )
+    payload = attendance_tokens.verify_token(token, attendance)
+    assert payload.event_id == event.id
+    assert payload.user_id == student.id
+
+
+@pytest.mark.anyio
+async def test_attendance_token_reuse_rejected_after_expiry(
+    async_client, db_session, user_factory, monkeypatch
+):
+    monkeypatch.setattr(attendance_tokens.settings, "attendance_token_ttl_seconds", 1)
+    token, attendance, _, _ = await _register_for_event(
+        async_client, db_session, user_factory
+    )
+    payload = attendance_tokens.verify_token(token, attendance)
+    expired_at = datetime.fromtimestamp(payload.expires_at + 1, tz=timezone.utc)
+    with pytest.raises(attendance_tokens.AttendanceTokenExpired):
+        attendance_tokens.verify_token(token, attendance, now=expired_at)
+
+
+@pytest.mark.anyio
+async def test_attendance_token_signature_tampering(async_client, db_session, user_factory):
+    token, attendance, _, _ = await _register_for_event(
+        async_client, db_session, user_factory
+    )
+    tampered = token[:-1] + ("A" if token[-1] != "A" else "B")
+    with pytest.raises(attendance_tokens.AttendanceTokenInvalid):
+        attendance_tokens.verify_token(tampered, attendance)

--- a/root/tests/test_event_time_constraints.py
+++ b/root/tests/test_event_time_constraints.py
@@ -148,10 +148,10 @@ async def test_event_detail_returns_qr_code_after_registration(
         "/events/attendance", headers=headers, json={"event_id": event.id}
     )
     assert attend_response.status_code == 200
-    qr_code = attend_response.json()["qr_code"]
-    assert qr_code
+    qr_token = attend_response.json()["qr_token"]
+    assert qr_token
 
     detail_response = await async_client.get(f"/events/{event.id}", headers=headers)
     assert detail_response.status_code == 200
     payload = detail_response.json()
-    assert payload["my_qr_code"] == qr_code
+    assert payload["my_qr_token"] == qr_token

--- a/root/tests/test_events_localization.py
+++ b/root/tests/test_events_localization.py
@@ -6,6 +6,7 @@ from fastapi import status
 from app import crud
 from app.auth.security import get_password_hash
 from app.models import models
+from app.services import attendance_tokens
 
 
 async def _login(async_client, email: str, password: str) -> dict[str, str]:
@@ -147,10 +148,12 @@ async def test_events_etag_and_not_modified(async_client, db_session, user_facto
     await db_session.commit()
     await db_session.refresh(event)
 
+    secret = attendance_tokens.generate_secret()
     attendance = models.EventAttendance(
         event_id=event.id,
         user_id=student.id,
-        qr_code="qr-test",
+        qr_secret=secret,
+        qr_hmac=attendance_tokens.compute_secret_hmac(secret),
     )
     db_session.add(attendance)
     await db_session.commit()


### PR DESCRIPTION
## Summary
- replace the event attendance QR code column with secret and HMAC fields via a new Alembic migration
- add an attendance token service and settings to mint HMAC-signed QR envelopes
- update event models, CRUD helpers, and API responses to return signed QR tokens and refresh the related tests

## Testing
- pytest root/tests/test_event_attendance_api.py
- pytest root/tests/test_event_time_constraints.py root/tests/test_events_localization.py

------
https://chatgpt.com/codex/tasks/task_e_68fc2788d3c88327ac29ffc0140255d4