### PR TITLE
Add WebAuthn metadata resolver and attestation validation

### DIFF
--- a/root/app/auth/mfa.py
+++ b/root/app/auth/mfa.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import base64
 import hashlib
+import json
+import logging
 import secrets
 from collections.abc import Mapping, MutableMapping
 from dataclasses import dataclass
@@ -50,6 +52,7 @@ from app.models.models import (
     User,
 )
 from app.utils import ratelimit as ratelimit_utils
+from app.services.webauthn_metadata import MetadataLoadError, metadata_resolver
 
 _RECOVERY_CODE_ALPHABET = "23456789ABCDEFGHJKLMNPQRSTUVWXYZ"
 _RECOVERY_CODE_LENGTH = 10
@@ -68,6 +71,10 @@ CHALLENGE_TYPE_RECOVERY = "recovery-code"
 MFA_METHOD_TOTP = "totp"
 MFA_METHOD_WEBAUTHN = "webauthn"
 MFA_METHOD_RECOVERY = "recovery"
+
+
+audit_logger = logging.getLogger("app.users.audit")
+metadata_logger = logging.getLogger("app.auth.webauthn")
 
 
 @dataclass(slots=True)
@@ -581,7 +588,86 @@ async def complete_webauthn_enrollment(
                 transport.value for transport in credential.response.transports
             ]
     elif isinstance(credential, Mapping):
-        transports = credential.get("transports")
+        raw_transports = credential.get("transports")
+        if isinstance(raw_transports, list):
+            transports = [
+                str(item).lower()
+                for item in raw_transports
+                if isinstance(item, str) and item
+            ]
+    transports_list = transports or []
+    metadata_entry = None
+    metadata_info: dict[str, Any] | None = None
+    metadata_warnings: list[str] = []
+    trust_score: int | None = None
+    enforcement = settings.mfa_webauthn_metadata_enforcement
+    metadata_configured = bool(
+        settings.mfa_webauthn_metadata_url.strip()
+        or settings.mfa_webauthn_metadata_json.strip()
+    )
+    if metadata_configured or enforcement != "disabled":
+        try:
+            metadata_entry = await metadata_resolver.get_entry(verified.aaguid)
+        except MetadataLoadError as exc:
+            metadata_logger.warning("WebAuthn metadata refresh failed: %s", exc)
+            if metadata_configured:
+                metadata_warnings.append("metadata_error")
+        except Exception as exc:  # pragma: no cover - defensive
+            metadata_logger.warning("Unexpected WebAuthn metadata failure: %s", exc)
+            if metadata_configured:
+                metadata_warnings.append("metadata_error")
+    if metadata_entry:
+        trust_score = metadata_entry.trust_score
+        metadata_info = metadata_entry.to_dict()
+        if metadata_entry.status_warning:
+            metadata_warnings.append("status_warning")
+        if metadata_entry.trust_score == 0:
+            metadata_warnings.append("untrusted_status")
+        if transports_list and metadata_entry.allowed_transports:
+            invalid_transports = sorted(
+                transport
+                for transport in transports_list
+                if transport not in metadata_entry.allowed_transports
+            )
+            if invalid_transports:
+                metadata_warnings.append("transport_mismatch")
+                metadata_info["invalid_transports"] = invalid_transports
+        if verified.credential_backed_up and metadata_entry.backup_eligible is False:
+            metadata_warnings.append("backup_not_permitted")
+        if transports_list:
+            metadata_info.setdefault("observed_transports", transports_list)
+    elif metadata_configured:
+        metadata_warnings.append("metadata_missing")
+        metadata_info = {"metadata_available": False}
+    metadata_warnings = sorted(set(metadata_warnings))
+    if metadata_warnings:
+        audit_payload: dict[str, Any] = {
+            "event": "users.mfa.webauthn.metadata_warning",
+            "user_id": user.id,
+            "credential_id": credential_id,
+            "aaguid": verified.aaguid or None,
+            "warnings": metadata_warnings,
+            "enforcement": enforcement,
+        }
+        if trust_score is not None:
+            audit_payload["attestation_trust_score"] = trust_score
+        if metadata_entry and metadata_entry.description:
+            audit_payload["description"] = metadata_entry.description
+        audit_logger.warning(json.dumps(audit_payload, ensure_ascii=False))
+    blockable_warnings = {
+        "metadata_error",
+        "metadata_missing",
+        "untrusted_status",
+        "transport_mismatch",
+        "backup_not_permitted",
+    }
+    if enforcement == "strict" and any(
+        warning in blockable_warnings for warning in metadata_warnings
+    ):
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            "Authenticator attestation failed metadata policy",
+        )
     record = MfaWebAuthnCredential(
         user_id=user.id,
         credential_id=credential_id,
@@ -591,6 +677,11 @@ async def complete_webauthn_enrollment(
         device_name=device_name,
         backed_up=verified.credential_backed_up,
         clone_warning=False,
+        aaguid=verified.aaguid or None,
+        attestation_format=verified.fmt.value if verified.fmt else None,
+        attestation_trust_score=trust_score,
+        attestation_metadata=metadata_info,
+        metadata_warnings=metadata_warnings or None,
     )
     db.add(record)
     await db.flush()

--- a/root/app/auth/mfa.py
+++ b/root/app/auth/mfa.py
@@ -51,8 +51,8 @@ from app.models.models import (
     MfaWebAuthnCredential,
     User,
 )
-from app.utils import ratelimit as ratelimit_utils
 from app.services.webauthn_metadata import MetadataLoadError, metadata_resolver
+from app.utils import ratelimit as ratelimit_utils
 
 _RECOVERY_CODE_ALPHABET = "23456789ABCDEFGHJKLMNPQRSTUVWXYZ"
 _RECOVERY_CODE_LENGTH = 10

--- a/root/app/core/config.py
+++ b/root/app/core/config.py
@@ -153,6 +153,10 @@ class Settings(BaseSettings):
     mfa_webauthn_rp_id: str = "localhost"
     mfa_webauthn_rp_name: str = "University Ecosystem"
     mfa_webauthn_origin: str = "http://localhost:5173"
+    mfa_webauthn_metadata_url: str = ""
+    mfa_webauthn_metadata_json: str = ""
+    mfa_webauthn_metadata_refresh_seconds: int = 86_400
+    mfa_webauthn_metadata_enforcement: str = "log"
     mfa_step_up_ttl_seconds: int = 300
     security_csp: str = ""
     # Extra hosts for connect-src; merged with defaults dynamically.
@@ -255,6 +259,25 @@ class Settings(BaseSettings):
     @classmethod
     def _validate_mfa_webauthn_origin(cls, value: str) -> str:
         return _validate_webauthn_origin(value)
+
+    @field_validator("mfa_webauthn_metadata_enforcement")
+    @classmethod
+    def _validate_webauthn_metadata_enforcement(cls, value: str) -> str:
+        normalized = value.strip().lower()
+        if normalized not in {"disabled", "log", "strict"}:
+            raise ValueError(
+                "MFA_WEBAUTHN_METADATA_ENFORCEMENT must be disabled, log, or strict"
+            )
+        return normalized
+
+    @field_validator("mfa_webauthn_metadata_refresh_seconds")
+    @classmethod
+    def _validate_webauthn_metadata_refresh(cls, value: int) -> int:
+        if value < 0:
+            raise ValueError(
+                "MFA_WEBAUTHN_METADATA_REFRESH_SECONDS must be zero or positive"
+            )
+        return value
 
     @field_validator(
         "mfa_challenge_ttl_seconds",

--- a/root/app/models/models.py
+++ b/root/app/models/models.py
@@ -270,6 +270,11 @@ class MfaWebAuthnCredential(Base):
     device_name = Column(String(255))
     backed_up = Column(Boolean, nullable=False, default=False, index=True)
     clone_warning = Column(Boolean, nullable=False, default=False)
+    aaguid = Column(String(64), nullable=True, index=True)
+    attestation_format = Column(String(64), nullable=True)
+    attestation_trust_score = Column(Integer, nullable=True)
+    attestation_metadata = Column(JSON, nullable=True)
+    metadata_warnings = Column(JSON, nullable=True)
     created_at = Column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/root/app/services/webauthn_metadata.py
+++ b/root/app/services/webauthn_metadata.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+import httpx
+
+from app.core.config import settings
+
+logger = logging.getLogger("app.auth.webauthn.metadata")
+
+
+@dataclass(frozen=True, slots=True)
+class MetadataEntry:
+    """Summary information for a WebAuthn authenticator."""
+
+    aaguid: str
+    description: str | None
+    attestation_root_certificates: tuple[str, ...]
+    status_reports: tuple[Mapping[str, Any], ...]
+    allowed_transports: frozenset[str]
+    backup_eligible: bool | None
+    trust_score: int
+    status_warning: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serialisable representation of the metadata."""
+
+        return {
+            "aaguid": self.aaguid,
+            "description": self.description,
+            "attestation_root_certificates": list(self.attestation_root_certificates),
+            "status_reports": [dict(report) for report in self.status_reports],
+            "allowed_transports": sorted(self.allowed_transports),
+            "backup_eligible": self.backup_eligible,
+            "trust_score": self.trust_score,
+            "status_warning": self.status_warning,
+        }
+
+
+class MetadataLoadError(RuntimeError):
+    """Raised when metadata cannot be loaded."""
+
+
+class WebAuthnMetadataResolver:
+    """Resolve metadata for authenticators via the FIDO Metadata Service."""
+
+    def __init__(self) -> None:
+        self._lock = asyncio.Lock()
+        self._entries: dict[str, MetadataEntry] = {}
+        self._trusted_roots: dict[str, tuple[str, ...]] = {}
+        self._fetched_at: float | None = None
+
+    async def get_entry(self, aaguid: str | None) -> MetadataEntry | None:
+        if not aaguid:
+            return None
+        await self._ensure_fresh()
+        return self._entries.get(aaguid.lower())
+
+    async def get_trusted_root_certificates(self) -> dict[str, tuple[str, ...]]:
+        await self._ensure_fresh()
+        return dict(self._trusted_roots)
+
+    async def refresh(self, *, force: bool = False) -> None:
+        if not force and not await self._should_refresh():
+            return
+        async with self._lock:
+            if not force and not await self._should_refresh():
+                return
+            await self._reload()
+
+    def invalidate(self) -> None:
+        self._entries.clear()
+        self._trusted_roots.clear()
+        self._fetched_at = None
+
+    async def _ensure_fresh(self) -> None:
+        await self.refresh()
+
+    async def _should_refresh(self) -> bool:
+        if not (settings.mfa_webauthn_metadata_url or settings.mfa_webauthn_metadata_json):
+            if self._entries:
+                self.invalidate()
+            return False
+        if self._fetched_at is None:
+            return True
+        ttl = max(0, settings.mfa_webauthn_metadata_refresh_seconds)
+        if ttl == 0:
+            return True
+        return (time.time() - self._fetched_at) >= ttl
+
+    async def _reload(self) -> None:
+        try:
+            raw = await self._load_source()
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("Failed to load WebAuthn metadata: %s", exc)
+            raise MetadataLoadError(str(exc)) from exc
+        if raw is None:
+            self.invalidate()
+            self._fetched_at = time.time()
+            return
+        entries = self._parse_entries(raw)
+        self._entries = entries
+        self._trusted_roots = {
+            aaguid: entry.attestation_root_certificates for aaguid, entry in entries.items()
+        }
+        self._fetched_at = time.time()
+
+    async def _load_source(self) -> Mapping[str, Any] | None:
+        json_payload = settings.mfa_webauthn_metadata_json.strip()
+        if json_payload:
+            try:
+                return json.loads(json_payload)
+            except json.JSONDecodeError as exc:
+                raise MetadataLoadError("Invalid MFA WebAuthn metadata JSON") from exc
+        url = settings.mfa_webauthn_metadata_url.strip()
+        if not url:
+            return {"entries": []}
+        timeout = httpx.Timeout(10.0, read=20.0)
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            response = await client.get(url)
+            response.raise_for_status()
+            return response.json()
+
+    def _parse_entries(self, raw: Mapping[str, Any]) -> dict[str, MetadataEntry]:
+        entries_data = raw.get("entries")
+        if not isinstance(entries_data, list):
+            return {}
+        result: dict[str, MetadataEntry] = {}
+        for item in entries_data:
+            if not isinstance(item, Mapping):  # pragma: no cover - defensive
+                continue
+            metadata = self._build_entry(item)
+            if metadata:
+                result[metadata.aaguid] = metadata
+        return result
+
+    def _build_entry(self, payload: Mapping[str, Any]) -> MetadataEntry | None:
+        statement = payload.get("metadataStatement")
+        if not isinstance(statement, Mapping):
+            return None
+        aaguid = (payload.get("aaguid") or statement.get("aaguid") or "").strip()
+        if not aaguid:
+            return None
+        aaguid = aaguid.lower()
+        description = statement.get("description")
+        root_certs = tuple(
+            cert
+            for cert in statement.get("attestationRootCertificates", [])
+            if isinstance(cert, str) and cert.strip()
+        )
+        status_reports_raw = payload.get("statusReports") or []
+        status_reports: list[Mapping[str, Any]] = []
+        for report in status_reports_raw:
+            if isinstance(report, Mapping):
+                status_reports.append(report)
+        transports: set[str] = set()
+        get_info = statement.get("authenticatorGetInfo")
+        if isinstance(get_info, Mapping):
+            for transport in get_info.get("transports", []) or []:
+                if isinstance(transport, str):
+                    transports.add(transport.lower())
+        default_transports = statement.get("defaultTransports") or []
+        for transport in default_transports:
+            if isinstance(transport, str):
+                transports.add(transport.lower())
+        backup_eligible = statement.get("isBackupEligible")
+        if isinstance(backup_eligible, str):
+            backup_eligible = backup_eligible.lower() in {"true", "1", "yes"}
+        elif not isinstance(backup_eligible, bool):
+            backup_eligible = None
+        trust_score, status_warning = self._compute_trust_score(status_reports)
+        return MetadataEntry(
+            aaguid=aaguid,
+            description=description if isinstance(description, str) else None,
+            attestation_root_certificates=root_certs,
+            status_reports=tuple(status_reports),
+            allowed_transports=frozenset(transports),
+            backup_eligible=backup_eligible,
+            trust_score=trust_score,
+            status_warning=status_warning,
+        )
+
+    def _compute_trust_score(
+        self, status_reports: list[Mapping[str, Any]]
+    ) -> tuple[int, bool]:
+        if not status_reports:
+            return (50, False)
+        score = 50
+        warning = False
+        for report in status_reports:
+            status = str(report.get("status") or "").upper()
+            if not status:
+                continue
+            if status in {
+                "REVOKED",
+                "ATTESTATION_KEY_COMPROMISE",
+                "USER_VERIFICATION_BYPASS",
+                "FIDO_CERTIFIED_WITH_METADATA_L1",
+                "CERTIFIED_WITH_METADATA_L1_REVOKED",
+                "CERTIFIED_WITH_METADATA_L2_REVOKED",
+            }:
+                return (0, True)
+            if status.startswith("FIDO_CERTIFIED"):
+                score = max(score, 100)
+            elif status in {"NOT_FIDO_CERTIFIED", "SELF_ASSERTION_SUBMITTED"}:
+                score = max(score, 40)
+            elif status.endswith("UPDATE_AVAILABLE"):
+                warning = True
+                score = max(score, 60)
+        return (score, warning)
+
+
+metadata_resolver = WebAuthnMetadataResolver()
+
+__all__ = ["MetadataEntry", "MetadataLoadError", "WebAuthnMetadataResolver", "metadata_resolver"]

--- a/root/app/services/webauthn_metadata.py
+++ b/root/app/services/webauthn_metadata.py
@@ -82,7 +82,9 @@ class WebAuthnMetadataResolver:
         await self.refresh()
 
     async def _should_refresh(self) -> bool:
-        if not (settings.mfa_webauthn_metadata_url or settings.mfa_webauthn_metadata_json):
+        if not (
+            settings.mfa_webauthn_metadata_url or settings.mfa_webauthn_metadata_json
+        ):
             if self._entries:
                 self.invalidate()
             return False
@@ -106,7 +108,8 @@ class WebAuthnMetadataResolver:
         entries = self._parse_entries(raw)
         self._entries = entries
         self._trusted_roots = {
-            aaguid: entry.attestation_root_certificates for aaguid, entry in entries.items()
+            aaguid: entry.attestation_root_certificates
+            for aaguid, entry in entries.items()
         }
         self._fetched_at = time.time()
 
@@ -217,4 +220,9 @@ class WebAuthnMetadataResolver:
 
 metadata_resolver = WebAuthnMetadataResolver()
 
-__all__ = ["MetadataEntry", "MetadataLoadError", "WebAuthnMetadataResolver", "metadata_resolver"]
+__all__ = [
+    "MetadataEntry",
+    "MetadataLoadError",
+    "WebAuthnMetadataResolver",
+    "metadata_resolver",
+]

--- a/root/tests/test_auth_mfa.py
+++ b/root/tests/test_auth_mfa.py
@@ -8,11 +8,10 @@ import pyotp
 import pytest
 from fastapi import HTTPException, status
 from sqlalchemy import select
-
 from webauthn.helpers.structs import (
+    AttestationFormat,
     AuthenticatorAttestationResponse,
     AuthenticatorTransport,
-    AttestationFormat,
     CredentialDeviceType,
     PublicKeyCredentialType,
     RegistrationCredential,
@@ -685,7 +684,9 @@ async def test_webauthn_enrollment_with_trusted_metadata(
             }
         ]
     }
-    monkeypatch.setattr(settings, "mfa_webauthn_metadata_json", json.dumps(metadata_payload))
+    monkeypatch.setattr(
+        settings, "mfa_webauthn_metadata_json", json.dumps(metadata_payload)
+    )
     monkeypatch.setattr(settings, "mfa_webauthn_metadata_url", "")
     monkeypatch.setattr(settings, "mfa_webauthn_metadata_enforcement", "log")
     metadata_resolver.invalidate()
@@ -750,7 +751,8 @@ async def test_webauthn_enrollment_with_trusted_metadata(
             continue
         audit_events.append(payload)
     assert not any(
-        event.get("event") == "users.mfa.webauthn.metadata_warning" for event in audit_events
+        event.get("event") == "users.mfa.webauthn.metadata_warning"
+        for event in audit_events
     )
 
     metadata_resolver.invalidate()
@@ -780,7 +782,9 @@ async def test_webauthn_enrollment_rejects_untrusted_authenticator(
             }
         ]
     }
-    monkeypatch.setattr(settings, "mfa_webauthn_metadata_json", json.dumps(metadata_payload))
+    monkeypatch.setattr(
+        settings, "mfa_webauthn_metadata_json", json.dumps(metadata_payload)
+    )
     monkeypatch.setattr(settings, "mfa_webauthn_metadata_url", "")
     monkeypatch.setattr(settings, "mfa_webauthn_metadata_enforcement", "strict")
     metadata_resolver.invalidate()
@@ -847,7 +851,7 @@ async def test_webauthn_enrollment_rejects_untrusted_authenticator(
 @pytest.mark.anyio
 async def test_webauthn_metadata_resolver_refresh(monkeypatch):
     metadata_resolver.invalidate()
-    monkeypatch.setattr(settings, "mfa_webauthn_metadata_json", "{\"entries\": []}")
+    monkeypatch.setattr(settings, "mfa_webauthn_metadata_json", '{"entries": []}')
     monkeypatch.setattr(settings, "mfa_webauthn_metadata_url", "")
     monkeypatch.setattr(settings, "mfa_webauthn_metadata_refresh_seconds", 60)
 

--- a/root/tests/test_auth_mfa.py
+++ b/root/tests/test_auth_mfa.py
@@ -6,8 +6,18 @@ from types import SimpleNamespace
 
 import pyotp
 import pytest
-from fastapi import status
+from fastapi import HTTPException, status
 from sqlalchemy import select
+
+from webauthn.helpers.structs import (
+    AuthenticatorAttestationResponse,
+    AuthenticatorTransport,
+    AttestationFormat,
+    CredentialDeviceType,
+    PublicKeyCredentialType,
+    RegistrationCredential,
+)
+from webauthn.registration.verify_registration_response import VerifiedRegistration
 
 from app.api import users as users_api
 from app.auth import mfa
@@ -15,6 +25,7 @@ from app.auth.security import get_password_hash
 from app.core.config import settings
 from app.management import reset_mfa
 from app.models import models
+from app.services.webauthn_metadata import metadata_resolver
 
 
 def _base64url(data: bytes) -> str:
@@ -302,11 +313,16 @@ async def test_webauthn_attestation_and_assertion_flow(
 
     def fake_verify_registration_response(**kwargs):
         assert kwargs["expected_challenge"] == registration_challenge
-        return SimpleNamespace(
+        return VerifiedRegistration(
             credential_id=credential_id,
             credential_public_key=public_key,
             sign_count=1,
-            transports=["internal"],
+            aaguid="cccccccc-cccc-cccc-cccc-cccccccccccc",
+            fmt=AttestationFormat.PACKED,
+            credential_type=PublicKeyCredentialType.PUBLIC_KEY,
+            user_verified=True,
+            attestation_object=b"attestation",
+            credential_device_type=CredentialDeviceType.MULTI_DEVICE,
             credential_backed_up=False,
         )
 
@@ -643,3 +659,217 @@ async def test_reset_mfa_command_noop_logs_reason(user_factory, caplog, monkeypa
     audit_event = _find_audit_event(caplog, "app.users.audit", "users.mfa.reset")
     assert audit_event["user_id"] == str(user.id)
     assert audit_event["reason"] == "admin_reset_noop"
+
+
+@pytest.mark.anyio
+async def test_webauthn_enrollment_with_trusted_metadata(
+    db_session, user_factory, monkeypatch, caplog
+):
+    caplog.set_level(logging.WARNING, logger="app.users.audit")
+    user = await user_factory(
+        email="trusted-webauthn@example.com",
+        hashed_password=get_password_hash("TrustedPass123!"),
+    )
+
+    metadata_payload = {
+        "entries": [
+            {
+                "aaguid": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                "metadataStatement": {
+                    "description": "Trusted Hardware Key",
+                    "attestationRootCertificates": ["root-cert"],
+                    "authenticatorGetInfo": {"transports": ["usb", "nfc"]},
+                    "isBackupEligible": False,
+                },
+                "statusReports": [{"status": "FIDO_CERTIFIED"}],
+            }
+        ]
+    }
+    monkeypatch.setattr(settings, "mfa_webauthn_metadata_json", json.dumps(metadata_payload))
+    monkeypatch.setattr(settings, "mfa_webauthn_metadata_url", "")
+    monkeypatch.setattr(settings, "mfa_webauthn_metadata_enforcement", "log")
+    metadata_resolver.invalidate()
+
+    challenge = await mfa.issue_challenge(
+        db_session,
+        user_id=user.id,
+        challenge_type=mfa.CHALLENGE_TYPE_WEBAUTHN_ENROLL,
+        payload={"challenge": _base64url(b"challenge")},
+    )
+
+    response = AuthenticatorAttestationResponse(
+        client_data_json=b"client",
+        attestation_object=b"object",
+        transports=[AuthenticatorTransport.USB],
+    )
+    registration = RegistrationCredential(
+        id="cred-id",
+        raw_id=b"cred-id",
+        response=response,
+    )
+    verified = VerifiedRegistration(
+        credential_id=b"cred-id",
+        credential_public_key=b"public",
+        sign_count=1,
+        aaguid="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        fmt=AttestationFormat.PACKED,
+        credential_type=PublicKeyCredentialType.PUBLIC_KEY,
+        user_verified=True,
+        attestation_object=b"object",
+        credential_device_type=CredentialDeviceType.MULTI_DEVICE,
+        credential_backed_up=False,
+    )
+    monkeypatch.setattr(mfa, "verify_registration_response", lambda **_: verified)
+
+    record = await mfa.complete_webauthn_enrollment(
+        db_session,
+        user=user,
+        credential=registration,
+        challenge_token=challenge.token,
+        device_name="Trusted Key",
+    )
+    await db_session.flush()
+
+    assert record.aaguid == verified.aaguid
+    assert record.attestation_trust_score == 100
+    assert record.metadata_warnings is None
+    assert record.attestation_metadata["description"] == "Trusted Hardware Key"
+    assert record.attestation_metadata["attestation_root_certificates"] == ["root-cert"]
+    assert set(record.attestation_metadata["allowed_transports"]) == {"nfc", "usb"}
+
+    trusted_roots = await metadata_resolver.get_trusted_root_certificates()
+    assert trusted_roots[verified.aaguid] == ("root-cert",)
+
+    audit_events: list[dict] = []
+    for entry in caplog.records:
+        if entry.name != "app.users.audit":
+            continue
+        try:
+            payload = json.loads(entry.message)
+        except json.JSONDecodeError:  # pragma: no cover - defensive guard
+            continue
+        audit_events.append(payload)
+    assert not any(
+        event.get("event") == "users.mfa.webauthn.metadata_warning" for event in audit_events
+    )
+
+    metadata_resolver.invalidate()
+
+
+@pytest.mark.anyio
+async def test_webauthn_enrollment_rejects_untrusted_authenticator(
+    db_session, user_factory, monkeypatch, caplog
+):
+    caplog.set_level(logging.WARNING, logger="app.users.audit")
+    user = await user_factory(
+        email="untrusted-webauthn@example.com",
+        hashed_password=get_password_hash("UntrustedPass123!"),
+    )
+
+    metadata_payload = {
+        "entries": [
+            {
+                "aaguid": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+                "metadataStatement": {
+                    "description": "Revoked Key",
+                    "attestationRootCertificates": ["revoked-root"],
+                    "authenticatorGetInfo": {"transports": ["usb"]},
+                    "isBackupEligible": True,
+                },
+                "statusReports": [{"status": "REVOKED"}],
+            }
+        ]
+    }
+    monkeypatch.setattr(settings, "mfa_webauthn_metadata_json", json.dumps(metadata_payload))
+    monkeypatch.setattr(settings, "mfa_webauthn_metadata_url", "")
+    monkeypatch.setattr(settings, "mfa_webauthn_metadata_enforcement", "strict")
+    metadata_resolver.invalidate()
+
+    challenge = await mfa.issue_challenge(
+        db_session,
+        user_id=user.id,
+        challenge_type=mfa.CHALLENGE_TYPE_WEBAUTHN_ENROLL,
+        payload={"challenge": _base64url(b"challenge")},
+    )
+
+    response = AuthenticatorAttestationResponse(
+        client_data_json=b"client",
+        attestation_object=b"object",
+        transports=[AuthenticatorTransport.USB],
+    )
+    registration = RegistrationCredential(
+        id="revoked",
+        raw_id=b"revoked",
+        response=response,
+    )
+    verified = VerifiedRegistration(
+        credential_id=b"revoked",
+        credential_public_key=b"public",
+        sign_count=1,
+        aaguid="bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+        fmt=AttestationFormat.PACKED,
+        credential_type=PublicKeyCredentialType.PUBLIC_KEY,
+        user_verified=True,
+        attestation_object=b"object",
+        credential_device_type=CredentialDeviceType.MULTI_DEVICE,
+        credential_backed_up=True,
+    )
+    monkeypatch.setattr(mfa, "verify_registration_response", lambda **_: verified)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await mfa.complete_webauthn_enrollment(
+            db_session,
+            user=user,
+            credential=registration,
+            challenge_token=challenge.token,
+            device_name="Revoked Key",
+        )
+
+    assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
+
+    warning_events: list[dict] = []
+    for entry in caplog.records:
+        if entry.name != "app.users.audit":
+            continue
+        try:
+            payload = json.loads(entry.message)
+        except json.JSONDecodeError:  # pragma: no cover - defensive guard
+            continue
+        if payload.get("event") == "users.mfa.webauthn.metadata_warning":
+            warning_events.append(payload)
+    assert warning_events, "Expected metadata warning audit event"
+    assert "untrusted_status" in warning_events[0]["warnings"]
+    assert warning_events[0].get("attestation_trust_score") == 0
+
+    metadata_resolver.invalidate()
+
+
+@pytest.mark.anyio
+async def test_webauthn_metadata_resolver_refresh(monkeypatch):
+    metadata_resolver.invalidate()
+    monkeypatch.setattr(settings, "mfa_webauthn_metadata_json", "{\"entries\": []}")
+    monkeypatch.setattr(settings, "mfa_webauthn_metadata_url", "")
+    monkeypatch.setattr(settings, "mfa_webauthn_metadata_refresh_seconds", 60)
+
+    calls: list[int] = []
+
+    async def fake_load_source():
+        calls.append(1)
+        return {"entries": []}
+
+    monkeypatch.setattr(metadata_resolver, "_load_source", fake_load_source)
+
+    await metadata_resolver.refresh(force=True)
+    assert len(calls) == 1
+
+    await metadata_resolver.refresh()
+    assert len(calls) == 1
+
+    monkeypatch.setattr(settings, "mfa_webauthn_metadata_refresh_seconds", 0)
+    await metadata_resolver.refresh()
+    assert len(calls) == 2
+
+    await metadata_resolver.refresh(force=True)
+    assert len(calls) == 3
+
+    metadata_resolver.invalidate()


### PR DESCRIPTION
## Summary
- add a WebAuthn metadata resolver service that fetches FIDO metadata, caches trusted roots, and exposes lookup helpers
- extend WebAuthn enrollment to persist attestation metadata, enforce configurable policies, and emit audit warnings
- introduce configuration knobs for metadata sources/enforcement and add targeted MFA tests for trusted/untrusted authenticators

## Testing
- pytest root/tests/test_auth_mfa.py

------
https://chatgpt.com/codex/tasks/task_e_68fd0be16620832798cf1f5937450204