### PR TITLE
feat: migrate news page to use a React Query news feed hook

### DIFF
--- a/root/frontend/src/hooks/useNewsFeed.ts
+++ b/root/frontend/src/hooks/useNewsFeed.ts
@@ -108,8 +108,6 @@ const clearLegacyStorageKeys = () => {
 const buildQueryKey = (language: SupportedLanguage) =>
   ["news", "feed", language] as const satisfies QueryKey
 
-type NewsFeedQueryKey = ReturnType<typeof buildQueryKey>
-
 const fetchNewsSnapshot = async (
   language: SupportedLanguage,
   signal: AbortSignal | undefined,

--- a/root/frontend/src/hooks/useNewsFeed.ts
+++ b/root/frontend/src/hooks/useNewsFeed.ts
@@ -1,0 +1,214 @@
+import { useEffect, useMemo } from "react"
+import { useQuery, useQueryClient, type QueryKey } from "@tanstack/react-query"
+import { isAxiosError } from "axios"
+
+import { fetchNews, parseNewsList, type NewsItem } from "@/api/news"
+import { ApiResponseValidationError } from "@/api/validation"
+import type { SupportedLanguage } from "@/contexts/LanguageContext"
+
+const NEWS_CACHE_NAME = "api-cache"
+const NEWS_ENDPOINT = "/api/news"
+const ACCEPT_LANGUAGE_HEADER = "Accept-Language"
+const JSON_CONTENT_TYPE = "application/json"
+
+const LEGACY_STORAGE_KEYS = [
+  "news:list",
+  "news:etag",
+  "news:list:ru",
+  "news:list:en",
+  "news:etag:ru",
+  "news:etag:en",
+]
+
+type NewsFeedSnapshot = {
+  items: NewsItem[]
+  etag: string | null
+}
+
+const buildCacheRequest = (language: SupportedLanguage) => {
+  const base = typeof window !== "undefined" ? window.location.origin : ""
+  const url = base ? new URL(NEWS_ENDPOINT, base).toString() : NEWS_ENDPOINT
+  const headers = new Headers()
+  headers.set(ACCEPT_LANGUAGE_HEADER, language)
+  return new Request(url, {
+    headers,
+    credentials: "include",
+  })
+}
+
+const readCacheSnapshot = async (language: SupportedLanguage) => {
+  if (typeof window === "undefined" || !("caches" in window) || !window.caches) {
+    return undefined
+  }
+
+  try {
+    const cache = await window.caches.open(NEWS_CACHE_NAME)
+    const response = await cache.match(buildCacheRequest(language), { ignoreMethod: true })
+    if (!response) return undefined
+
+    try {
+      const payload = await response.clone().json()
+      const items = parseNewsList(payload)
+      const etag = response.headers.get("etag")
+      return { items, etag: etag ?? null }
+    } catch (error) {
+      if (!(error instanceof ApiResponseValidationError)) {
+        console.warn("useNewsFeed: failed to parse cached payload", error)
+      }
+      return undefined
+    }
+  } catch (error) {
+    console.warn("useNewsFeed: failed to read cache", error)
+    return undefined
+  }
+}
+
+const persistCacheSnapshot = async (language: SupportedLanguage, snapshot: NewsFeedSnapshot) => {
+  if (typeof window === "undefined" || !("caches" in window) || !window.caches) {
+    return
+  }
+
+  try {
+    const cache = await window.caches.open(NEWS_CACHE_NAME)
+    const headers = new Headers({
+      "Content-Type": JSON_CONTENT_TYPE,
+    })
+    if (snapshot.etag) {
+      headers.set("ETag", snapshot.etag)
+    }
+
+    const response = new Response(JSON.stringify(snapshot.items), {
+      status: 200,
+      headers,
+    })
+
+    await cache.put(buildCacheRequest(language), response)
+  } catch (error) {
+    console.warn("useNewsFeed: failed to persist cache", error)
+  }
+}
+
+let legacyKeysCleared = false
+
+const clearLegacyStorageKeys = () => {
+  if (legacyKeysCleared || typeof window === "undefined") {
+    return
+  }
+  try {
+    const storage = window.localStorage
+    for (const key of LEGACY_STORAGE_KEYS) {
+      storage.removeItem(key)
+    }
+  } catch {
+    /* noop */
+  }
+  legacyKeysCleared = true
+}
+
+const buildQueryKey = (language: SupportedLanguage) =>
+  ["news", "feed", language] as const satisfies QueryKey
+
+type NewsFeedQueryKey = ReturnType<typeof buildQueryKey>
+
+const fetchNewsSnapshot = async (
+  language: SupportedLanguage,
+  signal: AbortSignal | undefined,
+  getCached: () => NewsFeedSnapshot | undefined | Promise<NewsFeedSnapshot | undefined>
+) => {
+  let cached: NewsFeedSnapshot | undefined
+  const resolveCached = async () => {
+    if (cached) return cached
+    const maybeCached = await getCached()
+    if (maybeCached) {
+      cached = maybeCached
+    }
+    return cached
+  }
+
+  const previous = await resolveCached()
+  const ifNoneMatch = previous?.etag ?? undefined
+
+  try {
+    const response = await fetchNews({ ifNoneMatch, signal })
+    if (response.status === 304) {
+      return (
+        previous ??
+        (await resolveCached()) ?? {
+          items: [],
+          etag: ifNoneMatch ?? null,
+        }
+      )
+    }
+
+    const items = parseNewsList(response.data)
+    const etagHeader = response.headers?.etag
+    const etag = typeof etagHeader === "string" ? etagHeader : null
+    const snapshot: NewsFeedSnapshot = { items, etag }
+    await persistCacheSnapshot(language, snapshot)
+    return snapshot
+  } catch (error) {
+    if (signal?.aborted) {
+      throw error
+    }
+    if (isAxiosError(error) && error.code === "ERR_CANCELED") {
+      throw error
+    }
+
+    const fallback = (await resolveCached()) ?? previous
+    if (fallback) {
+      return fallback
+    }
+    throw error
+  }
+}
+
+export const useNewsFeed = (language: SupportedLanguage) => {
+  const queryClient = useQueryClient()
+
+  const queryKey = useMemo(() => buildQueryKey(language), [language])
+
+  useEffect(() => {
+    clearLegacyStorageKeys()
+  }, [])
+
+  useEffect(() => {
+    let cancelled = false
+    const syncFromCache = async () => {
+      const existing = queryClient.getQueryData<NewsFeedSnapshot>(queryKey)
+      if (existing?.items?.length) return
+      const cached = await readCacheSnapshot(language)
+      if (cancelled || !cached) return
+      queryClient.setQueryData(queryKey, cached)
+    }
+    void syncFromCache()
+    return () => {
+      cancelled = true
+    }
+  }, [language, queryClient, queryKey])
+
+  const query = useQuery<NewsFeedSnapshot, Error, NewsItem[], NewsFeedQueryKey>({
+    queryKey,
+    queryFn: async ({ signal }) =>
+      fetchNewsSnapshot(language, signal, () =>
+        queryClient.getQueryData<NewsFeedSnapshot>(queryKey) ?? readCacheSnapshot(language)
+      ),
+    select: (snapshot) => snapshot.items,
+    placeholderData: (previous) => previous,
+    staleTime: 2 * 60_000,
+    gcTime: 30 * 60_000,
+    networkMode: "offlineFirst",
+    retry: (failureCount, error) => {
+      if (isAxiosError(error) && error.response?.status && error.response.status < 500) {
+        return false
+      }
+      return failureCount < 2
+    },
+  })
+
+  return query
+}
+
+export type UseNewsFeedResult = ReturnType<typeof useNewsFeed>
+export type NewsFeedQueryKey = ReturnType<typeof buildQueryKey>
+
+export const newsFeedQueryKey = buildQueryKey

--- a/root/frontend/src/hooks/useNewsFeed.ts
+++ b/root/frontend/src/hooks/useNewsFeed.ts
@@ -189,8 +189,10 @@ export const useNewsFeed = (language: SupportedLanguage) => {
   const query = useQuery<NewsFeedSnapshot, Error, NewsItem[], NewsFeedQueryKey>({
     queryKey,
     queryFn: async ({ signal }) =>
-      fetchNewsSnapshot(language, signal, () =>
-        queryClient.getQueryData<NewsFeedSnapshot>(queryKey) ?? readCacheSnapshot(language)
+      fetchNewsSnapshot(
+        language,
+        signal,
+        () => queryClient.getQueryData<NewsFeedSnapshot>(queryKey) ?? readCacheSnapshot(language)
       ),
     select: (snapshot) => snapshot.items,
     placeholderData: (previous) => previous,

--- a/root/frontend/src/pages/News.tsx
+++ b/root/frontend/src/pages/News.tsx
@@ -29,8 +29,7 @@ import SmartImage from "@/components/SmartImage"
 import { useAuth } from "../contexts/AuthContext"
 import { useLanguage } from "../contexts/LanguageContext"
 import { useTranslation } from "react-i18next"
-import { ApiResponseValidationError } from "@/api/validation"
-import { fetchNews as fetchNewsRequest, parseNewsList, type NewsItem } from "@/api/news"
+import { useNewsFeed } from "@/hooks/useNewsFeed"
 
 type NewsFormState = {
   title: string
@@ -50,105 +49,20 @@ const News = () => {
   const { user } = useAuth()
   const { t } = useTranslation(["news", "common"])
   const { language } = useLanguage()
-  const [newsList, setNewsList] = useState<NewsItem[]>([])
+  const { data: newsDataList, refetch: refetchNews, isPending, isFetching } = useNewsFeed(language)
+  const newsList = newsDataList ?? []
   const deferredList = useDeferredValue(newsList)
   const [visibleCount, setVisibleCount] = useState(0)
   const [addOpen, setAddOpen] = useState(false)
   const [newsData, setNewsData] = useState(initialNews)
   const [adding, setAdding] = useState(false)
-  const [loading, setLoading] = useState(false)
   const [imageFile, setImageFile] = useState<File | null>(null)
   const [imagePreview, setImagePreview] = useState<string | null>(null)
   const imageInputRef = useRef<HTMLInputElement | null>(null)
-  const hydratedFromCache = useRef(false)
   const isMobile = useMediaQuery("(max-width:600px)")
 
-  const cacheKey = useMemo(() => `news:list:${language}`, [language])
-  const etagKey = useMemo(() => `news:etag:${language}`, [language])
-  const legacyCacheKey = "news:list"
-  const legacyEtagKey = "news:etag"
-
-  const fetchNews = useCallback(
-    async (signal?: AbortSignal) => {
-      const cachedPrimary = localStorage.getItem(cacheKey)
-      const cachedLegacy = language === "ru" ? localStorage.getItem(legacyCacheKey) : null
-      const cached = cachedPrimary ?? cachedLegacy
-
-      if (cached && !hydratedFromCache.current) {
-        try {
-          const arr = parseNewsList(JSON.parse(cached))
-          startTransition(() => setNewsList(arr))
-          hydratedFromCache.current = true
-        } catch (error) {
-          if (!(error instanceof ApiResponseValidationError)) {
-            console.error(error)
-          }
-        }
-      }
-
-      const shouldShowLoader = !cached && !hydratedFromCache.current
-      if (shouldShowLoader) setLoading(true)
-
-      try {
-        const storedTagPrimary = localStorage.getItem(etagKey)
-        const storedTagLegacy = language === "ru" ? localStorage.getItem(legacyEtagKey) : null
-        const etag = storedTagPrimary ?? storedTagLegacy ?? ""
-        const res = await fetchNewsRequest({
-          ifNoneMatch: etag,
-          signal,
-        })
-
-        if (signal?.aborted) return
-
-        if (res.status === 200) {
-          let arr: NewsItem[] = []
-          try {
-            arr = parseNewsList(res.data)
-          } catch (error) {
-            if (!(error instanceof ApiResponseValidationError)) {
-              console.error(error)
-            }
-          }
-          startTransition(() => setNewsList(arr))
-          hydratedFromCache.current = true
-          localStorage.setItem(cacheKey, JSON.stringify(arr))
-          if (language === "ru") localStorage.setItem(legacyCacheKey, JSON.stringify(arr))
-          const newTag = (res.headers?.etag as string) || ""
-          if (newTag) {
-            localStorage.setItem(etagKey, newTag)
-            if (language === "ru") localStorage.setItem(legacyEtagKey, newTag)
-          }
-        } else if (res.status === 304 && cached) {
-          try {
-            const arr = parseNewsList(JSON.parse(cached))
-            startTransition(() => setNewsList(arr))
-            hydratedFromCache.current = true
-          } catch {
-            startTransition(() => setNewsList([]))
-          }
-        }
-      } catch {
-        if (signal?.aborted) {
-          return
-        }
-        if (!cached) startTransition(() => setNewsList([]))
-      } finally {
-        if (!signal?.aborted && shouldShowLoader) {
-          setLoading(false)
-        }
-      }
-      if (signal?.aborted) {
-        return
-      }
-    },
-    [cacheKey, etagKey, language, legacyCacheKey, legacyEtagKey]
-  )
-
-  useEffect(() => {
-    const controller = new AbortController()
-    void fetchNews(controller.signal)
-    return () => controller.abort()
-  }, [fetchNews])
+  const isInitialLoading = isPending && newsList.length === 0
+  const showEmptyState = !isInitialLoading && !isFetching && newsList.length === 0
 
   useEffect(() => {
     return () => {
@@ -231,12 +145,12 @@ const News = () => {
         URL.revokeObjectURL(imagePreview)
         setImagePreview(null)
       }
-      void fetchNews()
+      void refetchNews()
       if (imageInputRef.current) imageInputRef.current.value = ""
     } finally {
       setAdding(false)
     }
-  }, [adding, fetchNews, imageFile, imagePreview, language, newsData])
+  }, [adding, imageFile, imagePreview, newsData, refetchNews])
 
   const handleCloseDialog = useCallback(() => {
     setAddOpen(false)
@@ -328,13 +242,13 @@ const News = () => {
                     {...news}
                     image_url={news.image_url ?? undefined}
                     onChange={() => {
-                      void fetchNews()
+                      void refetchNews()
                     }}
                   />
                 </Box>
               ))}
 
-            {Array.isArray(newsList) && newsList.length === 0 && !loading && (
+            {Array.isArray(newsList) && showEmptyState && (
               <Box sx={{ width: "100%", textAlign: "center", mt: 7, mb: 7 }}>
                 <Typography fontSize={24} className="events-empty-text">
                   {t("news:states.empty")}

--- a/root/frontend/src/tests/pages/News/NewsFeed.test.tsx
+++ b/root/frontend/src/tests/pages/News/NewsFeed.test.tsx
@@ -1,0 +1,242 @@
+import { act, render, screen, waitFor } from "@testing-library/react"
+import { MemoryRouter } from "react-router-dom"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { HttpResponse, http } from "msw"
+import type { ContextType } from "react"
+
+import type { User } from "@/types/User"
+import { server } from "../../mocks/server"
+
+type CacheEntry = { key: string; response: Response }
+
+const buildCacheKey = (language: string) => {
+  const origin = window.location.origin
+  const url = new URL("/api/news", origin).toString()
+  return `${url}::${language}`
+}
+
+const createNewsItem = (id: number, title: string) => ({
+  id,
+  title,
+  content: `${title} content`,
+  created_at: new Date(Date.UTC(2024, 0, id)).toISOString(),
+  title_en: title,
+  content_en: `${title} content`,
+  image_url: null,
+})
+
+const createNewsResponse = (items: ReturnType<typeof createNewsItem>[], etag?: string) => {
+  const headers = new Headers({ "Content-Type": "application/json" })
+  if (etag) headers.set("ETag", etag)
+  return new Response(JSON.stringify(items), { status: 200, headers })
+}
+
+const createMockCaches = (initialEntries: CacheEntry[] = []) => {
+  const entries = new Map<string, Response>()
+  for (const entry of initialEntries) {
+    entries.set(entry.key, entry.response)
+  }
+
+  const resolveKey = (request: RequestInfo | URL) => {
+    if (typeof request === "string") {
+      const url = new URL(request, window.location.origin).toString()
+      return `${url}::`
+    }
+    if (request instanceof Request) {
+      const language = request.headers.get("accept-language") ?? ""
+      return `${request.url}::${language}`
+    }
+    if (request instanceof URL) {
+      return `${request.toString()}::`
+    }
+    return `${String(request)}::`
+  }
+
+  const match = vi.fn(async (request: RequestInfo | URL) => {
+    const key = resolveKey(request)
+    const value = entries.get(key)
+    return value ? value.clone() : undefined
+  })
+
+  const put = vi.fn(async (request: RequestInfo | URL, response: Response) => {
+    const key = resolveKey(request)
+    entries.set(key, response.clone())
+  })
+
+  const cache = {
+    match,
+    put,
+    delete: vi.fn(async () => false),
+    add: vi.fn(),
+    addAll: vi.fn(),
+    keys: vi.fn(async () => Array.from(entries.keys()).map((key) => new Request(key.split("::")[0]!))),
+  } as unknown as Cache
+
+  const cachesStorage = {
+    open: vi.fn(async () => cache),
+    match: vi.fn(),
+    has: vi.fn(),
+    delete: vi.fn(),
+    keys: vi.fn(),
+  } as unknown as CacheStorage
+
+  return { cachesStorage, cache, match, put, entries }
+}
+
+const baseUser: User = {
+  id: 1,
+  email: "user@example.com",
+  full_name: "Test User",
+  role: "student",
+  group_id: null,
+  avatar_url: null,
+  cover_url: null,
+  about: null,
+  record_book_number: null,
+  status: null,
+  institute: null,
+  course: null,
+  education_level: null,
+  track: null,
+  program: null,
+  telegram: null,
+  achievements: null,
+  department: null,
+  position: null,
+  spotify_connected: false,
+  spotify_display_name: null,
+  spotify_is_connected: null,
+  dnd_enabled: false,
+  dnd_start: null,
+  dnd_end: null,
+  is_active: true,
+  mfa_required: false,
+  mfa_default_method: null,
+  mfa_last_verified_at: null,
+  mfa_recovery_codes_generated_at: null,
+  totp_enrollments: [],
+  webauthn_credentials: [],
+  recovery_codes: [],
+  mfa_challenges: [],
+}
+
+const renderNewsPage = async (queryClient?: QueryClient) => {
+  const [{ AuthContext }, { LanguageProvider }] = await Promise.all([
+    import("@/contexts/AuthContext"),
+    import("@/contexts/LanguageContext"),
+  ])
+
+  type AuthContextValue = ContextType<typeof AuthContext>
+
+  const authValue: AuthContextValue = {
+    isAuth: true,
+    login: vi.fn().mockResolvedValue(null),
+    logout: vi.fn().mockResolvedValue(undefined),
+    user: baseUser,
+    loading: false,
+    setUser: vi.fn(),
+    refresh: vi.fn().mockResolvedValue(undefined),
+    pendingMfa: null,
+    submitMfaChallenge: vi.fn().mockResolvedValue(undefined),
+    requireMfa: vi.fn().mockResolvedValue(null),
+  }
+
+  const client =
+    queryClient ??
+    new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+      },
+    })
+
+  const { default: News } = await import("@/pages/News")
+
+  render(
+    <AuthContext.Provider value={authValue}>
+      <LanguageProvider>
+        <QueryClientProvider client={client}>
+          <MemoryRouter initialEntries={["/news"]}>
+            <News />
+          </MemoryRouter>
+        </QueryClientProvider>
+      </LanguageProvider>
+    </AuthContext.Provider>
+  )
+
+  return { queryClient: client }
+}
+
+describe("News page feed integration", () => {
+  beforeEach(() => {
+    vi.resetModules()
+    window.localStorage.clear()
+    delete (window as unknown as { caches?: CacheStorage }).caches
+    window.localStorage.setItem("ue:language", "ru")
+    server.resetHandlers()
+  })
+
+  it("persists API responses and revalidates using cached ETags", async () => {
+    const { cachesStorage, put } = createMockCaches()
+    Object.defineProperty(window, "caches", { value: cachesStorage, configurable: true })
+
+    const stories = [createNewsItem(1, "API headline")]
+    let requestCount = 0
+
+    server.use(
+      http.get("*/news", ({ request }) => {
+        requestCount += 1
+        if (requestCount === 1) {
+          return HttpResponse.json(stories, { headers: { ETag: '"api-tag"' } })
+        }
+        expect(request.headers.get("if-none-match")).toBe('"api-tag"')
+        return new HttpResponse(null, { status: 304, headers: { ETag: '"api-tag"' } })
+      })
+    )
+
+    const { queryClient } = await renderNewsPage()
+
+    expect(await screen.findByText("API headline")).toBeInTheDocument()
+    await waitFor(() => expect(requestCount).toBe(1))
+    expect(put).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      await queryClient.invalidateQueries({ queryKey: ["news", "feed", "ru"] })
+    })
+
+    await waitFor(() => expect(requestCount).toBe(2))
+    expect(screen.getByText("API headline")).toBeInTheDocument()
+    expect(put).toHaveBeenCalledTimes(1)
+
+    queryClient.clear()
+  })
+
+  it("hydrates from service worker caches during network failures and clears legacy storage", async () => {
+    const cachedItems = [createNewsItem(2, "Cached bulletin")]
+    const cacheKey = buildCacheKey("ru")
+    const cachedResponse = createNewsResponse(cachedItems, '"cached-tag"')
+    const { cachesStorage, match } = createMockCaches([{ key: cacheKey, response: cachedResponse }])
+    Object.defineProperty(window, "caches", { value: cachesStorage, configurable: true })
+
+    window.localStorage.setItem("news:list", "legacy")
+    window.localStorage.setItem("news:etag", "legacy")
+    window.localStorage.setItem("news:list:ru", "legacy")
+    window.localStorage.setItem("news:etag:ru", "legacy")
+
+    server.use(http.get("*/news", () => HttpResponse.json({ detail: "offline" }, { status: 503 })))
+
+    const { queryClient } = await renderNewsPage()
+
+    expect(await screen.findByText("Cached bulletin")).toBeInTheDocument()
+    expect(match).toHaveBeenCalled()
+    expect(window.localStorage.getItem("news:list")).toBeNull()
+    expect(window.localStorage.getItem("news:etag")).toBeNull()
+    expect(window.localStorage.getItem("news:list:ru")).toBeNull()
+    expect(window.localStorage.getItem("news:etag:ru")).toBeNull()
+
+    const cached = queryClient.getQueryData(["news", "feed", "ru"])
+    expect(cached).toBeDefined()
+
+    queryClient.clear()
+  })
+})

--- a/root/frontend/src/tests/pages/News/NewsFeed.test.tsx
+++ b/root/frontend/src/tests/pages/News/NewsFeed.test.tsx
@@ -70,7 +70,9 @@ const createMockCaches = (initialEntries: CacheEntry[] = []) => {
     delete: vi.fn(async () => false),
     add: vi.fn(),
     addAll: vi.fn(),
-    keys: vi.fn(async () => Array.from(entries.keys()).map((key) => new Request(key.split("::")[0]!))),
+    keys: vi.fn(async () =>
+      Array.from(entries.keys()).map((key) => new Request(key.split("::")[0]!))
+    ),
   } as unknown as Cache
 
   const cachesStorage = {


### PR DESCRIPTION
## Summary
- add a `useNewsFeed` hook that wraps React Query with ETag-aware fetch logic and synchronises with service worker caches
- replace the bespoke state management in the news page with the shared hook and React Query lifecycle flags
- add page-level tests that exercise cache hydration, offline fallbacks, and removal of legacy storage keys

## Testing
- npm run test -- NewsFeed

------
https://chatgpt.com/codex/tasks/task_e_68fd0f70cb7c8327a61159bfce6ed42f