### PR TITLE
Fix duplicate Alembic revision IDs

### DIFF
--- a/root/alembic/versions/202507310001_add_webauthn_attestation_fields.py
+++ b/root/alembic/versions/202507310001_add_webauthn_attestation_fields.py
@@ -9,7 +9,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "202507310001"
-down_revision: str | None = "202507300001"
+down_revision: str | None = "202507300002"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/root/alembic/versions/202507310002_tokenize_event_attendance.py
+++ b/root/alembic/versions/202507310002_tokenize_event_attendance.py
@@ -1,7 +1,7 @@
 """tokenize event attendance qr codes
 
-Revision ID: 202507310001
-Revises: 202507300002
+Revision ID: 202507310002
+Revises: 202507310001
 Create Date: 2025-07-31 00:01:00.000000
 """
 
@@ -21,8 +21,8 @@ from sqlalchemy.exc import NoSuchTableError
 from alembic import context, op
 
 # revision identifiers, used by Alembic.
-revision = "202507310001"
-down_revision = "202507300002"
+revision = "202507310002"
+down_revision = "202507310001"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Summary
- rename the event attendance tokenization migration to a unique revision ID
- update down_revision links so the latest migrations form a single linear history

## Testing
- not run (database unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68fd1d197b2c83278b04e8594444b849