### PR TITLE
Ensure WebAuthn attestation columns exist in dev

### DIFF
--- a/root/app/core/schema_upgrade.py
+++ b/root/app/core/schema_upgrade.py
@@ -47,9 +47,7 @@ def _ensure_webauthn_columns(sync_conn: Connection) -> None:
             column_type,
         )
         sync_conn.execute(
-            sa.text(
-                f"ALTER TABLE {_TABLE_NAME} ADD COLUMN {column_name} {column_type}"
-            )
+            sa.text(f"ALTER TABLE {_TABLE_NAME} ADD COLUMN {column_name} {column_type}")
         )
         columns.add(column_name)
 
@@ -59,9 +57,7 @@ def _ensure_webauthn_columns(sync_conn: Connection) -> None:
 
     logger.info("Creating missing index %s on %s", _INDEX_NAME, _TABLE_NAME)
     sync_conn.execute(
-        sa.text(
-            f"CREATE INDEX IF NOT EXISTS {_INDEX_NAME} ON {_TABLE_NAME} (aaguid)"
-        )
+        sa.text(f"CREATE INDEX IF NOT EXISTS {_INDEX_NAME} ON {_TABLE_NAME} (aaguid)")
     )
 
 

--- a/root/app/core/schema_upgrade.py
+++ b/root/app/core/schema_upgrade.py
@@ -1,0 +1,75 @@
+"""Utilities for applying lightweight schema upgrades at runtime."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+
+import sqlalchemy as sa
+from sqlalchemy.engine import Connection
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+logger = logging.getLogger(__name__)
+
+_TABLE_NAME = "mfa_webauthn_credentials"
+_INDEX_NAME = "ix_mfa_webauthn_credentials_aaguid"
+
+_COLUMN_DEFINITIONS: Mapping[str, Mapping[str, str]] = {
+    "aaguid": {"default": "VARCHAR(64)"},
+    "attestation_format": {"default": "VARCHAR(64)"},
+    "attestation_trust_score": {"default": "INTEGER"},
+    "attestation_metadata": {"default": "JSON", "sqlite": "TEXT"},
+    "metadata_warnings": {"default": "JSON", "sqlite": "TEXT"},
+}
+
+
+def _column_sql(dialect: str, column: str) -> str:
+    overrides = _COLUMN_DEFINITIONS[column]
+    return overrides.get(dialect, overrides["default"])
+
+
+def _ensure_webauthn_columns(sync_conn: Connection) -> None:
+    inspector = sa.inspect(sync_conn)
+    tables = set(inspector.get_table_names())
+    if _TABLE_NAME not in tables:
+        return
+
+    columns = {column["name"] for column in inspector.get_columns(_TABLE_NAME)}
+
+    for column_name in _COLUMN_DEFINITIONS:
+        if column_name in columns:
+            continue
+        column_type = _column_sql(sync_conn.dialect.name, column_name)
+        logger.info(
+            "Adding missing column %s.%s (%s)",
+            _TABLE_NAME,
+            column_name,
+            column_type,
+        )
+        sync_conn.execute(
+            sa.text(
+                f"ALTER TABLE {_TABLE_NAME} ADD COLUMN {column_name} {column_type}"
+            )
+        )
+        columns.add(column_name)
+
+    indexes = {index["name"] for index in inspector.get_indexes(_TABLE_NAME)}
+    if _INDEX_NAME in indexes or "aaguid" not in columns:
+        return
+
+    logger.info("Creating missing index %s on %s", _INDEX_NAME, _TABLE_NAME)
+    sync_conn.execute(
+        sa.text(
+            f"CREATE INDEX IF NOT EXISTS {_INDEX_NAME} ON {_TABLE_NAME} (aaguid)"
+        )
+    )
+
+
+async def ensure_webauthn_attestation_columns(engine: AsyncEngine) -> None:
+    """Ensure WebAuthn attestation columns exist for development databases."""
+
+    try:
+        async with engine.begin() as conn:
+            await conn.run_sync(_ensure_webauthn_columns)
+    except Exception:  # pragma: no cover - defensive
+        logger.exception("Failed to ensure WebAuthn attestation columns exist")

--- a/root/app/main.py
+++ b/root/app/main.py
@@ -22,6 +22,7 @@ from app.core.database import Base, engine, wait_db
 from app.core.metrics import configure_metrics
 from app.core.observability import configure_observability, shutdown_observability
 from app.core.rate_limit import RateLimitMiddleware, parse_rate_limit
+from app.core.schema_upgrade import ensure_webauthn_attestation_columns
 from app.core.security_headers import SecurityHeadersMiddleware
 from app.deps.cache import shutdown_cache
 from app.routers.notifications import legacy_router as legacy_push_router
@@ -51,7 +52,6 @@ from app.services.story_cleanup import (
     cleanup_expired_stories,
     start_story_cleanup_scheduler,
 )
-from app.core.schema_upgrade import ensure_webauthn_attestation_columns
 
 try:
     from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware

--- a/root/app/main.py
+++ b/root/app/main.py
@@ -51,6 +51,7 @@ from app.services.story_cleanup import (
     cleanup_expired_stories,
     start_story_cleanup_scheduler,
 )
+from app.core.schema_upgrade import ensure_webauthn_attestation_columns
 
 try:
     from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
@@ -64,6 +65,7 @@ async def lifespan(app: FastAPI):
     if settings.auto_create_schema:
         async with engine.begin() as conn:
             await conn.run_sync(Base.metadata.create_all)
+        await ensure_webauthn_attestation_columns(engine)
     stop_scheduler = None
     stop_notifications_retention = None
     stop_session_cleanup = None

--- a/root/tests/test_schema_upgrade.py
+++ b/root/tests/test_schema_upgrade.py
@@ -1,0 +1,96 @@
+import asyncio
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+
+from app.core.schema_upgrade import ensure_webauthn_attestation_columns
+
+
+@pytest.fixture()
+def sqlite_engine(tmp_path: Path) -> AsyncEngine:
+    db_path = tmp_path / "test.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+
+    async def _setup() -> None:
+        async with engine.begin() as conn:
+            await conn.execute(
+                sa.text(
+                    """
+                    CREATE TABLE mfa_webauthn_credentials (
+                        id INTEGER PRIMARY KEY,
+                        user_id INTEGER NOT NULL,
+                        credential_id VARCHAR(255) NOT NULL,
+                        public_key TEXT NOT NULL,
+                        sign_count INTEGER NOT NULL DEFAULT 0,
+                        transports TEXT,
+                        device_name VARCHAR(255),
+                        backed_up BOOLEAN NOT NULL DEFAULT 0,
+                        clone_warning BOOLEAN NOT NULL DEFAULT 0,
+                        created_at TIMESTAMP,
+                        last_used_at TIMESTAMP,
+                        is_active BOOLEAN NOT NULL DEFAULT 1
+                    )
+                    """
+                )
+            )
+
+    asyncio.run(_setup())
+
+    yield engine
+
+    asyncio.run(engine.dispose())
+
+
+def _get_columns(engine: AsyncEngine) -> set[str]:
+
+    async def _inner() -> set[str]:
+        async with engine.connect() as conn:
+            return await conn.run_sync(
+                lambda sync_conn: {
+                    column["name"]
+                    for column in sa.inspect(sync_conn).get_columns(
+                        "mfa_webauthn_credentials"
+                    )
+                }
+            )
+
+    return asyncio.run(_inner())
+
+
+def _get_indexes(engine: AsyncEngine) -> set[str]:
+
+    async def _inner() -> set[str]:
+        async with engine.connect() as conn:
+            return await conn.run_sync(
+                lambda sync_conn: {
+                    index["name"]
+                    for index in sa.inspect(sync_conn).get_indexes(
+                        "mfa_webauthn_credentials"
+                    )
+                }
+            )
+
+    return asyncio.run(_inner())
+
+
+def test_ensure_webauthn_attestation_columns_adds_missing_fields(
+    sqlite_engine: AsyncEngine,
+) -> None:
+    before_columns = _get_columns(sqlite_engine)
+    assert "aaguid" not in before_columns
+
+    asyncio.run(ensure_webauthn_attestation_columns(sqlite_engine))
+
+    after_columns = _get_columns(sqlite_engine)
+    assert {"aaguid", "attestation_format", "attestation_trust_score"}.issubset(
+        after_columns
+    )
+    assert {"attestation_metadata", "metadata_warnings"}.issubset(after_columns)
+
+    indexes = _get_indexes(sqlite_engine)
+    assert "ix_mfa_webauthn_credentials_aaguid" in indexes
+
+    # Second run should be a no-op and not raise.
+    asyncio.run(ensure_webauthn_attestation_columns(sqlite_engine))

--- a/root/tests/test_schema_upgrade.py
+++ b/root/tests/test_schema_upgrade.py
@@ -44,7 +44,6 @@ def sqlite_engine(tmp_path: Path) -> AsyncEngine:
 
 
 def _get_columns(engine: AsyncEngine) -> set[str]:
-
     async def _inner() -> set[str]:
         async with engine.connect() as conn:
             return await conn.run_sync(
@@ -60,7 +59,6 @@ def _get_columns(engine: AsyncEngine) -> set[str]:
 
 
 def _get_indexes(engine: AsyncEngine) -> set[str]:
-
     async def _inner() -> set[str]:
         async with engine.connect() as conn:
             return await conn.run_sync(


### PR DESCRIPTION
## Summary
- add a startup schema upgrade helper that backfills missing WebAuthn attestation columns and index when auto_create_schema is enabled
- call the helper from the FastAPI lifespan hook and add coverage to ensure the runtime upgrade is idempotent

## Testing
- pytest tests/test_schema_upgrade.py

------
https://chatgpt.com/codex/tasks/task_e_68fd1efb63b883278b9cb09ca7b371b2