### PR TITLE
Hide empty stories heading on dashboard

### DIFF
--- a/root/frontend/src/api/generated/schema.ts
+++ b/root/frontend/src/api/generated/schema.ts
@@ -2579,13 +2579,6 @@ export interface components {
       /** Pending Challenges */
       pending_challenges?: components["schemas"]["MfaChallengeOut"][]
     }
-    /** UserPasswordChangeIn */
-    UserPasswordChangeIn: {
-      /** Current Password */
-      current_password: string
-      /** New Password */
-      new_password: string
-    }
     /** UserOut */
     UserOut: {
       /**
@@ -2670,6 +2663,13 @@ export interface components {
       recovery_codes?: components["schemas"]["MfaRecoveryCodeOut"][]
       /** Mfa Challenges */
       mfa_challenges?: components["schemas"]["MfaChallengeOut"][]
+    }
+    /** UserPasswordChangeIn */
+    UserPasswordChangeIn: {
+      /** Current Password */
+      current_password: string
+      /** New Password */
+      new_password: string
     }
     /** UserProfileUpdate */
     UserProfileUpdate: {

--- a/root/frontend/src/api/generated/schema.ts
+++ b/root/frontend/src/api/generated/schema.ts
@@ -209,40 +209,6 @@ export interface paths {
     patch?: never
     trace?: never
   }
-  "/auth/mfa/recovery": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** List Recovery Codes */
-    get: operations["list_recovery_codes_auth_mfa_recovery_get"]
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/auth/mfa/recovery/regenerate": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Regenerate Recovery Codes */
-    post: operations["regenerate_recovery_codes_auth_mfa_recovery_regenerate_post"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
   "/auth/mfa/webauthn/attestation/finish": {
     parameters: {
       query?: never
@@ -271,6 +237,40 @@ export interface paths {
     put?: never
     /** Start Webauthn Assertion Endpoint */
     post: operations["start_webauthn_assertion_endpoint_auth_mfa_webauthn_assertion_start_post"]
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/auth/mfa/recovery": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** List Recovery Codes */
+    get: operations["list_recovery_codes_auth_mfa_recovery_get"]
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/auth/mfa/recovery/regenerate": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Regenerate Recovery Codes */
+    post: operations["regenerate_recovery_codes_auth_mfa_recovery_regenerate_post"]
     delete?: never
     options?: never
     head?: never
@@ -450,23 +450,6 @@ export interface paths {
     patch?: never
     trace?: never
   }
-  "/auth/sessions/revoke-others": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Revoke Other Sessions */
-    post: operations["revoke_other_sessions_auth_sessions_revoke_others_post"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
   "/auth/sessions/{session_id}": {
     parameters: {
       query?: never
@@ -479,6 +462,23 @@ export interface paths {
     post?: never
     /** Revoke Session */
     delete: operations["revoke_session_auth_sessions__session_id__delete"]
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/auth/sessions/revoke-others": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Revoke Other Sessions */
+    post: operations["revoke_other_sessions_auth_sessions_revoke_others_post"]
+    delete?: never
     options?: never
     head?: never
     patch?: never
@@ -3085,46 +3085,6 @@ export interface operations {
       }
     }
   }
-  list_recovery_codes_auth_mfa_recovery_get: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["MfaRecoveryCodeOut"][]
-        }
-      }
-    }
-  }
-  regenerate_recovery_codes_auth_mfa_recovery_regenerate_post: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": unknown
-        }
-      }
-    }
-  }
   start_webauthn_attestation_auth_mfa_webauthn_attestation_start_post: {
     parameters: {
       query?: never
@@ -3194,6 +3154,46 @@ export interface operations {
         }
         content: {
           "application/json": components["schemas"]["WebAuthnAssertionStartOut"]
+        }
+      }
+    }
+  }
+  list_recovery_codes_auth_mfa_recovery_get: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["MfaRecoveryCodeOut"][]
+        }
+      }
+    }
+  }
+  regenerate_recovery_codes_auth_mfa_recovery_regenerate_post: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": unknown
         }
       }
     }
@@ -3456,37 +3456,6 @@ export interface operations {
       }
     }
   }
-  revoke_other_sessions_auth_sessions_revoke_others_post: {
-    parameters: {
-      query?: {
-        user_id?: number | null
-      }
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["SessionBulkRevokeOut"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
   revoke_session_auth_sessions__session_id__delete: {
     parameters: {
       query?: never
@@ -3505,6 +3474,37 @@ export interface operations {
         }
         content: {
           "application/json": components["schemas"]["ActiveSessionOut"]
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  revoke_other_sessions_auth_sessions_revoke_others_post: {
+    parameters: {
+      query?: {
+        user_id?: number | null
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["SessionBulkRevokeOut"]
         }
       }
       /** @description Validation Error */

--- a/root/frontend/src/api/generated/schema.ts
+++ b/root/frontend/src/api/generated/schema.ts
@@ -209,6 +209,40 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  "/auth/mfa/recovery": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** List Recovery Codes */
+    get: operations["list_recovery_codes_auth_mfa_recovery_get"]
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/auth/mfa/recovery/regenerate": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Regenerate Recovery Codes */
+    post: operations["regenerate_recovery_codes_auth_mfa_recovery_regenerate_post"]
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   "/auth/mfa/webauthn/attestation/finish": {
     parameters: {
       query?: never
@@ -410,6 +444,23 @@ export interface paths {
     get: operations["list_sessions_auth_sessions_get"]
     put?: never
     post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/auth/sessions/revoke-others": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Revoke Other Sessions */
+    post: operations["revoke_other_sessions_auth_sessions_revoke_others_post"]
     delete?: never
     options?: never
     head?: never
@@ -860,6 +911,40 @@ export interface paths {
     /** Update Me */
     put: operations["update_me_users_me_put"]
     post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/users/me/email": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Change Email */
+    post: operations["change_email_users_me_email_post"]
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/users/me/password": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Change Password */
+    post: operations["change_password_users_me_password_post"]
     delete?: never
     options?: never
     head?: never
@@ -1989,6 +2074,16 @@ export interface components {
       /** Has More */
       has_more: boolean
     }
+    /** PasswordChangeOut */
+    PasswordChangeOut: {
+      /** Ok */
+      ok: boolean
+      /**
+       * Revoked Sessions
+       * @default 0
+       */
+      revoked_sessions: number
+    }
     /** PendingMfaResponse */
     PendingMfaResponse: {
       /**
@@ -2230,6 +2325,14 @@ export interface components {
       /** Detail */
       detail?: string | null
     }
+    /** SessionBulkRevokeOut */
+    SessionBulkRevokeOut: {
+      /**
+       * Revoked
+       * @default 0
+       */
+      revoked: number
+    }
     /** SessionSigningKeyOut */
     SessionSigningKeyOut: {
       /** Signing Key */
@@ -2455,6 +2558,16 @@ export interface components {
       /** Invite Code */
       invite_code?: string | null
     }
+    /** UserEmailChangeIn */
+    UserEmailChangeIn: {
+      /**
+       * Email
+       * Format: email
+       */
+      email: string
+      /** Password */
+      password: string
+    }
     /** UserMfaMethodsOut */
     UserMfaMethodsOut: {
       /** Totp Enrollments */
@@ -2465,6 +2578,13 @@ export interface components {
       recovery_codes?: components["schemas"]["MfaRecoveryCodeOut"][]
       /** Pending Challenges */
       pending_challenges?: components["schemas"]["MfaChallengeOut"][]
+    }
+    /** UserPasswordChangeIn */
+    UserPasswordChangeIn: {
+      /** Current Password */
+      current_password: string
+      /** New Password */
+      new_password: string
     }
     /** UserOut */
     UserOut: {
@@ -2965,6 +3085,46 @@ export interface operations {
       }
     }
   }
+  list_recovery_codes_auth_mfa_recovery_get: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["MfaRecoveryCodeOut"][]
+        }
+      }
+    }
+  }
+  regenerate_recovery_codes_auth_mfa_recovery_regenerate_post: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": unknown
+        }
+      }
+    }
+  }
   start_webauthn_attestation_auth_mfa_webauthn_attestation_start_post: {
     parameters: {
       query?: never
@@ -3283,6 +3443,37 @@ export interface operations {
         }
         content: {
           "application/json": components["schemas"]["ActiveSessionOut"][]
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  revoke_other_sessions_auth_sessions_revoke_others_post: {
+    parameters: {
+      query?: {
+        user_id?: number | null
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["SessionBulkRevokeOut"]
         }
       }
       /** @description Validation Error */
@@ -4143,6 +4334,72 @@ export interface operations {
         }
         content: {
           "application/json": components["schemas"]["UserOut"]
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  change_email_users_me_email_post: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["UserEmailChangeIn"]
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["UserOut"]
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  change_password_users_me_password_post: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["UserPasswordChangeIn"]
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["PasswordChangeOut"]
         }
       }
       /** @description Validation Error */

--- a/root/frontend/src/components/DashboardStories.tsx
+++ b/root/frontend/src/components/DashboardStories.tsx
@@ -55,7 +55,6 @@ export default function DashboardStories({
   const prefersReducedMotion = useMediaQuery("(prefers-reduced-motion: reduce)")
 
   const listLabel = t("aria.storiesList")
-  const emptyLabel = t("stories.empty")
   const emptyDescription = t("stories.emptyDescription")
 
   const displayStories = useMemo(() => {
@@ -302,14 +301,11 @@ export default function DashboardStories({
           ))}
         </Stack>
       )}
-      {!loading && displayStories.length === 0 && (
+      {!loading && displayStories.length === 0 && hasEmptyDescription && (
         <Stack spacing={0.5}>
-          <Typography color="text.secondary">{emptyLabel}</Typography>
-          {hasEmptyDescription && (
-            <Typography color="text.secondary" variant="body2">
-              {emptyDescription}
-            </Typography>
-          )}
+          <Typography color="text.secondary" variant="body2">
+            {emptyDescription}
+          </Typography>
         </Stack>
       )}
       {!loading && displayStories.length > 0 && (

--- a/root/frontend/src/components/DashboardStories.tsx
+++ b/root/frontend/src/components/DashboardStories.tsx
@@ -250,6 +250,8 @@ export default function DashboardStories({
     : undefined
 
   const hasEmptyDescription = emptyDescription && emptyDescription !== "stories.emptyDescription"
+  const hasStories = displayStories.length > 0
+  const shouldShowHeading = loading || hasStories
 
   const handlePointerStart = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
     touchOrigin.current = { x: event.clientX, y: event.clientY }
@@ -284,9 +286,11 @@ export default function DashboardStories({
       onPointerEnter={onPrefetch}
       onFocusCapture={onPrefetch}
     >
-      <Typography component="h2" variant="h6" sx={{ ...visuallyHidden }}>
-        {t("stories.heading")}
-      </Typography>
+      {shouldShowHeading && (
+        <Typography component="h2" variant="h6" sx={{ ...visuallyHidden }}>
+          {t("stories.heading")}
+        </Typography>
+      )}
       {loading && (
         <Stack direction="row" spacing={1.6} sx={{ flexWrap: "wrap", rowGap: 1.6, py: 0.75 }}>
           {Array.from({ length: SKELETON_COUNT }).map((_, index) => (
@@ -308,7 +312,7 @@ export default function DashboardStories({
           </Typography>
         </Stack>
       )}
-      {!loading && displayStories.length > 0 && (
+      {!loading && hasStories && (
         <Stack
           component="ul"
           direction="row"

--- a/root/frontend/src/components/__tests__/DashboardStories.test.tsx
+++ b/root/frontend/src/components/__tests__/DashboardStories.test.tsx
@@ -211,4 +211,10 @@ describe("DashboardStories", () => {
       expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
     })
   })
+
+  it("omits the stories heading when there are no stories", () => {
+    renderStories({ stories: [] })
+
+    expect(screen.queryByRole("heading", { name: "Stories" })).not.toBeInTheDocument()
+  })
 })

--- a/root/frontend/src/pages/Settings.tsx
+++ b/root/frontend/src/pages/Settings.tsx
@@ -863,10 +863,7 @@ export default function Settings() {
           return
         }
         setSnack({
-          text: resolveDetailMessage(
-            error,
-            t("settings:sessions.snackbar.revokeAllFailed")
-          ),
+          text: resolveDetailMessage(error, t("settings:sessions.snackbar.revokeAllFailed")),
           sev: "error",
         })
       }
@@ -932,10 +929,7 @@ export default function Settings() {
           }
         }
         if (!handled) {
-          const message = resolveDetailMessage(
-            error,
-            t("settings:security.email.failed")
-          )
+          const message = resolveDetailMessage(error, t("settings:security.email.failed"))
           setEmailError(message)
           setSnack({ text: message, sev: "error" })
         }
@@ -964,9 +958,7 @@ export default function Settings() {
       setPasswordError(null)
       let hasError = false
       if (!currentPasswordValue) {
-        setCurrentPasswordError(
-          t("settings:security.password.errors.currentRequired")
-        )
+        setCurrentPasswordError(t("settings:security.password.errors.currentRequired"))
         hasError = true
       }
       let derivedError: string | null = null
@@ -1011,10 +1003,7 @@ export default function Settings() {
           })
           return
         }
-        const message = resolveDetailMessage(
-          error,
-          t("settings:security.password.failed")
-        )
+        const message = resolveDetailMessage(error, t("settings:security.password.failed"))
         let handled = false
         if (isAxiosError(error)) {
           const detail = (error.response?.data as { detail?: unknown } | undefined)?.detail
@@ -1781,7 +1770,6 @@ export default function Settings() {
                 {t("settings:account.logout.button")}
               </Button>
             </SectionCard>
-
           </Stack>
         )}
 
@@ -1919,7 +1907,7 @@ export default function Settings() {
                       if (passwordError) setPasswordError(null)
                     }}
                     error={isNewPasswordError}
-                    helperText={isNewPasswordError ? passwordError ?? undefined : undefined}
+                    helperText={isNewPasswordError ? (passwordError ?? undefined) : undefined}
                     autoComplete="new-password"
                   />
                 </Stack>


### PR DESCRIPTION
## Summary
- remove the empty stories title from the dashboard stories block when no stories are available
- only render the optional empty-state description when it is defined

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fe23965f5c83279b88ba3c6cf8fe96