### PR TITLE
Surface security settings on the Account tab

### DIFF
--- a/root/frontend/src/api/generated/schema.ts
+++ b/root/frontend/src/api/generated/schema.ts
@@ -243,6 +243,40 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  "/auth/mfa/recovery": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** List Recovery Codes */
+    get: operations["list_recovery_codes_auth_mfa_recovery_get"]
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/auth/mfa/recovery/regenerate": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Regenerate Recovery Codes */
+    post: operations["regenerate_recovery_codes_auth_mfa_recovery_regenerate_post"]
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   "/auth/mfa/verify": {
     parameters: {
       query?: never
@@ -428,6 +462,23 @@ export interface paths {
     post?: never
     /** Revoke Session */
     delete: operations["revoke_session_auth_sessions__session_id__delete"]
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/auth/sessions/revoke-others": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Revoke Other Sessions */
+    post: operations["revoke_other_sessions_auth_sessions_revoke_others_post"]
+    delete?: never
     options?: never
     head?: never
     patch?: never
@@ -860,6 +911,40 @@ export interface paths {
     /** Update Me */
     put: operations["update_me_users_me_put"]
     post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/users/me/email": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Change Email */
+    post: operations["change_email_users_me_email_post"]
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/users/me/password": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Change Password */
+    post: operations["change_password_users_me_password_post"]
     delete?: never
     options?: never
     head?: never
@@ -1989,6 +2074,16 @@ export interface components {
       /** Has More */
       has_more: boolean
     }
+    /** PasswordChangeOut */
+    PasswordChangeOut: {
+      /** Ok */
+      ok: boolean
+      /**
+       * Revoked Sessions
+       * @default 0
+       */
+      revoked_sessions: number
+    }
     /** PendingMfaResponse */
     PendingMfaResponse: {
       /**
@@ -2230,6 +2325,14 @@ export interface components {
       /** Detail */
       detail?: string | null
     }
+    /** SessionBulkRevokeOut */
+    SessionBulkRevokeOut: {
+      /**
+       * Revoked
+       * @default 0
+       */
+      revoked: number
+    }
     /** SessionSigningKeyOut */
     SessionSigningKeyOut: {
       /** Signing Key */
@@ -2455,6 +2558,16 @@ export interface components {
       /** Invite Code */
       invite_code?: string | null
     }
+    /** UserEmailChangeIn */
+    UserEmailChangeIn: {
+      /**
+       * Email
+       * Format: email
+       */
+      email: string
+      /** Password */
+      password: string
+    }
     /** UserMfaMethodsOut */
     UserMfaMethodsOut: {
       /** Totp Enrollments */
@@ -2550,6 +2663,13 @@ export interface components {
       recovery_codes?: components["schemas"]["MfaRecoveryCodeOut"][]
       /** Mfa Challenges */
       mfa_challenges?: components["schemas"]["MfaChallengeOut"][]
+    }
+    /** UserPasswordChangeIn */
+    UserPasswordChangeIn: {
+      /** Current Password */
+      current_password: string
+      /** New Password */
+      new_password: string
     }
     /** UserProfileUpdate */
     UserProfileUpdate: {
@@ -3038,6 +3158,46 @@ export interface operations {
       }
     }
   }
+  list_recovery_codes_auth_mfa_recovery_get: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["MfaRecoveryCodeOut"][]
+        }
+      }
+    }
+  }
+  regenerate_recovery_codes_auth_mfa_recovery_regenerate_post: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": unknown
+        }
+      }
+    }
+  }
   verify_mfa_challenge_auth_mfa_verify_post: {
     parameters: {
       query?: never
@@ -3314,6 +3474,37 @@ export interface operations {
         }
         content: {
           "application/json": components["schemas"]["ActiveSessionOut"]
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  revoke_other_sessions_auth_sessions_revoke_others_post: {
+    parameters: {
+      query?: {
+        user_id?: number | null
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["SessionBulkRevokeOut"]
         }
       }
       /** @description Validation Error */
@@ -4143,6 +4334,72 @@ export interface operations {
         }
         content: {
           "application/json": components["schemas"]["UserOut"]
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  change_email_users_me_email_post: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["UserEmailChangeIn"]
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["UserOut"]
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  change_password_users_me_password_post: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["UserPasswordChangeIn"]
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["PasswordChangeOut"]
         }
       }
       /** @description Validation Error */

--- a/root/frontend/src/components/DashboardStories.tsx
+++ b/root/frontend/src/components/DashboardStories.tsx
@@ -55,7 +55,6 @@ export default function DashboardStories({
   const prefersReducedMotion = useMediaQuery("(prefers-reduced-motion: reduce)")
 
   const listLabel = t("aria.storiesList")
-  const emptyLabel = t("stories.empty")
   const emptyDescription = t("stories.emptyDescription")
 
   const displayStories = useMemo(() => {
@@ -251,6 +250,8 @@ export default function DashboardStories({
     : undefined
 
   const hasEmptyDescription = emptyDescription && emptyDescription !== "stories.emptyDescription"
+  const hasStories = displayStories.length > 0
+  const shouldShowHeading = loading || hasStories
 
   const handlePointerStart = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
     touchOrigin.current = { x: event.clientX, y: event.clientY }
@@ -285,9 +286,11 @@ export default function DashboardStories({
       onPointerEnter={onPrefetch}
       onFocusCapture={onPrefetch}
     >
-      <Typography component="h2" variant="h6" sx={{ ...visuallyHidden }}>
-        {t("stories.heading")}
-      </Typography>
+      {shouldShowHeading && (
+        <Typography component="h2" variant="h6" sx={{ ...visuallyHidden }}>
+          {t("stories.heading")}
+        </Typography>
+      )}
       {loading && (
         <Stack direction="row" spacing={1.6} sx={{ flexWrap: "wrap", rowGap: 1.6, py: 0.75 }}>
           {Array.from({ length: SKELETON_COUNT }).map((_, index) => (
@@ -302,17 +305,14 @@ export default function DashboardStories({
           ))}
         </Stack>
       )}
-      {!loading && displayStories.length === 0 && (
+      {!loading && displayStories.length === 0 && hasEmptyDescription && (
         <Stack spacing={0.5}>
-          <Typography color="text.secondary">{emptyLabel}</Typography>
-          {hasEmptyDescription && (
-            <Typography color="text.secondary" variant="body2">
-              {emptyDescription}
-            </Typography>
-          )}
+          <Typography color="text.secondary" variant="body2">
+            {emptyDescription}
+          </Typography>
         </Stack>
       )}
-      {!loading && displayStories.length > 0 && (
+      {!loading && hasStories && (
         <Stack
           component="ul"
           direction="row"

--- a/root/frontend/src/components/__tests__/DashboardStories.test.tsx
+++ b/root/frontend/src/components/__tests__/DashboardStories.test.tsx
@@ -211,4 +211,10 @@ describe("DashboardStories", () => {
       expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
     })
   })
+
+  it("omits the stories heading when there are no stories", () => {
+    renderStories({ stories: [] })
+
+    expect(screen.queryByRole("heading", { name: "Stories" })).not.toBeInTheDocument()
+  })
 })

--- a/root/frontend/src/pages/Settings.tsx
+++ b/root/frontend/src/pages/Settings.tsx
@@ -60,6 +60,7 @@ import {
 import dayjs from "dayjs"
 import { useColorScheme, styled, alpha } from "@mui/material/styles"
 import type { PaperProps } from "@mui/material/Paper"
+import type { TypographyProps } from "@mui/material/Typography"
 import SettingsIcon from "@mui/icons-material/Settings"
 import DarkModeIcon from "@mui/icons-material/DarkMode"
 import LightModeIcon from "@mui/icons-material/LightMode"
@@ -195,7 +196,9 @@ const SectionCard = styled((props: PaperProps) => <Paper {...props} />)(({ theme
   gap: theme.spacing(1.5),
 }))
 
-const SectionTitle = styled(Typography)({
+const SectionTitle = styled(({ component = "h2", ...props }: TypographyProps) => (
+  <Typography {...props} component={component} />
+))({
   fontWeight: 600,
   color: "var(--page-text)",
 })
@@ -381,7 +384,7 @@ export default function Settings() {
   } = useQuery<ActiveSession[], unknown>({
     queryKey: sessionsKey,
     queryFn: fetchSessions,
-    enabled: tab === 2 && Boolean(user),
+    enabled: tab === 1 && Boolean(user),
     staleTime: 30_000,
   })
 
@@ -863,10 +866,7 @@ export default function Settings() {
           return
         }
         setSnack({
-          text: resolveDetailMessage(
-            error,
-            t("settings:sessions.snackbar.revokeAllFailed")
-          ),
+          text: resolveDetailMessage(error, t("settings:sessions.snackbar.revokeAllFailed")),
           sev: "error",
         })
       }
@@ -932,10 +932,7 @@ export default function Settings() {
           }
         }
         if (!handled) {
-          const message = resolveDetailMessage(
-            error,
-            t("settings:security.email.failed")
-          )
+          const message = resolveDetailMessage(error, t("settings:security.email.failed"))
           setEmailError(message)
           setSnack({ text: message, sev: "error" })
         }
@@ -964,9 +961,7 @@ export default function Settings() {
       setPasswordError(null)
       let hasError = false
       if (!currentPasswordValue) {
-        setCurrentPasswordError(
-          t("settings:security.password.errors.currentRequired")
-        )
+        setCurrentPasswordError(t("settings:security.password.errors.currentRequired"))
         hasError = true
       }
       let derivedError: string | null = null
@@ -1011,10 +1006,7 @@ export default function Settings() {
           })
           return
         }
-        const message = resolveDetailMessage(
-          error,
-          t("settings:security.password.failed")
-        )
+        const message = resolveDetailMessage(error, t("settings:security.password.failed"))
         let handled = false
         if (isAxiosError(error)) {
           const detail = (error.response?.data as { detail?: unknown } | undefined)?.detail
@@ -1333,7 +1325,6 @@ export default function Settings() {
           >
             <Tab label={t("settings:tabs.general")} />
             <Tab label={t("settings:tabs.account")} />
-            <Tab label={t("settings:tabs.security")} />
             <Tab label={t("settings:tabs.integrations")} />
           </Tabs>
         </Paper>
@@ -1781,15 +1772,6 @@ export default function Settings() {
                 {t("settings:account.logout.button")}
               </Button>
             </SectionCard>
-
-          </Stack>
-        )}
-
-        {tab === 2 && (
-          <Stack
-            spacing={2.5}
-            sx={{ width: "100%", maxWidth: { xs: "100%", sm: 640, md: 760, lg: 880 } }}
-          >
             <SectionCard component="section">
               <Stack spacing={1}>
                 <SectionTitle variant="subtitle1">
@@ -1810,7 +1792,7 @@ export default function Settings() {
                 sx={{ mt: 2 }}
               >
                 <Stack spacing={1}>
-                  <SectionTitle variant="subtitle2">
+                  <SectionTitle component="h3" variant="subtitle2">
                     {t("settings:security.email.title")}
                   </SectionTitle>
                   <SectionSubtitle variant="body2">
@@ -1886,7 +1868,7 @@ export default function Settings() {
                 }}
               >
                 <Stack spacing={1}>
-                  <SectionTitle variant="subtitle2">
+                  <SectionTitle component="h3" variant="subtitle2">
                     {t("settings:security.password.title")}
                   </SectionTitle>
                   <SectionSubtitle variant="body2">
@@ -1919,7 +1901,7 @@ export default function Settings() {
                       if (passwordError) setPasswordError(null)
                     }}
                     error={isNewPasswordError}
-                    helperText={isNewPasswordError ? passwordError ?? undefined : undefined}
+                    helperText={isNewPasswordError ? (passwordError ?? undefined) : undefined}
                     autoComplete="new-password"
                   />
                 </Stack>
@@ -2121,7 +2103,7 @@ export default function Settings() {
 
               <Stack spacing={2.5} sx={{ mt: 1.5 }}>
                 <Stack spacing={1}>
-                  <SectionTitle variant="subtitle2">
+                  <SectionTitle component="h3" variant="subtitle2">
                     {t("settings:security.method.totp")}
                   </SectionTitle>
                   <SectionSubtitle variant="body2">
@@ -2225,7 +2207,7 @@ export default function Settings() {
                 <Divider sx={{ my: 1 }} />
 
                 <Stack spacing={1}>
-                  <SectionTitle variant="subtitle2">
+                  <SectionTitle component="h3" variant="subtitle2">
                     {t("settings:security.method.webauthn")}
                   </SectionTitle>
                   <SectionSubtitle variant="body2">
@@ -2326,7 +2308,7 @@ export default function Settings() {
                 <Divider sx={{ my: 1 }} />
 
                 <Stack spacing={1}>
-                  <SectionTitle variant="subtitle2">
+                  <SectionTitle component="h3" variant="subtitle2">
                     {t("settings:security.method.recovery")}
                   </SectionTitle>
                   <SectionSubtitle variant="body2">
@@ -2367,7 +2349,7 @@ export default function Settings() {
           </Stack>
         )}
 
-        {tab === 3 && (
+        {tab === 2 && (
           <Stack spacing={3}>
             <Stack spacing={2}>
               <Stack direction="row" alignItems="center" spacing={1}>


### PR DESCRIPTION
## Summary
- update the shared `SectionTitle` styling to default to semantic heading elements and mark nested subtitles as h3 for accessibility
- fold the security, session management, and MFA panels into the Account tab while removing the extra Security tab and ensuring related queries load for that view

## Testing
- npm run lint
- npm run format:check
- npm run test -- Settings.totp
- npm run test -- Settings.sessions
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68fe23965f5c83279b88ba3c6cf8fe96