### PR TITLE
Improve Schedule page dark theme styling

### DIFF
--- a/root/frontend/src/pages/Schedule.tsx
+++ b/root/frontend/src/pages/Schedule.tsx
@@ -234,21 +234,16 @@ export default function Schedule() {
     const surface = isDark ? lighten(surfaceBase, 0.04) : surfaceBase
     const elevatedSurface = isDark ? lighten(surfaceBase, 0.1) : surface
     const tintedSurface = isDark ? alpha(lighten(surfaceBase, 0.12), 0.78) : "#f4f7fb"
-    const subtleShadow =
-      isDark
-        ? "0 18px 44px rgba(6, 12, 24, 0.55)"
-        : "0 18px 44px rgba(15, 23, 42, 0.08)"
-    const cardShadow =
-      isDark
-        ? "0 26px 64px rgba(5, 12, 24, 0.62)"
-        : "0 26px 64px rgba(15, 23, 42, 0.12)"
-    const hoverShadow =
-      isDark
-        ? "0 32px 82px rgba(3, 8, 18, 0.7)"
-        : "0 36px 88px rgba(15, 23, 42, 0.16)"
-    const pageBackgroundColor = isDark
-      ? darken(theme.palette.background.default, 0.04)
-      : "#f5f7fb"
+    const subtleShadow = isDark
+      ? "0 18px 44px rgba(6, 12, 24, 0.55)"
+      : "0 18px 44px rgba(15, 23, 42, 0.08)"
+    const cardShadow = isDark
+      ? "0 26px 64px rgba(5, 12, 24, 0.62)"
+      : "0 26px 64px rgba(15, 23, 42, 0.12)"
+    const hoverShadow = isDark
+      ? "0 32px 82px rgba(3, 8, 18, 0.7)"
+      : "0 36px 88px rgba(15, 23, 42, 0.16)"
+    const pageBackgroundColor = isDark ? darken(theme.palette.background.default, 0.04) : "#f5f7fb"
     const pageOverlay = isDark
       ? `radial-gradient(140% 140% at 0% 0%, ${alpha(primary, 0.18)}, transparent 55%), linear-gradient(180deg, ${alpha(elevatedSurface, 0.42)}, transparent 65%)`
       : `linear-gradient(180deg, ${alpha(primary, 0.08)} 0%, transparent 60%)`
@@ -1243,8 +1238,7 @@ export default function Schedule() {
                             ml: 1,
                             borderRadius: 2,
                             border: `1px solid ${design.border}`,
-                            bgcolor:
-                              design.cardBackground,
+                            bgcolor: design.cardBackground,
                             transition:
                               "background-color 160ms ease, transform 160ms ease, box-shadow 160ms ease",
                             "&:hover": {
@@ -1279,10 +1273,7 @@ export default function Schedule() {
                   key={rowIdx}
                   sx={{
                     "&:hover": {
-                      backgroundColor: alpha(
-                        design.primary,
-                        design.isDark ? 0.24 : 0.08
-                      ),
+                      backgroundColor: alpha(design.primary, design.isDark ? 0.24 : 0.08),
                     },
                     transition: "background-color 160ms ease",
                   }}
@@ -1311,9 +1302,7 @@ export default function Schedule() {
                         <TableCell
                           key={`empty-${rowIdx}-${colIdx}`}
                           sx={{
-                            backgroundColor: colIsToday
-                              ? design.tableHighlight
-                              : "transparent",
+                            backgroundColor: colIsToday ? design.tableHighlight : "transparent",
                             p: 1.2,
                             borderLeft: `1px solid ${design.border}`,
                             borderBottom: `1px solid ${design.border}`,
@@ -1346,9 +1335,7 @@ export default function Schedule() {
                         sx={{
                           position: "relative",
                           color: design.text,
-                          backgroundColor: colIsToday
-                            ? design.tableHighlight
-                            : "transparent",
+                          backgroundColor: colIsToday ? design.tableHighlight : "transparent",
                           overflow: "visible",
                           p: 1.2,
                           borderLeft: `1px solid ${design.border}`,
@@ -1437,9 +1424,7 @@ export default function Schedule() {
               p: { xs: 2, md: 2.4 },
               mb: 1,
               backgroundColor:
-                hasToday && dayIdx === todayIdx
-                  ? design.tableHighlight
-                  : design.cardBackground,
+                hasToday && dayIdx === todayIdx ? design.tableHighlight : design.cardBackground,
               border: `1px solid ${design.border}`,
               boxShadow: design.cardShadow,
               contentVisibility: "auto",

--- a/root/frontend/src/pages/Schedule.tsx
+++ b/root/frontend/src/pages/Schedule.tsx
@@ -39,7 +39,7 @@ import {
   Divider,
   LinearProgress,
 } from "@mui/material"
-import { alpha, useTheme } from "@mui/material/styles"
+import { alpha, darken, lighten, useTheme } from "@mui/material/styles"
 import DeleteIcon from "@mui/icons-material/Delete"
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined"
 import AddIcon from "@mui/icons-material/Add"
@@ -223,45 +223,70 @@ export default function Schedule() {
   const locale = getLocaleForLanguage(language)
   const theme = useTheme()
   const design = useMemo(() => {
+    const isDark = theme.palette.mode === "dark"
     const text = theme.palette.text.primary
     const secondary = theme.palette.text.secondary
-    const border = alpha(text, theme.palette.mode === "dark" ? 0.28 : 0.08)
-    const borderMuted = alpha(text, theme.palette.mode === "dark" ? 0.18 : 0.06)
-    const borderStrong = alpha(text, theme.palette.mode === "dark" ? 0.32 : 0.12)
-    const surface = theme.palette.background.paper
-    const tintedSurface = theme.palette.mode === "dark" ? alpha(surface, 0.65) : "#f4f7fb"
+    const primary = theme.palette.primary.main
+    const border = alpha(text, isDark ? 0.28 : 0.08)
+    const borderMuted = alpha(text, isDark ? 0.18 : 0.06)
+    const borderStrong = alpha(text, isDark ? 0.32 : 0.12)
+    const surfaceBase = theme.palette.background.paper
+    const surface = isDark ? lighten(surfaceBase, 0.04) : surfaceBase
+    const elevatedSurface = isDark ? lighten(surfaceBase, 0.1) : surface
+    const tintedSurface = isDark ? alpha(lighten(surfaceBase, 0.12), 0.78) : "#f4f7fb"
     const subtleShadow =
-      theme.palette.mode === "dark"
-        ? "0 18px 44px rgba(13, 23, 42, 0.55)"
+      isDark
+        ? "0 18px 44px rgba(6, 12, 24, 0.55)"
         : "0 18px 44px rgba(15, 23, 42, 0.08)"
     const cardShadow =
-      theme.palette.mode === "dark"
-        ? "0 26px 64px rgba(13, 23, 42, 0.62)"
+      isDark
+        ? "0 26px 64px rgba(5, 12, 24, 0.62)"
         : "0 26px 64px rgba(15, 23, 42, 0.12)"
     const hoverShadow =
-      theme.palette.mode === "dark"
-        ? "0 32px 82px rgba(13, 23, 42, 0.7)"
+      isDark
+        ? "0 32px 82px rgba(3, 8, 18, 0.7)"
         : "0 36px 88px rgba(15, 23, 42, 0.16)"
-    const primary = theme.palette.primary.main
+    const pageBackgroundColor = isDark
+      ? darken(theme.palette.background.default, 0.04)
+      : "#f5f7fb"
+    const pageOverlay = isDark
+      ? `radial-gradient(140% 140% at 0% 0%, ${alpha(primary, 0.18)}, transparent 55%), linear-gradient(180deg, ${alpha(elevatedSurface, 0.42)}, transparent 65%)`
+      : `linear-gradient(180deg, ${alpha(primary, 0.08)} 0%, transparent 60%)`
+    const heroBackground = isDark
+      ? `linear-gradient(135deg, ${alpha(primary, 0.22)}, ${alpha(elevatedSurface, 0.95)})`
+      : `linear-gradient(135deg, ${tintedSurface}, ${surface})`
+    const headerBackground = isDark ? alpha(elevatedSurface, 0.96) : surface
+    const cardBackground = isDark ? alpha(elevatedSurface, 0.94) : surface
+    const tableStickyBackground = isDark ? alpha(elevatedSurface, 0.92) : tintedSurface
+    const tableHighlight = isDark ? alpha(primary, 0.24) : alpha(primary, 0.08)
+    const chipBackground = isDark ? alpha(text, 0.16) : alpha(primary, 0.05)
+    const chipBorder = isDark ? alpha(text, 0.24) : alpha(text, 0.1)
     return {
+      isDark,
       text,
       secondary,
       border,
       borderMuted,
       borderStrong,
       surface,
+      elevatedSurface,
       tintedSurface,
       subtleShadow,
       cardShadow,
       hoverShadow,
       primary,
       primaryContrast: theme.palette.primary.contrastText,
-      accentSoft: alpha(primary, theme.palette.mode === "dark" ? 0.25 : 0.12),
-      accentSoftStrong: alpha(primary, theme.palette.mode === "dark" ? 0.4 : 0.18),
-      chipBackground: theme.palette.mode === "dark" ? alpha(text, 0.14) : alpha(primary, 0.05),
-      chipBorder: theme.palette.mode === "dark" ? alpha(text, 0.2) : alpha(text, 0.1),
-      pageBackground:
-        theme.palette.mode === "dark" ? alpha(theme.palette.background.default, 0.72) : "#f5f7fb",
+      accentSoft: alpha(primary, isDark ? 0.25 : 0.12),
+      accentSoftStrong: alpha(primary, isDark ? 0.45 : 0.18),
+      chipBackground,
+      chipBorder,
+      pageBackground: pageBackgroundColor,
+      pageOverlay,
+      heroBackground,
+      headerBackground,
+      cardBackground,
+      tableStickyBackground,
+      tableHighlight,
     }
   }, [theme])
   const weekdayConfigs = useMemo(() => {
@@ -776,10 +801,7 @@ export default function Schedule() {
     borderRadius: { xs: 3, md: 4 },
     px: { xs: 2.4, md: 3.4 },
     py: { xs: 2.6, md: 3.2 },
-    background:
-      theme.palette.mode === "dark"
-        ? alpha(design.surface, 0.92)
-        : `linear-gradient(135deg, ${design.tintedSurface}, ${design.surface})`,
+    background: design.heroBackground,
     border: `1px solid ${design.border}`,
     boxShadow: design.cardShadow,
     overflow: "hidden",
@@ -855,7 +877,7 @@ export default function Schedule() {
   } as const
 
   const chipLeftSx = {
-    bgcolor: alpha(design.primary, theme.palette.mode === "dark" ? 0.28 : 0.12),
+    bgcolor: alpha(design.primary, design.isDark ? 0.32 : 0.12),
     border: `1px solid ${design.accentSoftStrong}`,
     color: design.primary,
     fontWeight: 600,
@@ -870,7 +892,7 @@ export default function Schedule() {
   const headerCardSx = {
     borderRadius: { xs: 2, md: 3 },
     p: { xs: 1.8, md: 2.2 },
-    backgroundColor: theme.palette.mode === "dark" ? alpha(design.surface, 0.9) : design.surface,
+    backgroundColor: design.headerBackground,
     boxShadow: design.subtleShadow,
     border: `1px solid ${design.border}`,
   } as const
@@ -985,8 +1007,7 @@ export default function Schedule() {
         pl: { xs: 1.7, md: 1.9 },
         pr: { xs: 1.35, md: 1.55 },
         borderRadius: 3,
-        backgroundColor:
-          theme.palette.mode === "dark" ? alpha(design.surface, 0.85) : design.surface,
+        backgroundColor: design.cardBackground,
         border: `1px solid ${design.border}`,
         boxShadow: design.subtleShadow,
         transition:
@@ -1012,7 +1033,9 @@ export default function Schedule() {
           borderTopLeftRadius: 10,
           borderBottomLeftRadius: 10,
           background: getLessonTypeColor(lesson.lesson_type),
-          boxShadow: "0 0 0 1px rgba(255, 255, 255, 0.18) inset",
+          boxShadow: design.isDark
+            ? `0 0 0 1px ${alpha(design.primaryContrast, 0.2)} inset`
+            : "0 0 0 1px rgba(255, 255, 255, 0.18) inset",
         }}
       />
       <Stack spacing={0.6}>
@@ -1101,15 +1124,14 @@ export default function Schedule() {
             position: "absolute",
             top: 6,
             right: 6,
-            bgcolor: theme.palette.mode === "dark" ? alpha(design.surface, 0.7) : design.surface,
+            bgcolor: design.cardBackground,
             border: `1px solid ${design.border}`,
             boxShadow: design.subtleShadow,
             zIndex: 2,
             "&:hover": {
-              bgcolor:
-                theme.palette.mode === "dark"
-                  ? alpha(design.surface, 0.85)
-                  : alpha(design.primary, 0.08),
+              bgcolor: design.isDark
+                ? alpha(design.cardBackground, 0.9)
+                : alpha(design.primary, 0.08),
             },
           }}
           onClick={(e) => {
@@ -1148,8 +1170,7 @@ export default function Schedule() {
           border: `1px solid ${design.border}`,
           boxShadow: design.cardShadow,
           minHeight: 360,
-          backgroundColor:
-            theme.palette.mode === "dark" ? alpha(design.surface, 0.9) : design.surface,
+          backgroundColor: design.cardBackground,
           color: design.text,
           overflowX: "auto",
           scrollBehavior: "smooth",
@@ -1165,10 +1186,7 @@ export default function Schedule() {
                 sx={{
                   fontWeight: 700,
                   width: 52,
-                  backgroundColor:
-                    theme.palette.mode === "dark"
-                      ? alpha(design.surface, 0.8)
-                      : design.tintedSurface,
+                  backgroundColor: design.tableStickyBackground,
                   zIndex: 10,
                   position: "sticky",
                   left: 0,
@@ -1195,10 +1213,8 @@ export default function Schedule() {
                       fontWeight: 700,
                       backgroundColor:
                         hasToday && idx === todayIdx
-                          ? design.accentSoft
-                          : theme.palette.mode === "dark"
-                            ? alpha(design.surface, 0.75)
-                            : design.tintedSurface,
+                          ? design.tableHighlight
+                          : design.tableStickyBackground,
                       fontSize: "clamp(0.97rem, 1.4vw, 1.11rem)",
                       zIndex: 5,
                       color: design.text,
@@ -1228,9 +1244,7 @@ export default function Schedule() {
                             borderRadius: 2,
                             border: `1px solid ${design.border}`,
                             bgcolor:
-                              theme.palette.mode === "dark"
-                                ? alpha(design.surface, 0.75)
-                                : design.surface,
+                              design.cardBackground,
                             transition:
                               "background-color 160ms ease, transform 160ms ease, box-shadow 160ms ease",
                             "&:hover": {
@@ -1267,7 +1281,7 @@ export default function Schedule() {
                     "&:hover": {
                       backgroundColor: alpha(
                         design.primary,
-                        theme.palette.mode === "dark" ? 0.24 : 0.08
+                        design.isDark ? 0.24 : 0.08
                       ),
                     },
                     transition: "background-color 160ms ease",
@@ -1277,10 +1291,7 @@ export default function Schedule() {
                     align="center"
                     sx={{
                       fontWeight: 700,
-                      backgroundColor:
-                        theme.palette.mode === "dark"
-                          ? alpha(design.surface, 0.75)
-                          : design.tintedSurface,
+                      backgroundColor: design.tableStickyBackground,
                       position: "sticky",
                       left: 0,
                       color: design.text,
@@ -1301,7 +1312,7 @@ export default function Schedule() {
                           key={`empty-${rowIdx}-${colIdx}`}
                           sx={{
                             backgroundColor: colIsToday
-                              ? alpha(design.primary, theme.palette.mode === "dark" ? 0.22 : 0.08)
+                              ? design.tableHighlight
                               : "transparent",
                             p: 1.2,
                             borderLeft: `1px solid ${design.border}`,
@@ -1336,7 +1347,7 @@ export default function Schedule() {
                           position: "relative",
                           color: design.text,
                           backgroundColor: colIsToday
-                            ? alpha(design.primary, theme.palette.mode === "dark" ? 0.22 : 0.08)
+                            ? design.tableHighlight
                             : "transparent",
                           overflow: "visible",
                           p: 1.2,
@@ -1397,7 +1408,7 @@ export default function Schedule() {
               backgroundColor:
                 hasToday && i === todayIdx
                   ? design.primary
-                  : alpha(design.primary, theme.palette.mode === "dark" ? 0.28 : 0.12),
+                  : alpha(design.primary, design.isDark ? 0.3 : 0.12),
               boxShadow: design.subtleShadow,
             },
           }}
@@ -1427,10 +1438,8 @@ export default function Schedule() {
               mb: 1,
               backgroundColor:
                 hasToday && dayIdx === todayIdx
-                  ? alpha(design.primary, theme.palette.mode === "dark" ? 0.22 : 0.08)
-                  : theme.palette.mode === "dark"
-                    ? alpha(design.surface, 0.9)
-                    : design.surface,
+                  ? design.tableHighlight
+                  : design.cardBackground,
               border: `1px solid ${design.border}`,
               boxShadow: design.cardShadow,
               contentVisibility: "auto",
@@ -1458,8 +1467,7 @@ export default function Schedule() {
                     ml: 0.5,
                     borderRadius: 2,
                     border: `1px solid ${design.border}`,
-                    bgcolor:
-                      theme.palette.mode === "dark" ? alpha(design.surface, 0.75) : design.surface,
+                    bgcolor: design.cardBackground,
                     transition:
                       "background-color 160ms ease, transform 160ms ease, box-shadow 160ms ease",
                     "&:hover": {
@@ -1509,20 +1517,16 @@ export default function Schedule() {
                         sx={{
                           p: { xs: 1.25, md: 1.35 },
                           borderRadius: 3,
-                          backgroundColor:
-                            theme.palette.mode === "dark"
-                              ? alpha(design.surface, 0.85)
-                              : design.surface,
+                          backgroundColor: design.cardBackground,
                           boxShadow: design.subtleShadow,
                           border: `1px solid ${design.border}`,
                           cursor: "pointer",
                           transition:
                             "transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease, background-color 160ms ease",
                           "&:hover": {
-                            backgroundColor:
-                              theme.palette.mode === "dark"
-                                ? alpha(design.surface, 0.92)
-                                : alpha(design.primary, 0.04),
+                            backgroundColor: design.isDark
+                              ? alpha(design.cardBackground, 0.96)
+                              : alpha(design.primary, 0.04),
                             transform: "translateY(-4px)",
                             boxShadow: design.hoverShadow,
                             borderColor: design.accentSoftStrong,
@@ -1541,7 +1545,9 @@ export default function Schedule() {
                             borderTopLeftRadius: 10,
                             borderBottomLeftRadius: 10,
                             background: getLessonTypeColor(lesson.lesson_type),
-                            boxShadow: "0 0 0 1px rgba(255, 255, 255, 0.18) inset",
+                            boxShadow: design.isDark
+                              ? `0 0 0 1px ${alpha(design.primaryContrast, 0.2)} inset`
+                              : "0 0 0 1px rgba(255, 255, 255, 0.18) inset",
                           }}
                         />
                         <Stack
@@ -1661,10 +1667,7 @@ export default function Schedule() {
             width: "100%",
             minHeight: "100vh",
             backgroundColor: design.pageBackground,
-            backgroundImage:
-              theme.palette.mode === "dark"
-                ? `linear-gradient(180deg, ${alpha(design.surface, 0.18)}, transparent)`
-                : `linear-gradient(180deg, ${alpha(design.primary, 0.08)} 0%, transparent 60%)`,
+            backgroundImage: design.pageOverlay,
             backgroundRepeat: "no-repeat",
             color: design.text,
             py: { xs: 4, sm: 4.2, md: 4.5 },


### PR DESCRIPTION
## Summary
- refine schedule design tokens to better align with dark theme palettes
- update schedule table, cards, and mobile layouts to reuse the new dark-friendly colors
- adjust gradients and interactive elements for consistent appearance across themes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fe9cc1c2808327a8f36862982cb1c3