### PR TITLE
Improve light theme text contrast

### DIFF
--- a/root/frontend/src/theme.ts
+++ b/root/frontend/src/theme.ts
@@ -65,8 +65,9 @@ const baseTheme = extendTheme({
           contrastText: "#ffffff",
         },
         text: {
-          primary: "#10151B",
-          secondary: "#4B5563",
+          primary: "#0B121A",
+          secondary: "#2F3B4C",
+          disabled: "rgba(47, 59, 76, 0.45)",
         },
         divider: "rgba(16, 21, 27, 0.12)",
         background: {


### PR DESCRIPTION
## Summary
- darken the primary and secondary light theme text colors to increase readability
- add a tuned disabled text color to maintain consistent contrast levels

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fea43d976c8327ab6d65d0e3d4408d