### PR TITLE
Enhance schedule instructor and room visuals

### DIFF
--- a/root/frontend/src/pages/Schedule.tsx
+++ b/root/frontend/src/pages/Schedule.tsx
@@ -883,14 +883,28 @@ export default function Schedule() {
             variant="outlined"
             icon={<SchoolIcon sx={{ fontSize: 16 }} />}
             label={lesson.teacher}
-            sx={{ borderColor: "var(--btn-border)", color: "var(--page-text)" }}
+            sx={(theme) => {
+              const primaryColor = theme.vars?.palette.primary.main ?? theme.palette.primary.main
+              return {
+                borderColor: "var(--btn-border)",
+                color: "var(--page-text)",
+                "& .MuiChip-icon": { color: primaryColor },
+              }
+            }}
           />
           <Chip
             size="small"
             variant="outlined"
             icon={<RoomIcon sx={{ fontSize: 16 }} />}
             label={lesson.room}
-            sx={{ borderColor: "var(--btn-border)", color: "var(--page-text)" }}
+            sx={(theme) => {
+              const primaryColor = theme.vars?.palette.primary.main ?? theme.palette.primary.main
+              return {
+                borderColor: "var(--btn-border)",
+                color: "var(--page-text)",
+                "& .MuiChip-icon": { color: primaryColor },
+              }
+            }}
           />
         </Stack>
       </Stack>
@@ -1285,12 +1299,30 @@ export default function Schedule() {
                             variant="outlined"
                             icon={<SchoolIcon sx={{ fontSize: 16 }} />}
                             label={lesson.teacher}
+                            sx={(theme) => {
+                              const primaryColor = theme.vars?.palette.primary.main ?? theme.palette.primary.main
+                              return {
+                                borderColor: primaryColor,
+                                color: primaryColor,
+                                fontWeight: 600,
+                                "& .MuiChip-icon": { color: primaryColor },
+                              }
+                            }}
                           />
                           <Chip
                             size="small"
                             variant="outlined"
                             icon={<RoomIcon sx={{ fontSize: 16 }} />}
                             label={lesson.room}
+                            sx={(theme) => {
+                              const primaryColor = theme.vars?.palette.primary.main ?? theme.palette.primary.main
+                              return {
+                                borderColor: primaryColor,
+                                color: primaryColor,
+                                fontWeight: 600,
+                                "& .MuiChip-icon": { color: primaryColor },
+                              }
+                            }}
                           />
                         </Stack>
                       </Box>
@@ -1413,12 +1445,20 @@ export default function Schedule() {
                       variant="outlined"
                       icon={<SchoolIcon sx={{ fontSize: 16 }} />}
                       label={currentLesson.teacher}
+                      sx={(theme) => {
+                        const primaryColor = theme.vars?.palette.primary.main ?? theme.palette.primary.main
+                        return { "& .MuiChip-icon": { color: primaryColor } }
+                      }}
                     />
                     <Chip
                       size="small"
                       variant="outlined"
                       icon={<RoomIcon sx={{ fontSize: 16 }} />}
                       label={currentLesson.room}
+                      sx={(theme) => {
+                        const primaryColor = theme.vars?.palette.primary.main ?? theme.palette.primary.main
+                        return { "& .MuiChip-icon": { color: primaryColor } }
+                      }}
                     />
                   </Stack>
                   <LinearProgress

--- a/root/frontend/src/pages/Schedule.tsx
+++ b/root/frontend/src/pages/Schedule.tsx
@@ -1300,7 +1300,8 @@ export default function Schedule() {
                             icon={<SchoolIcon sx={{ fontSize: 16 }} />}
                             label={lesson.teacher}
                             sx={(theme) => {
-                              const primaryColor = theme.vars?.palette.primary.main ?? theme.palette.primary.main
+                              const primaryColor =
+                                theme.vars?.palette.primary.main ?? theme.palette.primary.main
                               return {
                                 borderColor: primaryColor,
                                 color: primaryColor,
@@ -1315,7 +1316,8 @@ export default function Schedule() {
                             icon={<RoomIcon sx={{ fontSize: 16 }} />}
                             label={lesson.room}
                             sx={(theme) => {
-                              const primaryColor = theme.vars?.palette.primary.main ?? theme.palette.primary.main
+                              const primaryColor =
+                                theme.vars?.palette.primary.main ?? theme.palette.primary.main
                               return {
                                 borderColor: primaryColor,
                                 color: primaryColor,
@@ -1446,7 +1448,8 @@ export default function Schedule() {
                       icon={<SchoolIcon sx={{ fontSize: 16 }} />}
                       label={currentLesson.teacher}
                       sx={(theme) => {
-                        const primaryColor = theme.vars?.palette.primary.main ?? theme.palette.primary.main
+                        const primaryColor =
+                          theme.vars?.palette.primary.main ?? theme.palette.primary.main
                         return { "& .MuiChip-icon": { color: primaryColor } }
                       }}
                     />
@@ -1456,7 +1459,8 @@ export default function Schedule() {
                       icon={<RoomIcon sx={{ fontSize: 16 }} />}
                       label={currentLesson.room}
                       sx={(theme) => {
-                        const primaryColor = theme.vars?.palette.primary.main ?? theme.palette.primary.main
+                        const primaryColor =
+                          theme.vars?.palette.primary.main ?? theme.palette.primary.main
                         return { "& .MuiChip-icon": { color: primaryColor } }
                       }}
                     />


### PR DESCRIPTION
## Summary
- highlight teacher and room icons in schedule chips with the primary color for better readability
- emphasize instructor and room names in the mobile schedule view to give them a saturated appearance
- align the current lesson chips with the same accent styling for consistency

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fea66a7ee88327848e4c49530f6c5f