### PR TITLE
Add notification queue success metrics

### DIFF
--- a/root/app/core/observability.py
+++ b/root/app/core/observability.py
@@ -524,7 +524,10 @@ class NotificationQueueMetrics:
     queue_size: Gauge
     dropped_jobs_total: Counter
     failed_jobs_total: Counter
+    processed_jobs_total: Counter
     processing_latency_seconds: Histogram
+    queue_wait_time_seconds: Histogram
+    retry_delay_seconds: Histogram
     dead_lettered_jobs: Gauge
     oldest_dead_letter_age_seconds: Histogram | None
 
@@ -536,9 +539,29 @@ class NotificationQueueMetrics:
         # hence the type: ignore annotations.
         self.dropped_jobs_total._value.set(0)  # type: ignore[attr-defined]
         self.failed_jobs_total._value.set(0)  # type: ignore[attr-defined]
+        # Reset labelled counters by clearing underlying metrics or zeroing values.
+        metrics = getattr(self.processed_jobs_total, "_metrics", None)
+        if metrics:
+            for metric in metrics.values():
+                metric._value.set(0)  # type: ignore[attr-defined]
+        value = getattr(self.processed_jobs_total, "_value", None)
+        if value is not None:
+            value.set(0)
         self.processing_latency_seconds._sum.set(0)  # type: ignore[attr-defined]
         for bucket in getattr(self.processing_latency_seconds, "_buckets", []):  # type: ignore[attr-defined]
             bucket.set(0)
+        queue_wait_metrics = getattr(self.queue_wait_time_seconds, "_metrics", None)
+        if queue_wait_metrics:
+            for metric in queue_wait_metrics.values():
+                metric._sum.set(0)  # type: ignore[attr-defined]
+                for bucket in getattr(metric, "_buckets", []):
+                    bucket.set(0)
+        retry_delay_metrics = getattr(self.retry_delay_seconds, "_metrics", None)
+        if retry_delay_metrics:
+            for metric in retry_delay_metrics.values():
+                metric._sum.set(0)  # type: ignore[attr-defined]
+                for bucket in getattr(metric, "_buckets", []):
+                    bucket.set(0)
         self.dead_lettered_jobs.set(0)
         histogram = self.oldest_dead_letter_age_seconds
         if histogram is not None:
@@ -570,6 +593,11 @@ def get_notification_queue_metrics() -> NotificationQueueMetrics:
                 "notification_queue_failed_jobs_total",
                 "Total notification jobs permanently failed or dead-lettered",
             ),
+            processed_jobs_total=Counter(
+                "notification_queue_processed_jobs_total",
+                "Total notification jobs successfully processed",
+                labelnames=("kind",),
+            ),
             processing_latency_seconds=Histogram(
                 "notification_queue_processing_latency_seconds",
                 "Time spent processing individual notification jobs in seconds",
@@ -582,6 +610,41 @@ def get_notification_queue_metrics() -> NotificationQueueMetrics:
                     2.5,
                     5.0,
                     10.0,
+                ),
+            ),
+            queue_wait_time_seconds=Histogram(
+                "notification_queue_queue_wait_time_seconds",
+                "Time notification jobs spend waiting in the queue before processing",
+                labelnames=("kind",),
+                buckets=(
+                    0.01,
+                    0.05,
+                    0.1,
+                    0.5,
+                    1.0,
+                    2.5,
+                    5.0,
+                    10.0,
+                    30.0,
+                    60.0,
+                ),
+            ),
+            retry_delay_seconds=Histogram(
+                "notification_queue_retry_delay_seconds",
+                "Delay applied before retrying failed notification jobs",
+                labelnames=("kind",),
+                buckets=(
+                    0.01,
+                    0.05,
+                    0.1,
+                    0.5,
+                    1.0,
+                    2.5,
+                    5.0,
+                    10.0,
+                    30.0,
+                    60.0,
+                    120.0,
                 ),
             ),
             dead_lettered_jobs=Gauge(

--- a/root/app/services/notification_queue.py
+++ b/root/app/services/notification_queue.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime, timedelta, timezone
 from typing import Iterable, Literal, Sequence, cast
 from weakref import WeakKeyDictionary
@@ -37,6 +37,8 @@ class NotificationJob:
     record_id: int
     locale: str | None
     queue_id: int | None = None
+    enqueued_at: datetime | None = None
+    claimed_at: datetime | None = None
 
 
 @dataclass(slots=True)
@@ -132,6 +134,17 @@ async def _worker_loop(state: _LoopState) -> None:
                 state.active_jobs += 1
                 if metrics is not None:
                     _update_in_memory_metrics(metrics, state.queue)
+            if metrics is not None and job.enqueued_at is not None:
+                claimed_at = job.claimed_at or datetime.now(timezone.utc)
+                enqueued_at = job.enqueued_at
+                if enqueued_at.tzinfo is None:
+                    enqueued_at = enqueued_at.replace(tzinfo=timezone.utc)
+                if claimed_at.tzinfo is None:
+                    claimed_at = claimed_at.replace(tzinfo=timezone.utc)
+                wait_seconds = max((claimed_at - enqueued_at).total_seconds(), 0.0)
+                metrics.queue_wait_time_seconds.labels(kind=job.kind).observe(
+                    wait_seconds
+                )
             started = time.perf_counter()
             success = False
             error: BaseException | None = None
@@ -149,6 +162,8 @@ async def _worker_loop(state: _LoopState) -> None:
                 if metrics is not None:
                     elapsed = max(time.perf_counter() - started, 0.0)
                     metrics.processing_latency_seconds.observe(elapsed)
+                    if success:
+                        metrics.processed_jobs_total.labels(kind=job.kind).inc()
                 if _use_persistent_backend():
                     await _acknowledge_persistent_job(
                         job,
@@ -175,6 +190,8 @@ def _evict_oldest(queue: asyncio.Queue[NotificationJob]) -> NotificationJob | No
 
 
 async def _enqueue_job(job: NotificationJob) -> None:
+    if job.enqueued_at is None:
+        job = replace(job, enqueued_at=datetime.now(timezone.utc))
     if _use_persistent_backend():
         await _enqueue_persistent_job(job)
     else:
@@ -359,6 +376,7 @@ async def reset_testing_state() -> None:
     state.job_event.clear()
     await _clear_persistent_jobs()
     if metrics is not None:
+        metrics.reset()
         if _use_persistent_backend():
             await _refresh_persistent_queue_size(metrics)
         else:
@@ -523,6 +541,8 @@ async def _claim_next_persistent_job() -> NotificationJob | None:
                 record_id=row.record_id,
                 locale=row.locale,
                 queue_id=row.id,
+                enqueued_at=row.enqueued_at,
+                claimed_at=now,
             )
     metrics = _get_metrics()
     if metrics is not None:
@@ -719,6 +739,10 @@ async def _acknowledge_persistent_job(
                         )
                         record.dead_lettered = False
                         record.next_retry_at = next_retry
+                        if metrics is not None and wake_delay > 0:
+                            metrics.retry_delay_seconds.labels(kind=job.kind).observe(
+                                wake_delay
+                            )
                         logger.warning(
                             "Notification job failed; scheduling retry",
                             extra={

--- a/root/tests/test_notification_queue_worker.py
+++ b/root/tests/test_notification_queue_worker.py
@@ -212,7 +212,9 @@ async def test_reset_testing_state_resets_metrics(monkeypatch: pytest.MonkeyPatc
         {"kind": "news"},
     ) in (None, pytest.approx(0.0))
     assert _metric_value("notification_queue_failed_jobs_total") == pytest.approx(0.0)
-    assert _metric_value("notification_queue_queue_wait_time_seconds_sum", {"kind": "news"}) in (
+    assert _metric_value(
+        "notification_queue_queue_wait_time_seconds_sum", {"kind": "news"}
+    ) in (
         None,
         pytest.approx(0.0),
     )

--- a/root/tests/test_notification_queue_worker.py
+++ b/root/tests/test_notification_queue_worker.py
@@ -97,8 +97,10 @@ async def test_shutdown_notification_queue_does_not_leak_tasks(
     assert not worker_tasks
 
 
-def _metric_value(name: str) -> float | None:
-    return REGISTRY.get_sample_value(name)
+def _metric_value(name: str, labels: dict[str, str] | None = None) -> float | None:
+    if labels is None:
+        return REGISTRY.get_sample_value(name)
+    return REGISTRY.get_sample_value(name, labels)
 
 
 @pytest.mark.anyio
@@ -161,9 +163,59 @@ async def test_notification_queue_records_processing_latency(
 
     count = _metric_value("notification_queue_processing_latency_seconds_count")
     total = _metric_value("notification_queue_processing_latency_seconds_sum")
+    processed = _metric_value(
+        "notification_queue_processed_jobs_total",
+        {"kind": "event"},
+    )
+    queue_wait_total = _metric_value(
+        "notification_queue_queue_wait_time_seconds_sum",
+        {"kind": "event"},
+    )
     assert count == pytest.approx(1.0)
     assert total is not None and total > 0
+    assert processed == pytest.approx(1.0)
+    assert queue_wait_total is not None and queue_wait_total >= 0
     assert _metric_value("notification_queue_size") == pytest.approx(0.0)
+
+    notification_queue._loop_states.clear()
+
+
+@pytest.mark.anyio
+async def test_reset_testing_state_resets_metrics(monkeypatch: pytest.MonkeyPatch):
+    metrics = observability.get_notification_queue_metrics()
+    metrics.reset()
+    notification_queue._loop_states.clear()
+
+    processed_event = asyncio.Event()
+
+    async def _fake_process(job):
+        processed_event.set()
+
+    monkeypatch.setattr(notification_queue, "_process_job", _fake_process)
+
+    await notification_queue.enqueue_news_notification(6)
+
+    await asyncio.wait_for(processed_event.wait(), timeout=1.0)
+    await notification_queue.wait_for_all_jobs(timeout=1.0)
+    await notification_queue.shutdown_notification_queue()
+
+    processed = _metric_value(
+        "notification_queue_processed_jobs_total",
+        {"kind": "news"},
+    )
+    assert processed == pytest.approx(1.0)
+
+    await notification_queue.reset_testing_state()
+
+    assert _metric_value(
+        "notification_queue_processed_jobs_total",
+        {"kind": "news"},
+    ) in (None, pytest.approx(0.0))
+    assert _metric_value("notification_queue_failed_jobs_total") == pytest.approx(0.0)
+    assert _metric_value("notification_queue_queue_wait_time_seconds_sum", {"kind": "news"}) in (
+        None,
+        pytest.approx(0.0),
+    )
 
     notification_queue._loop_states.clear()
 


### PR DESCRIPTION
## Summary
- add Prometheus counters for successful notification jobs together with queue wait and retry histograms
- track enqueue/claim timestamps so the worker can record wait times and retry delays while updating success counts
- extend notification queue worker tests to cover the new metrics and reset behaviour

## Testing
- pytest root/tests/test_notification_queue_worker.py

------
https://chatgpt.com/codex/tasks/task_e_68fecc576e408327a11a1df83fef8f80