### PR TITLE
Add Prometheus metrics for periodic cleanup tasks

### DIFF
--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -9,6 +9,19 @@
 - Для лимитирования запросов настройте backend с помощью `RATE_LIMIT_STORAGE_BACKEND` и `RATE_LIMIT_STORAGE_URI`. Значение `redis` + Redis URL (например, `redis://user:pass@host:6379/0`) включает общий сторедж для middleware и чувствительных эндпоинтов. Установите `memory` или `memory://` для простого однопроцессного режима без внешнего Redis.
 - Для экспонирования Prometheus-метрик установите `ENABLE_METRICS_ENDPOINT=true` и задайте собственные, стойкие значения `METRICS_BASIC_AUTH_USERNAME` и `METRICS_BASIC_AUTH_PASSWORD` (docker-compose больше не подставляет плейсхолдеры). Backend откажется отдавать `/metrics`, если пароль равен известному плейсхолдеру вроде `changeme`.
 
+### Метрики фоновых задач
+
+- `/metrics` теперь публикует счётчики и гистограммы для фоновых очисток:
+  - `periodic_task_notifications_retention_*` — удаление старых уведомлений и доставок.
+  - `periodic_task_password_reset_cleanup_*` — очистка токенов восстановления пароля.
+  - `periodic_task_session_cleanup_*` — удаление протухших пользовательских сессий.
+  - `periodic_task_story_cleanup_*` — очистка просроченных историй.
+- Для каждой задачи доступны:
+  - `*_runs_total` — количество успешных итераций.
+  - `*_errors_total` — количество завершений с исключением.
+  - `*_deleted_total` — суммарное число удалённых записей за всё время.
+  - `*_duration_seconds{_bucket,_sum,_count}` — гистограмма продолжительности выполнения.
+
 ```bash
 # пример
 cd frontend

--- a/root/app/core/observability.py
+++ b/root/app/core/observability.py
@@ -7,10 +7,11 @@ import re
 import socket
 import time
 import uuid
-from contextlib import suppress
+from contextlib import asynccontextmanager, suppress
 from contextvars import ContextVar
 from dataclasses import dataclass
-from typing import Any, Awaitable, Callable, Iterable, Mapping
+from collections.abc import Iterable
+from typing import Any, AsyncIterator, Awaitable, Callable, Mapping
 
 import uvicorn
 from fastapi import FastAPI
@@ -80,6 +81,7 @@ _sqlalchemy_instrumented = False
 _otel_logger_provider: LoggerProvider | None = None
 _otel_logging_handler: LoggingHandler | None = None
 _notification_queue_metrics: "NotificationQueueMetrics | None" = None
+_periodic_task_metrics: dict[str, "PeriodicTaskMetrics"] = {}
 
 _request_id_ctx: ContextVar[str | None] = ContextVar("request_id", default=None)
 
@@ -449,6 +451,117 @@ def create_worker_metrics(name: str) -> WorkerMetrics:
         heartbeat_timestamp=heartbeat,
     )
     metrics.mark_startup()
+    return metrics
+
+
+@dataclass(slots=True)
+class PeriodicTaskRun:
+    metrics: "PeriodicTaskMetrics"
+    _deleted_total: int = 0
+
+    def observe_deleted(self, value: int | Iterable[int | None] | None) -> None:
+        total = 0
+        if value is None:
+            total = 0
+        elif isinstance(value, Iterable) and not isinstance(value, (str, bytes)):
+            for item in value:
+                total += _coerce_deleted_value(item)
+        else:
+            total = _coerce_deleted_value(value)
+        if total > 0:
+            self._deleted_total += total
+
+    @property
+    def deleted_total(self) -> int:
+        return self._deleted_total
+
+
+def _coerce_deleted_value(value: object) -> int:
+    try:
+        number = int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return 0
+    return number if number > 0 else 0
+
+
+@dataclass(slots=True)
+class PeriodicTaskMetrics:
+    name: str
+    metric_prefix: str
+    runs_total: Counter
+    errors_total: Counter
+    deleted_total: Counter
+    duration_seconds: Histogram
+
+    @asynccontextmanager
+    async def track_execution(self) -> AsyncIterator[PeriodicTaskRun]:
+        run = PeriodicTaskRun(self)
+        start = time.perf_counter()
+        try:
+            yield run
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            elapsed = max(time.perf_counter() - start, 0.0)
+            self.errors_total.inc()
+            self.duration_seconds.observe(elapsed)
+            raise
+        else:
+            elapsed = max(time.perf_counter() - start, 0.0)
+            self.runs_total.inc()
+            if run.deleted_total > 0:
+                self.deleted_total.inc(run.deleted_total)
+            self.duration_seconds.observe(elapsed)
+
+
+def get_periodic_task_metrics(name: str) -> PeriodicTaskMetrics:
+    if Counter is None or Histogram is None:  # pragma: no cover - safety
+        raise RuntimeError("prometheus-client is required for periodic task metrics")
+
+    metric_key = _sanitize_metric_name(name)
+    if metric_key in _periodic_task_metrics:
+        return _periodic_task_metrics[metric_key]
+
+    prefix = f"periodic_task_{metric_key}"
+    runs = Counter(
+        f"{prefix}_runs_total",
+        "Total successful executions of the periodic task",
+    )
+    errors = Counter(
+        f"{prefix}_errors_total",
+        "Total exceptions raised by the periodic task",
+    )
+    deleted = Counter(
+        f"{prefix}_deleted_total",
+        "Total database rows deleted by the periodic task",
+    )
+    duration = Histogram(
+        f"{prefix}_duration_seconds",
+        "Runtime of the periodic task execution in seconds",
+        buckets=(
+            0.01,
+            0.05,
+            0.1,
+            0.5,
+            1.0,
+            2.5,
+            5.0,
+            10.0,
+            30.0,
+            60.0,
+            120.0,
+        ),
+    )
+
+    metrics = PeriodicTaskMetrics(
+        name=name,
+        metric_prefix=prefix,
+        runs_total=runs,
+        errors_total=errors,
+        deleted_total=deleted,
+        duration_seconds=duration,
+    )
+    _periodic_task_metrics[metric_key] = metrics
     return metrics
 
 

--- a/root/app/core/observability.py
+++ b/root/app/core/observability.py
@@ -7,10 +7,10 @@ import re
 import socket
 import time
 import uuid
+from collections.abc import Iterable
 from contextlib import asynccontextmanager, suppress
 from contextvars import ContextVar
 from dataclasses import dataclass
-from collections.abc import Iterable
 from typing import Any, AsyncIterator, Awaitable, Callable, Mapping
 
 import uvicorn

--- a/root/app/services/notifications_retention.py
+++ b/root/app/services/notifications_retention.py
@@ -6,9 +6,13 @@ from contextlib import suppress
 from dataclasses import dataclass
 from typing import Awaitable, Callable
 
+from app.core.observability import get_periodic_task_metrics
 from app.services.notifications import cleanup_stale_notifications
 
 logger = logging.getLogger(__name__)
+
+
+_METRICS = get_periodic_task_metrics("notifications_retention")
 
 
 @dataclass(slots=True)
@@ -47,7 +51,15 @@ async def start_notifications_retention_scheduler(
         try:
             while True:
                 try:
-                    await cleanup_stale_notifications(retention_days=retention_days)
+                    async with _METRICS.track_execution() as run:
+                        deleted_notifications, deleted_deliveries = (
+                            await cleanup_stale_notifications(
+                                retention_days=retention_days
+                            )
+                        )
+                        run.observe_deleted(
+                            (deleted_notifications, deleted_deliveries)
+                        )
                 except asyncio.CancelledError:
                     raise
                 except Exception:  # pragma: no cover - defensive logging

--- a/root/app/services/notifications_retention.py
+++ b/root/app/services/notifications_retention.py
@@ -52,14 +52,13 @@ async def start_notifications_retention_scheduler(
             while True:
                 try:
                     async with _METRICS.track_execution() as run:
-                        deleted_notifications, deleted_deliveries = (
-                            await cleanup_stale_notifications(
-                                retention_days=retention_days
-                            )
+                        (
+                            deleted_notifications,
+                            deleted_deliveries,
+                        ) = await cleanup_stale_notifications(
+                            retention_days=retention_days
                         )
-                        run.observe_deleted(
-                            (deleted_notifications, deleted_deliveries)
-                        )
+                        run.observe_deleted((deleted_notifications, deleted_deliveries))
                 except asyncio.CancelledError:
                     raise
                 except Exception:  # pragma: no cover - defensive logging

--- a/root/app/services/password_reset_cleanup.py
+++ b/root/app/services/password_reset_cleanup.py
@@ -12,11 +12,15 @@ from typing import Awaitable, Callable
 from sqlalchemy import and_, delete, or_
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.observability import get_periodic_task_metrics
 from app.core.database import async_session
 from app.models.models import PasswordResetToken
 from app.utils.email import RESET_TOKEN_EXPIRY_MINUTES
 
 logger = logging.getLogger(__name__)
+
+
+_METRICS = get_periodic_task_metrics("password_reset_cleanup")
 
 
 def _now() -> datetime:
@@ -91,9 +95,11 @@ async def start_password_reset_cleanup_scheduler(
         try:
             while True:
                 try:
-                    await cleanup_stale_password_reset_tokens(
-                        retention_minutes=retention
-                    )
+                    async with _METRICS.track_execution() as run:
+                        deleted = await cleanup_stale_password_reset_tokens(
+                            retention_minutes=retention
+                        )
+                        run.observe_deleted(deleted)
                 except asyncio.CancelledError:
                     raise
                 except Exception:  # pragma: no cover - defensive logging
@@ -120,3 +126,4 @@ async def start_password_reset_cleanup_scheduler(
 
 if __name__ == "__main__":  # pragma: no cover - convenience entrypoint
     asyncio.run(cleanup_stale_password_reset_tokens())
+

--- a/root/app/services/password_reset_cleanup.py
+++ b/root/app/services/password_reset_cleanup.py
@@ -12,8 +12,8 @@ from typing import Awaitable, Callable
 from sqlalchemy import and_, delete, or_
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.observability import get_periodic_task_metrics
 from app.core.database import async_session
+from app.core.observability import get_periodic_task_metrics
 from app.models.models import PasswordResetToken
 from app.utils.email import RESET_TOKEN_EXPIRY_MINUTES
 
@@ -126,4 +126,3 @@ async def start_password_reset_cleanup_scheduler(
 
 if __name__ == "__main__":  # pragma: no cover - convenience entrypoint
     asyncio.run(cleanup_stale_password_reset_tokens())
-

--- a/root/app/services/session_cleanup.py
+++ b/root/app/services/session_cleanup.py
@@ -12,10 +12,14 @@ from typing import Awaitable, Callable
 from sqlalchemy import delete, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.observability import get_periodic_task_metrics
 from app.core.database import async_session
 from app.models.models import ActiveSession, MfaChallenge
 
 logger = logging.getLogger(__name__)
+
+
+_METRICS = get_periodic_task_metrics("session_cleanup")
 
 
 def _now() -> datetime:
@@ -73,7 +77,9 @@ async def start_session_cleanup_scheduler(
         try:
             while True:
                 try:
-                    await cleanup_expired_sessions()
+                    async with _METRICS.track_execution() as run:
+                        deleted = await cleanup_expired_sessions()
+                        run.observe_deleted(deleted)
                 except asyncio.CancelledError:
                     raise
                 except Exception:  # pragma: no cover - defensive logging
@@ -100,3 +106,4 @@ async def start_session_cleanup_scheduler(
 
 if __name__ == "__main__":  # pragma: no cover - convenience entrypoint
     asyncio.run(cleanup_expired_sessions())
+

--- a/root/app/services/session_cleanup.py
+++ b/root/app/services/session_cleanup.py
@@ -12,8 +12,8 @@ from typing import Awaitable, Callable
 from sqlalchemy import delete, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.observability import get_periodic_task_metrics
 from app.core.database import async_session
+from app.core.observability import get_periodic_task_metrics
 from app.models.models import ActiveSession, MfaChallenge
 
 logger = logging.getLogger(__name__)
@@ -106,4 +106,3 @@ async def start_session_cleanup_scheduler(
 
 if __name__ == "__main__":  # pragma: no cover - convenience entrypoint
     asyncio.run(cleanup_expired_sessions())
-

--- a/root/app/services/story_cleanup.py
+++ b/root/app/services/story_cleanup.py
@@ -12,8 +12,8 @@ from typing import Awaitable, Callable
 from sqlalchemy import delete
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.observability import get_periodic_task_metrics
 from app.core.database import async_session
+from app.core.observability import get_periodic_task_metrics
 from app.models.models import Story
 
 logger = logging.getLogger(__name__)
@@ -100,4 +100,3 @@ async def start_story_cleanup_scheduler(
 
 if __name__ == "__main__":  # pragma: no cover - convenience entrypoint
     asyncio.run(cleanup_expired_stories())
-

--- a/root/app/services/story_cleanup.py
+++ b/root/app/services/story_cleanup.py
@@ -12,10 +12,14 @@ from typing import Awaitable, Callable
 from sqlalchemy import delete
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.observability import get_periodic_task_metrics
 from app.core.database import async_session
 from app.models.models import Story
 
 logger = logging.getLogger(__name__)
+
+
+_METRICS = get_periodic_task_metrics("story_cleanup")
 
 
 def _now() -> datetime:
@@ -67,7 +71,9 @@ async def start_story_cleanup_scheduler(
         try:
             while True:
                 try:
-                    await cleanup_expired_stories()
+                    async with _METRICS.track_execution() as run:
+                        deleted = await cleanup_expired_stories()
+                        run.observe_deleted(deleted)
                 except asyncio.CancelledError:
                     raise
                 except Exception:  # pragma: no cover - defensive logging
@@ -94,3 +100,4 @@ async def start_story_cleanup_scheduler(
 
 if __name__ == "__main__":  # pragma: no cover - convenience entrypoint
     asyncio.run(cleanup_expired_stories())
+

--- a/root/tests/test_periodic_task_metrics.py
+++ b/root/tests/test_periodic_task_metrics.py
@@ -1,0 +1,43 @@
+import pytest
+from prometheus_client import REGISTRY
+
+from app.core.observability import get_periodic_task_metrics
+
+
+@pytest.mark.anyio
+async def test_periodic_task_metrics_records_success() -> None:
+    metrics = get_periodic_task_metrics("test_periodic_task_success")
+
+    async with metrics.track_execution() as run:
+        run.observe_deleted((3, 2, None))
+
+    prefix = "periodic_task_test_periodic_task_success"
+    assert REGISTRY.get_sample_value(f"{prefix}_runs_total") == pytest.approx(1.0)
+    assert REGISTRY.get_sample_value(f"{prefix}_errors_total") == pytest.approx(0.0)
+    assert REGISTRY.get_sample_value(f"{prefix}_deleted_total") == pytest.approx(5.0)
+    assert (
+        REGISTRY.get_sample_value(f"{prefix}_duration_seconds_count")
+        == pytest.approx(1.0)
+    )
+    duration_sum = REGISTRY.get_sample_value(f"{prefix}_duration_seconds_sum")
+    assert duration_sum is not None and duration_sum >= 0.0
+
+
+@pytest.mark.anyio
+async def test_periodic_task_metrics_records_failure() -> None:
+    metrics = get_periodic_task_metrics("test_periodic_task_failure")
+
+    with pytest.raises(RuntimeError):
+        async with metrics.track_execution():
+            raise RuntimeError("boom")
+
+    prefix = "periodic_task_test_periodic_task_failure"
+    assert REGISTRY.get_sample_value(f"{prefix}_runs_total") == pytest.approx(0.0)
+    assert REGISTRY.get_sample_value(f"{prefix}_errors_total") == pytest.approx(1.0)
+    assert REGISTRY.get_sample_value(f"{prefix}_deleted_total") == pytest.approx(0.0)
+    assert (
+        REGISTRY.get_sample_value(f"{prefix}_duration_seconds_count")
+        == pytest.approx(1.0)
+    )
+    duration_sum = REGISTRY.get_sample_value(f"{prefix}_duration_seconds_sum")
+    assert duration_sum is not None and duration_sum >= 0.0

--- a/root/tests/test_periodic_task_metrics.py
+++ b/root/tests/test_periodic_task_metrics.py
@@ -15,10 +15,9 @@ async def test_periodic_task_metrics_records_success() -> None:
     assert REGISTRY.get_sample_value(f"{prefix}_runs_total") == pytest.approx(1.0)
     assert REGISTRY.get_sample_value(f"{prefix}_errors_total") == pytest.approx(0.0)
     assert REGISTRY.get_sample_value(f"{prefix}_deleted_total") == pytest.approx(5.0)
-    assert (
-        REGISTRY.get_sample_value(f"{prefix}_duration_seconds_count")
-        == pytest.approx(1.0)
-    )
+    assert REGISTRY.get_sample_value(
+        f"{prefix}_duration_seconds_count"
+    ) == pytest.approx(1.0)
     duration_sum = REGISTRY.get_sample_value(f"{prefix}_duration_seconds_sum")
     assert duration_sum is not None and duration_sum >= 0.0
 
@@ -35,9 +34,8 @@ async def test_periodic_task_metrics_records_failure() -> None:
     assert REGISTRY.get_sample_value(f"{prefix}_runs_total") == pytest.approx(0.0)
     assert REGISTRY.get_sample_value(f"{prefix}_errors_total") == pytest.approx(1.0)
     assert REGISTRY.get_sample_value(f"{prefix}_deleted_total") == pytest.approx(0.0)
-    assert (
-        REGISTRY.get_sample_value(f"{prefix}_duration_seconds_count")
-        == pytest.approx(1.0)
-    )
+    assert REGISTRY.get_sample_value(
+        f"{prefix}_duration_seconds_count"
+    ) == pytest.approx(1.0)
     duration_sum = REGISTRY.get_sample_value(f"{prefix}_duration_seconds_sum")
     assert duration_sum is not None and duration_sum >= 0.0


### PR DESCRIPTION
## Summary
- add a reusable helper in `observability` to expose Prometheus counters and histograms for periodic jobs
- instrument notification, password reset, session, and story cleanup loops to record runtimes, deletions, and errors
- cover the new metrics with tests and document the exported Prometheus series

## Testing
- pytest root/tests/test_periodic_task_metrics.py root/tests/test_notifications_retention.py root/tests/test_password_reset_cleanup.py root/tests/test_session_cleanup.py root/tests/test_story_cleanup.py *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68fed01f58448327aaa483d4fe64cece