### PR TITLE
Optimize expired session cleanup queries

### DIFF
--- a/root/app/services/session_cleanup.py
+++ b/root/app/services/session_cleanup.py
@@ -38,19 +38,21 @@ async def cleanup_expired_sessions(
         async with async_session() as session:
             return await cleanup_expired_sessions(db=session, now=now)
 
-    target_sessions_stmt = select(ActiveSession.id).where(
-        or_(ActiveSession.expires_at <= now, ActiveSession.revoked_at <= now)
+    expiry_condition = or_(
+        ActiveSession.expires_at <= now, ActiveSession.revoked_at <= now
     )
-    result = await db.execute(target_sessions_stmt)
-    session_ids = [row[0] for row in result]
-    deleted = 0
-    if session_ids:
-        await db.execute(
-            delete(MfaChallenge).where(MfaChallenge.session_id.in_(session_ids))
-        )
-        delete_stmt = delete(ActiveSession).where(ActiveSession.id.in_(session_ids))
-        delete_result = await db.execute(delete_stmt)
-        deleted = int(delete_result.rowcount or 0)
+
+    expired_session_exists = (
+        select(1)
+        .where(ActiveSession.id == MfaChallenge.session_id)
+        .where(expiry_condition)
+        .exists()
+    )
+    await db.execute(delete(MfaChallenge).where(expired_session_exists))
+
+    delete_stmt = delete(ActiveSession).where(expiry_condition)
+    delete_result = await db.execute(delete_stmt)
+    deleted = int(delete_result.rowcount or 0)
     await db.commit()
     if deleted:
         logger.info("Removed %s expired sessions", deleted)

--- a/root/tests/test_session_cleanup.py
+++ b/root/tests/test_session_cleanup.py
@@ -84,3 +84,68 @@ async def test_cleanup_expired_sessions_removes_mfa_challenges(db_session):
             select(MfaChallenge).where(MfaChallenge.id == challenge.id)
         )
         assert result.scalars().first() is None
+
+
+@pytest.mark.anyio
+async def test_cleanup_expired_sessions_handles_large_batches(db_session):
+    now = dt.datetime.now(dt.UTC)
+
+    user = User(email="bulk@example.com", hashed_password="x")
+    db_session.add(user)
+    await db_session.flush()
+
+    expired_sessions = [
+        ActiveSession(
+            user_id=user.id,
+            jti=f"expired-{idx}",
+            expires_at=now - dt.timedelta(minutes=idx + 1),
+        )
+        for idx in range(300)
+    ]
+    revoked_sessions = [
+        ActiveSession(
+            user_id=user.id,
+            jti=f"revoked-{idx}",
+            expires_at=now + dt.timedelta(hours=1),
+            revoked_at=now - dt.timedelta(minutes=idx + 1),
+        )
+        for idx in range(150)
+    ]
+    active_sessions = [
+        ActiveSession(
+            user_id=user.id,
+            jti=f"active-{idx}",
+            expires_at=now + dt.timedelta(hours=2),
+        )
+        for idx in range(50)
+    ]
+
+    db_session.add_all(expired_sessions + revoked_sessions + active_sessions)
+    await db_session.flush()
+
+    active_ids = {session.id for session in active_sessions}
+
+    challenge_targets = expired_sessions[:180] + revoked_sessions[:40]
+    db_session.add_all(
+        [
+            MfaChallenge(
+                user_id=user.id,
+                session_id=session.id,
+                challenge_type=mfa.CHALLENGE_TYPE_TOTP_VERIFY,
+                token=f"token-{session.id}",
+                expires_at=now + dt.timedelta(minutes=5),
+            )
+            for session in challenge_targets
+        ]
+    )
+    await db_session.commit()
+
+    removed = await cleanup_expired_sessions(now=now)
+
+    assert removed == len(expired_sessions) + len(revoked_sessions)
+
+    remaining_sessions = await db_session.execute(select(ActiveSession.id))
+    assert set(remaining_sessions.scalars().all()) == active_ids
+
+    remaining_challenges = await db_session.execute(select(MfaChallenge.id))
+    assert remaining_challenges.scalars().all() == []


### PR DESCRIPTION
## Summary
- delete MFA challenges and expired sessions using set-based SQL to avoid materializing large ID lists
- keep cleanup logic transactional and report the number of removed sessions via rowcount
- extend session cleanup tests with a large batch scenario to guard against memory-heavy regressions

## Testing
- pytest root/tests/test_session_cleanup.py

------
https://chatgpt.com/codex/tasks/task_e_68fed7b7a5888327979c49ea4cdc1350