### PR TITLE
Expose theme tokens to Tailwind utilities

### DIFF
--- a/root/frontend/src/styles/tailwind.css
+++ b/root/frontend/src/styles/tailwind.css
@@ -1,3 +1,91 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  body {
+    @apply min-h-screen bg-page text-page-foreground font-ui antialiased transition-colors duration-300 ease-out;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    @apply font-display;
+  }
+
+  .skip-link {
+    @apply fixed left-1/2 top-2 -translate-x-1/2 -translate-y-full rounded-b-ue-md bg-nav px-5 py-3 font-bold text-nav-text shadow-surface opacity-0;
+    z-index: calc(var(--ue-z-index-nav) + 10);
+    transition:
+      transform var(--anim-med),
+      opacity var(--anim-med);
+  }
+
+  .skip-link:focus-visible {
+    @apply translate-y-0 opacity-100 outline-none shadow-focus;
+  }
+}
+
+@layer components {
+  /* Component tokens
+     .card-glass   → Frosted surface using the glass palette + blur.
+     .btn-gradient → Primary CTA gradient button with hover lift.
+     .chip         → Compact pill badge for schedules/filters.
+     .skeleton     → Neutral loading shimmer wrapper.
+  */
+  .card-glass {
+    @apply relative overflow-hidden rounded-ue-xl border border-glass-border bg-glass text-page-foreground shadow-glass backdrop-blur-md;
+  }
+
+  .card-glass::before {
+    content: "";
+    @apply pointer-events-none absolute inset-0 bg-gradient-to-br from-glass-tint1 via-glass-tint2 to-glass-tint3 opacity-80;
+  }
+
+  .card-glass::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    pointer-events: none;
+  }
+
+  .btn-gradient {
+    @apply inline-flex w-full items-center justify-center rounded-surface-lg bg-btn-gradient px-ue-lg py-ue-md font-display text-white font-extrabold tracking-wide shadow-surface transition-transform duration-200 ease-out;
+    letter-spacing: 0.02em;
+  }
+
+  .btn-gradient:hover,
+  .btn-gradient:focus-visible {
+    @apply bg-btn-gradient-hover shadow-surface-strong;
+  }
+
+  .btn-gradient:focus-visible {
+    @apply outline-none shadow-focus;
+  }
+
+  .chip {
+    @apply inline-flex items-center gap-ue-2xs rounded-ue-pill border border-button-border bg-button px-ue-sm py-ue-2xs text-sm font-semibold text-nav-text transition-colors duration-200 ease-out;
+  }
+
+  .chip[data-scope="today"] {
+    @apply bg-surface-accent font-bold;
+  }
+
+  .skeleton {
+    @apply relative overflow-hidden rounded-ue-md bg-skeleton text-transparent;
+    animation: fade-in var(--anim-med, 0.3s ease) both;
+  }
+
+  .skeleton::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(90deg, transparent 0%, rgba(255, 255, 255, 0.25) 45%, transparent 100%);
+    animation: fade-in var(--anim-med, 0.3s ease) forwards, skeleton-wave 1.6s ease-in-out infinite;
+  }
+}

--- a/root/frontend/src/styles/tailwind.css
+++ b/root/frontend/src/styles/tailwind.css
@@ -85,7 +85,14 @@
     content: "";
     position: absolute;
     inset: 0;
-    background: linear-gradient(90deg, transparent 0%, rgba(255, 255, 255, 0.25) 45%, transparent 100%);
-    animation: fade-in var(--anim-med, 0.3s ease) forwards, skeleton-wave 1.6s ease-in-out infinite;
+    background: linear-gradient(
+      90deg,
+      transparent 0%,
+      rgba(255, 255, 255, 0.25) 45%,
+      transparent 100%
+    );
+    animation:
+      fade-in var(--anim-med, 0.3s ease) forwards,
+      skeleton-wave 1.6s ease-in-out infinite;
   }
 }

--- a/root/frontend/tailwind.config.ts
+++ b/root/frontend/tailwind.config.ts
@@ -1,11 +1,170 @@
+import plugin from "tailwindcss/plugin";
 import type { Config } from "tailwindcss";
+
+const attributeSelector = (attribute: "data" | "aria", value: string) => {
+  const [rawAttr, rawValue] = value.split("=");
+  const attr = rawAttr?.trim();
+  const attrValue = rawValue?.trim();
+
+  if (!attr) {
+    return "";
+  }
+
+  return attrValue
+    ? `[${attribute}-${attr}="${attrValue}"]`
+    : `[${attribute}-${attr}="true"]`;
+};
 
 const config: Config = {
   content: ["./index.html", "./src/**/*.{ts,tsx,js,jsx}"],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        page: {
+          DEFAULT: "var(--page-bg)",
+          foreground: "var(--page-text)",
+        },
+        surface: {
+          DEFAULT: "var(--card-bg)",
+          accent: "var(--option-hover-bg)",
+        },
+        nav: {
+          DEFAULT: "var(--nav-bg)",
+          text: "var(--nav-text)",
+          link: "var(--nav-link)",
+          hover: "var(--nav-link-hover)",
+        },
+        button: {
+          DEFAULT: "var(--btn-bg)",
+          border: "var(--btn-border)",
+        },
+        secondary: "var(--secondary-text)",
+        glass: {
+          DEFAULT: "var(--glass-bg)",
+          border: "var(--glass-border)",
+          highlight: "var(--glass-highlight)",
+          tint1: "var(--glass-tint-1)",
+          tint2: "var(--glass-tint-2)",
+          tint3: "var(--glass-tint-3)",
+        },
+        progress: {
+          track: "var(--progress-track)",
+          bar: "var(--progress-bar)",
+        },
+        slate: {
+          5: "var(--slate-05)",
+          10: "var(--slate-10)",
+          20: "var(--slate-20)",
+          40: "var(--slate-40)",
+        },
+        hint: "var(--hint-fg)",
+        placeholder: "var(--placeholder-fg)",
+      },
+      backgroundImage: {
+        "hero-gradient":
+          "linear-gradient(100deg,var(--hero-grad-start) 40%,var(--hero-grad-end) 100%)",
+        "hero-gradient-strong":
+          "linear-gradient(100deg,var(--hero-grad-start) 50%,var(--hero-grad-end) 100%)",
+        "btn-gradient":
+          "linear-gradient(98deg,var(--fed-blue-60v) 10%,var(--fed-blue-70v) 55%,var(--fed-blue-80v) 100%)",
+        "btn-gradient-hover":
+          "linear-gradient(98deg,var(--fed-blue-70v) 8%,#3e78b2 55%,#69a9dc 100%)",
+        skeleton:
+          "linear-gradient(180deg,var(--slate-05) 0%,var(--slate-10) 50%,var(--slate-05) 100%)",
+      },
+      boxShadow: {
+        surface: "var(--shadow-1)",
+        "surface-strong": "var(--shadow-2)",
+        focus: "var(--shadow-focus)",
+        "focus-ring": "var(--ue-focus-ring)",
+        glass: "var(--glass-shadow)",
+      },
+      borderRadius: {
+        surface: "var(--radius-md)",
+        "surface-lg": "var(--radius-lg)",
+        "ue-xs": "var(--ue-radius-xs)",
+        "ue-sm": "var(--ue-radius-sm)",
+        "ue-md": "var(--ue-radius-md)",
+        "ue-lg": "var(--ue-radius-lg)",
+        "ue-xl": "var(--ue-radius-xl)",
+        "ue-pill": "var(--ue-radius-pill)",
+      },
+      spacing: {
+        "ue-2xs": "var(--ue-spacing-2xs)",
+        "ue-xs": "var(--ue-spacing-xs)",
+        "ue-sm": "var(--ue-spacing-sm)",
+        "ue-md": "var(--ue-spacing-md)",
+        "ue-lg": "var(--ue-spacing-lg)",
+        "ue-xl": "var(--ue-spacing-xl)",
+      },
+      fontFamily: {
+        ui: ["var(--font-ui)"],
+        display: ["var(--font-display)"],
+      },
+      keyframes: {
+        "fade-in": {
+          "0%": { opacity: "0", transform: "translateY(0.25rem)" },
+          "100%": { opacity: "1", transform: "translateY(0)" },
+        },
+        "card-hover": {
+          "0%": {
+            transform: "translateY(0) scale(1)",
+            boxShadow: "var(--shadow-1)",
+          },
+          "100%": {
+            transform: "translateY(-2px) scale(1.03)",
+            boxShadow: "var(--shadow-2)",
+          },
+        },
+        "skeleton-wave": {
+          "0%": { transform: "translateX(-100%)" },
+          "100%": { transform: "translateX(100%)" },
+        },
+      },
+      animation: {
+        "fade-in":
+          "fade-in var(--anim-med, 0.3s cubic-bezier(0.42, 0, 0.58, 1)) both",
+        "card-hover":
+          "card-hover var(--anim-card, 0.42s cubic-bezier(0.22, 0.61, 0.36, 1)) both",
+        "skeleton-wave": "skeleton-wave 1.6s ease-in-out infinite",
+      },
+    },
   },
-  plugins: [],
+  plugins: [
+    plugin(({ addVariant, matchVariant }) => {
+      addVariant("supports-scroll", "@supports (scroll-behavior: smooth)");
+
+      matchVariant("data", (value) => {
+        const selector = attributeSelector("data", value);
+        return selector ? `&${selector}` : "&";
+      });
+
+      matchVariant("aria", (value) => {
+        const selector = attributeSelector("aria", value);
+        return selector ? `&${selector}` : "&";
+      });
+
+      matchVariant("group-data", (value) => {
+        const selector = attributeSelector("data", value);
+        return selector ? `.group${selector} &` : ".group &";
+      });
+
+      matchVariant("group-aria", (value) => {
+        const selector = attributeSelector("aria", value);
+        return selector ? `.group${selector} &` : ".group &";
+      });
+
+      matchVariant("peer-data", (value) => {
+        const selector = attributeSelector("data", value);
+        return selector ? `.peer${selector} ~ &` : ".peer ~ &";
+      });
+
+      matchVariant("peer-aria", (value) => {
+        const selector = attributeSelector("aria", value);
+        return selector ? `.peer${selector} ~ &` : ".peer ~ &";
+      });
+    }),
+  ],
 };
 
 export default config;


### PR DESCRIPTION
## Summary
- expose project design tokens to Tailwind by extending colors, radii, spacing, shadows, fonts, and gradients
- add reusable animations and data/aria variants so utilities can react to runtime state
- move base styles and reusable card/button/chip/skeleton components into Tailwind layers with documentation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ff5f0936088327a0a5d6f66f754036