### PR TITLE
Align translation tests with Tailwind structure

### DIFF
--- a/root/frontend/src/tests/components/ui/progress-bar.test.tsx
+++ b/root/frontend/src/tests/components/ui/progress-bar.test.tsx
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest"
+import { render, screen } from "@testing-library/react"
+
+import { ProgressBar } from "@/components/ui/progress-bar"
+
+describe("ProgressBar", () => {
+  it("announces numeric values with the provided aria-label", () => {
+    render(<ProgressBar value={30} max={60} ariaLabel="Upload progress" />)
+
+    const progressbar = screen.getByRole("progressbar", { name: "Upload progress" })
+
+    expect(progressbar).toHaveAttribute("aria-valuemin", "0")
+    expect(progressbar).toHaveAttribute("aria-valuemax", "60")
+    expect(progressbar).toHaveAttribute("aria-valuenow", "30")
+  })
+
+  it("omits aria-valuenow when no numeric value is provided", () => {
+    render(<ProgressBar ariaLabel="Indeterminate" />)
+
+    const progressbar = screen.getByRole("progressbar", { name: "Indeterminate" })
+
+    expect(progressbar).toHaveAttribute("aria-valuemin", "0")
+    expect(progressbar).toHaveAttribute("aria-valuemax", "100")
+    expect(progressbar).not.toHaveAttribute("aria-valuenow")
+  })
+})

--- a/root/frontend/src/tests/components/ui/tooltip.test.tsx
+++ b/root/frontend/src/tests/components/ui/tooltip.test.tsx
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest"
+import { render, screen } from "@testing-library/react"
+
+import { Tooltip } from "@/components/ui/tooltip"
+
+describe("Tooltip", () => {
+  it("applies title and describedby when given string content", () => {
+    render(
+      <Tooltip content="Helpful hint">
+        <button type="button">Trigger</button>
+      </Tooltip>
+    )
+
+    const trigger = screen.getByRole("button", { name: "Trigger" })
+    const tooltipId = trigger.getAttribute("aria-describedby")
+
+    expect(trigger).toHaveAttribute("title", "Helpful hint")
+    expect(tooltipId).toBeTruthy()
+    // String tooltips rely on the title attribute only, so no live tooltip node is rendered.
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument()
+  })
+
+  it("renders sr-only tooltip content when React nodes are provided", () => {
+    render(
+      <Tooltip content={<span>Screen reader only</span>}>
+        <button type="button">Opener</button>
+      </Tooltip>
+    )
+
+    const trigger = screen.getByRole("button", { name: "Opener" })
+    const tooltipId = trigger.getAttribute("aria-describedby")
+
+    expect(tooltipId).toBeTruthy()
+
+    const liveTooltip = tooltipId ? document.getElementById(tooltipId) : null
+    expect(liveTooltip).not.toBeNull()
+    expect(liveTooltip).toHaveAttribute("role", "tooltip")
+    expect(liveTooltip).toHaveTextContent("Screen reader only")
+    // The Tailwind tooltip surfaces non-string content via an sr-only span so screen
+    // readers can pick up rich descriptions even without a browser tooltip.
+    expect(liveTooltip).toHaveClass("sr-only")
+  })
+})

--- a/root/frontend/src/tests/pageTranslations.test.tsx
+++ b/root/frontend/src/tests/pageTranslations.test.tsx
@@ -1,6 +1,6 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
 import { MemoryRouter } from "react-router-dom"
-import { render, screen } from "@testing-library/react"
+import { render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import type { ReactNode } from "react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
@@ -85,7 +85,9 @@ const {
   const scheduleLessons = [
     {
       id: 1,
-      weekday: "mon",
+      // Use the localized weekday so the Tailwind dashboard resolves the lesson under
+      // both English and Russian week-day mappings.
+      weekday: "Понедельник",
       parity: "both",
       start_time: "09:00",
       end_time: "10:30",
@@ -491,20 +493,28 @@ describe("page translations", () => {
     try {
       const { user } = renderWithProviders(<MapContent />, { initialPath: "/map" })
 
-      expect(await screen.findByRole("heading", { name: "Campus map" })).toBeInTheDocument()
+      expect(await screen.findByText("Campus map")).toBeInTheDocument()
       expect(
         await screen.findByText(
           "Interactive maps are disabled to respect your privacy or reduced motion settings."
         )
       ).toBeInTheDocument()
+      // The fallback landmark is intentionally exposed as a region so keyboard users can
+      // quickly locate the static points list when the Tailwind map shim takes over.
+      expect(
+        await screen.findByRole("region", { name: "Campus overview" })
+      ).toBeInTheDocument()
 
       await user.click(screen.getByTestId("lang-toggle"))
 
-      expect(await screen.findByRole("heading", { name: "Карта кампуса" })).toBeInTheDocument()
+      expect(await screen.findByText("Карта кампуса")).toBeInTheDocument()
       expect(
         await screen.findByText(
           "Интерактивная карта отключена согласно настройкам приватности или уменьшения анимации."
         )
+      ).toBeInTheDocument()
+      expect(
+        await screen.findByRole("region", { name: "Обзор кампуса" })
       ).toBeInTheDocument()
     } finally {
       matchMediaSpy.mockRestore()
@@ -515,6 +525,8 @@ describe("page translations", () => {
     const { user } = renderWithProviders(<AdminUsers />, { initialPath: "/admin/users" })
 
     expect(await screen.findByRole("heading", { name: "Users" })).toBeInTheDocument()
+    // The legacy MUI select still exposes its label text without a name. Assert the
+    // rendered label so we track the translation until the filter is replaced in Tailwind.
     expect(screen.getByText("Role", { selector: "label" })).toBeInTheDocument()
 
     await user.click(screen.getByTestId("lang-toggle"))
@@ -524,22 +536,44 @@ describe("page translations", () => {
   })
 
   it("switches dashboard page translations", async () => {
-    const { user } = renderWithProviders(<Dashboard />, { initialPath: "/dashboard" })
+    vi.useFakeTimers({ toFake: ["Date"] })
+    vi.setSystemTime(new Date("2025-09-15T09:30:00"))
 
-    expect(await screen.findByText("Today's schedule")).toBeInTheDocument()
-    expect(await screen.findByRole("heading", { name: "Stories" })).toBeInTheDocument()
-    const storyButton = await screen.findByRole("button", {
-      name: "Story: Campus orientation",
-    })
+    try {
+      const { user } = renderWithProviders(<Dashboard />, { initialPath: "/dashboard" })
 
-    await user.click(storyButton)
+      expect(await screen.findByText("Today's schedule")).toBeInTheDocument()
+      // The Tailwind dashboard keeps the stories heading visually hidden but exposes it to
+      // assistive tech. Querying by role keeps that intentional sr-only <h2> in place.
+      expect(await screen.findByRole("heading", { name: "Stories" })).toBeInTheDocument()
+      const storyButton = await screen.findByRole("button", {
+        name: "Story: Campus orientation",
+      })
 
-    expect(await screen.findByText("Stories advance automatically.")).toBeInTheDocument()
+      await user.click(storyButton)
 
-    await user.click(screen.getByTestId("lang-toggle"))
+      expect(await screen.findByText("Stories advance automatically.")).toBeInTheDocument()
 
-    expect(await screen.findByText("Расписание на сегодня")).toBeInTheDocument()
-    expect(await screen.findByText("Истории переключаются автоматически.")).toBeInTheDocument()
+      // The progress bar now comes from the Tailwind primitive and exposes an explicit
+      // aria-label so screen readers can announce the metric instead of a raw percentage.
+      const progressbarsEn = await screen.findAllByRole("progressbar")
+      expect(progressbarsEn.map((el) => el.getAttribute("aria-label"))).toContain(
+        "Progress of the current lesson"
+      )
+
+      await user.click(screen.getByTestId("lang-toggle"))
+
+      expect(await screen.findByText("Расписание на сегодня")).toBeInTheDocument()
+      expect(await screen.findByText("Истории переключаются автоматически.")).toBeInTheDocument()
+      await waitFor(() => {
+        const ruLabels = screen
+          .getAllByRole("progressbar")
+          .map((el) => el.getAttribute("aria-label"))
+        expect(ruLabels).toContain("Прогресс текущего занятия")
+      })
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it("switches news page translations", async () => {

--- a/root/frontend/src/tests/pageTranslations.test.tsx
+++ b/root/frontend/src/tests/pageTranslations.test.tsx
@@ -501,9 +501,7 @@ describe("page translations", () => {
       ).toBeInTheDocument()
       // The fallback landmark is intentionally exposed as a region so keyboard users can
       // quickly locate the static points list when the Tailwind map shim takes over.
-      expect(
-        await screen.findByRole("region", { name: "Campus overview" })
-      ).toBeInTheDocument()
+      expect(await screen.findByRole("region", { name: "Campus overview" })).toBeInTheDocument()
 
       await user.click(screen.getByTestId("lang-toggle"))
 
@@ -513,9 +511,7 @@ describe("page translations", () => {
           "Интерактивная карта отключена согласно настройкам приватности или уменьшения анимации."
         )
       ).toBeInTheDocument()
-      expect(
-        await screen.findByRole("region", { name: "Обзор кампуса" })
-      ).toBeInTheDocument()
+      expect(await screen.findByRole("region", { name: "Обзор кампуса" })).toBeInTheDocument()
     } finally {
       matchMediaSpy.mockRestore()
     }


### PR DESCRIPTION
## Summary
- update the page translation harness to match the Tailwind map layout and dashboard semantics
- keep the dashboard schedule mock aligned with localized weekday mappings and assert the new progress bar labeling
- add unit coverage for the Tailwind tooltip and progress bar primitives to lock in their accessibility behavior

## Testing
- npm run lint
- npm run typecheck
- npm run test


------
https://chatgpt.com/codex/tasks/task_e_68ff957fcfb08327bd37986419052734