### PR TITLE
Align dashboard accents with navbar palette

### DIFF
--- a/root/frontend/src/assets/themes.css
+++ b/root/frontend/src/assets/themes.css
@@ -59,6 +59,38 @@
   --dash-hero-conic-accent: color-mix(in srgb, transparent 66%, var(--fed-blue-60v) 34%);
   --dash-hero-highlight: color-mix(in srgb, transparent 55%, var(--fed-blue-60v) 45%);
   --dash-hero-highlight-soft: color-mix(in srgb, transparent 70%, var(--fed-blue-60v) 30%);
+  --dash-conic-stop-1: color-mix(in srgb, white 92%, var(--nav-link) 8%);
+  --dash-conic-stop-2: color-mix(in srgb, white 74%, var(--nav-link) 26%);
+  --dash-conic-stop-3: color-mix(in srgb, white 68%, var(--nav-link-hover) 32%);
+  --dash-conic-stop-4: color-mix(in srgb, white 92%, var(--nav-link) 8%);
+  --dash-date-shadow: 0 18px 40px -22px color-mix(in srgb, var(--nav-link-hover) 55%, transparent);
+  --dash-panel-hover-shadow: 0 70px 160px -90px color-mix(in srgb, var(--nav-link-hover) 55%, transparent);
+  --dash-glass-sheen-start: color-mix(in srgb, white 65%, transparent);
+  --dash-glass-sheen-end: color-mix(in srgb, white 12%, transparent);
+  --dash-stories-radial: color-mix(in srgb, var(--nav-link) 24%, transparent);
+  --dash-card-schedule-radial: color-mix(in srgb, var(--nav-link) 22%, transparent);
+  --dash-card-schedule-orb: color-mix(in srgb, var(--fed-blue-60v) 48%, transparent);
+  --dash-card-news-radial: color-mix(in srgb, var(--fed-blue-70v) 24%, transparent);
+  --dash-card-news-orb: color-mix(in srgb, var(--fed-blue-80v) 52%, transparent);
+  --dash-card-events-radial: color-mix(in srgb, var(--nav-link-hover) 22%, transparent);
+  --dash-card-events-orb: color-mix(in srgb, var(--fed-blue-70v) 55%, transparent);
+  --dash-arrow-pill-bg: color-mix(in srgb, white 90%, var(--nav-link) 10%);
+  --dash-arrow-pill-border: color-mix(in srgb, white 66%, var(--nav-link) 34%);
+  --dash-arrow-pill-text: color-mix(in srgb, var(--secondary-text) 55%, var(--nav-link) 45%);
+  --dash-arrow-pill-bg-active: color-mix(in srgb, white 84%, var(--nav-link) 16%);
+  --dash-arrow-pill-border-active: color-mix(in srgb, white 50%, var(--nav-link-hover) 50%);
+  --dash-arrow-pill-text-active: color-mix(in srgb, var(--page-text) 88%, var(--nav-link) 12%);
+  --dash-icon-halo-bg: color-mix(in srgb, white 92%, var(--nav-link) 8%);
+  --dash-icon-halo-border: color-mix(in srgb, white 60%, var(--nav-link-hover) 40%);
+  --dash-icon-halo-text: color-mix(in srgb, var(--secondary-text) 55%, var(--nav-link-hover) 45%);
+  --dash-icon-halo-border-active: color-mix(in srgb, var(--nav-link-hover) 55%, transparent);
+  --dash-icon-halo-text-active: color-mix(in srgb, var(--page-text) 90%, var(--nav-link-hover) 10%);
+  --dash-chip-time-bg: color-mix(in srgb, white 86%, var(--nav-link) 14%);
+  --dash-chip-time-border: color-mix(in srgb, white 62%, var(--nav-link) 38%);
+  --dash-chip-time-text: color-mix(in srgb, var(--nav-text) 80%, var(--nav-link) 20%);
+  --dash-chip-type-bg: color-mix(in srgb, white 92%, var(--nav-link) 8%);
+  --dash-chip-type-border: color-mix(in srgb, white 58%, var(--nav-link-hover) 42%);
+  --dash-chip-type-text: color-mix(in srgb, var(--nav-text) 78%, var(--nav-link-hover) 22%);
   --progress-track: #dde6f3;
   --progress-bar: #0f4faa;
   --glass-bg: rgba(255, 255, 255, 0.78);
@@ -137,6 +169,38 @@ body.dark {
   --dash-hero-conic-accent: color-mix(in srgb, transparent 48%, var(--fed-blue-60v) 52%);
   --dash-hero-highlight: color-mix(in srgb, transparent 46%, var(--fed-blue-60v) 54%);
   --dash-hero-highlight-soft: color-mix(in srgb, transparent 58%, var(--fed-blue-60v) 42%);
+  --dash-conic-stop-1: color-mix(in srgb, var(--nav-link) 50%, transparent);
+  --dash-conic-stop-2: color-mix(in srgb, var(--nav-link-hover) 60%, transparent);
+  --dash-conic-stop-3: color-mix(in srgb, var(--fed-blue-80v) 55%, transparent);
+  --dash-conic-stop-4: color-mix(in srgb, var(--nav-link) 45%, transparent);
+  --dash-date-shadow: 0 18px 44px -20px color-mix(in srgb, var(--nav-link) 70%, transparent);
+  --dash-panel-hover-shadow: 0 70px 170px -90px color-mix(in srgb, var(--nav-link-hover) 65%, transparent);
+  --dash-glass-sheen-start: color-mix(in srgb, white 35%, transparent);
+  --dash-glass-sheen-end: color-mix(in srgb, white 6%, transparent);
+  --dash-stories-radial: color-mix(in srgb, var(--nav-link) 40%, transparent);
+  --dash-card-schedule-radial: color-mix(in srgb, var(--nav-link) 45%, transparent);
+  --dash-card-schedule-orb: color-mix(in srgb, var(--nav-link-hover) 68%, transparent);
+  --dash-card-news-radial: color-mix(in srgb, var(--nav-link-hover) 48%, transparent);
+  --dash-card-news-orb: color-mix(in srgb, var(--fed-blue-80v) 70%, transparent);
+  --dash-card-events-radial: color-mix(in srgb, var(--nav-link) 46%, transparent);
+  --dash-card-events-orb: color-mix(in srgb, var(--fed-blue-70v) 72%, transparent);
+  --dash-arrow-pill-bg: color-mix(in srgb, var(--nav-link) 22%, transparent);
+  --dash-arrow-pill-border: color-mix(in srgb, var(--nav-link-hover) 42%, transparent);
+  --dash-arrow-pill-text: color-mix(in srgb, var(--page-text) 78%, var(--nav-link) 22%);
+  --dash-arrow-pill-bg-active: color-mix(in srgb, var(--nav-link-hover) 30%, transparent);
+  --dash-arrow-pill-border-active: color-mix(in srgb, var(--nav-link-hover) 58%, transparent);
+  --dash-arrow-pill-text-active: color-mix(in srgb, var(--page-text) 92%, var(--nav-link) 8%);
+  --dash-icon-halo-bg: color-mix(in srgb, var(--nav-link) 26%, transparent);
+  --dash-icon-halo-border: color-mix(in srgb, var(--nav-link-hover) 55%, transparent);
+  --dash-icon-halo-text: color-mix(in srgb, var(--page-text) 75%, var(--nav-link) 25%);
+  --dash-icon-halo-border-active: color-mix(in srgb, var(--nav-link-hover) 68%, transparent);
+  --dash-icon-halo-text-active: color-mix(in srgb, var(--page-text) 94%, var(--nav-link) 6%);
+  --dash-chip-time-bg: color-mix(in srgb, var(--nav-link) 32%, transparent);
+  --dash-chip-time-border: color-mix(in srgb, var(--nav-link-hover) 58%, transparent);
+  --dash-chip-time-text: color-mix(in srgb, var(--page-text) 88%, var(--nav-link) 12%);
+  --dash-chip-type-bg: color-mix(in srgb, var(--nav-link-hover) 28%, transparent);
+  --dash-chip-type-border: color-mix(in srgb, var(--nav-link-hover) 60%, transparent);
+  --dash-chip-type-text: color-mix(in srgb, var(--page-text) 90%, var(--nav-link) 10%);
   --progress-track: #142033;
   --progress-bar: #7fb6e6;
   --glass-bg: rgba(9, 17, 29, 0.76);
@@ -761,60 +825,47 @@ body.dark .menu-link:not(.logout):focus {
   border: 1px solid var(--btn-border) !important;
 }
 .chip-time {
-  background: #e6f0fa !important;
-  color: #0f2b4a !important;
-  border: 1px solid #c9ddf1 !important;
+  background: var(--dash-chip-time-bg) !important;
+  color: var(--dash-chip-time-text) !important;
+  border: 1px solid var(--dash-chip-time-border) !important;
 }
 .chip-type {
-  border: 1px solid transparent !important;
+  background: var(--dash-chip-type-bg) !important;
+  color: var(--dash-chip-type-text) !important;
+  border: 1px solid var(--dash-chip-type-border) !important;
 }
 .chip-left {
-  background: #eef3f8 !important;
-  color: #243142 !important;
-  border: 1px solid #d6e2ef !important;
+  background: color-mix(in srgb, white 94%, var(--nav-link) 6%) !important;
+  color: color-mix(in srgb, var(--nav-text) 82%, var(--nav-link) 18%) !important;
+  border: 1px solid color-mix(in srgb, white 58%, var(--nav-link) 42%) !important;
 }
 .chip-break {
   background: var(--card-bg) !important;
   color: var(--nav-text) !important;
   border: 1px solid var(--btn-border) !important;
-  box-shadow: 0 6px 14px rgba(0, 0, 0, 0.12) !important;
+  box-shadow: 0 6px 14px color-mix(in srgb, black 12%, transparent) !important;
 }
 .chip-day {
-  background: var(--btn-bg) !important;
+  background: color-mix(in srgb, white 92%, var(--nav-link) 8%) !important;
   color: var(--nav-text) !important;
-  border: 1px solid var(--btn-border) !important;
+  border: 1px solid color-mix(in srgb, white 60%, var(--nav-link) 40%) !important;
   font-weight: 700 !important;
 }
-body.dark .chip-clock {
-  background: #11161e !important;
-  color: #e6ebf2 !important;
-  border: 1px solid #263142 !important;
-}
-body.dark .chip-time {
-  background: #152031 !important;
-  color: #eaf4ff !important;
-  border: 1px solid #223349 !important;
-}
-body.dark .chip-type {
-  background: #152031 !important;
-  color: #eaf4ff !important;
-  border: 1px solid #223349 !important;
-}
 body.dark .chip-left {
-  background: #11161e !important;
-  color: #eaf4ff !important;
-  border: 1px solid #223349 !important;
+  background: color-mix(in srgb, var(--nav-link) 26%, transparent) !important;
+  color: color-mix(in srgb, var(--page-text) 88%, var(--nav-link) 12%) !important;
+  border: 1px solid color-mix(in srgb, var(--nav-link) 50%, transparent) !important;
 }
 body.dark .chip-break {
-  background: #152031 !important;
-  color: #eaf4ff !important;
-  border: 1px solid #223349 !important;
-  box-shadow: 0 6px 14px rgba(0, 0, 0, 0.28) !important;
+  background: color-mix(in srgb, var(--nav-link) 24%, transparent) !important;
+  color: var(--page-text) !important;
+  border: 1px solid color-mix(in srgb, var(--nav-link-hover) 45%, transparent) !important;
+  box-shadow: 0 6px 14px color-mix(in srgb, black 38%, transparent) !important;
 }
 body.dark .chip-day {
-  background: #152031 !important;
-  color: #eaf4ff !important;
-  border: 1px solid #223349 !important;
+  background: color-mix(in srgb, var(--nav-link) 22%, transparent) !important;
+  color: var(--page-text) !important;
+  border: 1px solid color-mix(in srgb, var(--nav-link) 46%, transparent) !important;
 }
 body.dark .MuiChip-outlined {
   border-color: #223349 !important;

--- a/root/frontend/src/assets/themes.css
+++ b/root/frontend/src/assets/themes.css
@@ -64,7 +64,8 @@
   --dash-conic-stop-3: color-mix(in srgb, white 68%, var(--nav-link-hover) 32%);
   --dash-conic-stop-4: color-mix(in srgb, white 92%, var(--nav-link) 8%);
   --dash-date-shadow: 0 18px 40px -22px color-mix(in srgb, var(--nav-link-hover) 55%, transparent);
-  --dash-panel-hover-shadow: 0 70px 160px -90px color-mix(in srgb, var(--nav-link-hover) 55%, transparent);
+  --dash-panel-hover-shadow: 0 70px 160px -90px
+    color-mix(in srgb, var(--nav-link-hover) 55%, transparent);
   --dash-glass-sheen-start: color-mix(in srgb, white 65%, transparent);
   --dash-glass-sheen-end: color-mix(in srgb, white 12%, transparent);
   --dash-stories-radial: color-mix(in srgb, var(--nav-link) 24%, transparent);
@@ -174,7 +175,8 @@ body.dark {
   --dash-conic-stop-3: color-mix(in srgb, var(--fed-blue-80v) 55%, transparent);
   --dash-conic-stop-4: color-mix(in srgb, var(--nav-link) 45%, transparent);
   --dash-date-shadow: 0 18px 44px -20px color-mix(in srgb, var(--nav-link) 70%, transparent);
-  --dash-panel-hover-shadow: 0 70px 170px -90px color-mix(in srgb, var(--nav-link-hover) 65%, transparent);
+  --dash-panel-hover-shadow: 0 70px 170px -90px
+    color-mix(in srgb, var(--nav-link-hover) 65%, transparent);
   --dash-glass-sheen-start: color-mix(in srgb, white 35%, transparent);
   --dash-glass-sheen-end: color-mix(in srgb, white 6%, transparent);
   --dash-stories-radial: color-mix(in srgb, var(--nav-link) 40%, transparent);

--- a/root/frontend/src/pages/Dashboard.tsx
+++ b/root/frontend/src/pages/Dashboard.tsx
@@ -89,8 +89,8 @@ function DateBullet({ date, locale }: { date?: string; locale: string }) {
         aria-label={t("ariaDatePublished", { date: full })}
         className={cn(
           "flex h-11 w-11 min-h-11 min-w-11 flex-col items-center justify-center rounded-full border border-[var(--glass-border)] text-page-foreground backdrop-blur-md",
-          "bg-[conic-gradient(at_50%_50%,rgba(255,255,255,0.92),rgba(148,163,184,0.25),rgba(59,130,246,0.45),rgba(255,255,255,0.92))] dark:bg-[conic-gradient(at_50%_50%,rgba(255,255,255,0.32),rgba(148,163,184,0.25),rgba(56,189,248,0.55),rgba(255,255,255,0.32))]",
-          "shadow-[0_18px_40px_-22px_rgba(30,64,175,0.35)]"
+          "bg-[conic-gradient(at_50%_50%,var(--dash-conic-stop-1),var(--dash-conic-stop-2),var(--dash-conic-stop-3),var(--dash-conic-stop-4))]",
+          "shadow-[var(--dash-date-shadow)]"
         )}
       >
         <span className="text-[0.85rem] font-black leading-none tracking-tight">{dd}</span>
@@ -422,9 +422,9 @@ export default function Dashboard() {
   const glassPanelBase =
     "group relative isolate overflow-hidden rounded-[2.4rem] border border-[var(--glass-border)] bg-[var(--glass-bg)] text-page-foreground shadow-[var(--glass-shadow)] backdrop-blur-[38px] transition-all duration-500"
   const glassPanelHover =
-    "hover:-translate-y-[6px] hover:shadow-[0_70px_160px_-90px_rgba(37,99,235,0.55)] motion-reduce:hover:translate-y-0 motion-reduce:hover:shadow-[var(--glass-shadow)]"
+    "hover:-translate-y-[6px] hover:shadow-[var(--dash-panel-hover-shadow)] motion-reduce:hover:translate-y-0 motion-reduce:hover:shadow-[var(--glass-shadow)]"
   const glassSheen =
-    "before:pointer-events-none before:absolute before:inset-px before:rounded-[inherit] before:bg-[linear-gradient(135deg,rgba(255,255,255,0.65),rgba(255,255,255,0.08))] before:opacity-75 before:transition-opacity before:duration-700 before:content-[''] group-hover:before:opacity-100"
+    "before:pointer-events-none before:absolute before:inset-px before:rounded-[inherit] before:bg-[linear-gradient(135deg,var(--dash-glass-sheen-start),var(--dash-glass-sheen-end))] before:opacity-75 before:transition-opacity before:duration-700 before:content-[''] group-hover:before:opacity-100"
 
   const warmNewsPage = () => import("../pages/News").catch(() => {})
   const warmEventsPage = () => import("../pages/Events").catch(() => {})
@@ -490,7 +490,7 @@ export default function Dashboard() {
             >
               <span
                 aria-hidden="true"
-                className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(255,255,255,0.45),transparent_60%)] opacity-80 mix-blend-soft-light transition-opacity duration-700 group-hover:opacity-100"
+                className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,color-mix(in_srgb,var(--glass-highlight)_65%,transparent),transparent_60%)] opacity-80 mix-blend-soft-light transition-opacity duration-700 group-hover:opacity-100"
               />
               <span
                 aria-hidden="true"
@@ -555,7 +555,7 @@ export default function Dashboard() {
             >
               <div
                 aria-hidden="true"
-                className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_right,rgba(191,219,254,0.28),transparent_65%)] opacity-80"
+                className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_right,var(--dash-stories-radial),transparent_65%)] opacity-80"
               />
               <div
                 aria-hidden="true"
@@ -681,11 +681,11 @@ export default function Dashboard() {
                 </div>
                 <span
                   aria-hidden="true"
-                  className="pointer-events-none absolute inset-0 z-0 bg-[radial-gradient(circle_at_top,rgba(59,130,246,0.18),transparent_72%)] opacity-0 transition-opacity duration-500 group-hover:opacity-100"
+                  className="pointer-events-none absolute inset-0 z-0 bg-[radial-gradient(circle_at_top,var(--dash-card-schedule-radial),transparent_72%)] opacity-0 transition-opacity duration-500 group-hover:opacity-100"
                 />
                 <span
                   aria-hidden="true"
-                  className="pointer-events-none absolute -top-24 right-10 z-0 h-36 w-36 rounded-full bg-[radial-gradient(circle,rgba(14,165,233,0.45),transparent)] opacity-40 blur-3xl transition duration-700 group-hover:opacity-80"
+                  className="pointer-events-none absolute -top-24 right-10 z-0 h-36 w-36 rounded-full bg-[radial-gradient(circle,var(--dash-card-schedule-orb),transparent)] opacity-40 blur-3xl transition duration-700 group-hover:opacity-80"
                 />
               </Card>
 
@@ -771,7 +771,7 @@ export default function Dashboard() {
                             </div>
                             <span
                               aria-hidden="true"
-                              className="ml-auto inline-flex h-8 w-8 items-center justify-center rounded-full border border-[var(--glass-border)] bg-[var(--glass-tint-2)] text-xs font-semibold uppercase tracking-[0.2em] text-[var(--secondary-text)] opacity-0 transition-all duration-300 group-hover:-translate-y-[1px] group-hover:opacity-100 group-hover:text-page-foreground"
+                              className="ml-auto inline-flex h-8 w-8 items-center justify-center rounded-full border border-[color:var(--dash-arrow-pill-border)] bg-[color:var(--dash-arrow-pill-bg)] text-xs font-semibold uppercase tracking-[0.2em] text-[color:var(--dash-arrow-pill-text)] opacity-0 transition-all duration-300 group-hover:-translate-y-[1px] group-hover:opacity-100 group-hover:border-[color:var(--dash-arrow-pill-border-active)] group-hover:bg-[color:var(--dash-arrow-pill-bg-active)] group-hover:text-[color:var(--dash-arrow-pill-text-active)]"
                             >
                               →
                             </span>
@@ -783,11 +783,11 @@ export default function Dashboard() {
                 </div>
                 <span
                   aria-hidden="true"
-                  className="pointer-events-none absolute inset-0 z-0 bg-[radial-gradient(circle_at_top_right,rgba(99,102,241,0.18),transparent_68%)] opacity-0 transition-opacity duration-500 group-hover:opacity-100"
+                  className="pointer-events-none absolute inset-0 z-0 bg-[radial-gradient(circle_at_top_right,var(--dash-card-news-radial),transparent_68%)] opacity-0 transition-opacity duration-500 group-hover:opacity-100"
                 />
                 <span
                   aria-hidden="true"
-                  className="pointer-events-none absolute -bottom-20 left-1/3 z-0 h-44 w-44 rounded-full bg-[radial-gradient(circle,rgba(129,140,248,0.45),transparent)] opacity-45 blur-3xl transition duration-700 group-hover:opacity-80"
+                  className="pointer-events-none absolute -bottom-20 left-1/3 z-0 h-44 w-44 rounded-full bg-[radial-gradient(circle,var(--dash-card-news-orb),transparent)] opacity-45 blur-3xl transition duration-700 group-hover:opacity-80"
                 />
               </Card>
 
@@ -879,7 +879,7 @@ export default function Dashboard() {
                                 <span className="text-base font-semibold text-page-foreground">
                                   {e.title}
                                 </span>
-                                <span className="inline-flex h-6 w-6 flex-none items-center justify-center rounded-full border border-[var(--glass-border)] text-[0.65rem] font-semibold uppercase tracking-[0.18em] text-[var(--secondary-text)] transition-colors duration-300 group-hover:border-[var(--page-text)] group-hover:text-page-foreground">
+                                <span className="inline-flex h-6 w-6 flex-none items-center justify-center rounded-full border border-[color:var(--dash-icon-halo-border)] bg-[color:var(--dash-icon-halo-bg)] text-[0.65rem] font-semibold uppercase tracking-[0.18em] text-[color:var(--dash-icon-halo-text)] transition-colors duration-300 group-hover:border-[color:var(--dash-icon-halo-border-active)] group-hover:text-[color:var(--dash-icon-halo-text-active)]">
                                   <AutoAwesomeRoundedIcon
                                     aria-hidden="true"
                                     fontSize="inherit"
@@ -915,11 +915,11 @@ export default function Dashboard() {
                 </div>
                 <span
                   aria-hidden="true"
-                  className="pointer-events-none absolute inset-0 z-0 bg-[radial-gradient(circle_at_top_left,rgba(59,130,246,0.16),transparent_70%)] opacity-0 transition-opacity duration-500 group-hover:opacity-100"
+                  className="pointer-events-none absolute inset-0 z-0 bg-[radial-gradient(circle_at_top_left,var(--dash-card-events-radial),transparent_70%)] opacity-0 transition-opacity duration-500 group-hover:opacity-100"
                 />
                 <span
                   aria-hidden="true"
-                  className="pointer-events-none absolute -top-16 left-1/4 z-0 h-40 w-40 rounded-full bg-[radial-gradient(circle,rgba(56,189,248,0.5),transparent)] opacity-45 blur-3xl transition duration-700 group-hover:opacity-85"
+                  className="pointer-events-none absolute -top-16 left-1/4 z-0 h-40 w-40 rounded-full bg-[radial-gradient(circle,var(--dash-card-events-orb),transparent)] opacity-45 blur-3xl transition duration-700 group-hover:opacity-85"
                 />
               </Card>
             </section>


### PR DESCRIPTION
## Summary
- add dashboard accent variables derived from the navbar blue spectrum to the shared theme, including hover shadows, gradients, and chip styling
- refactor dashboard cards and DateBullet to consume the new tokens, removing inline rgba gradients and shadows
- update arrow pill, icon halo, and chip elements to inherit the refreshed palette while preserving contrast in light and dark modes

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ffcdefafb88327bc7b36f9ce6f9909