### PR TITLE
Refine dashboard panel theming

### DIFF
--- a/root/frontend/src/assets/themes.css
+++ b/root/frontend/src/assets/themes.css
@@ -64,6 +64,10 @@
   --dash-conic-stop-3: color-mix(in srgb, white 68%, var(--nav-link-hover) 32%);
   --dash-conic-stop-4: color-mix(in srgb, white 92%, var(--nav-link) 8%);
   --dash-date-shadow: 0 18px 40px -22px color-mix(in srgb, var(--nav-link-hover) 55%, transparent);
+  --dash-panel-bg: color-mix(in srgb, white 94%, var(--nav-link) 6%);
+  --dash-panel-border: color-mix(in srgb, white 62%, var(--nav-link) 38%);
+  --dash-panel-shadow: 0 34px 110px -70px color-mix(in srgb, var(--nav-link-hover) 45%, transparent);
+  --dash-panel-item-hover: color-mix(in srgb, white 88%, var(--nav-link) 12%);
   --dash-panel-hover-shadow: 0 70px 160px -90px
     color-mix(in srgb, var(--nav-link-hover) 55%, transparent);
   --dash-glass-sheen-start: color-mix(in srgb, white 65%, transparent);
@@ -175,6 +179,10 @@ body.dark {
   --dash-conic-stop-3: color-mix(in srgb, var(--fed-blue-80v) 55%, transparent);
   --dash-conic-stop-4: color-mix(in srgb, var(--nav-link) 45%, transparent);
   --dash-date-shadow: 0 18px 44px -20px color-mix(in srgb, var(--nav-link) 70%, transparent);
+  --dash-panel-bg: color-mix(in srgb, var(--nav-link) 24%, transparent);
+  --dash-panel-border: color-mix(in srgb, var(--nav-link-hover) 55%, transparent);
+  --dash-panel-shadow: 0 42px 140px -90px color-mix(in srgb, black 65%, var(--nav-link) 35%);
+  --dash-panel-item-hover: color-mix(in srgb, var(--nav-link-hover) 36%, transparent);
   --dash-panel-hover-shadow: 0 70px 170px -90px
     color-mix(in srgb, var(--nav-link-hover) 65%, transparent);
   --dash-glass-sheen-start: color-mix(in srgb, white 35%, transparent);
@@ -821,18 +829,34 @@ body.dark .menu-link:not(.logout):focus {
   background: #121923;
   box-shadow: 0 2px 12px #0002;
 }
+.chip-clock,
+.chip-time,
+.chip-type {
+  position: relative;
+  overflow: hidden;
+  -webkit-backdrop-filter: blur(calc(var(--glass-blur) * 0.6));
+  backdrop-filter: blur(calc(var(--glass-blur) * 0.6));
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, var(--glass-highlight) 45%, transparent),
+    0 14px 32px -20px color-mix(in srgb, var(--nav-link-hover) 48%, transparent);
+  background-image: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--glass-highlight) 50%, transparent) 0%,
+    transparent 72%
+  );
+}
 .chip-clock {
-  background: var(--btn-bg) !important;
+  background-color: var(--btn-bg) !important;
   color: var(--nav-text) !important;
   border: 1px solid var(--btn-border) !important;
 }
 .chip-time {
-  background: var(--dash-chip-time-bg) !important;
+  background-color: var(--dash-chip-time-bg) !important;
   color: var(--dash-chip-time-text) !important;
   border: 1px solid var(--dash-chip-time-border) !important;
 }
 .chip-type {
-  background: var(--dash-chip-type-bg) !important;
+  background-color: var(--dash-chip-type-bg) !important;
   color: var(--dash-chip-type-text) !important;
   border: 1px solid var(--dash-chip-type-border) !important;
 }

--- a/root/frontend/src/pages/Dashboard.tsx
+++ b/root/frontend/src/pages/Dashboard.tsx
@@ -420,9 +420,9 @@ export default function Dashboard() {
   ]
 
   const panelBase =
-    "group relative isolate overflow-hidden rounded-[2.4rem] border border-[color-mix(in_srgb,var(--page-text)_8%,transparent)] bg-surface text-page-foreground shadow-surface transition-all duration-500"
+    "group relative isolate overflow-hidden rounded-[2.4rem] border !border-[color:var(--dash-panel-border)] !bg-[color:var(--dash-panel-bg)] text-page-foreground !shadow-[var(--dash-panel-shadow)] transition-all duration-500"
   const panelHover =
-    "hover:-translate-y-[6px] hover:shadow-[var(--dash-panel-hover-shadow)] motion-reduce:hover:translate-y-0 motion-reduce:hover:shadow-surface"
+    "hover:-translate-y-[6px] hover:shadow-[var(--dash-panel-hover-shadow)] motion-reduce:hover:translate-y-0 motion-reduce:hover:shadow-[var(--dash-panel-shadow)]"
 
   const warmNewsPage = () => import("../pages/News").catch(() => {})
   const warmEventsPage = () => import("../pages/Events").catch(() => {})
@@ -751,7 +751,7 @@ export default function Dashboard() {
                         <li key={n.id} className="py-3 first:pt-0 last:pb-0">
                           <button
                             type="button"
-                            className="group flex w-full items-center gap-3 rounded-ue-lg px-2 py-3 text-left transition-all duration-300 ease-out hover:-translate-y-[1px] hover:bg-surface-accent focus-visible:outline-none focus-visible:shadow-focus"
+                            className="group flex w-full items-center gap-3 rounded-ue-lg px-2 py-3 text-left transition-all duration-300 ease-out hover:-translate-y-[1px] hover:bg-[color:var(--dash-panel-item-hover)] focus-visible:outline-none focus-visible:shadow-focus"
                             onClick={() => navigate(`/news/${n.id}`)}
                             title={n.title}
                             aria-label={t("dashboard:aria.newsItem", { title: n.title })}
@@ -868,7 +868,7 @@ export default function Dashboard() {
                           <li key={e.id} className="py-3 first:pt-0 last:pb-0">
                             <button
                               type="button"
-                              className="group flex w-full flex-col gap-2 rounded-ue-lg px-3 py-3 text-left transition-all duration-300 ease-out hover:-translate-y-[1px] hover:bg-surface-accent focus-visible:outline-none focus-visible:shadow-focus"
+                              className="group flex w-full flex-col gap-2 rounded-ue-lg px-3 py-3 text-left transition-all duration-300 ease-out hover:-translate-y-[1px] hover:bg-[color:var(--dash-panel-item-hover)] focus-visible:outline-none focus-visible:shadow-focus"
                               onClick={() => navigate(`/events/${e.id}`)}
                               aria-label={t("dashboard:aria.eventItem", { title: e.title })}
                             >


### PR DESCRIPTION
## Summary
- add dedicated dashboard panel tokens for background, border, shadow, and hover fill in both light and dark themes
- update dashboard panels and list item hovers to consume the new design tokens
- enhance dashboard chips with explicit glass blur and sheen styling while keeping their existing color variables

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ffd96609d883278e12628c23999e4f