### PR TITLE
Remove stories panel from the dashboard

### DIFF
--- a/root/frontend/src/pages/Dashboard.tsx
+++ b/root/frontend/src/pages/Dashboard.tsx
@@ -548,24 +548,13 @@ export default function Dashboard() {
               data-fade="up"
               data-pop="true"
               style={fadeDelayStyle("100ms")}
-              className={cn(panelBase, panelHover, "p-2 md:p-3")}
             >
-              <div
-                aria-hidden="true"
-                className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_right,var(--dash-stories-radial),transparent_65%)] opacity-80"
+              <DashboardStories
+                stories={stories}
+                loading={loadingStories}
+                onPrefetch={triggerStoriesPrefetch}
+                onStoryOpen={handleStoryOpen}
               />
-              <div
-                aria-hidden="true"
-                className="pointer-events-none absolute inset-x-10 top-0 h-2 bg-gradient-to-r from-transparent via-white/40 to-transparent opacity-60"
-              />
-              <div className="relative z-[1]">
-                <DashboardStories
-                  stories={stories}
-                  loading={loadingStories}
-                  onPrefetch={triggerStoriesPrefetch}
-                  onStoryOpen={handleStoryOpen}
-                />
-              </div>
             </div>
             <section className="mt-6 grid grid-cols-1 gap-4 md:mt-8 md:gap-6 lg:grid-cols-12">
               <Card

--- a/root/frontend/src/pages/Dashboard.tsx
+++ b/root/frontend/src/pages/Dashboard.tsx
@@ -544,11 +544,7 @@ export default function Dashboard() {
               </div>
             </header>
 
-            <div
-              data-fade="up"
-              data-pop="true"
-              style={fadeDelayStyle("100ms")}
-            >
+            <div data-fade="up" data-pop="true" style={fadeDelayStyle("100ms")}>
               <DashboardStories
                 stories={stories}
                 loading={loadingStories}


### PR DESCRIPTION
## Summary
- remove the dashboard stories panel wrapper so only the story circles are rendered

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ffdc4ed55c83278786934c421c43ad