### PR TITLE
Reduce spacing around dashboard stories

### DIFF
--- a/root/frontend/src/components/DashboardStories.tsx
+++ b/root/frontend/src/components/DashboardStories.tsx
@@ -463,7 +463,7 @@ export default function DashboardStories({
       <div
         data-fade
         style={{ "--fade-delay": "120ms" } as CSSProperties}
-        className="mt-3 mb-3 flex flex-col gap-2"
+        className="flex flex-col gap-2"
         aria-busy={loading}
         onPointerEnter={onPrefetch}
         onFocusCapture={onPrefetch}

--- a/root/frontend/src/pages/Dashboard.tsx
+++ b/root/frontend/src/pages/Dashboard.tsx
@@ -473,7 +473,7 @@ export default function Dashboard() {
               <div key={index} className={layer} />
             ))}
           </div>
-          <div className="relative z-[1] space-y-8">
+          <div className="relative z-[1] space-y-6">
             <header
               data-fade="up"
               data-pop="true"


### PR DESCRIPTION
## Summary
- remove the extra vertical margins around the dashboard stories list so the circles sit closer to nearby panels
- tighten the dashboard layout spacing so the stories row sits closer to the surrounding panels

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ffe07219248327ae50de6729321187