### PR TITLE
feat: enlarge dashboard stories circle

### DIFF
--- a/root/frontend/src/components/DashboardStories.tsx
+++ b/root/frontend/src/components/DashboardStories.tsx
@@ -31,6 +31,7 @@ type DashboardStoriesProps = {
   onPrefetch?: () => void
   onStoryOpen?: (story: StoryItem) => void
   maxVisibleStories?: number
+  circleScale?: number
 }
 
 export default function DashboardStories({
@@ -39,6 +40,7 @@ export default function DashboardStories({
   onPrefetch,
   onStoryOpen,
   maxVisibleStories = 12,
+  circleScale = 1,
 }: DashboardStoriesProps) {
   const { t } = useTranslation("dashboard")
   const prefersReducedMotion = useMediaQuery("(prefers-reduced-motion: reduce)")
@@ -47,6 +49,21 @@ export default function DashboardStories({
   useEffect(() => setIsClient(true), [])
 
   const listLabel = t("aria.storiesList")
+
+  const normalizedCircleScale = useMemo(() => {
+    if (!Number.isFinite(circleScale) || circleScale <= 0) {
+      return 1
+    }
+    return circleScale
+  }, [circleScale])
+
+  const baseCircleSize = 76
+  const baseItemWidth = 92
+  const baseItemMinHeight = 112
+
+  const scaledCircleSize = baseCircleSize * normalizedCircleScale
+  const scaledItemWidth = baseItemWidth * normalizedCircleScale
+  const scaledItemMinHeight = baseItemMinHeight * normalizedCircleScale
 
   const displayStories = useMemo(() => {
     const filtered = Array.isArray(stories) ? stories.filter(Boolean) : []
@@ -472,8 +489,17 @@ export default function DashboardStories({
         {loading && (
           <div className="flex flex-wrap gap-x-6 gap-y-6 py-3">
             {Array.from({ length: SKELETON_COUNT }).map((_, index) => (
-              <div key={index} className="flex w-[92px] min-h-[112px] items-center justify-center">
-                <Skeleton width={76} height={76} rounded="9999px" />
+              <div
+                key={index}
+                className="flex items-center justify-center"
+                style={{
+                  width: scaledItemWidth,
+                  minWidth: scaledItemWidth,
+                  minHeight: scaledItemMinHeight,
+                  flexBasis: scaledItemWidth,
+                }}
+              >
+                <Skeleton width={scaledCircleSize} height={scaledCircleSize} rounded="9999px" />
               </div>
             ))}
           </div>
@@ -490,15 +516,27 @@ export default function DashboardStories({
                 <li
                   key={story.id}
                   className={cn(
-                    "flex min-h-[112px] w-[92px] flex-shrink-0 flex-col items-center justify-center overflow-visible sm:basis-[92px]",
+                    "flex flex-shrink-0 flex-col items-center justify-center overflow-visible sm:basis-[92px]",
                     index === 0 ? "ml-3 sm:ml-2" : ""
                   )}
+                  style={{
+                    width: scaledItemWidth,
+                    minWidth: scaledItemWidth,
+                    minHeight: scaledItemMinHeight,
+                    flexBasis: scaledItemWidth,
+                  }}
                 >
                   <StoryCircle
                     as="button"
                     type="button"
                     size="md"
                     borderWidth={2}
+                    style={{
+                      width: scaledCircleSize,
+                      height: scaledCircleSize,
+                      minWidth: scaledCircleSize,
+                      minHeight: scaledCircleSize,
+                    }}
                     onClick={() => openStory(story, index)}
                     onFocus={onPrefetch}
                     onMouseEnter={onPrefetch}

--- a/root/frontend/src/pages/Dashboard.tsx
+++ b/root/frontend/src/pages/Dashboard.tsx
@@ -550,6 +550,7 @@ export default function Dashboard() {
                 loading={loadingStories}
                 onPrefetch={triggerStoriesPrefetch}
                 onStoryOpen={handleStoryOpen}
+                circleScale={2}
               />
             </div>
             <section className="mt-6 grid grid-cols-1 gap-4 md:mt-8 md:gap-6 lg:grid-cols-12">


### PR DESCRIPTION
## Summary
- add support for scaling story circles in the dashboard stories component
- adjust skeleton and story item layout to respect the scaled dimensions
- double the circle size for stories on the dashboard page

## Testing
- npm run test -- DashboardStories

------
https://chatgpt.com/codex/tasks/task_e_68ffe2def9fc8327b92f239e784eaf44