### PR TITLE
Increase story circle size and adjust spacing on dashboard

### DIFF
--- a/root/frontend/src/components/DashboardStories.tsx
+++ b/root/frontend/src/components/DashboardStories.tsx
@@ -13,7 +13,7 @@ import { createPortal } from "react-dom"
 import { useTranslation } from "react-i18next"
 import { Link } from "react-router-dom"
 import SmartImage from "@/components/SmartImage"
-import { Button, ProgressBar, Skeleton, StoryCircle } from "@/components/ui"
+import { Button, ProgressBar, Skeleton, StoryCircle, STORY_CIRCLE_SIZE_MAP } from "@/components/ui"
 import type { ButtonProps } from "@/components/ui/button"
 import type { StoryItem } from "@/types/Story"
 import useFocusTrap from "@/hooks/useFocusTrap"
@@ -22,6 +22,7 @@ import { cn } from "@/utils/cn"
 
 const STORY_AUTO_ADVANCE_MS = 6500
 const SKELETON_COUNT = 8
+const STORY_CIRCLE_DIAMETER = STORY_CIRCLE_SIZE_MAP.md
 
 const isBrowser = typeof document !== "undefined"
 
@@ -472,8 +473,17 @@ export default function DashboardStories({
         {loading && (
           <div className="flex flex-wrap gap-x-6 gap-y-6 py-3">
             {Array.from({ length: SKELETON_COUNT }).map((_, index) => (
-              <div key={index} className="flex w-[92px] min-h-[112px] items-center justify-center">
-                <Skeleton width={76} height={76} rounded="9999px" />
+              <div
+                key={index}
+                className="flex flex-shrink-0 flex-col items-center justify-center"
+                style={{
+                  width: STORY_CIRCLE_DIAMETER,
+                  minHeight: STORY_CIRCLE_DIAMETER,
+                  minWidth: STORY_CIRCLE_DIAMETER,
+                  flexBasis: STORY_CIRCLE_DIAMETER,
+                }}
+              >
+                <Skeleton width={STORY_CIRCLE_DIAMETER} height={STORY_CIRCLE_DIAMETER} rounded="9999px" />
               </div>
             ))}
           </div>
@@ -490,9 +500,15 @@ export default function DashboardStories({
                 <li
                   key={story.id}
                   className={cn(
-                    "flex min-h-[112px] w-[92px] flex-shrink-0 flex-col items-center justify-center overflow-visible sm:basis-[92px]",
+                    "flex flex-shrink-0 flex-col items-center justify-center overflow-visible",
                     index === 0 ? "ml-3 sm:ml-2" : ""
                   )}
+                  style={{
+                    width: STORY_CIRCLE_DIAMETER,
+                    minHeight: STORY_CIRCLE_DIAMETER,
+                    minWidth: STORY_CIRCLE_DIAMETER,
+                    flexBasis: STORY_CIRCLE_DIAMETER,
+                  }}
                 >
                   <StoryCircle
                     as="button"

--- a/root/frontend/src/components/DashboardStories.tsx
+++ b/root/frontend/src/components/DashboardStories.tsx
@@ -483,7 +483,11 @@ export default function DashboardStories({
                   flexBasis: STORY_CIRCLE_DIAMETER,
                 }}
               >
-                <Skeleton width={STORY_CIRCLE_DIAMETER} height={STORY_CIRCLE_DIAMETER} rounded="9999px" />
+                <Skeleton
+                  width={STORY_CIRCLE_DIAMETER}
+                  height={STORY_CIRCLE_DIAMETER}
+                  rounded="9999px"
+                />
               </div>
             ))}
           </div>

--- a/root/frontend/src/components/ui/story-circle.tsx
+++ b/root/frontend/src/components/ui/story-circle.tsx
@@ -2,12 +2,12 @@ import { cn } from "@/utils/cn"
 import type { CSSProperties, ElementType } from "react"
 import type { PolymorphicComponentProps } from "@/types/polymorphic"
 
-type StoryCircleSize = "sm" | "md" | "lg"
+export type StoryCircleSize = "sm" | "md" | "lg"
 
-const sizeMap: Record<StoryCircleSize, number> = {
-  sm: 64,
-  md: 76,
-  lg: 92,
+export const STORY_CIRCLE_SIZE_MAP: Record<StoryCircleSize, number> = {
+  sm: 76.8,
+  md: 91.2,
+  lg: 110.4,
 }
 
 type StoryCircleOwnProps = {
@@ -32,7 +32,7 @@ export const StoryCircle = <T extends ElementType = "div">({
   ...rest
 }: StoryCircleProps<T>) => {
   const Component = (as ?? "div") as ElementType
-  const dimension = sizeMap[size]
+  const dimension = STORY_CIRCLE_SIZE_MAP[size]
 
   return (
     <Component


### PR DESCRIPTION
## Summary
- increase the shared story circle diameter by 20%
- align dashboard story list items and skeletons to the new diameter to eliminate extra vertical padding

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ffe5f9f1dc832786237be2fc0e6c54