### PR TITLE
Add weather data client and shared campus coordinates

### DIFF
--- a/root/frontend/src/api/weather.ts
+++ b/root/frontend/src/api/weather.ts
@@ -1,0 +1,194 @@
+import { CAMPUS_COORDINATES } from "@/constants/campus"
+import type { CampusCoordinates } from "@/constants/campus"
+import { getWeatherIconMeta } from "@/utils/weatherIcons"
+
+export interface WeatherSnapshot {
+  conditionCode: number
+  conditionLabel: string
+  /** Temperature in degrees Celsius. Null when unavailable. */
+  temperatureC: number | null
+  /** ISO timestamp reported by the provider. */
+  observedAt: string
+}
+
+export type WeatherCoordinates = CampusCoordinates
+
+export interface WeatherCacheEntry {
+  data: WeatherSnapshot
+  expiresAt: number
+}
+
+export const WEATHER_CACHE_TTL_MS = 10 * 60_000
+
+const WEATHER_CACHE_PREFIX = "weather:snapshot"
+
+const toNumber = (value: unknown): number | null => {
+  if (value == null) return null
+  const num = Number(value)
+  return Number.isFinite(num) ? num : null
+}
+
+const toIsoString = (value: unknown): string | null => {
+  if (typeof value !== "string" || value.trim().length === 0) return null
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) return null
+  return parsed.toISOString()
+}
+
+const toCacheKey = ({ lat, lon }: WeatherCoordinates) => {
+  const latKey = Number(lat).toFixed(4)
+  const lonKey = Number(lon).toFixed(4)
+  return `${WEATHER_CACHE_PREFIX}:${latKey},${lonKey}`
+}
+
+const readCacheEntry = (
+  key: string,
+  { allowExpired = false }: { allowExpired?: boolean } = {}
+): WeatherCacheEntry | null => {
+  if (typeof window === "undefined") return null
+  try {
+    const raw = window.sessionStorage?.getItem(key)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as WeatherCacheEntry
+    if (!parsed || typeof parsed !== "object") return null
+    if (typeof parsed.expiresAt !== "number" || !parsed.data) return null
+    if (!allowExpired && parsed.expiresAt <= Date.now()) return null
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+const writeCacheEntry = (key: string, entry: WeatherCacheEntry) => {
+  if (typeof window === "undefined") return
+  try {
+    window.sessionStorage?.setItem(key, JSON.stringify(entry))
+  } catch {
+    /* ignore persistence failures */
+  }
+}
+
+const pickCurrentBlock = (input: unknown) => {
+  if (!input || typeof input !== "object") return null
+  const current = (input as { current?: unknown }).current
+  if (current && typeof current === "object") return current
+  const legacy = (input as { current_weather?: unknown }).current_weather
+  if (legacy && typeof legacy === "object") {
+    const block = legacy as { time?: unknown; temperature?: unknown; weathercode?: unknown }
+    return {
+      time: block.time,
+      temperature_2m: block.temperature,
+      weather_code: block.weathercode,
+    }
+  }
+  return null
+}
+
+const normalizeSnapshot = (payload: unknown): WeatherSnapshot => {
+  const current = pickCurrentBlock(payload)
+  if (!current || typeof current !== "object") {
+    throw new Error("Missing current weather data")
+  }
+
+  const codeValue =
+    (current as { weather_code?: unknown }).weather_code ??
+    (current as { weathercode?: unknown }).weathercode
+  const tempValue =
+    (current as { temperature_2m?: unknown }).temperature_2m ??
+    (current as { temperature?: unknown }).temperature
+  const timeValue = (current as { time?: unknown }).time
+
+  const parsedCode = toNumber(codeValue)
+  const conditionCode = Number.isFinite(parsedCode ?? NaN) ? Math.trunc(parsedCode as number) : -1
+  const meta = getWeatherIconMeta(conditionCode)
+  const observedAt = toIsoString(timeValue) ?? new Date().toISOString()
+  const temperature = toNumber(tempValue)
+
+  return {
+    conditionCode,
+    conditionLabel: meta.label,
+    temperatureC: temperature,
+    observedAt,
+  }
+}
+
+export class WeatherFetchError extends Error {
+  fallback: WeatherSnapshot | null
+  aborted: boolean
+  cause?: unknown
+
+  constructor(
+    message: string,
+    options: { fallback?: WeatherSnapshot | null; cause?: unknown; aborted?: boolean } = {}
+  ) {
+    super(message)
+    this.name = "WeatherFetchError"
+    this.fallback = options.fallback ?? null
+    this.aborted = Boolean(options.aborted)
+    if (options.cause !== undefined) {
+      this.cause = options.cause
+    }
+  }
+}
+
+export const readWeatherCache = (
+  coordinates: WeatherCoordinates = CAMPUS_COORDINATES,
+  options?: { allowExpired?: boolean }
+): WeatherCacheEntry | null => {
+  const key = toCacheKey(coordinates)
+  return readCacheEntry(key, options)
+}
+
+export interface FetchWeatherOptions {
+  coordinates?: WeatherCoordinates
+  cacheTtlMs?: number
+  forceRefresh?: boolean
+  signal?: AbortSignal
+}
+
+export const fetchWeatherSnapshot = async (
+  options: FetchWeatherOptions = {}
+): Promise<WeatherSnapshot> => {
+  const coordinates = options.coordinates ?? CAMPUS_COORDINATES
+  const ttl = Math.max(30_000, options.cacheTtlMs ?? WEATHER_CACHE_TTL_MS)
+  const key = toCacheKey(coordinates)
+  const cached = readCacheEntry(key, { allowExpired: true })
+
+  if (!options.forceRefresh && cached && cached.expiresAt > Date.now()) {
+    return cached.data
+  }
+
+  const controller = options.signal ? null : new AbortController()
+  const signal = options.signal ?? controller!.signal
+
+  const url = new URL("https://api.open-meteo.com/v1/forecast")
+  url.searchParams.set("latitude", Number(coordinates.lat).toFixed(5))
+  url.searchParams.set("longitude", Number(coordinates.lon).toFixed(5))
+  url.searchParams.set("current", "temperature_2m,weather_code")
+  url.searchParams.set("timeformat", "iso8601")
+  url.searchParams.set("forecast_days", "1")
+  url.searchParams.set("timezone", "auto")
+
+  try {
+    const response = await fetch(url.toString(), { signal })
+    if (!response.ok) {
+      throw new Error(`Weather request failed with status ${response.status}`)
+    }
+    const payload = await response.json()
+    const snapshot = normalizeSnapshot(payload)
+    writeCacheEntry(key, { data: snapshot, expiresAt: Date.now() + ttl })
+    return snapshot
+  } catch (error) {
+    if (controller && controller.signal.aborted) {
+      throw new WeatherFetchError("Weather request aborted", {
+        fallback: cached?.data ?? null,
+        cause: error,
+        aborted: true,
+      })
+    }
+    throw new WeatherFetchError("Failed to fetch weather", {
+      fallback: cached?.data ?? null,
+      cause: error,
+    })
+  }
+}

--- a/root/frontend/src/constants/campus.ts
+++ b/root/frontend/src/constants/campus.ts
@@ -1,0 +1,6 @@
+export type CampusCoordinates = { readonly lat: number; readonly lon: number }
+
+export const CAMPUS_COORDINATES: CampusCoordinates = Object.freeze({
+  lat: 55.71392,
+  lon: 37.81474,
+})

--- a/root/frontend/src/hooks/useWeather.ts
+++ b/root/frontend/src/hooks/useWeather.ts
@@ -39,10 +39,7 @@ const toSignature = (coordinates: WeatherCoordinates): string => {
   return `${lat},${lon}`
 }
 
-const normalizeError = (
-  error: unknown,
-  coordinates: WeatherCoordinates
-): WeatherFetchError => {
+const normalizeError = (error: unknown, coordinates: WeatherCoordinates): WeatherFetchError => {
   if (error instanceof WeatherFetchError) return error
   const fallback = readWeatherCache(coordinates, { allowExpired: true })?.data ?? null
   return new WeatherFetchError("Failed to fetch weather", { fallback, cause: error })
@@ -61,7 +58,10 @@ export const useWeather = (options: UseWeatherOptions = {}): UseWeatherResult =>
   const prefersReducedMotion = useMediaQuery("(prefers-reduced-motion: reduce)")
   const abortRef = useRef<AbortController | null>(null)
 
-  const initialCached = useMemo(() => readWeatherCache(coordinates, { allowExpired: true }), [signature])
+  const initialCached = useMemo(
+    () => readWeatherCache(coordinates, { allowExpired: true }),
+    [signature]
+  )
   const hasFreshCache = Boolean(initialCached && initialCached.expiresAt > Date.now())
 
   const [snapshot, setSnapshot] = useState<WeatherSnapshot | null>(initialCached?.data ?? null)

--- a/root/frontend/src/hooks/useWeather.ts
+++ b/root/frontend/src/hooks/useWeather.ts
@@ -1,0 +1,175 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+
+import { CAMPUS_COORDINATES } from "@/constants/campus"
+import {
+  WEATHER_CACHE_TTL_MS,
+  WeatherFetchError,
+  fetchWeatherSnapshot,
+  readWeatherCache,
+} from "@/api/weather"
+import type { WeatherCoordinates, WeatherSnapshot } from "@/api/weather"
+import { getWeatherIconMeta } from "@/utils/weatherIcons"
+import type { WeatherAnimationVariant } from "@/utils/weatherIcons"
+import useMediaQuery from "./useMediaQuery"
+
+const WEATHER_TRANSLATION_BASE = "system:weather.conditions"
+
+export interface UseWeatherOptions {
+  coordinates?: WeatherCoordinates
+  cacheTtlMs?: number
+}
+
+export interface WeatherData extends WeatherSnapshot {
+  icon: string
+  translationKey: string
+  translationKeySuffix: string
+  animation: WeatherAnimationVariant
+}
+
+export interface UseWeatherResult {
+  data: WeatherData | null
+  isLoading: boolean
+  error: Error | null
+  refresh: () => Promise<void>
+}
+
+const toSignature = (coordinates: WeatherCoordinates): string => {
+  const lat = Number(coordinates.lat).toFixed(4)
+  const lon = Number(coordinates.lon).toFixed(4)
+  return `${lat},${lon}`
+}
+
+const normalizeError = (
+  error: unknown,
+  coordinates: WeatherCoordinates
+): WeatherFetchError => {
+  if (error instanceof WeatherFetchError) return error
+  const fallback = readWeatherCache(coordinates, { allowExpired: true })?.data ?? null
+  return new WeatherFetchError("Failed to fetch weather", { fallback, cause: error })
+}
+
+export const useWeather = (options: UseWeatherOptions = {}): UseWeatherResult => {
+  const { coordinates: overrideCoordinates, cacheTtlMs = WEATHER_CACHE_TTL_MS } = options
+  const coordinates = useMemo<WeatherCoordinates>(
+    () =>
+      overrideCoordinates
+        ? Object.freeze({ lat: overrideCoordinates.lat, lon: overrideCoordinates.lon })
+        : CAMPUS_COORDINATES,
+    [overrideCoordinates?.lat, overrideCoordinates?.lon]
+  )
+  const signature = useMemo(() => toSignature(coordinates), [coordinates])
+  const prefersReducedMotion = useMediaQuery("(prefers-reduced-motion: reduce)")
+  const abortRef = useRef<AbortController | null>(null)
+
+  const initialCached = useMemo(() => readWeatherCache(coordinates, { allowExpired: true }), [signature])
+  const hasFreshCache = Boolean(initialCached && initialCached.expiresAt > Date.now())
+
+  const [snapshot, setSnapshot] = useState<WeatherSnapshot | null>(initialCached?.data ?? null)
+  const [isLoading, setIsLoading] = useState(!hasFreshCache)
+  const [error, setError] = useState<Error | null>(null)
+
+  useEffect(() => {
+    return () => {
+      abortRef.current?.abort()
+      abortRef.current = null
+    }
+  }, [])
+
+  useEffect(() => {
+    const cached = readWeatherCache(coordinates, { allowExpired: true })
+    setSnapshot(cached?.data ?? null)
+    const fresh = Boolean(cached && cached.expiresAt > Date.now())
+    if (fresh) {
+      setIsLoading(false)
+      setError(null)
+      return
+    }
+    setIsLoading(true)
+    setError(null)
+
+    const controller = new AbortController()
+    abortRef.current?.abort()
+    abortRef.current = controller
+
+    void fetchWeatherSnapshot({
+      coordinates,
+      cacheTtlMs,
+      signal: controller.signal,
+    })
+      .then((next) => {
+        if (controller.signal.aborted) return
+        setSnapshot(next)
+        setError(null)
+        setIsLoading(false)
+      })
+      .catch((err) => {
+        if (controller.signal.aborted) return
+        const normalized = normalizeError(err, coordinates)
+        if (!normalized.aborted && normalized.fallback) {
+          setSnapshot(normalized.fallback)
+        }
+        if (!normalized.aborted) {
+          setError(normalized)
+        }
+        setIsLoading(false)
+      })
+  }, [cacheTtlMs, coordinates, signature])
+
+  const load = useCallback(
+    async (force: boolean) => {
+      abortRef.current?.abort()
+      const controller = new AbortController()
+      abortRef.current = controller
+      try {
+        const next = await fetchWeatherSnapshot({
+          coordinates,
+          cacheTtlMs,
+          forceRefresh: force,
+          signal: controller.signal,
+        })
+        if (controller.signal.aborted) return
+        setSnapshot(next)
+        setError(null)
+        setIsLoading(false)
+      } catch (err) {
+        if (controller.signal.aborted) return
+        const normalized = normalizeError(err, coordinates)
+        if (normalized.aborted) {
+          setIsLoading(false)
+          return
+        }
+        if (normalized.fallback) {
+          setSnapshot(normalized.fallback)
+        }
+        setError(normalized)
+        setIsLoading(false)
+      } finally {
+        if (abortRef.current === controller) {
+          abortRef.current = null
+        }
+      }
+    },
+    [cacheTtlMs, coordinates]
+  )
+
+  const refresh = useCallback(async () => {
+    setIsLoading(true)
+    setError(null)
+    await load(true)
+  }, [load])
+
+  const data = useMemo<WeatherData | null>(() => {
+    if (!snapshot) return null
+    const meta = getWeatherIconMeta(snapshot.conditionCode)
+    const animation: WeatherAnimationVariant = prefersReducedMotion ? "none" : meta.animation
+    return {
+      ...snapshot,
+      icon: meta.icon,
+      translationKeySuffix: meta.translationKeySuffix,
+      translationKey: `${WEATHER_TRANSLATION_BASE}.${meta.translationKeySuffix}`,
+      animation,
+    }
+  }, [snapshot, prefersReducedMotion])
+
+  return { data, isLoading, error, refresh }
+}

--- a/root/frontend/src/i18n/locales/en/system.json
+++ b/root/frontend/src/i18n/locales/en/system.json
@@ -81,6 +81,25 @@
       }
     }
   },
+  "weather": {
+    "conditions": {
+      "clear": "Clear sky",
+      "mostlyClear": "Mostly clear",
+      "cloudy": "Overcast",
+      "fog": "Fog",
+      "drizzle": "Drizzle",
+      "freezingDrizzle": "Freezing drizzle",
+      "rain": "Rain",
+      "freezingRain": "Freezing rain",
+      "snow": "Snowfall",
+      "snowGrains": "Snow grains",
+      "rainShowers": "Rain showers",
+      "snowShowers": "Snow showers",
+      "thunderstorm": "Thunderstorm",
+      "thunderstormHail": "Thunderstorm with hail",
+      "unknown": "Weather unavailable"
+    }
+  },
   "installPrompt": {
     "installTitle": "Install “{{appName}}”",
     "title": "{{appName}}",

--- a/root/frontend/src/i18n/locales/ru/system.json
+++ b/root/frontend/src/i18n/locales/ru/system.json
@@ -81,6 +81,25 @@
       }
     }
   },
+  "weather": {
+    "conditions": {
+      "clear": "Ясно",
+      "mostlyClear": "Переменная облачность",
+      "cloudy": "Пасмурно",
+      "fog": "Туман",
+      "drizzle": "Морось",
+      "freezingDrizzle": "Переохлаждённая морось",
+      "rain": "Дождь",
+      "freezingRain": "Ледяной дождь",
+      "snow": "Снегопад",
+      "snowGrains": "Снежная крупа",
+      "rainShowers": "Ливневый дождь",
+      "snowShowers": "Снегопад с порывами",
+      "thunderstorm": "Гроза",
+      "thunderstormHail": "Гроза с градом",
+      "unknown": "Погода недоступна"
+    }
+  },
   "installPrompt": {
     "installTitle": "Установить «{{appName}}»",
     "title": "{{appName}}",

--- a/root/frontend/src/pages/MapContent.tsx
+++ b/root/frontend/src/pages/MapContent.tsx
@@ -21,11 +21,11 @@ import RestartAltIcon from "@mui/icons-material/RestartAlt"
 import "../assets/themes.css"
 import { useTranslation } from "react-i18next"
 import MapFallback from "@/components/MapFallback"
+import { CAMPUS_COORDINATES } from "@/constants/campus"
 
 type LayerMode = "map" | "hybrid"
 
 const MAP_ID = "128006a9ca6ecba0793cdcd05524ff66e1c0b5187d421dfcae39dd12345e4b57"
-const CAMPUS = { lat: 55.71392, lon: 37.81474 }
 const Z_DEFAULT = 16
 const LOAD_TIMEOUT_MS = 12000
 
@@ -105,7 +105,9 @@ export default function MapContent() {
     if (layer === "map" && !traffic) {
       return `https://yandex.ru/map-widget/v1/?um=constructor%3A${MAP_ID}&source=constructor`
     }
-    const ll = encodeURIComponent(`${CAMPUS.lon.toFixed(6)},${CAMPUS.lat.toFixed(6)}`)
+    const ll = encodeURIComponent(
+      `${CAMPUS_COORDINATES.lon.toFixed(6)},${CAMPUS_COORDINATES.lat.toFixed(6)}`
+    )
     return `https://yandex.ru/map-widget/v1/?ll=${ll}&z=${Z_DEFAULT}&l=${encodeURIComponent(lParam)}`
   }, [layer, traffic, lParam])
 
@@ -182,7 +184,7 @@ export default function MapContent() {
       )
       return
     }
-    const ll = `${CAMPUS.lon.toFixed(6)},${CAMPUS.lat.toFixed(6)}`
+    const ll = `${CAMPUS_COORDINATES.lon.toFixed(6)},${CAMPUS_COORDINATES.lat.toFixed(6)}`
     window.open(
       `https://yandex.ru/maps/?ll=${ll}&z=${Z_DEFAULT}&l=${lParam.replace(/%2C/g, ",")}`,
       "_blank",

--- a/root/frontend/src/utils/weatherIcons.ts
+++ b/root/frontend/src/utils/weatherIcons.ts
@@ -1,0 +1,68 @@
+export type WeatherAnimationVariant =
+  | "none"
+  | "glow"
+  | "breeze"
+  | "drizzle"
+  | "snow"
+  | "storm"
+
+export interface WeatherIconMeta {
+  /** Provider-specific condition identifier. */
+  icon: string
+  /** Translation key suffix appended to the weather namespace. */
+  translationKeySuffix: string
+  /** Short English label for quick fallbacks. */
+  label: string
+  /** Suggested animation style for expressive widgets. */
+  animation: WeatherAnimationVariant
+}
+
+const createMeta = (
+  label: string,
+  translationKeySuffix: string,
+  icon: string,
+  animation: WeatherAnimationVariant
+): WeatherIconMeta =>
+  Object.freeze({
+    label,
+    translationKeySuffix,
+    icon,
+    animation,
+  })
+
+const FALLBACK_META = createMeta("Unknown conditions", "unknown", "🌡️", "none")
+
+const CODE_GROUPS: Array<{ codes: number[]; meta: WeatherIconMeta }> = [
+  { codes: [0], meta: createMeta("Clear sky", "clear", "☀️", "glow") },
+  { codes: [1, 2], meta: createMeta("Mostly clear", "mostlyClear", "🌤️", "glow") },
+  { codes: [3], meta: createMeta("Overcast", "cloudy", "☁️", "breeze") },
+  { codes: [45, 48], meta: createMeta("Fog", "fog", "🌫️", "none") },
+  { codes: [51, 53, 55], meta: createMeta("Drizzle", "drizzle", "🌦️", "drizzle") },
+  { codes: [56, 57], meta: createMeta("Freezing drizzle", "freezingDrizzle", "🌧️", "drizzle") },
+  { codes: [61, 63, 65], meta: createMeta("Rain", "rain", "🌧️", "drizzle") },
+  { codes: [66, 67], meta: createMeta("Freezing rain", "freezingRain", "🌧️", "drizzle") },
+  { codes: [71, 73, 75], meta: createMeta("Snowfall", "snow", "🌨️", "snow") },
+  { codes: [77], meta: createMeta("Snow grains", "snowGrains", "❄️", "snow") },
+  { codes: [80, 81, 82], meta: createMeta("Rain showers", "rainShowers", "🌦️", "drizzle") },
+  { codes: [85, 86], meta: createMeta("Snow showers", "snowShowers", "🌨️", "snow") },
+  { codes: [95], meta: createMeta("Thunderstorm", "thunderstorm", "⛈️", "storm") },
+  { codes: [96, 99], meta: createMeta("Thunderstorm with hail", "thunderstormHail", "⛈️", "storm") },
+]
+
+const WEATHER_CODE_META: Record<number, WeatherIconMeta> = {}
+for (const { codes, meta } of CODE_GROUPS) {
+  for (const code of codes) {
+    WEATHER_CODE_META[code] = meta
+  }
+}
+
+export const getWeatherIconMeta = (code: number | null | undefined): WeatherIconMeta => {
+  if (code == null || !Number.isFinite(code)) return FALLBACK_META
+  const key = Math.trunc(code)
+  return WEATHER_CODE_META[key] ?? FALLBACK_META
+}
+
+export const getWeatherLabel = (code: number | null | undefined): string =>
+  getWeatherIconMeta(code).label
+
+export const WEATHER_ICON_FALLBACK = FALLBACK_META

--- a/root/frontend/src/utils/weatherIcons.ts
+++ b/root/frontend/src/utils/weatherIcons.ts
@@ -1,10 +1,4 @@
-export type WeatherAnimationVariant =
-  | "none"
-  | "glow"
-  | "breeze"
-  | "drizzle"
-  | "snow"
-  | "storm"
+export type WeatherAnimationVariant = "none" | "glow" | "breeze" | "drizzle" | "snow" | "storm"
 
 export interface WeatherIconMeta {
   /** Provider-specific condition identifier. */
@@ -46,7 +40,10 @@ const CODE_GROUPS: Array<{ codes: number[]; meta: WeatherIconMeta }> = [
   { codes: [80, 81, 82], meta: createMeta("Rain showers", "rainShowers", "🌦️", "drizzle") },
   { codes: [85, 86], meta: createMeta("Snow showers", "snowShowers", "🌨️", "snow") },
   { codes: [95], meta: createMeta("Thunderstorm", "thunderstorm", "⛈️", "storm") },
-  { codes: [96, 99], meta: createMeta("Thunderstorm with hail", "thunderstormHail", "⛈️", "storm") },
+  {
+    codes: [96, 99],
+    meta: createMeta("Thunderstorm with hail", "thunderstormHail", "⛈️", "storm"),
+  },
 ]
 
 const WEATHER_CODE_META: Record<number, WeatherIconMeta> = {}


### PR DESCRIPTION
## Summary
- extract campus coordinates into a shared constant and reuse them on the map page
- add a weather API client with caching, abort handling, and icon metadata
- introduce a weather hook with reduced-motion aware presentation and localized labels

## Testing
- npm --prefix root/frontend run lint

------
https://chatgpt.com/codex/tasks/task_e_68ffeeca25048327b4010491ff81f293