### PR TITLE
Add weather widget chip to dashboard hero

### DIFF
--- a/root/frontend/src/assets/themes.css
+++ b/root/frontend/src/assets/themes.css
@@ -831,7 +831,8 @@ body.dark .menu-link:not(.logout):focus {
 }
 .chip-clock,
 .chip-time,
-.chip-type {
+.chip-type,
+.chip-weather {
   position: relative;
   overflow: hidden;
   -webkit-backdrop-filter: blur(calc(var(--glass-blur) * 0.6));
@@ -859,6 +860,15 @@ body.dark .menu-link:not(.logout):focus {
   background-color: var(--dash-chip-type-bg) !important;
   color: var(--dash-chip-type-text) !important;
   border: 1px solid var(--dash-chip-type-border) !important;
+}
+.chip-weather {
+  background-color: color-mix(in srgb, white 90%, var(--nav-link) 10%) !important;
+  border: 1px solid color-mix(in srgb, white 52%, var(--nav-link) 48%) !important;
+  color: color-mix(in srgb, var(--nav-text) 84%, var(--nav-link) 16%) !important;
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, white 55%, transparent),
+    0 22px 48px -28px color-mix(in srgb, var(--nav-link-hover) 62%, transparent),
+    0 6px 18px -12px color-mix(in srgb, var(--nav-link) 28%, transparent);
 }
 .chip-left {
   background: color-mix(in srgb, white 94%, var(--nav-link) 6%) !important;
@@ -892,6 +902,125 @@ body.dark .chip-day {
   background: color-mix(in srgb, var(--nav-link) 22%, transparent) !important;
   color: var(--page-text) !important;
   border: 1px solid color-mix(in srgb, var(--nav-link) 46%, transparent) !important;
+}
+body.dark .chip-weather {
+  background-color: color-mix(in srgb, var(--nav-link-hover) 32%, transparent) !important;
+  border: 1px solid color-mix(in srgb, var(--nav-link-hover) 58%, transparent) !important;
+  color: color-mix(in srgb, var(--page-text) 88%, var(--nav-link-hover) 12%) !important;
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, white 18%, transparent),
+    0 30px 60px -32px color-mix(in srgb, black 65%, transparent),
+    0 10px 30px -20px color-mix(in srgb, var(--nav-link) 55%, transparent);
+}
+.chip-weather__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.1em;
+  line-height: 1;
+  filter: drop-shadow(0 3px 6px rgba(255, 255, 255, 0.4));
+  transition: transform var(--anim-med), filter var(--anim-med);
+}
+.chip-weather__temp {
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.01em;
+}
+.chip-weather__skeleton {
+  border-radius: 999px;
+  min-width: 88px;
+  opacity: 0.9;
+}
+body.dark .chip-weather__icon {
+  filter: drop-shadow(0 0 10px color-mix(in srgb, var(--nav-link-hover) 68%, transparent));
+}
+@media (prefers-reduced-motion: reduce) {
+  .chip-weather__icon {
+    animation: none !important;
+  }
+}
+@media (prefers-reduced-motion: no-preference) {
+  @keyframes weather-icon-glow {
+    0%,
+    100% {
+      transform: scale(1);
+      filter: drop-shadow(0 3px 6px rgba(255, 255, 255, 0.35));
+    }
+    50% {
+      transform: scale(1.08);
+      filter: drop-shadow(0 6px 12px rgba(255, 203, 107, 0.55));
+    }
+  }
+
+  @keyframes weather-icon-breeze {
+    0%,
+    100% {
+      transform: translate3d(0, 0, 0);
+    }
+    50% {
+      transform: translate3d(0, -2px, 0) rotate(-2deg);
+    }
+  }
+
+  @keyframes weather-icon-drizzle {
+    0%,
+    100% {
+      transform: translate3d(0, 0, 0);
+    }
+    40% {
+      transform: translate3d(0, 2px, 0);
+    }
+    70% {
+      transform: translate3d(0, -3px, 0);
+    }
+  }
+
+  @keyframes weather-icon-snow {
+    0% {
+      transform: translate3d(0, -1px, 0) rotate(0deg);
+    }
+    50% {
+      transform: translate3d(0, 2px, 0) rotate(4deg);
+    }
+    100% {
+      transform: translate3d(0, -1px, 0) rotate(-4deg);
+    }
+  }
+
+  @keyframes weather-icon-storm {
+    0%,
+    100% {
+      transform: translate3d(0, 0, 0);
+    }
+    25% {
+      transform: translate3d(-1px, 0, 0) rotate(-4deg);
+    }
+    50% {
+      transform: translate3d(1px, 0, 0) rotate(4deg);
+    }
+    75% {
+      transform: translate3d(-0.5px, 0, 0) rotate(-2deg);
+    }
+  }
+
+  .chip-weather[data-animation="glow"] .chip-weather__icon {
+    animation: weather-icon-glow 4.8s ease-in-out infinite;
+  }
+
+  .chip-weather[data-animation="breeze"] .chip-weather__icon {
+    animation: weather-icon-breeze 3.6s ease-in-out infinite;
+  }
+
+  .chip-weather[data-animation="drizzle"] .chip-weather__icon {
+    animation: weather-icon-drizzle 2.8s ease-in-out infinite;
+  }
+
+  .chip-weather[data-animation="snow"] .chip-weather__icon {
+    animation: weather-icon-snow 5.2s ease-in-out infinite;
+  }
+
+  .chip-weather[data-animation="storm"] .chip-weather__icon {
+    animation: weather-icon-storm 1.8s ease-in-out infinite;
+  }
 }
 body.dark .MuiChip-outlined {
   border-color: #223349 !important;

--- a/root/frontend/src/assets/themes.css
+++ b/root/frontend/src/assets/themes.css
@@ -919,7 +919,9 @@ body.dark .chip-weather {
   font-size: 1.1em;
   line-height: 1;
   filter: drop-shadow(0 3px 6px rgba(255, 255, 255, 0.4));
-  transition: transform var(--anim-med), filter var(--anim-med);
+  transition:
+    transform var(--anim-med),
+    filter var(--anim-med);
 }
 .chip-weather__temp {
   font-variant-numeric: tabular-nums;

--- a/root/frontend/src/components/WeatherWidget.tsx
+++ b/root/frontend/src/components/WeatherWidget.tsx
@@ -1,0 +1,87 @@
+import { useMemo } from "react"
+import { Badge, Skeleton, Tooltip } from "@/components/ui"
+import { useWeather } from "@/hooks/useWeather"
+import { getLocaleForLanguage, useLanguage } from "@/contexts/LanguageContext"
+import { useTranslation } from "react-i18next"
+import { cn } from "@/utils/cn"
+
+type WeatherWidgetProps = {
+  className?: string
+}
+
+const TEMPERATURE_PRECISION = 0
+
+const isFiniteNumber = (value: number | null | undefined): value is number =>
+  typeof value === "number" && Number.isFinite(value)
+
+export default function WeatherWidget({ className }: WeatherWidgetProps) {
+  const { data, isLoading } = useWeather()
+  const { language } = useLanguage()
+  const locale = getLocaleForLanguage(language)
+  const { t, i18n } = useTranslation(["system", "common"])
+
+  const formatter = useMemo(
+    () =>
+      new Intl.NumberFormat(locale ?? i18n.language, {
+        maximumFractionDigits: TEMPERATURE_PRECISION,
+        signDisplay: "always",
+      }),
+    [i18n.language, locale]
+  )
+
+  const wrapperClassName = cn("inline-flex", className)
+
+  if (isLoading) {
+    return (
+      <span className={wrapperClassName}>
+        <Skeleton
+          width={88}
+          height={30}
+          rounded="999px"
+          ariaLabel={t("common:loading")}
+          className="chip-weather__skeleton"
+        />
+      </span>
+    )
+  }
+
+  if (!data || !isFiniteNumber(data.temperatureC)) {
+    return null
+  }
+
+  const conditionText = t(data.translationKey, {
+    defaultValue: data.conditionLabel,
+  })
+
+  const roundedTemperature = Math.round(data.temperatureC)
+  const signedTemperature = formatter.format(roundedTemperature)
+  const displayTemperature = `${signedTemperature}°`
+
+  const ariaLabel = t("system:weather.aria.status", {
+    condition: conditionText,
+    temperature: signedTemperature,
+    defaultValue: `${conditionText}. Temperature ${signedTemperature}°C.`,
+  })
+
+  return (
+    <span className={wrapperClassName}>
+      <Tooltip content={conditionText}>
+        <Badge
+          size="sm"
+          className="chip-weather focus-visible:outline-none focus-visible:shadow-[var(--ue-focus-ring)]"
+          aria-live="polite"
+          aria-label={ariaLabel}
+          tabIndex={0}
+          data-animation={data.animation}
+        >
+          <span aria-hidden className="chip-weather__icon">
+            {data.icon}
+          </span>
+          <span className="chip-weather__temp" aria-hidden>
+            {displayTemperature}
+          </span>
+        </Badge>
+      </Tooltip>
+    </span>
+  )
+}

--- a/root/frontend/src/i18n/locales/en/system.json
+++ b/root/frontend/src/i18n/locales/en/system.json
@@ -98,6 +98,10 @@
       "thunderstorm": "Thunderstorm",
       "thunderstormHail": "Thunderstorm with hail",
       "unknown": "Weather unavailable"
+    },
+    "aria": {
+      "status": "{{condition}}. Temperature {{temperature}}°C.",
+      "statusNoTemp": "{{condition}}. Temperature unavailable."
     }
   },
   "installPrompt": {

--- a/root/frontend/src/i18n/locales/ru/system.json
+++ b/root/frontend/src/i18n/locales/ru/system.json
@@ -98,6 +98,10 @@
       "thunderstorm": "Гроза",
       "thunderstormHail": "Гроза с градом",
       "unknown": "Погода недоступна"
+    },
+    "aria": {
+      "status": "{{condition}}. Температура {{temperature}}°C.",
+      "statusNoTemp": "{{condition}}. Температура недоступна."
     }
   },
   "installPrompt": {

--- a/root/frontend/src/pages/Dashboard.tsx
+++ b/root/frontend/src/pages/Dashboard.tsx
@@ -22,6 +22,7 @@ import { getLocaleForLanguage, useLanguage } from "@/contexts/LanguageContext"
 import type { PaginatedResponse } from "@/types/Pagination"
 import type { StoryItem } from "@/types/Story"
 import { fetchStories as fetchStoriesRequest } from "@/api/stories"
+import WeatherWidget from "@/components/WeatherWidget"
 
 type NewsItem = {
   id: number
@@ -504,13 +505,13 @@ export default function Dashboard() {
                     {user?.full_name ? `, ${user.full_name.split(" ")[0]}` : ""}!
                   </h1>
                   <div
-                    className="flex flex-wrap items-center gap-3 text-sm text-nav-text/90"
+                    className="flex flex-wrap items-center gap-x-3 gap-y-2 text-sm text-nav-text/90"
                     role="status"
                     aria-live="polite"
                   >
                     <Badge
                       size="sm"
-                      className="chip-clock font-mono text-base"
+                      className="chip-clock flex-shrink-0 font-mono text-base"
                       aria-label={t("common:ariaCurrentTime")}
                     >
                       <span className="flex items-baseline gap-1 font-mono text-lg leading-none">
@@ -527,7 +528,10 @@ export default function Dashboard() {
                         <span>{mm}</span>
                       </span>
                     </Badge>
-                    <span className="text-sm font-medium tracking-tight">{dateStr}</span>
+                    <WeatherWidget className="flex-shrink-0" />
+                    <span className="text-sm font-medium tracking-tight leading-tight">
+                      {dateStr}
+                    </span>
                   </div>
                 </div>
                 <div className="hidden justify-end md:flex lg:col-span-4">


### PR DESCRIPTION
## Summary
- add a WeatherWidget component that surfaces the current conditions with tooltip, skeleton state, and aria updates
- extend the theme with a chip-weather style and motion-aware icon animations
- localize new aria strings and place the widget in the dashboard hero alongside the clock and date

## Testing
- npm run lint
- npm run i18n:check

------
https://chatgpt.com/codex/tasks/task_e_69005d06eb20832789c02fd848678879