### PR TITLE
Add weather localization entries and tests

### DIFF
--- a/docs/LOCALIZATION.md
+++ b/docs/LOCALIZATION.md
@@ -32,6 +32,19 @@ The dashboard "stories" carousel now exposes additional localized strings in
 Whenever you adjust these phrases, update both `en` and `ru` locales so the
 dashboard and accessibility hints stay in sync across languages.
 
+## Dashboard weather
+
+The dashboard weather chip uses new entries under `dashboard.weather` for both
+languages:
+
+- `label` — short name for the widget, reused in aria-labels.
+- `tooltip` — compact summary shown on hover/focus (`Weather · Clear sky · +21°`).
+- `conditions.*` — human-friendly descriptions for each weather code.
+- `aria.status` and `aria.statusNoTemp` — announcements for screen readers.
+
+Ensure any changes land in both locale files so the tooltip and aria-labels do
+not fall back to raw translation keys.
+
 ## Campus map fallback
 
 Privacy settings, reduced-motion preferences, or offline conditions can disable

--- a/root/frontend/src/components/WeatherWidget.tsx
+++ b/root/frontend/src/components/WeatherWidget.tsx
@@ -18,7 +18,7 @@ export default function WeatherWidget({ className }: WeatherWidgetProps) {
   const { data, isLoading } = useWeather()
   const { language } = useLanguage()
   const locale = getLocaleForLanguage(language)
-  const { t, i18n } = useTranslation(["system", "common"])
+  const { t, i18n } = useTranslation(["dashboard", "common"])
 
   const formatter = useMemo(
     () =>
@@ -53,11 +53,23 @@ export default function WeatherWidget({ className }: WeatherWidgetProps) {
     defaultValue: data.conditionLabel,
   })
 
+  const labelText = t("dashboard:weather.label", {
+    defaultValue: "Weather",
+  })
+
   const roundedTemperature = Math.round(data.temperatureC)
   const signedTemperature = formatter.format(roundedTemperature)
   const displayTemperature = `${signedTemperature}°`
 
-  const ariaLabel = t("system:weather.aria.status", {
+  const tooltipContent = t("dashboard:weather.tooltip", {
+    label: labelText,
+    condition: conditionText,
+    temperature: displayTemperature,
+    defaultValue: `${conditionText} · ${displayTemperature}`,
+  })
+
+  const ariaLabel = t("dashboard:weather.aria.status", {
+    label: labelText,
     condition: conditionText,
     temperature: signedTemperature,
     defaultValue: `${conditionText}. Temperature ${signedTemperature}°C.`,
@@ -65,7 +77,7 @@ export default function WeatherWidget({ className }: WeatherWidgetProps) {
 
   return (
     <span className={wrapperClassName}>
-      <Tooltip content={conditionText}>
+      <Tooltip content={tooltipContent}>
         <Badge
           size="sm"
           className="chip-weather focus-visible:outline-none focus-visible:shadow-[var(--ue-focus-ring)]"

--- a/root/frontend/src/components/__tests__/WeatherWidget.test.tsx
+++ b/root/frontend/src/components/__tests__/WeatherWidget.test.tsx
@@ -1,0 +1,164 @@
+import { describe, it, expect, beforeEach, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+
+import WeatherWidget from "../WeatherWidget"
+
+const translations: Record<string, string> = {
+  "common:loading": "Loading",
+  "dashboard:weather.label": "Weather",
+  "dashboard:weather.tooltip": "{{label}} · {{condition}} · {{temperature}}",
+  "dashboard:weather.conditions.clear": "Clear sky",
+  "dashboard:weather.conditions.unknown": "Weather unavailable",
+  "dashboard:weather.aria.status": "{{label}}. {{condition}}. Temperature {{temperature}}°C.",
+  "dashboard:weather.aria.statusNoTemp": "{{label}}. {{condition}}. Temperature unavailable.",
+}
+
+let mockLanguage: "en" | "ru" = "en"
+
+const weatherStore = vi.hoisted(() => {
+  function baseSnapshot() {
+    return {
+      conditionCode: 0,
+      conditionLabel: "Clear sky",
+      temperatureC: 21,
+      observedAt: new Date("2025-09-15T08:45:00Z").toISOString(),
+      icon: "☀️",
+      translationKeySuffix: "clear",
+      translationKey: "dashboard:weather.conditions.clear",
+      animation: "glow" as const,
+    }
+  }
+
+  const createData = (overrides: Partial<ReturnType<typeof baseSnapshot>> = {}) => ({
+    ...baseSnapshot(),
+    ...overrides,
+  })
+
+  type WeatherState = {
+    data: ReturnType<typeof baseSnapshot> | null
+    isLoading: boolean
+    error: Error | null
+    refresh: ReturnType<typeof vi.fn>
+  }
+
+  let state: WeatherState = {
+    data: baseSnapshot(),
+    isLoading: false,
+    error: null,
+    refresh: vi.fn(),
+  }
+
+  return {
+    createData,
+    getState: () => state,
+    setState: (next: Partial<WeatherState>) => {
+      state = { ...state, ...next }
+    },
+    reset: () => {
+      state = {
+        data: baseSnapshot(),
+        isLoading: false,
+        error: null,
+        refresh: vi.fn(),
+      }
+    },
+  }
+})
+
+vi.mock("react-i18next", () => ({
+  useTranslation: (namespaces: string | string[] = "common") => {
+    const defaultNamespace = Array.isArray(namespaces) ? namespaces[0] : namespaces
+    return {
+      t: (key: string, options: Record<string, unknown> = {}) => {
+        const namespacedKey = key.includes(":") ? key : `${defaultNamespace}:${key}`
+        const template = translations[namespacedKey] ?? namespacedKey
+        return template.replace(/{{\s*(\w+)\s*}}/g, (_, token) => {
+          const value = options[token]
+          return value === undefined || value === null ? "" : String(value)
+        })
+      },
+      i18n: { language: mockLanguage },
+    }
+  },
+}))
+
+vi.mock("@/contexts/LanguageContext", () => ({
+  useLanguage: () => ({ language: mockLanguage }),
+  getLocaleForLanguage: (language: string) => (language === "ru" ? "ru-RU" : "en-US"),
+}))
+
+vi.mock("@/hooks/useWeather", () => ({
+  useWeather: vi.fn(() => weatherStore.getState()),
+}))
+
+describe("WeatherWidget", () => {
+  beforeEach(() => {
+    mockLanguage = "en"
+    weatherStore.reset()
+  })
+
+  it("renders the current weather with tooltip details", () => {
+    render(<WeatherWidget />)
+
+    expect(screen.getByText("☀️")).toBeInTheDocument()
+    expect(screen.getByText("+21°")).toBeInTheDocument()
+
+    const badge = screen.getByLabelText("Weather. Clear sky. Temperature +21°C.")
+    expect(badge).toHaveAttribute("title", "Weather · Clear sky · +21°")
+    expect(badge).toHaveAttribute("data-animation", "glow")
+  })
+
+  it("disables icon animation when reduced motion is requested", () => {
+    const originalMatchMedia = window.matchMedia
+    if (!originalMatchMedia) {
+      Object.defineProperty(window, "matchMedia", {
+        configurable: true,
+        writable: true,
+        value: vi.fn(() => ({
+          matches: false,
+          media: "",
+          onchange: null,
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+          dispatchEvent: vi.fn(),
+        })),
+      })
+    }
+
+    const matchMediaSpy = vi
+      .spyOn(window, "matchMedia")
+      .mockImplementation((query: string) => ({
+        matches: query.includes("prefers-reduced-motion"),
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      }) as unknown as MediaQueryList)
+
+    weatherStore.setState({ data: weatherStore.createData({ animation: "none" }) })
+
+    try {
+      render(<WeatherWidget />)
+      const badge = screen.getByLabelText("Weather. Clear sky. Temperature +21°C.")
+      expect(badge).toHaveAttribute("data-animation", "none")
+    } finally {
+      matchMediaSpy.mockRestore()
+      if (!originalMatchMedia) {
+        delete (window as { matchMedia?: typeof window.matchMedia }).matchMedia
+      }
+    }
+  })
+
+  it("renders nothing when weather data is unavailable", () => {
+    weatherStore.setState({ data: null, isLoading: false })
+
+    const { container } = render(<WeatherWidget />)
+
+    expect(container.firstChild).toBeNull()
+  })
+})

--- a/root/frontend/src/components/__tests__/WeatherWidget.test.tsx
+++ b/root/frontend/src/components/__tests__/WeatherWidget.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi } from "vitest"
 import { render, screen } from "@testing-library/react"
 
 import WeatherWidget from "../WeatherWidget"
+import type { WeatherAnimationVariant } from "@/utils/weatherIcons"
 
 const translations: Record<string, string> = {
   "common:loading": "Loading",
@@ -15,8 +16,19 @@ const translations: Record<string, string> = {
 
 let mockLanguage: "en" | "ru" = "en"
 
+type WeatherSnapshotMock = {
+  conditionCode: number
+  conditionLabel: string
+  temperatureC: number
+  observedAt: string
+  icon: string
+  translationKeySuffix: string
+  translationKey: string
+  animation: WeatherAnimationVariant
+}
+
 const weatherStore = vi.hoisted(() => {
-  function baseSnapshot() {
+  function baseSnapshot(): WeatherSnapshotMock {
     return {
       conditionCode: 0,
       conditionLabel: "Clear sky",
@@ -25,17 +37,17 @@ const weatherStore = vi.hoisted(() => {
       icon: "☀️",
       translationKeySuffix: "clear",
       translationKey: "dashboard:weather.conditions.clear",
-      animation: "glow" as const,
+      animation: "glow",
     }
   }
 
-  const createData = (overrides: Partial<ReturnType<typeof baseSnapshot>> = {}) => ({
+  const createData = (overrides: Partial<WeatherSnapshotMock> = {}) => ({
     ...baseSnapshot(),
     ...overrides,
   })
 
   type WeatherState = {
-    data: ReturnType<typeof baseSnapshot> | null
+    data: WeatherSnapshotMock | null
     isLoading: boolean
     error: Error | null
     refresh: ReturnType<typeof vi.fn>

--- a/root/frontend/src/components/__tests__/WeatherWidget.test.tsx
+++ b/root/frontend/src/components/__tests__/WeatherWidget.test.tsx
@@ -127,18 +127,19 @@ describe("WeatherWidget", () => {
       })
     }
 
-    const matchMediaSpy = vi
-      .spyOn(window, "matchMedia")
-      .mockImplementation((query: string) => ({
-        matches: query.includes("prefers-reduced-motion"),
-        media: query,
-        onchange: null,
-        addEventListener: vi.fn(),
-        removeEventListener: vi.fn(),
-        addListener: vi.fn(),
-        removeListener: vi.fn(),
-        dispatchEvent: vi.fn(),
-      }) as unknown as MediaQueryList)
+    const matchMediaSpy = vi.spyOn(window, "matchMedia").mockImplementation(
+      (query: string) =>
+        ({
+          matches: query.includes("prefers-reduced-motion"),
+          media: query,
+          onchange: null,
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+          dispatchEvent: vi.fn(),
+        }) as unknown as MediaQueryList
+    )
 
     weatherStore.setState({ data: weatherStore.createData({ animation: "none" }) })
 

--- a/root/frontend/src/hooks/useWeather.ts
+++ b/root/frontend/src/hooks/useWeather.ts
@@ -12,7 +12,7 @@ import { getWeatherIconMeta } from "@/utils/weatherIcons"
 import type { WeatherAnimationVariant } from "@/utils/weatherIcons"
 import useMediaQuery from "./useMediaQuery"
 
-const WEATHER_TRANSLATION_BASE = "system:weather.conditions"
+const WEATHER_TRANSLATION_BASE = "dashboard:weather.conditions"
 
 export interface UseWeatherOptions {
   coordinates?: WeatherCoordinates

--- a/root/frontend/src/i18n/locales/en/dashboard.json
+++ b/root/frontend/src/i18n/locales/en/dashboard.json
@@ -18,6 +18,31 @@
     "eventsWeek": "Events this week",
     "eventItem": "Event: {{title}}"
   },
+  "weather": {
+    "label": "Weather",
+    "tooltip": "{{label}} · {{condition}} · {{temperature}}",
+    "conditions": {
+      "clear": "Clear sky",
+      "mostlyClear": "Mostly clear",
+      "cloudy": "Overcast",
+      "fog": "Fog",
+      "drizzle": "Drizzle",
+      "freezingDrizzle": "Freezing drizzle",
+      "rain": "Rain",
+      "freezingRain": "Freezing rain",
+      "snow": "Snowfall",
+      "snowGrains": "Snow grains",
+      "rainShowers": "Rain showers",
+      "snowShowers": "Snow showers",
+      "thunderstorm": "Thunderstorm",
+      "thunderstormHail": "Thunderstorm with hail",
+      "unknown": "Weather unavailable"
+    },
+    "aria": {
+      "status": "{{label}}. {{condition}}. Temperature {{temperature}}°C.",
+      "statusNoTemp": "{{label}}. {{condition}}. Temperature unavailable."
+    }
+  },
   "fullSchedule": "Full schedule",
   "now": "Now",
   "next": "Next",

--- a/root/frontend/src/i18n/locales/ru/dashboard.json
+++ b/root/frontend/src/i18n/locales/ru/dashboard.json
@@ -18,6 +18,31 @@
     "eventsWeek": "События на этой неделе",
     "eventItem": "Событие: {{title}}"
   },
+  "weather": {
+    "label": "Погода",
+    "tooltip": "{{label}} · {{condition}} · {{temperature}}",
+    "conditions": {
+      "clear": "Ясно",
+      "mostlyClear": "Переменная облачность",
+      "cloudy": "Пасмурно",
+      "fog": "Туман",
+      "drizzle": "Морось",
+      "freezingDrizzle": "Переохлаждённая морось",
+      "rain": "Дождь",
+      "freezingRain": "Ледяной дождь",
+      "snow": "Снегопад",
+      "snowGrains": "Снежная крупа",
+      "rainShowers": "Ливневый дождь",
+      "snowShowers": "Снегопад с порывами",
+      "thunderstorm": "Гроза",
+      "thunderstormHail": "Гроза с градом",
+      "unknown": "Погода недоступна"
+    },
+    "aria": {
+      "status": "{{label}}. {{condition}}. Температура {{temperature}}°C.",
+      "statusNoTemp": "{{label}}. {{condition}}. Температура недоступна."
+    }
+  },
   "fullSchedule": "Полное расписание",
   "now": "Сейчас",
   "next": "Далее",

--- a/root/frontend/src/tests/pageTranslations.test.tsx
+++ b/root/frontend/src/tests/pageTranslations.test.tsx
@@ -564,9 +564,7 @@ describe("page translations", () => {
       const { user } = renderWithProviders(<Dashboard />, { initialPath: "/dashboard" })
 
       expect(await screen.findByText("Today's schedule")).toBeInTheDocument()
-      const weatherBadgeEn = await screen.findByLabelText(
-        "Weather. Clear sky. Temperature +21°C."
-      )
+      const weatherBadgeEn = await screen.findByLabelText("Weather. Clear sky. Temperature +21°C.")
       expect(weatherBadgeEn).toHaveAttribute("data-animation", "glow")
       expect(weatherBadgeEn).toHaveAttribute("title", "Weather · Clear sky · +21°")
       // The Tailwind dashboard keeps the stories heading visually hidden but exposes it to
@@ -591,9 +589,7 @@ describe("page translations", () => {
 
       expect(await screen.findByText("Расписание на сегодня")).toBeInTheDocument()
       await waitFor(() => {
-        const weatherBadgeRu = screen.getByLabelText(
-          "Погода. Ясно. Температура +21°C."
-        )
+        const weatherBadgeRu = screen.getByLabelText("Погода. Ясно. Температура +21°C.")
         expect(weatherBadgeRu).toHaveAttribute("data-animation", "glow")
         expect(weatherBadgeRu).toHaveAttribute("title", "Погода · Ясно · +21°")
       })

--- a/root/frontend/src/tests/pageTranslations.test.tsx
+++ b/root/frontend/src/tests/pageTranslations.test.tsx
@@ -253,6 +253,26 @@ const {
   }
 })
 
+const { weatherResult } = vi.hoisted(() => {
+  const weatherResult = {
+    data: {
+      conditionCode: 0,
+      conditionLabel: "Clear sky",
+      temperatureC: 21,
+      observedAt: new Date("2025-09-15T08:45:00Z").toISOString(),
+      icon: "☀️",
+      translationKeySuffix: "clear",
+      translationKey: "dashboard:weather.conditions.clear",
+      animation: "glow" as const,
+    },
+    isLoading: false,
+    error: null,
+    refresh: vi.fn(),
+  }
+
+  return { weatherResult }
+})
+
 const authState = {
   isAuth: true,
   login: vi.fn(),
@@ -277,6 +297,10 @@ vi.mock("@/hooks/useNowPlaying", () => ({
     refetch: vi.fn(),
   }),
   nowPlayingQueryKey: ["now-playing"],
+}))
+
+vi.mock("@/hooks/useWeather", () => ({
+  useWeather: vi.fn(() => weatherResult),
 }))
 
 const pushPreferencesMock = {
@@ -410,6 +434,7 @@ beforeEach(() => {
   apiPutMock.mockClear()
   pushPreferencesMock.enableNotifications.mockClear()
   pushPreferencesMock.disableNotifications.mockClear()
+  weatherResult.refresh.mockClear()
 })
 
 afterEach(() => {
@@ -539,6 +564,11 @@ describe("page translations", () => {
       const { user } = renderWithProviders(<Dashboard />, { initialPath: "/dashboard" })
 
       expect(await screen.findByText("Today's schedule")).toBeInTheDocument()
+      const weatherBadgeEn = await screen.findByLabelText(
+        "Weather. Clear sky. Temperature +21°C."
+      )
+      expect(weatherBadgeEn).toHaveAttribute("data-animation", "glow")
+      expect(weatherBadgeEn).toHaveAttribute("title", "Weather · Clear sky · +21°")
       // The Tailwind dashboard keeps the stories heading visually hidden but exposes it to
       // assistive tech. Querying by role keeps that intentional sr-only <h2> in place.
       expect(await screen.findByRole("heading", { name: "Stories" })).toBeInTheDocument()
@@ -560,6 +590,13 @@ describe("page translations", () => {
       await user.click(screen.getByTestId("lang-toggle"))
 
       expect(await screen.findByText("Расписание на сегодня")).toBeInTheDocument()
+      await waitFor(() => {
+        const weatherBadgeRu = screen.getByLabelText(
+          "Погода. Ясно. Температура +21°C."
+        )
+        expect(weatherBadgeRu).toHaveAttribute("data-animation", "glow")
+        expect(weatherBadgeRu).toHaveAttribute("title", "Погода · Ясно · +21°")
+      })
       expect(await screen.findByText("Истории переключаются автоматически.")).toBeInTheDocument()
       await waitFor(() => {
         const ruLabels = screen


### PR DESCRIPTION
## Summary
- add dashboard weather translations and update the widget to use the new keys
- document the weather localization bundle in docs/LOCALIZATION.md
- cover the widget with vitest/RTL and ensure dashboard language toggles load weather strings

## Testing
- npm run test -- WeatherWidget
- npm run test -- pageTranslations

------
https://chatgpt.com/codex/tasks/task_e_690064cbc12c832782d837832d5b09f0