### PR TITLE
Use versioned event list cache keys

### DIFF
--- a/root/app/api/events.py
+++ b/root/app/api/events.py
@@ -26,7 +26,9 @@ from app import crud
 from app.api.deps import get_current_user
 from app.api.utils import save_upload
 from app.core.database import get_db
-from app.deps.cache import etag_matches, format_etag, get_cache
+from redis.exceptions import RedisError
+
+from app.deps.cache import RedisCache, etag_matches, format_etag, get_cache
 from app.localization import normalize_locale, resolve_locale, translate
 from app.models import models
 from app.schemas import schemas
@@ -39,28 +41,97 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/events", tags=["events"])
 
 _EVENTS_LIST_CACHE_PREFIX = "events:list"
-_events_list_cache_keys: set[str] = set()
+_EVENTS_LIST_VERSION_KEY = f"{_EVENTS_LIST_CACHE_PREFIX}:version"
+_LOCAL_EVENTS_LIST_VERSION = 0
 
 
-def _register_events_cache_key(key: str) -> None:
-    if key:
-        _events_list_cache_keys.add(key)
+async def _reset_events_list_cache_version() -> None:
+    global _LOCAL_EVENTS_LIST_VERSION
+    _LOCAL_EVENTS_LIST_VERSION = 0
+    cache = get_cache()
+    if isinstance(cache, RedisCache):
+        try:
+            client = await cache._get_client()
+            await client.delete(_EVENTS_LIST_VERSION_KEY)
+        except (RedisError, OSError):
+            logger.debug(
+                "Failed to reset events cache version in Redis", exc_info=True
+            )
 
 
-def _consume_events_cache_keys() -> list[str]:
-    if not _events_list_cache_keys:
-        return []
-    keys = list(_events_list_cache_keys)
-    _events_list_cache_keys.clear()
-    return keys
+async def _get_events_list_version(cache) -> str:
+    if not cache.enabled:
+        return str(_LOCAL_EVENTS_LIST_VERSION)
+    if isinstance(cache, RedisCache):
+        try:
+            client = await cache._get_client()
+            raw = await client.get(_EVENTS_LIST_VERSION_KEY)
+        except (RedisError, OSError):
+            logger.warning(
+                "Failed to read events cache version from Redis", exc_info=True
+            )
+            return "0"
+        try:
+            return str(int(raw)) if raw is not None else "0"
+        except (TypeError, ValueError):
+            logger.debug(
+                "Invalid events cache version %s, using zero", raw, exc_info=True
+            )
+            return "0"
+    return "0"
 
 
-def _events_cache_keys_snapshot() -> tuple[str, ...]:
-    return tuple(sorted(_events_list_cache_keys))
+async def _read_events_list_version(cache) -> int:
+    if not cache.enabled:
+        return _LOCAL_EVENTS_LIST_VERSION
+    if isinstance(cache, RedisCache):
+        try:
+            client = await cache._get_client()
+            raw = await client.get(_EVENTS_LIST_VERSION_KEY)
+        except (RedisError, OSError):
+            logger.debug(
+                "Failed to read events cache version for inspection", exc_info=True
+            )
+            return 0
+        try:
+            return int(raw) if raw is not None else 0
+        except (TypeError, ValueError):
+            logger.debug(
+                "Invalid cached events version %s during inspection", raw,
+                exc_info=True,
+            )
+            return 0
+    return 0
 
 
-def _reset_events_cache_registry() -> None:
-    _events_list_cache_keys.clear()
+async def _increment_events_list_version(cache) -> None:
+    global _LOCAL_EVENTS_LIST_VERSION
+    if not cache.enabled:
+        _LOCAL_EVENTS_LIST_VERSION += 1
+        return
+    if isinstance(cache, RedisCache):
+        try:
+            client = await cache._get_client()
+            increment = getattr(client, "incr", None)
+            if callable(increment):
+                await increment(_EVENTS_LIST_VERSION_KEY)
+            else:
+                await _manual_increment_events_version(client)
+        except (RedisError, OSError):
+            logger.warning(
+                "Failed to increment events cache version in Redis", exc_info=True
+            )
+        return
+    _LOCAL_EVENTS_LIST_VERSION += 1
+
+
+async def _manual_increment_events_version(client) -> None:
+    raw = await client.get(_EVENTS_LIST_VERSION_KEY)
+    try:
+        current = int(raw) if raw is not None else 0
+    except (TypeError, ValueError):
+        current = 0
+    await client.set(_EVENTS_LIST_VERSION_KEY, current + 1)
 
 
 def _events_list_cache_key(
@@ -72,12 +143,14 @@ def _events_list_cache_key(
     is_active: bool,
     limit: int,
     cursor: str | None,
+    version: str,
 ) -> str:
     normalized_locale = normalize_locale(locale)
     normalized_search = (search or "").strip().lower()
     normalized_type = (event_type or "").strip().lower()
     normalized_location = (location or "").strip().lower()
     normalized_cursor = (cursor or "").strip()
+    normalized_version = str(version or "0").strip() or "0"
     signature = json.dumps(
         {
             "search": normalized_search,
@@ -92,16 +165,14 @@ def _events_list_cache_key(
         sort_keys=True,
     ).encode("utf-8")
     digest = hashlib.sha256(signature).hexdigest()
-    return f"{_EVENTS_LIST_CACHE_PREFIX}:{normalized_locale}:{digest}"
+    return (
+        f"{_EVENTS_LIST_CACHE_PREFIX}:{normalized_version}:{normalized_locale}:{digest}"
+    )
 
 
 async def _invalidate_events_list_cache() -> None:
-    keys = _consume_events_cache_keys()
-    if not keys:
-        return
     cache = get_cache()
-    if cache.enabled:
-        await cache.invalidate(*keys)
+    await _increment_events_list_version(cache)
 
 
 @lru_cache(maxsize=1)
@@ -181,7 +252,9 @@ async def all_events(
     _set_language_headers(response, locale)
     cache = get_cache()
     cache_key: str | None = None
+    cache_version: str | None = None
     if cache.enabled:
+        cache_version = await _get_events_list_version(cache)
         cache_key = _events_list_cache_key(
             locale=locale,
             search=search,
@@ -190,8 +263,8 @@ async def all_events(
             is_active=is_active,
             limit=limit,
             cursor=cursor,
+            version=cache_version,
         )
-        _register_events_cache_key(cache_key)
         cached = await cache.get(cache_key)
         if cached:
             etag_header = format_etag(cached.etag)

--- a/root/app/api/events.py
+++ b/root/app/api/events.py
@@ -19,6 +19,7 @@ from fastapi import (
     status,
 )
 from fastapi.encoders import jsonable_encoder
+from redis.exceptions import RedisError
 from sqlalchemy import and_, delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -26,8 +27,6 @@ from app import crud
 from app.api.deps import get_current_user
 from app.api.utils import save_upload
 from app.core.database import get_db
-from redis.exceptions import RedisError
-
 from app.deps.cache import RedisCache, etag_matches, format_etag, get_cache
 from app.localization import normalize_locale, resolve_locale, translate
 from app.models import models
@@ -54,9 +53,7 @@ async def _reset_events_list_cache_version() -> None:
             client = await cache._get_client()
             await client.delete(_EVENTS_LIST_VERSION_KEY)
         except (RedisError, OSError):
-            logger.debug(
-                "Failed to reset events cache version in Redis", exc_info=True
-            )
+            logger.debug("Failed to reset events cache version in Redis", exc_info=True)
 
 
 async def _get_events_list_version(cache) -> str:
@@ -97,7 +94,8 @@ async def _read_events_list_version(cache) -> int:
             return int(raw) if raw is not None else 0
         except (TypeError, ValueError):
             logger.debug(
-                "Invalid cached events version %s during inspection", raw,
+                "Invalid cached events version %s during inspection",
+                raw,
                 exc_info=True,
             )
             return 0

--- a/root/tests/test_events_localization.py
+++ b/root/tests/test_events_localization.py
@@ -129,7 +129,7 @@ async def test_events_localization(async_client, db_session, user_factory):
 async def test_events_etag_and_not_modified(
     async_client, db_session, user_factory, fake_cache
 ):
-    events._reset_events_cache_registry()
+    await events._reset_events_list_cache_version()
     assert fake_cache is not None
     password = "TestEvent456!"
     hashed = get_password_hash(password)
@@ -299,7 +299,7 @@ async def test_events_pagination_semantics(async_client, db_session, user_factor
 async def test_events_cache_invalidation_on_mutations(
     async_client, db_session, user_factory, fake_cache
 ):
-    events._reset_events_cache_registry()
+    await events._reset_events_list_cache_version()
 
     admin_password = "CacheAdmin123!"
     student_password = "CacheStudent123!"
@@ -329,9 +329,17 @@ async def test_events_cache_invalidation_on_mutations(
 
     first_response = await async_client.get("/events", headers=list_headers)
     assert first_response.status_code == status.HTTP_200_OK
-    keys_after_first = events._events_cache_keys_snapshot()
-    assert keys_after_first
-    tracked_key = keys_after_first[0]
+    version_after_first = await events._read_events_list_version(fake_cache)
+    tracked_key = events._events_list_cache_key(
+        locale="en",
+        search="",
+        event_type="",
+        location="",
+        is_active=True,
+        limit=first_response.json()["limit"],
+        cursor=None,
+        version=str(version_after_first),
+    )
     cached_entry = await fake_cache.get(tracked_key)
     assert cached_entry is not None
 
@@ -359,14 +367,22 @@ async def test_events_cache_invalidation_on_mutations(
     assert create_response.status_code == status.HTTP_200_OK
     created_event_id = create_response.json()["id"]
 
-    assert await fake_cache.get(tracked_key) is None
-    assert not events._events_cache_keys_snapshot()
+    version_after_create = await events._read_events_list_version(fake_cache)
+    assert version_after_create == version_after_first + 1
+    assert await fake_cache.get(tracked_key) is not None
 
     after_create = await async_client.get("/events", headers=list_headers)
     assert after_create.status_code == status.HTTP_200_OK
-    keys_after_create = events._events_cache_keys_snapshot()
-    assert keys_after_create
-    active_key = keys_after_create[0]
+    active_key = events._events_list_cache_key(
+        locale="en",
+        search="",
+        event_type="",
+        location="",
+        is_active=True,
+        limit=after_create.json()["limit"],
+        cursor=None,
+        version=str(version_after_create),
+    )
     assert await fake_cache.get(active_key) is not None
 
     update_response = await async_client.patch(
@@ -375,19 +391,103 @@ async def test_events_cache_invalidation_on_mutations(
         json={"title": "Updated cached event"},
     )
     assert update_response.status_code == status.HTTP_200_OK
-    assert await fake_cache.get(active_key) is None
-    assert not events._events_cache_keys_snapshot()
+    version_after_update = await events._read_events_list_version(fake_cache)
+    assert version_after_update == version_after_create + 1
+    assert await fake_cache.get(active_key) is not None
 
     after_update = await async_client.get("/events", headers=list_headers)
     assert after_update.status_code == status.HTTP_200_OK
-    keys_after_update = events._events_cache_keys_snapshot()
-    assert keys_after_update
-    post_update_key = keys_after_update[0]
+    post_update_key = events._events_list_cache_key(
+        locale="en",
+        search="",
+        event_type="",
+        location="",
+        is_active=True,
+        limit=after_update.json()["limit"],
+        cursor=None,
+        version=str(version_after_update),
+    )
     assert await fake_cache.get(post_update_key) is not None
 
     delete_response = await async_client.delete(
         f"/events/{created_event_id}", headers=admin_headers
     )
     assert delete_response.status_code == status.HTTP_200_OK
-    assert await fake_cache.get(post_update_key) is None
-    assert not events._events_cache_keys_snapshot()
+    version_after_delete = await events._read_events_list_version(fake_cache)
+    assert version_after_delete == version_after_update + 1
+    assert await fake_cache.get(post_update_key) is not None
+
+
+@pytest.mark.anyio
+async def test_events_cache_uses_version_from_redis(
+    async_client, db_session, user_factory, fake_cache
+):
+    await events._reset_events_list_cache_version()
+
+    password = "VersionPass123!"
+    hashed = get_password_hash(password)
+    admin = await user_factory(role="admin")
+    student = await user_factory(hashed_password=hashed, is_active=True)
+
+    now = datetime.now(timezone.utc)
+    event = models.Event(
+        title="Original title",
+        description="Original description",
+        location="Campus",
+        starts_at=now + timedelta(days=1),
+        ends_at=now + timedelta(days=1, hours=2),
+        created_by=admin.id,
+        is_active=True,
+    )
+    db_session.add(event)
+    await db_session.commit()
+    await db_session.refresh(event)
+
+    headers = await _login(async_client, student.email, password)
+    list_headers = {**headers, "Accept-Language": "en"}
+
+    initial_response = await async_client.get("/events", headers=list_headers)
+    assert initial_response.status_code == status.HTTP_200_OK
+    initial_data = initial_response.json()
+    initial_items = {item["id"]: item for item in initial_data["items"]}
+    assert initial_items[event.id]["title"] == "Original title"
+
+    initial_version = await events._read_events_list_version(fake_cache)
+    initial_key = events._events_list_cache_key(
+        locale="en",
+        search="",
+        event_type="",
+        location="",
+        is_active=True,
+        limit=initial_data["limit"],
+        cursor=None,
+        version=str(initial_version),
+    )
+    assert await fake_cache.get(initial_key) is not None
+
+    event.title = "Updated title"
+    db_session.add(event)
+    await db_session.commit()
+    await db_session.refresh(event)
+
+    await events._increment_events_list_version(fake_cache)
+
+    refreshed = await async_client.get("/events", headers=list_headers)
+    assert refreshed.status_code == status.HTTP_200_OK
+    refreshed_data = refreshed.json()
+    refreshed_items = {item["id"]: item for item in refreshed_data["items"]}
+    assert refreshed_items[event.id]["title"] == "Updated title"
+
+    refreshed_version = await events._read_events_list_version(fake_cache)
+    assert refreshed_version == initial_version + 1
+    refreshed_key = events._events_list_cache_key(
+        locale="en",
+        search="",
+        event_type="",
+        location="",
+        is_active=True,
+        limit=refreshed_data["limit"],
+        cursor=None,
+        version=str(refreshed_version),
+    )
+    assert await fake_cache.get(refreshed_key) is not None


### PR DESCRIPTION
## Summary
- replace the per-process tracking of event list cache keys with a Redis-backed version counter and include the version in cache keys
- extend event localization tests to cover the new cache version workflow and ensure fresh data is served after version bumps

## Testing
- pytest root/tests/test_events_localization.py

------
https://chatgpt.com/codex/tasks/task_e_69008253b36483279316bdcd6f4775d9