### PR TITLE
Add localized period metadata to stats API responses

### DIFF
--- a/root/app/api/stats.py
+++ b/root/app/api/stats.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, Query, Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import crud
 from app.api.deps import get_current_user
 from app.core.database import get_db
 from app.models import models
+from app.localization import resolve_locale, translate
 
 router = APIRouter(prefix="/stats", tags=["stats"])
 
@@ -17,39 +18,96 @@ _PERIOD_ALIASES = {
     "180d": 180,
 }
 
+_PERIOD_DEFAULT = ("30d", 30)
 
-def _resolve_period(period: str | None) -> int:
+
+def _resolve_period(period: str | None) -> tuple[str, int]:
     if not period:
-        return 30
+        return _PERIOD_DEFAULT
     period_key = period.strip().lower()
-    return _PERIOD_ALIASES.get(period_key, 30)
+    days = _PERIOD_ALIASES.get(period_key)
+    if days is not None:
+        return period_key, days
+    return _PERIOD_DEFAULT
+
+
+def _period_response_payload(
+    *,
+    stats: dict[str, object],
+    period_key: str,
+    period_days: int,
+    request: Request,
+    user: models.User,
+) -> dict[str, object]:
+    locale = resolve_locale(request=request, user=user)
+    label = translate(
+        f"stats.period.{period_key}",
+        locale=locale,
+        default=period_key,
+        days=period_days,
+    )
+    payload = dict(stats)
+    payload["period_key"] = stats.get("period_key") or period_key
+    payload["period_label"] = label
+    return payload
 
 
 @router.get("/attendance")
 async def attendance_summary(
+    request: Request,
     period: str = Query("30d"),
     db: AsyncSession = Depends(get_db),
     user: models.User = Depends(get_current_user),
 ):
-    days = _resolve_period(period)
-    return await crud.get_attendance_stats(db, user_id=user.id, period_days=days)
+    period_key, days = _resolve_period(period)
+    stats = await crud.get_attendance_stats(
+        db,
+        user_id=user.id,
+        period_days=days,
+        period_key=period_key,
+    )
+    return _period_response_payload(
+        stats=stats,
+        period_key=period_key,
+        period_days=days,
+        request=request,
+        user=user,
+    )
 
 
 @router.get("/grades")
 async def grade_summary(
+    request: Request,
     period: str = Query("30d"),
     db: AsyncSession = Depends(get_db),
     user: models.User = Depends(get_current_user),
 ):
-    days = _resolve_period(period)
-    return await crud.get_grade_stats(db, user_id=user.id, period_days=days)
+    period_key, days = _resolve_period(period)
+    stats = await crud.get_grade_stats(db, user_id=user.id, period_days=days)
+    return _period_response_payload(
+        stats=stats,
+        period_key=period_key,
+        period_days=days,
+        request=request,
+        user=user,
+    )
 
 
 @router.get("/participation")
 async def participation_summary(
+    request: Request,
     period: str = Query("30d"),
     db: AsyncSession = Depends(get_db),
     user: models.User = Depends(get_current_user),
 ):
-    days = _resolve_period(period)
-    return await crud.get_participation_stats(db, user_id=user.id, period_days=days)
+    period_key, days = _resolve_period(period)
+    stats = await crud.get_participation_stats(
+        db, user_id=user.id, period_days=days
+    )
+    return _period_response_payload(
+        stats=stats,
+        period_key=period_key,
+        period_days=days,
+        request=request,
+        user=user,
+    )

--- a/root/app/api/stats.py
+++ b/root/app/api/stats.py
@@ -6,8 +6,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app import crud
 from app.api.deps import get_current_user
 from app.core.database import get_db
-from app.models import models
 from app.localization import resolve_locale, translate
+from app.models import models
 
 router = APIRouter(prefix="/stats", tags=["stats"])
 
@@ -101,9 +101,7 @@ async def participation_summary(
     user: models.User = Depends(get_current_user),
 ):
     period_key, days = _resolve_period(period)
-    stats = await crud.get_participation_stats(
-        db, user_id=user.id, period_days=days
-    )
+    stats = await crud.get_participation_stats(db, user_id=user.id, period_days=days)
     return _period_response_payload(
         stats=stats,
         period_key=period_key,

--- a/root/app/crud/__init__.py
+++ b/root/app/crud/__init__.py
@@ -841,7 +841,11 @@ def _dt_to_iso(value: datetime | None) -> str:
 
 
 async def get_attendance_stats(
-    db: AsyncSession, *, user_id: int, period_days: int
+    db: AsyncSession,
+    *,
+    user_id: int,
+    period_days: int,
+    period_key: str | None = None,
 ) -> Dict[str, Any]:
     now = datetime.now(UTC)
     window_start = now - timedelta(days=period_days)
@@ -926,7 +930,7 @@ async def get_attendance_stats(
         "present": attended_events,
         "total": total_events,
         "trend": round(percent - previous_percent, 2),
-        "window_label": f"last {period_days} days",
+        "period_key": period_key or f"{period_days}d",
         "recent": recent,
     }
 

--- a/root/app/localization.py
+++ b/root/app/localization.py
@@ -152,6 +152,18 @@ _TRANSLATIONS: Mapping[str, Mapping[str, str]] = {
         "ru": "Уведомление",
         "en": "Notification",
     },
+    "stats.period.30d": {
+        "ru": "За последние {days} дней",
+        "en": "Last {days} days",
+    },
+    "stats.period.90d": {
+        "ru": "За последние {days} дней",
+        "en": "Last {days} days",
+    },
+    "stats.period.180d": {
+        "ru": "За последние {days} дней",
+        "en": "Last {days} days",
+    },
     "errors.auth.credentials_invalid": {
         "ru": "Не удалось подтвердить учётные данные",
         "en": "Could not validate credentials",

--- a/root/frontend/src/pages/Activity.tsx
+++ b/root/frontend/src/pages/Activity.tsx
@@ -64,12 +64,16 @@ const periodDayCount = (key: PeriodKey): number => {
   }
 }
 
+const isPeriodKey = (value: unknown): value is PeriodKey =>
+  typeof value === "string" && periodValues.includes(value as PeriodKey)
+
 type AttendanceStats = {
   percent: number
   present: number
   total: number
   trend: number
-  windowLabel: string
+  periodLabel: string
+  periodKey: string
   recent: Array<{ date: string; status: "present" | "absent" | "late"; course?: string }>
 }
 type GradeStats = {
@@ -171,7 +175,8 @@ type AttendanceSummaryResponse = {
   present?: unknown
   total?: unknown
   trend?: unknown
-  window_label?: string
+  period_key?: unknown
+  period_label?: unknown
   recent?: unknown
 }
 
@@ -361,11 +366,6 @@ export default function Activity() {
       t(`activity:sections.attendance.status.${status}`, { defaultValue: status }),
     [t]
   )
-  const tRef = useRef(t)
-  useEffect(() => {
-    tRef.current = t
-  }, [t])
-
   const fallbackAttendanceRecentRef = useRef(defaultAttendanceRecent)
   const fallbackGradeRecentRef = useRef(defaultGradeRecent)
   const fallbackParticipationRecentRef = useRef(defaultParticipationRecent)
@@ -398,10 +398,6 @@ export default function Activity() {
     summaryRequestRef.current = controller
 
     setLoading(true)
-    const windowLabel = tRef.current(`activity:period.labels.${period}`, {
-      defaultValue: period,
-      count: periodDayCount(period),
-    })
 
     try {
       const [a, g, p] = await Promise.allSettled([
@@ -425,12 +421,20 @@ export default function Activity() {
 
       if (a.status === "fulfilled" && a.value?.data) {
         const d = a.value.data
+        const resolvedPeriodKey: PeriodKey = isPeriodKey(d.period_key)
+          ? d.period_key
+          : period
+        const periodLabel =
+          typeof d.period_label === "string" && d.period_label.trim()
+            ? d.period_label
+            : labelByPeriod(resolvedPeriodKey)
         setAttendance({
           percent: toNumber(d.percent),
           present: toNumber(d.present),
           total: toNumber(d.total),
           trend: toNumber(d.trend),
-          windowLabel,
+          periodKey: resolvedPeriodKey,
+          periodLabel,
           recent: Array.isArray(d.recent) ? d.recent : [],
         })
       } else {
@@ -440,7 +444,8 @@ export default function Activity() {
           present: 83,
           total: 90,
           trend: 1.4,
-          windowLabel,
+          periodKey: period,
+          periodLabel: labelByPeriod(period),
           recent: fallbackRecent.map((item) => ({ ...item })),
         })
       }
@@ -488,7 +493,7 @@ export default function Activity() {
         setLoading(false)
       }
     }
-  }, [period])
+  }, [period, labelByPeriod])
 
   useEffect(() => {
     void fetchSummary()
@@ -866,7 +871,7 @@ export default function Activity() {
                     {t("activity:sections.attendance.summary", {
                       present: attendance?.present ?? 0,
                       total: attendance?.total ?? 0,
-                      period: attendance?.windowLabel || labelByPeriod(period),
+                      period: attendance?.periodLabel || labelByPeriod(period),
                     })}
                   </Typography>
                 </Stack>
@@ -1198,7 +1203,7 @@ export default function Activity() {
                   {t("activity:sections.attendance.dialogTotal", {
                     present: attendance?.present ?? 0,
                     total: attendance?.total ?? 0,
-                    period: attendance?.windowLabel || labelByPeriod(period),
+                    period: attendance?.periodLabel || labelByPeriod(period),
                   })}
                 </Typography>
                 <LinearProgress

--- a/root/frontend/src/tests/pageTranslations.test.tsx
+++ b/root/frontend/src/tests/pageTranslations.test.tsx
@@ -186,13 +186,16 @@ const {
     present: 17,
     total: 20,
     trend: 4,
-    window_label: "last 30 days",
+    period_key: "30d",
+    period_label: "Last 30 days",
     recent: [{ date: "2025-09-19", status: "present", course: "Physics" }],
   }
   const gradeSummary = {
     average: 4.6,
     scale: "5" as const,
     trend: 2,
+    period_key: "30d",
+    period_label: "Last 30 days",
     recent: [{ course: "Physics", score: 5, date: "2025-09-10" }],
   }
   const participationSummary = {
@@ -200,6 +203,8 @@ const {
     hours: 6,
     groups: 2,
     trend: 1,
+    period_key: "30d",
+    period_label: "Last 30 days",
     recent: [{ title: "Volunteer Day", date: "2025-09-12", role: "helper" }],
   }
 

--- a/root/frontend/tests/e2e/utils/mockApi.ts
+++ b/root/frontend/tests/e2e/utils/mockApi.ts
@@ -944,7 +944,8 @@ export async function useMockApi(page: Page) {
           present: 18,
           total: 22,
           trend: 6.5,
-          window_label: "last 30 days",
+          period_key: "30d",
+          period_label: "Last 30 days",
           recent: [
             {
               date: new Date().toISOString(),
@@ -965,6 +966,8 @@ export async function useMockApi(page: Page) {
           average: 4.7,
           scale: "5",
           trend: 0.4,
+          period_key: "30d",
+          period_label: "Last 30 days",
           recent: [
             {
               course: "Physics",
@@ -987,6 +990,8 @@ export async function useMockApi(page: Page) {
           hours: 12,
           groups: 3,
           trend: 1,
+          period_key: "30d",
+          period_label: "Last 30 days",
           recent: [
             {
               title: "Volunteer Day",

--- a/root/tests/test_stats_api.py
+++ b/root/tests/test_stats_api.py
@@ -130,10 +130,28 @@ async def test_attendance_stats_returns_expected_payload(
     assert payload["total"] == 3
     assert payload["percent"] == pytest.approx(66.67, rel=1e-2)
     assert payload["trend"] == pytest.approx(16.67, rel=1e-2)
-    assert payload["window_label"].startswith("last ")
+    assert payload["period_key"] == "30d"
+    assert payload["period_label"] == "Last 30 days"
     assert len(payload["recent"]) == 2
     assert payload["recent"][0]["status"] == "present"
     assert payload["recent"][0]["course"] == "Modern Physics"
+
+
+@pytest.mark.anyio
+async def test_attendance_stats_period_label_localized(async_client, user_factory):
+    password = "LocalizedPass123!"
+    hashed = get_password_hash(password)
+    student = await user_factory(hashed_password=hashed, is_active=True)
+
+    headers = await _login(async_client, student.email, password)
+    headers["Accept-Language"] = "ru"
+
+    response = await async_client.get("/stats/attendance", headers=headers)
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload["period_key"] == "30d"
+    assert payload["period_label"] == "За последние 30 дней"
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- return the period key from attendance stats and provide translation entries for known ranges
- include the period key and localized label in stats API responses and surface them to the Activity page
- update client fixtures and API tests to cover the localized period label behaviour

## Testing
- pytest root/tests/test_stats_api.py

------
https://chatgpt.com/codex/tasks/task_e_69009b98c8fc8327a99451f9f640c5b7