### PR TITLE
Add configurable storage backends with S3 support

### DIFF
--- a/root/app/core/config.py
+++ b/root/app/core/config.py
@@ -198,6 +198,14 @@ class Settings(BaseSettings):
     notifications_webpush_concurrency_limit: int = 10
     notifications_retention_days: int = 90
     notifications_retention_cleanup_interval_seconds: int = 86_400
+    storage_backend: str = "static"
+    storage_static_base_url: str = "/static"
+    storage_s3_bucket: str = ""
+    storage_s3_region: str = ""
+    storage_s3_access_key_id: str = ""
+    storage_s3_secret_access_key: str = ""
+    storage_s3_endpoint_url: str = ""
+    storage_s3_base_url: str = ""
     notifications_queue_max_size: int = 1024
     notifications_queue_enqueue_timeout_seconds: float = 0.5
     notifications_queue_in_memory_only: bool = False
@@ -243,6 +251,16 @@ class Settings(BaseSettings):
         normalized = value.strip().lower()
         if normalized not in {"memory", "redis"}:
             raise ValueError("RATE_LIMIT_STORAGE_BACKEND must be 'memory' or 'redis'")
+        return normalized
+
+    @field_validator("storage_backend")
+    @classmethod
+    def _validate_storage_backend(cls, value: str) -> str:
+        normalized = value.strip().lower()
+        if normalized not in {"static", "filesystem", "local", "s3", "minio"}:
+            raise ValueError(
+                "STORAGE_BACKEND must be one of static, filesystem, local, s3, or minio"
+            )
         return normalized
 
     @field_validator("mfa_totp_issuer")

--- a/root/app/services/storage.py
+++ b/root/app/services/storage.py
@@ -1,0 +1,215 @@
+"""Storage backends for user-uploaded files."""
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from typing import Protocol
+from urllib.parse import urlparse
+
+from app.core.config import Settings
+
+logger = logging.getLogger(__name__)
+
+
+class StorageBackend(Protocol):
+    """Protocol implemented by storage backends."""
+
+    async def save_file(
+        self, relative_path: str, data: bytes, *, content_type: str | None = None
+    ) -> str:
+        """Persist ``data`` under ``relative_path`` and return a public URL."""
+
+    async def delete_file(self, file_url: str) -> None:
+        """Delete file referenced by ``file_url`` if it exists."""
+
+
+class StaticFSStorage(StorageBackend):
+    """Store files on the local filesystem under a static directory."""
+
+    def __init__(self, base_dir: Path, base_url: str = "/static") -> None:
+        self.base_dir = base_dir
+        self.base_url = base_url.rstrip("/") or ""
+
+    def _normalize_relative_path(self, relative_path: str) -> Path:
+        cleaned = relative_path.strip().strip("/")
+        if not cleaned:
+            raise ValueError("Relative path must not be empty")
+        candidate = Path(cleaned)
+        if candidate.is_absolute() or any(part == ".." for part in candidate.parts):
+            raise ValueError("Relative path must not escape base directory")
+        return candidate
+
+    async def save_file(
+        self, relative_path: str, data: bytes, *, content_type: str | None = None
+    ) -> str:
+        del content_type  # unused for filesystem storage
+        normalized = self._normalize_relative_path(relative_path)
+        target = self.base_dir / normalized
+        await asyncio.to_thread(target.parent.mkdir, parents=True, exist_ok=True)
+        await asyncio.to_thread(target.write_bytes, data)
+        relative_str = normalized.as_posix()
+        if self.base_url:
+            return f"{self.base_url}/{relative_str}"
+        return f"/{relative_str}"
+
+    def _extract_relative_path(self, file_url: str) -> Path | None:
+        if not file_url:
+            return None
+        trimmed = file_url.strip()
+        if not trimmed:
+            return None
+        prefix = self.base_url.rstrip("/") if self.base_url else ""
+        if prefix and trimmed.startswith(prefix):
+            trimmed = trimmed[len(prefix) :]
+        trimmed = trimmed.lstrip("/")
+        if not trimmed:
+            return None
+        try:
+            return self._normalize_relative_path(trimmed)
+        except ValueError:
+            return None
+
+    @staticmethod
+    def _unlink_ignore_missing(path: Path) -> None:
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            return
+        except OSError:
+            logger.warning("Failed to remove file at %s", path, exc_info=True)
+
+    async def delete_file(self, file_url: str) -> None:
+        relative = self._extract_relative_path(file_url)
+        if relative is None:
+            return
+        await asyncio.to_thread(self._unlink_ignore_missing, self.base_dir / relative)
+
+
+class S3Storage(StorageBackend):
+    """Store files in an S3-compatible object storage."""
+
+    def __init__(
+        self,
+        *,
+        bucket: str,
+        region: str | None = None,
+        access_key_id: str | None = None,
+        secret_access_key: str | None = None,
+        endpoint_url: str | None = None,
+        base_url: str | None = None,
+        client=None,
+        extra_put_object_args: dict[str, str] | None = None,
+    ) -> None:
+        if not bucket:
+            raise ValueError("Bucket name must not be empty")
+        self.bucket = bucket
+        if client is None:
+            try:
+                import boto3
+            except ImportError as exc:  # pragma: no cover - import error handled in tests
+                raise RuntimeError("boto3 is required for S3 storage") from exc
+            client = boto3.client(
+                "s3",
+                region_name=region,
+                aws_access_key_id=access_key_id or None,
+                aws_secret_access_key=secret_access_key or None,
+                endpoint_url=endpoint_url or None,
+            )
+        self.client = client
+        self._extra_put_object_args = extra_put_object_args or {}
+        resolved_base_url = base_url.rstrip("/") if base_url else None
+        if not resolved_base_url:
+            endpoint = getattr(getattr(self.client, "meta", None), "endpoint_url", "")
+            endpoint = (endpoint or "").rstrip("/")
+            if endpoint:
+                resolved_base_url = f"{endpoint}/{bucket}"
+            else:
+                resolved_base_url = f"https://{bucket}.s3.amazonaws.com"
+        self.base_url = resolved_base_url
+        self._base_url_parsed = urlparse(self.base_url)
+
+    def _normalize_key(self, relative_path: str) -> str:
+        cleaned = relative_path.strip().strip("/")
+        if not cleaned:
+            raise ValueError("Relative path must not be empty")
+        candidate = Path(cleaned)
+        if candidate.is_absolute() or any(part == ".." for part in candidate.parts):
+            raise ValueError("Relative path must not escape bucket prefix")
+        return candidate.as_posix()
+
+    async def save_file(
+        self, relative_path: str, data: bytes, *, content_type: str | None = None
+    ) -> str:
+        key = self._normalize_key(relative_path)
+        await asyncio.to_thread(self._put_object, key, data, content_type)
+        return f"{self.base_url}/{key}"
+
+    def _put_object(self, key: str, data: bytes, content_type: str | None) -> None:
+        args = {
+            "Bucket": self.bucket,
+            "Key": key,
+            "Body": data,
+            **self._extra_put_object_args,
+        }
+        if content_type:
+            args["ContentType"] = content_type
+        try:
+            self.client.put_object(**args)
+        except Exception:  # pragma: no cover - depends on boto3 internals
+            logger.exception("Failed to upload %s to bucket %s", key, self.bucket)
+            raise
+
+    def _extract_key(self, file_url: str) -> str | None:
+        if not file_url:
+            return None
+        trimmed = file_url.strip()
+        if not trimmed:
+            return None
+        parsed = urlparse(trimmed)
+        if parsed.scheme in {"http", "https"}:
+            if parsed.netloc and parsed.netloc != self._base_url_parsed.netloc:
+                return None
+            path = parsed.path or ""
+            base_path = (self._base_url_parsed.path or "").rstrip("/")
+            if base_path and path.startswith(base_path):
+                path = path[len(base_path) :]
+            key = path.lstrip("/")
+            return key or None
+        if parsed.scheme == "s3":
+            if parsed.netloc and parsed.netloc != self.bucket:
+                return None
+            key = parsed.path.lstrip("/")
+            return key or None
+        trimmed = trimmed.lstrip("/")
+        return trimmed or None
+
+    async def delete_file(self, file_url: str) -> None:
+        key = self._extract_key(file_url)
+        if not key:
+            return
+        await asyncio.to_thread(self._delete_object, key)
+
+    def _delete_object(self, key: str) -> None:
+        try:
+            self.client.delete_object(Bucket=self.bucket, Key=key)
+        except Exception:  # pragma: no cover - depends on boto3 internals
+            logger.warning(
+                "Failed to delete %s from bucket %s", key, self.bucket, exc_info=True
+            )
+
+
+def get_storage_backend(settings: Settings) -> StorageBackend:
+    backend = str(settings.storage_backend).strip().lower()
+    if backend in {"static", "filesystem", "local"}:
+        return StaticFSStorage(settings.static_dir_path, base_url=settings.storage_static_base_url)
+    if backend in {"s3", "minio"}:
+        return S3Storage(
+            bucket=settings.storage_s3_bucket,
+            region=getattr(settings, "storage_s3_region", None) or None,
+            access_key_id=getattr(settings, "storage_s3_access_key_id", None) or None,
+            secret_access_key=getattr(settings, "storage_s3_secret_access_key", None) or None,
+            endpoint_url=getattr(settings, "storage_s3_endpoint_url", None) or None,
+            base_url=getattr(settings, "storage_s3_base_url", None) or None,
+        )
+    raise ValueError(f"Unsupported storage backend: {settings.storage_backend}")

--- a/root/app/services/storage.py
+++ b/root/app/services/storage.py
@@ -1,4 +1,5 @@
 """Storage backends for user-uploaded files."""
+
 from __future__ import annotations
 
 import asyncio
@@ -107,7 +108,9 @@ class S3Storage(StorageBackend):
         if client is None:
             try:
                 import boto3
-            except ImportError as exc:  # pragma: no cover - import error handled in tests
+            except (
+                ImportError
+            ) as exc:  # pragma: no cover - import error handled in tests
                 raise RuntimeError("boto3 is required for S3 storage") from exc
             client = boto3.client(
                 "s3",
@@ -202,13 +205,16 @@ class S3Storage(StorageBackend):
 def get_storage_backend(settings: Settings) -> StorageBackend:
     backend = str(settings.storage_backend).strip().lower()
     if backend in {"static", "filesystem", "local"}:
-        return StaticFSStorage(settings.static_dir_path, base_url=settings.storage_static_base_url)
+        return StaticFSStorage(
+            settings.static_dir_path, base_url=settings.storage_static_base_url
+        )
     if backend in {"s3", "minio"}:
         return S3Storage(
             bucket=settings.storage_s3_bucket,
             region=getattr(settings, "storage_s3_region", None) or None,
             access_key_id=getattr(settings, "storage_s3_access_key_id", None) or None,
-            secret_access_key=getattr(settings, "storage_s3_secret_access_key", None) or None,
+            secret_access_key=getattr(settings, "storage_s3_secret_access_key", None)
+            or None,
             endpoint_url=getattr(settings, "storage_s3_endpoint_url", None) or None,
             base_url=getattr(settings, "storage_s3_base_url", None) or None,
         )

--- a/root/app/utils/files.py
+++ b/root/app/utils/files.py
@@ -5,16 +5,18 @@ import re
 import secrets
 from pathlib import Path
 from typing import Any, Final
-from urllib.parse import unquote, urlparse
 
 from fastapi import HTTPException, UploadFile, status
 
 from app.core.config import settings
 from app.localization import translate
 from app.services.file_scanner import scan_for_malware
+from app.services.storage import get_storage_backend
 from app.utils.images import optimize_image
 
 logger = logging.getLogger(__name__)
+
+storage_backend = get_storage_backend(settings)
 
 ALLOWED_IMAGE_TYPES: Final[set[str]] = {"image/jpeg", "image/png", "image/webp"}
 MAX_IMAGE_SIZE: Final[int] = 5 * 1024 * 1024
@@ -33,10 +35,6 @@ except ImportError:  # pragma: no cover - handled at runtime
 
 _MAGIC_NOT_INITIALIZED: Final[object] = object()
 _magic_mime_detector: Any = _MAGIC_NOT_INITIALIZED
-
-
-def _ensure_dir(p: Path) -> None:
-    p.mkdir(parents=True, exist_ok=True)
 
 
 async def _read_limited(
@@ -184,14 +182,11 @@ async def save_image(
 
     ext = _PREFERRED_EXTENSIONS.get(optimized_type) or _ext_from_mime(optimized_type)
     name = _gen_name(prefix, ext)
-    base = settings.static_dir_path
     sanitized_subdir = subdir.strip("/ ")
-    target_dir = base / sanitized_subdir
-    await asyncio.to_thread(_ensure_dir, target_dir)
-    path = target_dir / name
-    await asyncio.to_thread(path.write_bytes, optimized_data)
-    # Return canonical public URL without accidental duplicate slashes.
-    return f"/static/{sanitized_subdir}/{name}"
+    relative_path = f"{sanitized_subdir}/{name}" if sanitized_subdir else name
+    return await storage_backend.save_file(
+        relative_path, optimized_data, content_type=optimized_type
+    )
 
 
 async def save_attachment(
@@ -280,57 +275,12 @@ async def save_attachment(
     ext_for_name = f".{chosen_ext_without_dot}" if chosen_ext_without_dot else ""
     name = _gen_name(prefix, ext_for_name)
     await scan_for_malware(data, locale=locale)
-    base = settings.static_dir_path
     sanitized_subdir = subdir.strip("/ ")
-    target_dir = base / sanitized_subdir
-    path = target_dir / name
-    await asyncio.to_thread(_ensure_dir, target_dir)
-    await asyncio.to_thread(path.write_bytes, data)
-    return f"/static/{sanitized_subdir}/{name}"
-
-
-def _resolve_static_file_path(file_url: str) -> Path | None:
-    if not file_url:
-        return None
-
-    parsed = urlparse(file_url)
-    raw_path = unquote(parsed.path or "")
-    if not raw_path:
-        return None
-
-    trimmed = raw_path.lstrip("/")
-    if not trimmed:
-        return None
-
-    parts = Path(trimmed).parts
-    if not parts or parts[0] != "static":
-        return None
-
-    relative = Path(*parts[1:])
-    if not relative.parts:
-        return None
-
-    base = settings.static_dir_path
-    base_resolved = base.resolve()
-    target = (base_resolved / relative).resolve()
-    try:
-        target.relative_to(base_resolved)
-    except ValueError:
-        return None
-    return target
-
-
-def _unlink_ignore_missing(path: Path) -> None:
-    try:
-        path.unlink()
-    except FileNotFoundError:
-        return
-    except OSError:
-        logger.warning("Failed to remove file at %s", path, exc_info=True)
+    relative_path = f"{sanitized_subdir}/{name}" if sanitized_subdir else name
+    return await storage_backend.save_file(
+        relative_path, data, content_type=declared_type or detected_type or None
+    )
 
 
 async def delete_static_file(file_url: str) -> None:
-    path = _resolve_static_file_path(file_url)
-    if path is None:
-        return
-    await asyncio.to_thread(_unlink_ignore_missing, path)
+    await storage_backend.delete_file(file_url)

--- a/root/requirements-dev.txt
+++ b/root/requirements-dev.txt
@@ -7,3 +7,4 @@ asgi-lifespan>=2.1.0
 pre-commit>=3.8
 pyotp>=2.9
 webauthn>=1.11
+boto3>=1.34.0,<2.0.0

--- a/root/requirements.txt
+++ b/root/requirements.txt
@@ -17,6 +17,7 @@ email-validator>=2.0
 httpx>=0.27
 python-multipart>=0.0.7
 python-magic>=0.4.27
+boto3>=1.34.0,<2.0.0
 clamd>=1.0.2
 Pillow>=10
 aiofiles>=23.0

--- a/root/tests/test_file_utils.py
+++ b/root/tests/test_file_utils.py
@@ -30,10 +30,14 @@ class RecordingStorage:
     async def save_file(
         self, relative_path: str, data: bytes, *, content_type: str | None = None
     ) -> str:
-        self.calls.append(("save", (relative_path, data), {"content_type": content_type}))
+        self.calls.append(
+            ("save", (relative_path, data), {"content_type": content_type})
+        )
         return f"https://cdn.example/{relative_path}"
 
-    async def delete_file(self, file_url: str) -> None:  # pragma: no cover - unused in tests
+    async def delete_file(
+        self, file_url: str
+    ) -> None:  # pragma: no cover - unused in tests
         self.calls.append(("delete", (file_url,), {}))
 
 

--- a/root/tests/test_file_utils.py
+++ b/root/tests/test_file_utils.py
@@ -9,6 +9,7 @@ from starlette.datastructures import Headers
 
 from app.core.config import settings
 from app.localization import translate
+from app.services.storage import StaticFSStorage
 from app.utils import files
 
 
@@ -22,8 +23,22 @@ def test_normalize_filename_prefix_compacts_symbols():
     assert not re.search(r"\s", value)
 
 
+class RecordingStorage:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple[object, ...], dict[str, object]]] = []
+
+    async def save_file(
+        self, relative_path: str, data: bytes, *, content_type: str | None = None
+    ) -> str:
+        self.calls.append(("save", (relative_path, data), {"content_type": content_type}))
+        return f"https://cdn.example/{relative_path}"
+
+    async def delete_file(self, file_url: str) -> None:  # pragma: no cover - unused in tests
+        self.calls.append(("delete", (file_url,), {}))
+
+
 @pytest.mark.asyncio
-async def test_save_image_offloads_io(tmp_path, monkeypatch):
+async def test_save_image_uses_storage_backend(monkeypatch):
     buffer = io.BytesIO()
     Image.new("RGB", (2, 2), color=(255, 0, 0)).save(buffer, format="PNG")
     buffer.seek(0)
@@ -33,24 +48,24 @@ async def test_save_image_offloads_io(tmp_path, monkeypatch):
         headers=Headers({"content-type": "image/png"}),
     )
 
-    calls: list[tuple[object, tuple[object, ...], dict[str, object]]] = []
+    backend = RecordingStorage()
 
     async def fake_to_thread(func, /, *args, **kwargs):  # type: ignore[override]
-        calls.append((func, args, kwargs))
         return func(*args, **kwargs)
 
     monkeypatch.setattr(files, "asyncio", asyncio)
     monkeypatch.setattr(files.asyncio, "to_thread", fake_to_thread)
-    monkeypatch.setattr(settings, "static_dir_path", tmp_path)
+    monkeypatch.setattr(files, "storage_backend", backend)
 
     url = await files.save_image(upload, "avatars", "Profile Pic")
 
-    assert url.startswith("/static/avatars/")
-    stored = tmp_path / "avatars"
-    assert stored.exists()
-    assert any(stored.iterdir())
-    assert any(func is files._ensure_dir for func, _, _ in calls)
-    assert any(func.__name__ == "write_bytes" for func, _, _ in calls)
+    assert url.startswith("https://cdn.example/avatars/")
+    assert backend.calls
+    method, (relative_path, data), kwargs = backend.calls[0]
+    assert method == "save"
+    assert relative_path.startswith("avatars/")
+    assert isinstance(data, (bytes, bytearray))
+    assert kwargs["content_type"] in {"image/webp", "image/png"}
 
 
 @pytest.mark.parametrize(
@@ -103,13 +118,17 @@ async def test_save_image_resizes_and_converts_large_images(tmp_path, monkeypatc
         headers=Headers({"content-type": "image/png"}),
     )
 
-    monkeypatch.setattr(settings, "static_dir_path", tmp_path)
+    monkeypatch.setattr(
+        files,
+        "storage_backend",
+        StaticFSStorage(tmp_path, base_url="/static"),
+    )
     monkeypatch.setattr(settings, "image_max_width", 512)
     monkeypatch.setattr(settings, "image_max_height", 512)
 
     url = await files.save_image(upload, "avatars", "Large Pic")
     rel_path = url.removeprefix("/static/")
-    stored_path = settings.static_dir_path / rel_path
+    stored_path = files.storage_backend.base_dir / rel_path  # type: ignore[attr-defined]
 
     assert stored_path.suffix == ".webp"
     with Image.open(stored_path) as saved:
@@ -132,13 +151,17 @@ async def test_save_image_preserves_transparency_with_png(tmp_path, monkeypatch)
         headers=Headers({"content-type": "image/png"}),
     )
 
-    monkeypatch.setattr(settings, "static_dir_path", tmp_path)
+    monkeypatch.setattr(
+        files,
+        "storage_backend",
+        StaticFSStorage(tmp_path, base_url="/static"),
+    )
     monkeypatch.setattr(settings, "image_max_width", 512)
     monkeypatch.setattr(settings, "image_max_height", 512)
 
     url = await files.save_image(upload, "avatars", "Transparent Pic")
     rel_path = url.removeprefix("/static/")
-    stored_path = settings.static_dir_path / rel_path
+    stored_path = files.storage_backend.base_dir / rel_path  # type: ignore[attr-defined]
 
     assert stored_path.suffix == ".png"
     with Image.open(stored_path) as saved:

--- a/root/tests/test_storage_backends.py
+++ b/root/tests/test_storage_backends.py
@@ -8,7 +8,9 @@ from app.services.storage import S3Storage, StaticFSStorage
 @pytest.mark.asyncio
 async def test_static_storage_saves_and_deletes(tmp_path):
     backend = StaticFSStorage(tmp_path, base_url="/static")
-    url = await backend.save_file("avatars/test.png", b"payload", content_type="image/png")
+    url = await backend.save_file(
+        "avatars/test.png", b"payload", content_type="image/png"
+    )
 
     assert url == "/static/avatars/test.png"
     stored = tmp_path / "avatars" / "test.png"
@@ -41,7 +43,9 @@ async def test_s3_storage_uses_client():
         base_url="https://cdn.example/test-bucket",
     )
 
-    url = await backend.save_file("avatars/test.png", b"payload", content_type="image/png")
+    url = await backend.save_file(
+        "avatars/test.png", b"payload", content_type="image/png"
+    )
     assert url == "https://cdn.example/test-bucket/avatars/test.png"
 
     assert client.put_calls

--- a/root/tests/test_storage_backends.py
+++ b/root/tests/test_storage_backends.py
@@ -1,0 +1,64 @@
+import types
+
+import pytest
+
+from app.services.storage import S3Storage, StaticFSStorage
+
+
+@pytest.mark.asyncio
+async def test_static_storage_saves_and_deletes(tmp_path):
+    backend = StaticFSStorage(tmp_path, base_url="/static")
+    url = await backend.save_file("avatars/test.png", b"payload", content_type="image/png")
+
+    assert url == "/static/avatars/test.png"
+    stored = tmp_path / "avatars" / "test.png"
+    assert stored.exists()
+    assert stored.read_bytes() == b"payload"
+
+    await backend.delete_file(url)
+    assert not stored.exists()
+
+
+class DummyS3Client:
+    def __init__(self) -> None:
+        self.put_calls: list[dict[str, object]] = []
+        self.delete_calls: list[dict[str, object]] = []
+        self.meta = types.SimpleNamespace(endpoint_url="https://s3.mock.local")
+
+    def put_object(self, **kwargs):
+        self.put_calls.append(kwargs)
+
+    def delete_object(self, **kwargs):
+        self.delete_calls.append(kwargs)
+
+
+@pytest.mark.asyncio
+async def test_s3_storage_uses_client():
+    client = DummyS3Client()
+    backend = S3Storage(
+        bucket="test-bucket",
+        client=client,
+        base_url="https://cdn.example/test-bucket",
+    )
+
+    url = await backend.save_file("avatars/test.png", b"payload", content_type="image/png")
+    assert url == "https://cdn.example/test-bucket/avatars/test.png"
+
+    assert client.put_calls
+    put_args = client.put_calls[0]
+    assert put_args["Bucket"] == "test-bucket"
+    assert put_args["Key"] == "avatars/test.png"
+    assert put_args["Body"] == b"payload"
+    assert put_args["ContentType"] == "image/png"
+
+    await backend.delete_file(url)
+    assert client.delete_calls
+    delete_args = client.delete_calls[0]
+    assert delete_args["Bucket"] == "test-bucket"
+    assert delete_args["Key"] == "avatars/test.png"
+
+    # Deleting with raw key should also work and avoid extra calls.
+    client.delete_calls.clear()
+    await backend.delete_file("avatars/test.png")
+    assert client.delete_calls
+    assert client.delete_calls[0]["Key"] == "avatars/test.png"


### PR DESCRIPTION
## Summary
- introduce a storage backend abstraction with filesystem and S3 implementations
- wire the selected backend into file utilities and extend settings for configuration
- cover both backends with tests and add boto3 dependency

## Testing
- pytest tests/test_storage_backends.py tests/test_file_utils.py

------
https://chatgpt.com/codex/tasks/task_e_69014f30f3708327990b13baef0d6a6f