### PR TITLE
Implement Redis caching for stats API responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,13 @@ The frontend caches a lightweight profile snapshot in `localStorage` to speed up
 native `storage` event and a `BroadcastChannel` message so that other open tabs synchronize immediately. Logging out or being
 signed out in one tab clears the cached profile and authentication state everywhere.
 
+## Stats API caching
+
+The `/stats/*` endpoints cache responses per `(user_id, period)` key using Redis for **3 minutes** by default. The cache is
+automatically invalidated when a student registers for or unregisters from an event, and when new grade notifications are issued.
+Administrators can bypass the cache for a single request by appending `?skip_cache=true` to the stats URL; other roles always use
+the cached payload when available.
+
 ## Architecture overview
 
 ```

--- a/root/app/api/stats.py
+++ b/root/app/api/stats.py
@@ -6,6 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app import crud
 from app.api.deps import get_current_user
 from app.core.database import get_db
+from app.deps.cache import get_cache
 from app.localization import resolve_locale, translate
 from app.models import models
 
@@ -29,6 +30,12 @@ def _resolve_period(period: str | None) -> tuple[str, int]:
     if days is not None:
         return period_key, days
     return _PERIOD_DEFAULT
+
+
+def _should_skip_cache(requested: bool, user: models.User) -> bool:
+    if not requested:
+        return False
+    return user.role == "admin"
 
 
 def _period_response_payload(
@@ -56,15 +63,19 @@ def _period_response_payload(
 async def attendance_summary(
     request: Request,
     period: str = Query("30d"),
+    skip_cache: bool = Query(False, alias="skip_cache"),
     db: AsyncSession = Depends(get_db),
     user: models.User = Depends(get_current_user),
 ):
     period_key, days = _resolve_period(period)
+    cache_backend = get_cache()
     stats = await crud.get_attendance_stats(
         db,
         user_id=user.id,
         period_days=days,
         period_key=period_key,
+        cache=cache_backend,
+        skip_cache=_should_skip_cache(skip_cache, user),
     )
     return _period_response_payload(
         stats=stats,
@@ -79,11 +90,20 @@ async def attendance_summary(
 async def grade_summary(
     request: Request,
     period: str = Query("30d"),
+    skip_cache: bool = Query(False, alias="skip_cache"),
     db: AsyncSession = Depends(get_db),
     user: models.User = Depends(get_current_user),
 ):
     period_key, days = _resolve_period(period)
-    stats = await crud.get_grade_stats(db, user_id=user.id, period_days=days)
+    cache_backend = get_cache()
+    stats = await crud.get_grade_stats(
+        db,
+        user_id=user.id,
+        period_days=days,
+        cache=cache_backend,
+        period_key=period_key,
+        skip_cache=_should_skip_cache(skip_cache, user),
+    )
     return _period_response_payload(
         stats=stats,
         period_key=period_key,
@@ -97,11 +117,20 @@ async def grade_summary(
 async def participation_summary(
     request: Request,
     period: str = Query("30d"),
+    skip_cache: bool = Query(False, alias="skip_cache"),
     db: AsyncSession = Depends(get_db),
     user: models.User = Depends(get_current_user),
 ):
     period_key, days = _resolve_period(period)
-    stats = await crud.get_participation_stats(db, user_id=user.id, period_days=days)
+    cache_backend = get_cache()
+    stats = await crud.get_participation_stats(
+        db,
+        user_id=user.id,
+        period_days=days,
+        cache=cache_backend,
+        period_key=period_key,
+        skip_cache=_should_skip_cache(skip_cache, user),
+    )
     return _period_response_payload(
         stats=stats,
         period_key=period_key,

--- a/root/app/crud/__init__.py
+++ b/root/app/crud/__init__.py
@@ -10,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.auth import mfa
 from app.auth.security import get_password_hash
 from app.core.config import settings
+from app.deps.cache import BaseCache
 from app.localization import localized_text, normalize_locale, translate
 from app.models import models
 from app.models.enums import UserRole
@@ -18,7 +19,7 @@ from app.models.user_loaders import (
     ensure_mfa_relationships_loaded,
 )
 from app.schemas import schemas
-from app.services import attendance_tokens
+from app.services import attendance_tokens, stats_cache
 
 
 async def get_user_auth(db: AsyncSession, login: str):
@@ -628,6 +629,7 @@ async def update_event(
 async def register_attendance(
     db: AsyncSession, data: schemas.EventAttendanceCreate, user_id: int
 ):
+    cache_kinds = ("attendance", "participation")
     stmt = select(models.EventAttendance).where(
         and_(
             models.EventAttendance.event_id == data.event_id,
@@ -647,6 +649,10 @@ async def register_attendance(
             await db.commit()
             await db.refresh(exist)
         exist.qr_token = attendance_tokens.issue_token(exist)
+        await stats_cache.invalidate_user_stats_cache(
+            user_ids=user_id,
+            kinds=cache_kinds,
+        )
         return exist
 
     secret = attendance_tokens.generate_secret()
@@ -679,9 +685,17 @@ async def register_attendance(
             await db.commit()
             await db.refresh(exist)
         exist.qr_token = attendance_tokens.issue_token(exist)
+        await stats_cache.invalidate_user_stats_cache(
+            user_ids=user_id,
+            kinds=cache_kinds,
+        )
         return exist
     await db.refresh(record)
     record.qr_token = attendance_tokens.issue_token(record)
+    await stats_cache.invalidate_user_stats_cache(
+        user_ids=user_id,
+        kinds=cache_kinds,
+    )
     return record
 
 
@@ -699,6 +713,10 @@ async def unregister_attendance(
         return {"ok": False}
     await db.delete(record)
     await db.commit()
+    await stats_cache.invalidate_user_stats_cache(
+        user_ids=user_id,
+        kinds=("attendance", "participation"),
+    )
     return {"ok": True}
 
 
@@ -846,7 +864,20 @@ async def get_attendance_stats(
     user_id: int,
     period_days: int,
     period_key: str | None = None,
+    cache: BaseCache | None = None,
+    skip_cache: bool = False,
 ) -> Dict[str, Any]:
+    cache_period_key = stats_cache.resolve_period_key(period_key, period_days)
+    cached = await stats_cache.get_cached_stats(
+        cache=cache,
+        kind="attendance",
+        user_id=user_id,
+        period_key=cache_period_key,
+        skip_cache=skip_cache,
+    )
+    if cached is not None:
+        return cached
+
     now = datetime.now(UTC)
     window_start = now - timedelta(days=period_days)
     previous_start = window_start - timedelta(days=period_days)
@@ -925,14 +956,23 @@ async def get_attendance_stats(
             }
         )
 
-    return {
+    result = {
         "percent": round(percent, 2),
         "present": attended_events,
         "total": total_events,
         "trend": round(percent - previous_percent, 2),
-        "period_key": period_key or f"{period_days}d",
+        "period_key": cache_period_key,
         "recent": recent,
     }
+    await stats_cache.set_cached_stats(
+        cache=cache,
+        kind="attendance",
+        user_id=user_id,
+        period_key=cache_period_key,
+        payload=result,
+        skip_cache=skip_cache,
+    )
+    return result
 
 
 def _parse_grade_payload(
@@ -979,8 +1019,25 @@ def _parse_grade_payload(
 
 
 async def get_grade_stats(
-    db: AsyncSession, *, user_id: int, period_days: int
+    db: AsyncSession,
+    *,
+    user_id: int,
+    period_days: int,
+    period_key: str | None = None,
+    cache: BaseCache | None = None,
+    skip_cache: bool = False,
 ) -> Dict[str, Any]:
+    cache_period_key = stats_cache.resolve_period_key(period_key, period_days)
+    cached = await stats_cache.get_cached_stats(
+        cache=cache,
+        kind="grades",
+        user_id=user_id,
+        period_key=cache_period_key,
+        skip_cache=skip_cache,
+    )
+    if cached is not None:
+        return cached
+
     now = datetime.now(UTC)
     window_start = now - timedelta(days=period_days)
     previous_start = window_start - timedelta(days=period_days)
@@ -1038,17 +1095,44 @@ async def get_grade_stats(
 
     recent = current_entries[:5]
 
-    return {
+    result = {
         "average": round(average, 2) if current_entries else 0.0,
         "scale": scale,
         "trend": round(average - previous_average, 2),
         "recent": recent,
+        "period_key": cache_period_key,
     }
+    await stats_cache.set_cached_stats(
+        cache=cache,
+        kind="grades",
+        user_id=user_id,
+        period_key=cache_period_key,
+        payload=result,
+        skip_cache=skip_cache,
+    )
+    return result
 
 
 async def get_participation_stats(
-    db: AsyncSession, *, user_id: int, period_days: int
+    db: AsyncSession,
+    *,
+    user_id: int,
+    period_days: int,
+    period_key: str | None = None,
+    cache: BaseCache | None = None,
+    skip_cache: bool = False,
 ) -> Dict[str, Any]:
+    cache_period_key = stats_cache.resolve_period_key(period_key, period_days)
+    cached = await stats_cache.get_cached_stats(
+        cache=cache,
+        kind="participation",
+        user_id=user_id,
+        period_key=cache_period_key,
+        skip_cache=skip_cache,
+    )
+    if cached is not None:
+        return cached
+
     now = datetime.now(UTC)
     window_start = now - timedelta(days=period_days)
     previous_start = window_start - timedelta(days=period_days)
@@ -1113,10 +1197,20 @@ async def get_participation_stats(
 
     previous_event_ids = {row[0] for row in previous_entries}
 
-    return {
+    result = {
         "events": len(unique_events),
         "hours": round(total_hours, 2) if total_hours else 0.0,
         "groups": len(event_types),
         "trend": len(unique_events) - len(previous_event_ids),
         "recent": recent,
+        "period_key": cache_period_key,
     }
+    await stats_cache.set_cached_stats(
+        cache=cache,
+        kind="participation",
+        user_id=user_id,
+        period_key=cache_period_key,
+        payload=result,
+        skip_cache=skip_cache,
+    )
+    return result

--- a/root/app/services/notifications.py
+++ b/root/app/services/notifications.py
@@ -32,6 +32,7 @@ from app.models.models import (
     Schedule,
     User,
 )
+from app.services import stats_cache
 from app.services.notification_templates import render_notification_template
 from app.services.push_schema import ensure_push_subscription_schema
 from app.services.push_topics import normalize_topic, subscription_supports_topic
@@ -508,6 +509,12 @@ async def create_notifications_for_users(
         if notification.id is not None
     }
     await db.commit()
+
+    if notification_ids_by_user and type == "grade":
+        await stats_cache.invalidate_user_stats_cache(
+            user_ids=list(notification_ids_by_user.keys()),
+            kinds=("grades",),
+        )
 
     if not notification_ids_by_user:
         return 0

--- a/root/app/services/stats_cache.py
+++ b/root/app/services/stats_cache.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import copy
+from typing import Iterable, Sequence
+
+from app.deps.cache import BaseCache, get_cache
+
+_STATS_CACHE_PREFIX = "stats"
+_STATS_KNOWN_KINDS = ("attendance", "grades", "participation")
+_DEFAULT_PERIOD_KEYS = ("30d", "90d", "180d")
+
+STATS_CACHE_TTL_SECONDS = 180
+
+
+def _ensure_cache(cache: BaseCache | None) -> BaseCache:
+    return cache or get_cache()
+
+
+def resolve_period_key(period_key: str | None, period_days: int | None) -> str:
+    key = (period_key or "").strip().lower()
+    if key:
+        return key
+    if period_days:
+        return f"{int(period_days)}d"
+    return "default"
+
+
+def _make_cache_key(kind: str, user_id: int, period_key: str) -> str:
+    normalized_kind = kind.strip().lower()
+    normalized_period = period_key.strip().lower() or "default"
+    return f"{_STATS_CACHE_PREFIX}:{normalized_kind}:{int(user_id)}:{normalized_period}"
+
+
+async def get_cached_stats(
+    *,
+    cache: BaseCache | None,
+    kind: str,
+    user_id: int,
+    period_key: str,
+    skip_cache: bool = False,
+):
+    backend = _ensure_cache(cache)
+    if skip_cache or not backend.enabled:
+        return None
+    entry = await backend.get(_make_cache_key(kind, user_id, period_key))
+    if entry is None or not isinstance(entry.payload, dict):
+        return None
+    return copy.deepcopy(entry.payload)
+
+
+async def set_cached_stats(
+    *,
+    cache: BaseCache | None,
+    kind: str,
+    user_id: int,
+    period_key: str,
+    payload: dict[str, object],
+    skip_cache: bool = False,
+    ttl: int | None = None,
+) -> None:
+    backend = _ensure_cache(cache)
+    if skip_cache or not backend.enabled:
+        return
+    await backend.set(
+        _make_cache_key(kind, user_id, period_key),
+        copy.deepcopy(payload),
+        ttl=ttl or STATS_CACHE_TTL_SECONDS,
+    )
+
+
+async def invalidate_user_stats_cache(
+    *,
+    user_ids: Sequence[int] | int,
+    cache: BaseCache | None = None,
+    kinds: Iterable[str] | None = None,
+    period_keys: Iterable[str] | None = None,
+) -> None:
+    backend = _ensure_cache(cache)
+    if not backend.enabled:
+        return
+    if isinstance(user_ids, int):
+        user_ids = [user_ids]
+    unique_users = {int(uid) for uid in user_ids if uid is not None}
+    if not unique_users:
+        return
+    selected_kinds = tuple({kind.strip().lower() for kind in (kinds or _STATS_KNOWN_KINDS) if kind})
+    if not selected_kinds:
+        return
+    chosen_periods = tuple({(period or "").strip().lower() or "default" for period in (period_keys or _DEFAULT_PERIOD_KEYS)})
+    keys: list[str] = []
+    for user_id in unique_users:
+        for kind in selected_kinds:
+            for period in chosen_periods:
+                keys.append(_make_cache_key(kind, user_id, period))
+    if keys:
+        await backend.invalidate(*keys)

--- a/root/app/services/stats_cache.py
+++ b/root/app/services/stats_cache.py
@@ -83,10 +83,17 @@ async def invalidate_user_stats_cache(
     unique_users = {int(uid) for uid in user_ids if uid is not None}
     if not unique_users:
         return
-    selected_kinds = tuple({kind.strip().lower() for kind in (kinds or _STATS_KNOWN_KINDS) if kind})
+    selected_kinds = tuple(
+        {kind.strip().lower() for kind in (kinds or _STATS_KNOWN_KINDS) if kind}
+    )
     if not selected_kinds:
         return
-    chosen_periods = tuple({(period or "").strip().lower() or "default" for period in (period_keys or _DEFAULT_PERIOD_KEYS)})
+    chosen_periods = tuple(
+        {
+            (period or "").strip().lower() or "default"
+            for period in (period_keys or _DEFAULT_PERIOD_KEYS)
+        }
+    )
     keys: list[str] = []
     for user_id in unique_users:
         for kind in selected_kinds:

--- a/root/tests/test_stats_api.py
+++ b/root/tests/test_stats_api.py
@@ -293,7 +293,9 @@ async def test_participation_stats_summarize_events(
 
 
 @pytest.mark.anyio
-async def test_attendance_stats_uses_cache(async_client, fake_cache, user_factory, monkeypatch):
+async def test_attendance_stats_uses_cache(
+    async_client, fake_cache, user_factory, monkeypatch
+):
     password = "CachePass123!"
     hashed = get_password_hash(password)
     student = await user_factory(hashed_password=hashed, is_active=True)

--- a/root/tests/test_stats_api.py
+++ b/root/tests/test_stats_api.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta, timezone
 import pytest
 
 from app.auth.security import get_password_hash
+from app.deps import cache as cache_module
 from app.models import models
 from app.services import attendance_tokens
 
@@ -289,3 +290,87 @@ async def test_participation_stats_summarize_events(
         "Hackathon",
         "Volunteer Day",
     }
+
+
+@pytest.mark.anyio
+async def test_attendance_stats_uses_cache(async_client, fake_cache, user_factory, monkeypatch):
+    password = "CachePass123!"
+    hashed = get_password_hash(password)
+    student = await user_factory(hashed_password=hashed, is_active=True)
+
+    headers = await _login(async_client, student.email, password)
+
+    calls = {"get": 0, "set": 0}
+    original_get = cache_module.RedisCache.get
+    original_set = cache_module.RedisCache.set
+
+    async def tracked_get(self, key):  # type: ignore[override]
+        calls["get"] += 1
+        return await original_get(self, key)
+
+    async def tracked_set(self, key, payload, ttl=None):  # type: ignore[override]
+        calls["set"] += 1
+        return await original_set(self, key, payload, ttl=ttl)
+
+    monkeypatch.setattr(cache_module.RedisCache, "get", tracked_get)
+    monkeypatch.setattr(cache_module.RedisCache, "set", tracked_set)
+
+    first = await async_client.get("/stats/attendance", headers=headers)
+    assert first.status_code == 200
+
+    second = await async_client.get("/stats/attendance", headers=headers)
+    assert second.status_code == 200
+    assert second.json() == first.json()
+
+    assert calls["get"] == 2
+    assert calls["set"] == 1
+
+
+@pytest.mark.anyio
+async def test_registering_for_event_invalidates_stats_cache(
+    async_client,
+    fake_cache,
+    user_factory,
+    db_session,
+    monkeypatch,
+):
+    now = datetime.now(timezone.utc)
+    admin = await user_factory(role="admin")
+    password = "CacheInvalidate456!"
+    hashed = get_password_hash(password)
+    student = await user_factory(hashed_password=hashed, is_active=True)
+
+    event = models.Event(
+        title="New Seminar",
+        description="Discussion",
+        location="Hall 1",
+        event_type="seminar",
+        starts_at=now + timedelta(hours=1),
+        ends_at=now + timedelta(hours=3),
+        created_by=admin.id,
+        is_active=True,
+    )
+    db_session.add(event)
+    await db_session.commit()
+
+    headers = await _login(async_client, student.email, password)
+
+    invalidated: list[tuple[str, ...]] = []
+    original_invalidate = cache_module.RedisCache.invalidate
+
+    async def tracked_invalidate(self, *keys):  # type: ignore[override]
+        invalidated.append(keys)
+        return await original_invalidate(self, *keys)
+
+    monkeypatch.setattr(cache_module.RedisCache, "invalidate", tracked_invalidate)
+
+    response = await async_client.post(
+        "/events/attendance",
+        json={"event_id": event.id},
+        headers=headers,
+    )
+    assert response.status_code == 200
+
+    flattened = [key for call in invalidated for key in call]
+    assert any(key.startswith("stats:attendance") for key in flattened)
+    assert any(key.startswith("stats:participation") for key in flattened)


### PR DESCRIPTION
## Summary
- cache stats API responses per user/period via Redis with a short TTL and optional admin bypass
- invalidate cached stats when attendance registrations change or grade notifications are created
- add tests covering cache hits and invalidation and document the cache behaviour in the README

## Testing
- pytest tests/test_stats_api.py

------
https://chatgpt.com/codex/tasks/task_e_690163ab5d848327afda74a53f3ffa68