### PR TITLE
Normalize user email handling and enforce case-insensitive uniqueness

### DIFF
--- a/root/alembic/versions/202507310004_normalize_user_emails.py
+++ b/root/alembic/versions/202507310004_normalize_user_emails.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sqlalchemy as sa
+
 from alembic import op
 
 # revision identifiers, used by Alembic.

--- a/root/alembic/versions/202507310004_normalize_user_emails.py
+++ b/root/alembic/versions/202507310004_normalize_user_emails.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "202507310004"
+down_revision = "202507310003"
+branch_labels = None
+depends_on = None
+
+
+def _ensure_no_duplicates(bind) -> None:
+    duplicates = bind.execute(
+        sa.text(
+            "SELECT lower(email) AS normalized, COUNT(*) AS count "
+            "FROM users GROUP BY lower(email) HAVING COUNT(*) > 1"
+        )
+    ).fetchall()
+    if duplicates:
+        conflicts = ", ".join(row._mapping["normalized"] for row in duplicates)
+        raise RuntimeError(
+            "Duplicate user emails found after normalization: " f"{conflicts}"
+        )
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    op.execute(sa.text("UPDATE users SET email = lower(email)"))
+
+    _ensure_no_duplicates(bind)
+
+    dialect = bind.dialect.name
+    if dialect in {"postgresql", "sqlite"}:
+        op.execute(
+            sa.text(
+                "CREATE UNIQUE INDEX IF NOT EXISTS ux_users_lower_email "
+                "ON users (lower(email))"
+            )
+        )
+    else:
+        op.create_index(
+            "ux_users_lower_email",
+            "users",
+            [sa.text("lower(email)")],
+            unique=True,
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    dialect = bind.dialect.name
+    if dialect in {"postgresql", "sqlite"}:
+        op.execute(sa.text("DROP INDEX IF EXISTS ux_users_lower_email"))
+    else:
+        op.drop_index("ux_users_lower_email", table_name="users")

--- a/root/app/api/users.py
+++ b/root/app/api/users.py
@@ -20,7 +20,7 @@ from fastapi import (
     status,
 )
 from pydantic import EmailStr, TypeAdapter
-from sqlalchemy import select, update
+from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import crud
@@ -245,8 +245,9 @@ async def forgot_password(
     bg: BackgroundTasks,
     db: AsyncSession = Depends(get_db),
 ):
+    normalized_email = payload.email.strip().lower()
     result = await db.execute(
-        select(models.User).where(models.User.email == payload.email)
+        select(models.User).where(func.lower(models.User.email) == normalized_email)
     )
     user = result.scalar_one_or_none()
     if user:
@@ -406,7 +407,7 @@ async def update_me(
 
         existing = await db.execute(
             select(models.User.id).where(
-                models.User.email == validated_email,
+                func.lower(models.User.email) == validated_email,
                 models.User.id != user.id,
             )
         )
@@ -461,7 +462,7 @@ async def change_email(
 
     existing = await db.execute(
         select(models.User.id).where(
-            models.User.email == validated_email,
+            func.lower(models.User.email) == validated_email,
             models.User.id != user.id,
         )
     )
@@ -534,7 +535,7 @@ async def confirm_email_change(
 
     existing = await db.execute(
         select(models.User.id).where(
-            models.User.email == record.new_email,
+            func.lower(models.User.email) == record.new_email,
             models.User.id != user.id,
         )
     )

--- a/root/app/auth/auth.py
+++ b/root/app/auth/auth.py
@@ -11,7 +11,7 @@ from fastapi.responses import JSONResponse
 from fastapi.security import OAuth2PasswordRequestForm
 from jose import jwt
 from pydantic import BaseModel, EmailStr
-from sqlalchemy import delete, select
+from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps import get_current_user, require_fresh_mfa
@@ -517,7 +517,9 @@ async def _perform_login(
     normalized_email = email.strip().lower()
     base_locale = resolve_locale(request=request)
 
-    res = await db.execute(select(User).where(User.email == normalized_email))
+    res = await db.execute(
+        select(User).where(func.lower(User.email) == normalized_email)
+    )
     user = res.scalars().first()
     locale = resolve_locale(request=request, user=user) if user else base_locale
 
@@ -1273,7 +1275,7 @@ async def register(
 ):
     locale = resolve_locale(request=request)
     email = user.email.strip().lower()
-    res = await db.execute(select(User).where(User.email == email))
+    res = await db.execute(select(User).where(func.lower(User.email) == email))
     if res.scalars().first():
         message = translate("errors.users.email_in_use", locale=locale)
         raise HTTPException(

--- a/root/app/crud/__init__.py
+++ b/root/app/crud/__init__.py
@@ -94,6 +94,8 @@ async def create_user(db: AsyncSession, user_in: schemas.UserCreate):
     raw_role = getattr(user_in, "role", None)
     requested_role = UserRole(raw_role) if raw_role else UserRole.STUDENT
 
+    normalized_email = user_in.email.strip().lower()
+
     code = None
     if hasattr(user_in, "invite_code") and requested_role in (
         UserRole.TEACHER,
@@ -110,16 +112,14 @@ async def create_user(db: AsyncSession, user_in: schemas.UserCreate):
             raise ValueError(translate("errors.users.invalid_invite"))
 
     exists = await db.execute(
-        select(models.User).where(
-            func.lower(models.User.email) == user_in.email.strip().lower()
-        )
+        select(models.User).where(func.lower(models.User.email) == normalized_email)
     )
     if exists.scalar_one_or_none():
         raise ValueError(translate("errors.users.email_in_use"))
 
     hashed_password = get_password_hash(user_in.password)
     db_user = models.User(
-        email=user_in.email.strip(),
+        email=normalized_email,
         hashed_password=hashed_password,
         full_name=user_in.full_name,
         role=requested_role.value,
@@ -831,6 +831,8 @@ async def admin_update_user(
         raise ValueError(translate("errors.users.not_found"))
     payload = data.model_dump(exclude_unset=True)
     reset_requested = bool(payload.pop("reset_mfa", False))
+    if "email" in payload and payload["email"] is not None:
+        payload["email"] = str(payload["email"]).strip().lower()
     for field, value in payload.items():
         setattr(user, field, value)
     reset_stats: mfa.MfaResetStats | None = None

--- a/root/app/management/reset_mfa.py
+++ b/root/app/management/reset_mfa.py
@@ -8,7 +8,7 @@ import json
 import logging
 from typing import Any
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 
 from app.auth import mfa
 from app.core.database import async_session
@@ -63,8 +63,9 @@ async def _load_user(
         return await session.get(models.User, user_id)
     if email is None:
         return None
+    normalized_email = email.strip().lower()
     result = await session.execute(
-        select(models.User).where(models.User.email == email.strip())
+        select(models.User).where(func.lower(models.User.email) == normalized_email)
     )
     return result.scalar_one_or_none()
 

--- a/root/app/services/notification_queue.py
+++ b/root/app/services/notification_queue.py
@@ -471,14 +471,20 @@ async def _refresh_persistent_queue_size(metrics: NotificationQueueMetrics) -> N
 
 async def _pending_persistent_jobs() -> int:
     async with async_session() as session:
-        result = await session.execute(
-            select(func.count())
-            .select_from(NotificationQueueJob)
-            .where(
-                NotificationQueueJob.claimed_at.is_(None),
-                NotificationQueueJob.dead_lettered.is_(False),
+        try:
+            result = await session.execute(
+                select(func.count())
+                .select_from(NotificationQueueJob)
+                .where(
+                    NotificationQueueJob.claimed_at.is_(None),
+                    NotificationQueueJob.dead_lettered.is_(False),
+                )
             )
-        )
+        except OperationalError as exc:
+            message = str(exc).lower()
+            if "no such table" in message:
+                return 0
+            raise
         return int(result.scalar_one())
 
 
@@ -506,6 +512,8 @@ async def _clear_persistent_jobs() -> None:
             except OperationalError as exc:
                 await session.rollback()
                 message = str(exc).lower()
+                if "no such table" in message:
+                    return
                 if "locked" not in message or attempt == max_attempts:
                     raise
                 await asyncio.sleep(delay_seconds * attempt)

--- a/root/tests/test_auth_security.py
+++ b/root/tests/test_auth_security.py
@@ -1,6 +1,9 @@
+import uuid
+
 import pytest
 from fastapi import status
 from passlib.hash import bcrypt
+from sqlalchemy import select
 
 from app.auth.security import (
     LEGACY_BCRYPT_MAX_BYTES,
@@ -9,6 +12,7 @@ from app.auth.security import (
     verify_and_update_password,
     verify_password,
 )
+from app.models import models
 
 
 def _make_legacy_hash(password: str) -> str:
@@ -212,3 +216,106 @@ async def test_create_user_allows_admin(async_client, user_factory):
     body = response.json()
     assert body["email"] == payload["email"]
     assert body["role"] == "student"
+
+
+@pytest.mark.anyio
+async def test_register_normalizes_email(async_client, db_session):
+    raw_email = f"MixedCase{uuid.uuid4().hex[:6]}@Example.COM"
+    payload = {
+        "email": raw_email,
+        "password": "ValidPass123!",
+        "full_name": "Mixed Case",
+    }
+
+    response = await async_client.post("/auth/register", json=payload)
+
+    assert response.status_code == status.HTTP_200_OK
+    body = response.json()
+    assert body["status"] == "ok"
+
+    user = await db_session.get(models.User, body["id"])
+    assert user is not None
+    assert user.email == raw_email.lower()
+
+
+@pytest.mark.anyio
+async def test_login_accepts_mixed_case_username(async_client, user_factory):
+    password = "ValidLogin123!"
+    user = await user_factory(
+        email="login-case@example.com",
+        hashed_password=get_password_hash(password),
+        is_active=True,
+    )
+
+    response = await async_client.post(
+        "/auth/login",
+        data={"username": user.email.upper(), "password": password},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    body = response.json()
+    assert body["token_type"] == "bearer"
+    assert body["access_token"]
+
+
+@pytest.mark.anyio
+async def test_forgot_password_accepts_mixed_case_email(
+    async_client, user_factory, db_session
+):
+    user = await user_factory(email=f"forgot-{uuid.uuid4().hex[:6]}@example.com")
+
+    base_query = select(models.PasswordResetToken.id).where(
+        models.PasswordResetToken.user_id == user.id
+    )
+    before = await db_session.execute(base_query)
+    before_count = len(before.scalars().all())
+
+    response = await async_client.post(
+        "/password/forgot",
+        json={"email": user.email.upper()},
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {"ok": True}
+
+    after = await db_session.execute(base_query)
+    after_count = len(after.scalars().all())
+    assert after_count == before_count + 1
+
+
+@pytest.mark.anyio
+async def test_admin_update_normalizes_email(async_client, user_factory, db_session):
+    admin_password = "AdminMixed123!"
+    admin = await user_factory(
+        role="admin",
+        hashed_password=get_password_hash(admin_password),
+    )
+
+    login_response = await async_client.post(
+        "/auth/login",
+        data={"username": admin.email, "password": admin_password},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+
+    assert login_response.status_code == status.HTTP_200_OK
+    token = login_response.json()["access_token"]
+
+    target_user = await user_factory()
+    mixed_case_email = f"Updated{uuid.uuid4().hex[:6]}@Example.COM"
+
+    response = await async_client.patch(
+        f"/users/{target_user.id}",
+        json={"email": mixed_case_email},
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept-Language": "en",
+        },
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    body = response.json()
+    assert body["email"] == mixed_case_email.lower()
+
+    await db_session.refresh(target_user)
+    assert target_user.email == mixed_case_email.lower()


### PR DESCRIPTION
## Summary
- normalize user emails on creation and update while switching API lookups to case-insensitive comparisons
- add a migration to lowercase existing emails and create a unique index on lower(email)
- harden notification queue shutdown against missing tables and add tests covering mixed-case registration, login, password reset, and admin updates

## Testing
- pytest root/tests/test_auth_security.py

------
https://chatgpt.com/codex/tasks/task_e_69021b64f2c48327adac39cdceab8e1e