### PR TITLE
Add retention cleanup for notification queue dead letters

### DIFF
--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -141,6 +141,7 @@ server {
 - При запуске API и воркера в разных процессах выключите встроенный планировщик в API, установив `NOTIFICATIONS_SCHEDULER_INLINE_ENABLED=false`.
 - Воркер публикует здоровье и метрики Prometheus на `http://<host>:9101/healthz` и `http://<host>:9101/metrics` (порт можно изменить через `NOTIFICATIONS_WORKER_METRICS_PORT`).
 - В docker-compose уже добавлен сервис `notifications-worker` с политикой перезапуска `unless-stopped`.
+- Задания из dead-letter очереди автоматически удаляются по истечении 30 дней (управляется `NOTIFICATION_QUEUE_DEAD_LETTER_RETENTION_DAYS`). Периодичность проверки задаётся `NOTIFICATION_QUEUE_DEAD_LETTER_CLEANUP_INTERVAL_SECONDS` (минимум 300 секунд; значение `0` отключает планировщик).
 
 ## Очистка сессий пользователей
 

--- a/root/app/core/config.py
+++ b/root/app/core/config.py
@@ -274,6 +274,8 @@ class Settings(BaseSettings):
     notifications_webpush_concurrency_limit: int = 10
     notifications_retention_days: int = 90
     notifications_retention_cleanup_interval_seconds: int = 86_400
+    notification_queue_dead_letter_retention_days: int = 30
+    notification_queue_dead_letter_cleanup_interval_seconds: int = 86_400
     storage_backend: str = "static"
     storage_static_base_url: str = "/static"
     storage_s3_bucket: str = ""

--- a/root/app/main.py
+++ b/root/app/main.py
@@ -68,6 +68,7 @@ async def lifespan(app: FastAPI):
         await ensure_webauthn_attestation_columns(engine)
     stop_scheduler = None
     stop_notifications_retention = None
+    stop_dead_letter_cleanup = None
     stop_session_cleanup = None
     stop_story_cleanup = None
     stop_password_reset_cleanup = None
@@ -79,6 +80,9 @@ async def lifespan(app: FastAPI):
         )
     await cleanup_stale_notifications(
         retention_days=settings.notifications_retention_days
+    )
+    await notification_queue.cleanup_dead_lettered_jobs(
+        retention_days=settings.notification_queue_dead_letter_retention_days
     )
     await cleanup_expired_sessions()
     await cleanup_expired_stories()
@@ -93,6 +97,20 @@ async def lifespan(app: FastAPI):
             config=NotificationsRetentionConfig(
                 retention_days=settings.notifications_retention_days,
                 interval_seconds=settings.notifications_retention_cleanup_interval_seconds,
+            )
+        )
+    if (
+        settings.notification_queue_dead_letter_retention_days > 0
+        and settings.notification_queue_dead_letter_cleanup_interval_seconds > 0
+    ):
+        stop_dead_letter_cleanup = (
+            await notification_queue.start_dead_letter_cleanup_scheduler(
+                config=notification_queue.DeadLetterCleanupConfig(
+                    retention_days=settings.notification_queue_dead_letter_retention_days,
+                    interval_seconds=(
+                        settings.notification_queue_dead_letter_cleanup_interval_seconds
+                    ),
+                )
             )
         )
     if settings.session_cleanup_interval_seconds > 0:
@@ -124,6 +142,8 @@ async def lifespan(app: FastAPI):
             await stop_scheduler()
         if stop_notifications_retention is not None:
             await stop_notifications_retention()
+        if stop_dead_letter_cleanup is not None:
+            await stop_dead_letter_cleanup()
         if stop_session_cleanup is not None:
             await stop_session_cleanup()
         if stop_story_cleanup is not None:

--- a/root/app/main.py
+++ b/root/app/main.py
@@ -103,14 +103,12 @@ async def lifespan(app: FastAPI):
         settings.notification_queue_dead_letter_retention_days > 0
         and settings.notification_queue_dead_letter_cleanup_interval_seconds > 0
     ):
-        stop_dead_letter_cleanup = (
-            await notification_queue.start_dead_letter_cleanup_scheduler(
-                config=notification_queue.DeadLetterCleanupConfig(
-                    retention_days=settings.notification_queue_dead_letter_retention_days,
-                    interval_seconds=(
-                        settings.notification_queue_dead_letter_cleanup_interval_seconds
-                    ),
-                )
+        stop_dead_letter_cleanup = await notification_queue.start_dead_letter_cleanup_scheduler(
+            config=notification_queue.DeadLetterCleanupConfig(
+                retention_days=settings.notification_queue_dead_letter_retention_days,
+                interval_seconds=(
+                    settings.notification_queue_dead_letter_cleanup_interval_seconds
+                ),
             )
         )
     if settings.session_cleanup_interval_seconds > 0:

--- a/root/app/services/notification_queue.py
+++ b/root/app/services/notification_queue.py
@@ -751,7 +751,6 @@ async def start_dead_letter_cleanup_scheduler(
 
     persistent_backend = _use_persistent_backend()
     if retention_days <= 0 or not persistent_backend:
-
         reason = (
             "retention disabled"
             if retention_days <= 0
@@ -781,9 +780,7 @@ async def start_dead_letter_cleanup_scheduler(
                 except asyncio.CancelledError:
                     raise
                 except Exception:  # pragma: no cover - defensive logging
-                    logger.exception(
-                        "Failed to cleanup notification dead-letter queue"
-                    )
+                    logger.exception("Failed to cleanup notification dead-letter queue")
                 await asyncio.sleep(interval)
         except asyncio.CancelledError:  # pragma: no cover - cooperative shutdown
             logger.info("Notification queue dead-letter cleanup loop cancelled")

--- a/root/app/services/notification_queue.py
+++ b/root/app/services/notification_queue.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+from contextlib import suppress
 from dataclasses import dataclass, replace
 from datetime import datetime, timedelta, timezone
-from typing import Iterable, Literal, Sequence, cast
+from typing import Awaitable, Callable, Iterable, Literal, Sequence, cast
 from weakref import WeakKeyDictionary
 
 from opentelemetry import trace
@@ -21,6 +22,7 @@ from app.core.database import async_session
 from app.core.observability import (
     NotificationQueueMetrics,
     get_notification_queue_metrics,
+    get_periodic_task_metrics,
 )
 from app.models.models import Event, News, Notification, NotificationQueueJob
 from app.services.notifications import notify_about_event, notify_about_news
@@ -60,6 +62,9 @@ _loop_states: "WeakKeyDictionary[asyncio.AbstractEventLoop, _LoopState]" = (
 
 
 _queue_metrics: NotificationQueueMetrics | None = None
+_DEAD_LETTER_CLEANUP_METRICS = get_periodic_task_metrics(
+    "notification_queue_dead_letter_cleanup"
+)
 
 
 def _get_metrics() -> NotificationQueueMetrics | None:
@@ -693,6 +698,110 @@ async def delete_dead_lettered_jobs(job_ids: Sequence[int]) -> int:
     if metrics is not None:
         await _refresh_persistent_queue_size(metrics)
     return deleted
+
+
+@dataclass(slots=True)
+class DeadLetterCleanupConfig:
+    """Configuration for dead-letter retention cleanup."""
+
+    retention_days: int = 30
+    interval_seconds: int = 86_400
+
+    def normalized_retention_days(self) -> int:
+        return max(0, int(self.retention_days))
+
+    def normalized_interval(self) -> int:
+        return max(300, int(self.interval_seconds))
+
+
+async def cleanup_dead_lettered_jobs(*, retention_days: int) -> int:
+    """Delete dead-lettered jobs older than the configured retention window."""
+
+    if not _use_persistent_backend():
+        return 0
+
+    normalized_retention = max(0, int(retention_days))
+    if normalized_retention <= 0:
+        return 0
+
+    cutoff = datetime.now(timezone.utc) - timedelta(days=normalized_retention)
+    deleted = 0
+    async with async_session() as session:
+        async with session.begin():
+            result = await session.execute(
+                delete(NotificationQueueJob)
+                .where(NotificationQueueJob.dead_lettered.is_(True))
+                .where(NotificationQueueJob.enqueued_at < cutoff)
+            )
+            deleted = int(result.rowcount or 0)
+
+    metrics = _get_metrics()
+    if metrics is not None and deleted > 0:
+        await _refresh_persistent_queue_size(metrics)
+    return deleted
+
+
+async def start_dead_letter_cleanup_scheduler(
+    *, config: DeadLetterCleanupConfig | None = None
+) -> Callable[[], Awaitable[None]]:
+    """Start a periodic cleanup task for dead-lettered notification jobs."""
+
+    cfg = config or DeadLetterCleanupConfig()
+    retention_days = cfg.normalized_retention_days()
+
+    persistent_backend = _use_persistent_backend()
+    if retention_days <= 0 or not persistent_backend:
+
+        reason = (
+            "retention disabled"
+            if retention_days <= 0
+            else "persistent backend disabled"
+        )
+
+        async def _noop() -> None:
+            return None
+
+        logger.info(
+            "Notification queue dead-letter cleanup disabled (%s)",
+            reason,
+        )
+        return _noop
+
+    interval = cfg.normalized_interval()
+
+    async def _loop() -> None:
+        try:
+            while True:
+                try:
+                    async with _DEAD_LETTER_CLEANUP_METRICS.track_execution() as run:
+                        deleted = await cleanup_dead_lettered_jobs(
+                            retention_days=retention_days
+                        )
+                        run.observe_deleted(deleted)
+                except asyncio.CancelledError:
+                    raise
+                except Exception:  # pragma: no cover - defensive logging
+                    logger.exception(
+                        "Failed to cleanup notification dead-letter queue"
+                    )
+                await asyncio.sleep(interval)
+        except asyncio.CancelledError:  # pragma: no cover - cooperative shutdown
+            logger.info("Notification queue dead-letter cleanup loop cancelled")
+            raise
+
+    loop = asyncio.get_running_loop()
+    task = loop.create_task(_loop())
+
+    async def _stop() -> None:
+        if task.done():
+            with suppress(Exception):
+                task.result()
+            return
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+
+    return _stop
 
 
 def _format_job_error(error: BaseException | None) -> str:

--- a/root/tests/test_notification_queue_worker.py
+++ b/root/tests/test_notification_queue_worker.py
@@ -536,6 +536,94 @@ async def test_persistent_queue_claims_next_job_from_large_backlog() -> None:
 
 
 @pytest.mark.anyio
+async def test_cleanup_dead_lettered_jobs_respects_retention_window() -> None:
+    await notification_queue.reset_testing_state()
+
+    now = datetime.now(timezone.utc)
+    async with async_session() as session:
+        session.add_all(
+            [
+                NotificationQueueJob(
+                    kind="event",
+                    record_id=101,
+                    locale="en",
+                    enqueued_at=now - timedelta(days=45),
+                    dead_lettered=True,
+                ),
+                NotificationQueueJob(
+                    kind="news",
+                    record_id=202,
+                    locale="ru",
+                    enqueued_at=now - timedelta(days=5),
+                    dead_lettered=True,
+                ),
+                NotificationQueueJob(
+                    kind="event",
+                    record_id=303,
+                    locale=None,
+                    enqueued_at=now - timedelta(days=60),
+                    dead_lettered=False,
+                ),
+            ]
+        )
+        await session.commit()
+
+    deleted = await notification_queue.cleanup_dead_lettered_jobs(
+        retention_days=30
+    )
+    assert deleted == 1
+
+    async with async_session() as session:
+        remaining = (
+            await session.execute(
+                select(NotificationQueueJob).order_by(NotificationQueueJob.record_id)
+            )
+        ).scalars().all()
+
+    assert [job.record_id for job in remaining] == [202, 303]
+    fresh_dead_letter = next(job for job in remaining if job.record_id == 202)
+    assert fresh_dead_letter.dead_lettered is True
+    enqueued_at = fresh_dead_letter.enqueued_at
+    assert enqueued_at is not None
+    if enqueued_at.tzinfo is None:
+        enqueued_at = enqueued_at.replace(tzinfo=timezone.utc)
+    assert enqueued_at > now - timedelta(days=30)
+
+
+@pytest.mark.anyio
+async def test_cleanup_dead_lettered_jobs_disabled_with_zero_retention() -> None:
+    await notification_queue.reset_testing_state()
+
+    now = datetime.now(timezone.utc)
+    async with async_session() as session:
+        session.add(
+            NotificationQueueJob(
+                kind="event",
+                record_id=404,
+                locale=None,
+                enqueued_at=now - timedelta(days=120),
+                dead_lettered=True,
+            )
+        )
+        await session.commit()
+
+    deleted = await notification_queue.cleanup_dead_lettered_jobs(retention_days=0)
+    assert deleted == 0
+
+    async with async_session() as session:
+        remaining = (
+            await session.execute(
+                select(NotificationQueueJob).where(
+                    NotificationQueueJob.record_id == 404
+                )
+            )
+        ).scalar_one_or_none()
+
+    assert remaining is not None
+    assert remaining.dead_lettered is True
+
+
+@pytest.mark.anyio
 async def test_worker_loop_emits_tracing_spans(monkeypatch: pytest.MonkeyPatch):
     spans: list["FakeSpan"] = []
 

--- a/root/tests/test_notification_queue_worker.py
+++ b/root/tests/test_notification_queue_worker.py
@@ -568,17 +568,21 @@ async def test_cleanup_dead_lettered_jobs_respects_retention_window() -> None:
         )
         await session.commit()
 
-    deleted = await notification_queue.cleanup_dead_lettered_jobs(
-        retention_days=30
-    )
+    deleted = await notification_queue.cleanup_dead_lettered_jobs(retention_days=30)
     assert deleted == 1
 
     async with async_session() as session:
         remaining = (
-            await session.execute(
-                select(NotificationQueueJob).order_by(NotificationQueueJob.record_id)
+            (
+                await session.execute(
+                    select(NotificationQueueJob).order_by(
+                        NotificationQueueJob.record_id
+                    )
+                )
             )
-        ).scalars().all()
+            .scalars()
+            .all()
+        )
 
     assert [job.record_id for job in remaining] == [202, 303]
     fresh_dead_letter = next(job for job in remaining if job.record_id == 202)


### PR DESCRIPTION
## Summary
- add configurable retention and periodic cleanup for dead-lettered notification queue jobs
- wire the cleanup scheduler into API startup and document the new environment knobs
- cover dead-letter retention behavior with targeted tests

## Testing
- pytest root/tests/test_notification_queue_worker.py -k dead_lettered_jobs


------
https://chatgpt.com/codex/tasks/task_e_6902c320dfb08327b6255a654e1e202e