### PR TITLE
Improve development defaults warning hint

### DIFF
--- a/root/app/core/config.py
+++ b/root/app/core/config.py
@@ -774,10 +774,18 @@ def _load_settings() -> Settings:
         )
         if not missing:
             missing = "DATABASE_URL, SECRET_KEY"
-        _logger.warning(
-            "Using development defaults for %s because DATABASE_URL and SECRET_KEY are not configured. "
+        hint_parts = [
             "Provide real secrets via environment variables or a .env file before deploying.",
+        ]
+        if not (_PROJECT_ROOT / ".env").exists():
+            hint_parts.append(
+                "For local development, copy root/.env.example to root/.env and replace the placeholder"
+                " values before starting the application.",
+            )
+        _logger.warning(
+            "Using development defaults for %s because DATABASE_URL and SECRET_KEY are not configured. %s",
             missing,
+            " ".join(hint_parts),
         )
         return fallback
 


### PR DESCRIPTION
## Summary
- expand the configuration warning emitted when falling back to development defaults
- include a direct hint to copy `root/.env.example` when a `.env` file is missing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6902c5b342f083279d7995f63c3f8a2d