### PR TITLE
Warn when .env matches example instead of ignoring it

### DIFF
--- a/root/app/core/config.py
+++ b/root/app/core/config.py
@@ -34,7 +34,12 @@ def _resolve_env_file(base_dir: Path) -> Path | None:
                 candidate_bytes = None
             else:
                 if candidate_bytes == example_bytes:
-                    continue
+                    logging.getLogger(__name__).warning(
+                        "%s is identical to %s; update it with real secrets before "
+                        "deploying.",
+                        candidate,
+                        example_path,
+                    )
         return candidate
     return None
 

--- a/root/tests/test_core_config.py
+++ b/root/tests/test_core_config.py
@@ -94,5 +94,8 @@ def test_settings_warn_when_env_matches_example(monkeypatch, caplog):
             settings = config_module.Settings()
 
     assert settings.database_url.startswith("postgresql+asyncpg://")
-    assert settings.secret_key == "Qj7p4R2zYx8N1a5Hk9V3u0Mw6Tg4Lr8Cz2Jv5Qw7Xn1Dk6Fh0Sg3Vb9Pp4Rz8Lm2"
+    assert (
+        settings.secret_key
+        == "Qj7p4R2zYx8N1a5Hk9V3u0Mw6Tg4Lr8Cz2Jv5Qw7Xn1Dk6Fh0Sg3Vb9Pp4Rz8Lm2"
+    )
     assert any("identical to" in record.getMessage() for record in caplog.records)

--- a/root/tests/test_core_config.py
+++ b/root/tests/test_core_config.py
@@ -1,6 +1,31 @@
 import importlib
+from contextlib import contextmanager
+from pathlib import Path
 
 import pytest
+
+
+@contextmanager
+def _temporary_env_file(content: bytes | None):
+    env_path = Path("root/.env")
+    try:
+        original = env_path.read_bytes()
+    except FileNotFoundError:
+        original = None
+
+    try:
+        if content is None:
+            if env_path.exists():
+                env_path.unlink()
+        else:
+            env_path.write_bytes(content)
+        yield env_path
+    finally:
+        if original is None:
+            if env_path.exists():
+                env_path.unlink()
+        else:
+            env_path.write_bytes(original)
 
 
 def test_settings_require_real_secret_when_env_missing(monkeypatch):
@@ -9,14 +34,15 @@ def test_settings_require_real_secret_when_env_missing(monkeypatch):
     monkeypatch.delenv("DATABASE_URL", raising=False)
     monkeypatch.delenv("SECRET_KEY", raising=False)
 
-    from app.core import config as config_module
+    with _temporary_env_file(None):
+        from app.core import config as config_module
 
-    config_module = importlib.reload(config_module)
+        config_module = importlib.reload(config_module)
 
-    assert config_module._ENV_FILE is None
+        assert config_module._ENV_FILE is None
 
-    with pytest.raises(RuntimeError) as exc_info:
-        config_module.Settings()
+        with pytest.raises(RuntimeError) as exc_info:
+            config_module.Settings()
 
     message = str(exc_info.value)
     combined = message.lower()
@@ -32,18 +58,41 @@ def test_settings_allow_development_defaults_when_opted_in(monkeypatch):
     monkeypatch.delenv("DATABASE_URL", raising=False)
     monkeypatch.delenv("SECRET_KEY", raising=False)
 
-    from app.core import config as config_module
+    with _temporary_env_file(None):
+        from app.core import config as config_module
 
-    config_module = importlib.reload(config_module)
+        config_module = importlib.reload(config_module)
 
-    settings = config_module.Settings(_allow_missing=True)
+        settings = config_module.Settings(_allow_missing=True)
 
-    assert settings.database_url == "sqlite+aiosqlite:///./dev.db"
-    assert settings.secret_key == "development-secret-key"
-    assert settings.has_development_fallbacks is True
-    assert set(settings.development_fallback_fields) == {
-        "database_url",
-        "secret_key",
-    }
+        assert settings.database_url == "sqlite+aiosqlite:///./dev.db"
+        assert settings.secret_key == "development-secret-key"
+        assert settings.has_development_fallbacks is True
+        assert set(settings.development_fallback_fields) == {
+            "database_url",
+            "secret_key",
+        }
 
-    assert config_module.settings.has_development_fallbacks is True
+        assert config_module.settings.has_development_fallbacks is True
+
+
+def test_settings_warn_when_env_matches_example(monkeypatch, caplog):
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("SECRET_KEY", raising=False)
+
+    example_bytes = Path("root/.env.example").read_bytes()
+
+    with _temporary_env_file(example_bytes) as env_path:
+        from app.core import config as config_module
+
+        with caplog.at_level("WARNING"):
+            config_module = importlib.reload(config_module)
+
+        assert config_module._ENV_FILE == env_path.resolve()
+
+        with caplog.at_level("WARNING"):
+            settings = config_module.Settings()
+
+    assert settings.database_url.startswith("postgresql+asyncpg://")
+    assert settings.secret_key == "Qj7p4R2zYx8N1a5Hk9V3u0Mw6Tg4Lr8Cz2Jv5Qw7Xn1Dk6Fh0Sg3Vb9Pp4Rz8Lm2"
+    assert any("identical to" in record.getMessage() for record in caplog.records)


### PR DESCRIPTION
## Summary
- load root/.env even when it matches root/.env.example so copied sample values are respected
- emit a warning reminding developers to replace the example secrets before deploying

## Testing
- pytest *(fails: RuntimeError due to missing event loop in several tests)*

------
https://chatgpt.com/codex/tasks/task_e_69036f6d68948327830e3176ef3772ed