### PR TITLE
Align dashboard panels with navigation surface

### DIFF
--- a/root/frontend/src/assets/themes.css
+++ b/root/frontend/src/assets/themes.css
@@ -64,12 +64,12 @@
   --dash-conic-stop-3: color-mix(in srgb, white 68%, var(--nav-link-hover) 32%);
   --dash-conic-stop-4: color-mix(in srgb, white 92%, var(--nav-link) 8%);
   --dash-date-shadow: 0 18px 40px -22px color-mix(in srgb, var(--nav-link-hover) 55%, transparent);
-  --dash-panel-bg: color-mix(in srgb, white 94%, var(--nav-link) 6%);
-  --dash-panel-border: color-mix(in srgb, white 62%, var(--nav-link) 38%);
-  --dash-panel-shadow: 0 34px 110px -70px color-mix(in srgb, var(--nav-link-hover) 45%, transparent);
-  --dash-panel-item-hover: color-mix(in srgb, white 88%, var(--nav-link) 12%);
+  --dash-panel-bg: color-mix(in srgb, var(--nav-bg) 92%, black 8%);
+  --dash-panel-border: color-mix(in srgb, var(--nav-bg) 74%, var(--nav-link) 26%);
+  --dash-panel-shadow: 0 34px 110px -70px color-mix(in srgb, var(--nav-text) 22%, transparent);
+  --dash-panel-item-hover: color-mix(in srgb, var(--nav-bg) 88%, var(--nav-link) 12%);
   --dash-panel-hover-shadow: 0 70px 160px -90px
-    color-mix(in srgb, var(--nav-link-hover) 55%, transparent);
+    color-mix(in srgb, var(--nav-text) 26%, transparent);
   --dash-glass-sheen-start: color-mix(in srgb, white 65%, transparent);
   --dash-glass-sheen-end: color-mix(in srgb, white 12%, transparent);
   --dash-stories-radial: color-mix(in srgb, var(--nav-link) 24%, transparent);
@@ -179,12 +179,12 @@ body.dark {
   --dash-conic-stop-3: color-mix(in srgb, var(--fed-blue-80v) 55%, transparent);
   --dash-conic-stop-4: color-mix(in srgb, var(--nav-link) 45%, transparent);
   --dash-date-shadow: 0 18px 44px -20px color-mix(in srgb, var(--nav-link) 70%, transparent);
-  --dash-panel-bg: color-mix(in srgb, black 68%, var(--nav-link) 32%);
-  --dash-panel-border: color-mix(in srgb, black 52%, var(--nav-link-hover) 48%);
-  --dash-panel-shadow: 0 42px 140px -90px color-mix(in srgb, black 78%, var(--nav-link) 22%);
-  --dash-panel-item-hover: color-mix(in srgb, black 60%, var(--nav-link-hover) 40%);
+  --dash-panel-bg: color-mix(in srgb, var(--nav-bg) 88%, white 12%);
+  --dash-panel-border: color-mix(in srgb, var(--nav-bg) 70%, var(--nav-link-hover) 30%);
+  --dash-panel-shadow: 0 42px 140px -90px color-mix(in srgb, var(--nav-text) 18%, transparent);
+  --dash-panel-item-hover: color-mix(in srgb, var(--nav-bg) 72%, var(--nav-link-hover) 28%);
   --dash-panel-hover-shadow: 0 70px 170px -90px
-    color-mix(in srgb, black 74%, var(--nav-link-hover) 26%);
+    color-mix(in srgb, var(--nav-text) 24%, transparent);
   --dash-glass-sheen-start: color-mix(in srgb, white 35%, transparent);
   --dash-glass-sheen-end: color-mix(in srgb, white 6%, transparent);
   --dash-stories-radial: color-mix(in srgb, var(--nav-link) 40%, transparent);

--- a/root/frontend/src/pages/Dashboard.tsx
+++ b/root/frontend/src/pages/Dashboard.tsx
@@ -16,7 +16,6 @@ import { Link, useNavigate } from "react-router-dom"
 import { Badge, Button, Card, ProgressBar, Skeleton, Tooltip } from "@/components/ui"
 import AutoAwesomeRoundedIcon from "@mui/icons-material/AutoAwesomeRounded"
 import { cn } from "@/utils/cn"
-import useMediaQuery from "@/hooks/useMediaQuery"
 import { useTranslation } from "react-i18next"
 import { getLocaleForLanguage, useLanguage } from "@/contexts/LanguageContext"
 import type { PaginatedResponse } from "@/types/Pagination"
@@ -166,7 +165,6 @@ function setCache<T>(key: string, data: T) {
 
 export default function Dashboard() {
   const { user } = useAuth()
-  const isNarrow = useMediaQuery("(max-width:1100px)")
   const navigate = useNavigate()
   const { language } = useLanguage()
   const locale = getLocaleForLanguage(language)
@@ -399,13 +397,6 @@ export default function Dashboard() {
     fetchSchedule()
   }, [fetchSchedule])
 
-  const headerGradientClass = cn(
-    "transition-[background] duration-700",
-    isNarrow
-      ? "bg-[linear-gradient(135deg,var(--dash-header-grad-start),var(--dash-header-grad-end))]"
-      : "bg-[linear-gradient(125deg,var(--dash-header-grad-start),var(--dash-header-grad-end))]"
-  )
-
   const heroSectionClass = cn(
     "relative flex min-h-screen w-full flex-col overflow-hidden",
     "px-4 pb-16 pt-10 text-page-foreground sm:px-8 md:px-12 lg:px-16",
@@ -482,20 +473,13 @@ export default function Dashboard() {
               className={cn(
                 panelBase,
                 panelHover,
-                "p-6 md:p-9 focus-within:shadow-focus focus-visible:outline-none focus-visible:shadow-focus",
-                headerGradientClass
+                "p-6 md:p-9 focus-within:shadow-focus focus-visible:outline-none focus-visible:shadow-focus transition-colors duration-700"
               )}
             >
               <span
                 aria-hidden="true"
-                className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,color-mix(in_srgb,var(--dash-hero-highlight-soft)_65%,transparent),transparent_60%)] opacity-80 mix-blend-soft-light transition-opacity duration-700 group-hover:opacity-100"
+                className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,color-mix(in_srgb,var(--nav-bg)_78%,transparent),transparent_65%)] opacity-40 mix-blend-multiply transition-opacity duration-700 group-hover:opacity-60"
               />
-              <span
-                aria-hidden="true"
-                className="pointer-events-none absolute -inset-y-24 -left-1/2 w-[170%] skew-x-[-18deg] bg-gradient-to-r from-transparent via-white/55 to-transparent opacity-0 transition-all duration-[2200ms] ease-out group-hover:translate-x-[35%] group-hover:opacity-70"
-              >
-                <span className="block h-full w-full animate-skeleton-wave bg-gradient-to-r from-transparent via-white/70 to-transparent" />
-              </span>
               <div className="pointer-events-none absolute -right-24 top-1/2 h-64 w-64 -translate-y-1/2 rounded-full bg-[radial-gradient(circle,var(--dash-hero-highlight),transparent)] opacity-70 blur-3xl" />
               <div className="pointer-events-none absolute left-[-20%] top-[-40%] h-56 w-56 animate-[spin_18s_linear_infinite] rounded-full bg-[conic-gradient(from_90deg_at_50%_50%,var(--dash-hero-conic-primary),var(--dash-hero-conic-secondary),var(--dash-hero-conic-tertiary),var(--dash-hero-conic-accent))] opacity-60 blur-[120px]" />
               <div className="relative grid gap-6 lg:grid-cols-12 lg:items-center">


### PR DESCRIPTION
## Summary
- align dashboard panel surface variables with the navigation background in light and dark themes
- adjust dashboard hero panel decoration to preserve the matte appearance of the shared surface

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_69038a1e9a308327a5881ab58fca0ca9