### PR TITLE
Add subtle page fade variant for News

### DIFF
--- a/root/frontend/src/assets/themes.css
+++ b/root/frontend/src/assets/themes.css
@@ -68,8 +68,7 @@
   --dash-panel-border: color-mix(in srgb, var(--nav-bg) 74%, var(--nav-link) 26%);
   --dash-panel-shadow: 0 34px 110px -70px color-mix(in srgb, var(--nav-text) 22%, transparent);
   --dash-panel-item-hover: color-mix(in srgb, var(--nav-bg) 88%, var(--nav-link) 12%);
-  --dash-panel-hover-shadow: 0 70px 160px -90px
-    color-mix(in srgb, var(--nav-text) 26%, transparent);
+  --dash-panel-hover-shadow: 0 70px 160px -90px color-mix(in srgb, var(--nav-text) 26%, transparent);
   --dash-glass-sheen-start: color-mix(in srgb, white 65%, transparent);
   --dash-glass-sheen-end: color-mix(in srgb, white 12%, transparent);
   --dash-stories-radial: color-mix(in srgb, var(--nav-link) 24%, transparent);
@@ -183,8 +182,7 @@ body.dark {
   --dash-panel-border: color-mix(in srgb, var(--nav-bg) 70%, var(--nav-link-hover) 30%);
   --dash-panel-shadow: 0 42px 140px -90px color-mix(in srgb, var(--nav-text) 18%, transparent);
   --dash-panel-item-hover: color-mix(in srgb, var(--nav-bg) 72%, var(--nav-link-hover) 28%);
-  --dash-panel-hover-shadow: 0 70px 170px -90px
-    color-mix(in srgb, var(--nav-text) 24%, transparent);
+  --dash-panel-hover-shadow: 0 70px 170px -90px color-mix(in srgb, var(--nav-text) 24%, transparent);
   --dash-glass-sheen-start: color-mix(in srgb, white 35%, transparent);
   --dash-glass-sheen-end: color-mix(in srgb, white 6%, transparent);
   --dash-stories-radial: color-mix(in srgb, var(--nav-link) 40%, transparent);

--- a/root/frontend/src/components/PageFadeIn.tsx
+++ b/root/frontend/src/components/PageFadeIn.tsx
@@ -3,9 +3,14 @@ import { type CSSProperties, type ReactNode, useEffect, useState } from "react"
 type PageFadeInProps = {
   children: ReactNode
   delay?: number
+  variant?: "default" | "subtle"
 }
 
-export default function PageFadeIn({ children, delay = 80 }: PageFadeInProps) {
+export default function PageFadeIn({
+  children,
+  delay = 80,
+  variant = "default",
+}: PageFadeInProps) {
   const [ready, setReady] = useState(false)
 
   useEffect(() => {
@@ -17,6 +22,7 @@ export default function PageFadeIn({ children, delay = 80 }: PageFadeInProps) {
     <div
       data-page-fade
       data-ready={ready ? "true" : "false"}
+      data-variant={variant}
       style={
         {
           "--page-fade-delay": `${delay}ms`,

--- a/root/frontend/src/components/PageFadeIn.tsx
+++ b/root/frontend/src/components/PageFadeIn.tsx
@@ -6,11 +6,7 @@ type PageFadeInProps = {
   variant?: "default" | "subtle"
 }
 
-export default function PageFadeIn({
-  children,
-  delay = 80,
-  variant = "default",
-}: PageFadeInProps) {
+export default function PageFadeIn({ children, delay = 80, variant = "default" }: PageFadeInProps) {
   const [ready, setReady] = useState(false)
 
   useEffect(() => {

--- a/root/frontend/src/pages/News.tsx
+++ b/root/frontend/src/pages/News.tsx
@@ -170,7 +170,7 @@ const News = () => {
 
   return (
     <Layout>
-      <PageFadeIn>
+      <PageFadeIn variant="subtle">
         <Box
           sx={{
             width: "100vw",

--- a/root/frontend/src/styles/tailwind.css
+++ b/root/frontend/src/styles/tailwind.css
@@ -160,6 +160,19 @@
       var(--page-fade-delay) both;
   }
 
+  [data-page-fade][data-variant="subtle"] {
+    --page-fade-duration: 360ms;
+    --page-fade-blur: 0px;
+    --page-fade-scale: 0.995;
+    --page-fade-translate-y: 10px;
+    filter: none;
+    will-change: opacity, transform;
+  }
+
+  [data-page-fade][data-variant="subtle"][data-ready="true"] {
+    filter: none;
+  }
+
   [data-page-fade] [data-fade] {
     --fade-x: 0px;
     --fade-y: 22px;
@@ -175,6 +188,17 @@
   [data-page-fade][data-ready="true"] [data-fade] {
     animation: ue-page-fade-item var(--page-fade-duration) var(--page-fade-easing)
       calc(var(--fade-delay, 120ms) + var(--page-fade-delay)) both;
+  }
+
+  [data-page-fade][data-variant="subtle"] [data-fade] {
+    --fade-y: 18px;
+    --fade-blur: 0px;
+    filter: none;
+    will-change: opacity, transform;
+  }
+
+  [data-page-fade][data-variant="subtle"][data-ready="true"] [data-fade] {
+    filter: none;
   }
 
   [data-page-fade] [data-fade][data-direction="left"] {


### PR DESCRIPTION
## Summary
- add a new `variant` option to the PageFadeIn wrapper to allow lighter animations
- introduce CSS overrides for the subtle animation variant with reduced blur and motion
- switch the News page to use the subtle fade to smooth rendering of large lists

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69038b540a3c8327a6ba472b434124ab