### PR TITLE
Reduce page fade blur and add News feed test

### DIFF
--- a/root/frontend/src/components/PageFadeIn.tsx
+++ b/root/frontend/src/components/PageFadeIn.tsx
@@ -6,11 +6,7 @@ type PageFadeInProps = {
   effect?: "default" | "soft-blur"
 }
 
-export default function PageFadeIn({
-  children,
-  delay = 80,
-  effect = "default",
-}: PageFadeInProps) {
+export default function PageFadeIn({ children, delay = 80, effect = "default" }: PageFadeInProps) {
   const [ready, setReady] = useState(false)
   const [prefersReducedMotion, setPrefersReducedMotion] = useState(false)
 
@@ -42,7 +38,11 @@ export default function PageFadeIn({
     return
   }, [])
 
-  const resolvedEffect = prefersReducedMotion ? undefined : effect === "soft-blur" ? "soft-blur" : undefined
+  const resolvedEffect = prefersReducedMotion
+    ? undefined
+    : effect === "soft-blur"
+      ? "soft-blur"
+      : undefined
 
   return (
     <div

--- a/root/frontend/src/components/PageFadeIn.tsx
+++ b/root/frontend/src/components/PageFadeIn.tsx
@@ -3,20 +3,52 @@ import { type CSSProperties, type ReactNode, useEffect, useState } from "react"
 type PageFadeInProps = {
   children: ReactNode
   delay?: number
+  effect?: "default" | "soft-blur"
 }
 
-export default function PageFadeIn({ children, delay = 80 }: PageFadeInProps) {
+export default function PageFadeIn({
+  children,
+  delay = 80,
+  effect = "default",
+}: PageFadeInProps) {
   const [ready, setReady] = useState(false)
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false)
 
   useEffect(() => {
     const frame = requestAnimationFrame(() => setReady(true))
     return () => cancelAnimationFrame(frame)
   }, [])
 
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return
+    }
+
+    const query = window.matchMedia("(prefers-reduced-motion: reduce)")
+    const updatePreference = () => setPrefersReducedMotion(query.matches)
+
+    updatePreference()
+
+    if (typeof query.addEventListener === "function") {
+      query.addEventListener("change", updatePreference)
+      return () => query.removeEventListener("change", updatePreference)
+    }
+
+    if (typeof query.addListener === "function") {
+      query.addListener(updatePreference)
+      return () => query.removeListener(updatePreference)
+    }
+
+    return
+  }, [])
+
+  const resolvedEffect = prefersReducedMotion ? undefined : effect === "soft-blur" ? "soft-blur" : undefined
+
   return (
     <div
       data-page-fade
       data-ready={ready ? "true" : "false"}
+      data-effect={resolvedEffect}
       style={
         {
           "--page-fade-delay": `${delay}ms`,

--- a/root/frontend/src/pages/__tests__/News.performance.test.tsx
+++ b/root/frontend/src/pages/__tests__/News.performance.test.tsx
@@ -1,0 +1,170 @@
+import type { ReactNode } from "react"
+import { render, screen } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { ThemeProvider, createTheme } from "@mui/material/styles"
+import { LanguageProvider } from "@/contexts/LanguageContext"
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("../../components/NewsCard", () => ({
+  __esModule: true,
+  default: ({ id }: { id: number }) => (
+    <div data-testid="news-card" data-news-id={id}>
+      News {id}
+    </div>
+  ),
+}))
+
+vi.mock("../../contexts/AuthContext", () => ({
+  useAuth: () => ({
+    user: { id: 1, role: "admin" },
+  }),
+}))
+
+vi.mock("@/hooks/useNewsFeed", () => ({
+  useNewsFeed: vi.fn(),
+}))
+
+import News from "../News"
+import { useNewsFeed } from "@/hooks/useNewsFeed"
+
+const largeFeed = Array.from({ length: 96 }, (_, index) => ({
+  id: index + 1,
+  title: `Sample news ${index + 1}`,
+  content: `Sample news body ${index + 1}`,
+  created_at: new Date(2024, 0, 1 + index).toISOString(),
+  image_url: null,
+}))
+
+const useNewsFeedMock = vi.mocked(useNewsFeed)
+
+const buildWrapper = (mode: "light" | "dark") => {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  })
+
+  const theme = createTheme({ palette: { mode } })
+
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>
+      <LanguageProvider>
+        <ThemeProvider theme={theme}>{children}</ThemeProvider>
+      </LanguageProvider>
+    </QueryClientProvider>
+  )
+}
+
+let matchMediaMock: ReturnType<typeof vi.fn>
+let originalMatchMedia: typeof window.matchMedia | undefined
+let originalRequestIdleCallback: typeof window.requestIdleCallback | undefined
+let originalCancelIdleCallback: typeof window.cancelIdleCallback | undefined
+let currentMode: "light" | "dark" = "light"
+
+describe("News page feed rendering", () => {
+  beforeAll(() => {
+    originalMatchMedia = window.matchMedia
+    originalRequestIdleCallback = window.requestIdleCallback
+    originalCancelIdleCallback = window.cancelIdleCallback
+    matchMediaMock = vi.fn((query: string) => ({
+      matches:
+        query.includes("prefers-color-scheme") && query.includes("dark")
+          ? currentMode === "dark"
+          : false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(() => false),
+    }))
+
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      writable: true,
+      value: matchMediaMock,
+    })
+
+    Object.defineProperty(window, "requestIdleCallback", {
+      configurable: true,
+      writable: true,
+      value: ((callback: IdleRequestCallback) => {
+        callback({ didTimeout: false, timeRemaining: () => 16 })
+        return 1
+      }) as typeof window.requestIdleCallback,
+    })
+
+    Object.defineProperty(window, "cancelIdleCallback", {
+      configurable: true,
+      writable: true,
+      value: (() => {}) as typeof window.cancelIdleCallback,
+    })
+  })
+
+  afterAll(() => {
+    if (originalMatchMedia) {
+      Object.defineProperty(window, "matchMedia", {
+        configurable: true,
+        writable: true,
+        value: originalMatchMedia,
+      })
+    } else {
+      delete (window as { matchMedia?: typeof window.matchMedia }).matchMedia
+    }
+
+    if (originalRequestIdleCallback) {
+      Object.defineProperty(window, "requestIdleCallback", {
+        configurable: true,
+        writable: true,
+        value: originalRequestIdleCallback,
+      })
+    } else {
+      delete (window as { requestIdleCallback?: typeof window.requestIdleCallback }).requestIdleCallback
+    }
+
+    if (originalCancelIdleCallback) {
+      Object.defineProperty(window, "cancelIdleCallback", {
+        configurable: true,
+        writable: true,
+        value: originalCancelIdleCallback,
+      })
+    } else {
+      delete (window as { cancelIdleCallback?: typeof window.cancelIdleCallback }).cancelIdleCallback
+    }
+  })
+
+  beforeEach(() => {
+    useNewsFeedMock.mockReturnValue({
+      data: largeFeed,
+      isPending: false,
+      isFetching: false,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useNewsFeed>)
+    localStorage.setItem("ue:language", "en")
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+    matchMediaMock.mockClear()
+    useNewsFeedMock.mockClear()
+  })
+
+  it.each([
+    ["light"],
+    ["dark"],
+  ] as const)("renders a large news feed without blur in %s mode", async (mode) => {
+    currentMode = mode
+    const wrapper = buildWrapper(mode)
+
+    const { container } = render(<News />, { wrapper })
+
+    const cards = await screen.findAllByTestId("news-card")
+    expect(cards.length).toBeGreaterThan(0)
+
+    const fadeContainer = container.querySelector<HTMLElement>("[data-page-fade]")
+    expect(fadeContainer).not.toBeNull()
+    expect(fadeContainer?.dataset.effect).toBeUndefined()
+    expect(useNewsFeedMock).toHaveBeenCalled()
+  })
+})

--- a/root/frontend/src/pages/__tests__/News.performance.test.tsx
+++ b/root/frontend/src/pages/__tests__/News.performance.test.tsx
@@ -5,14 +5,20 @@ import { ThemeProvider, createTheme } from "@mui/material/styles"
 import { LanguageProvider } from "@/contexts/LanguageContext"
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
 
-vi.mock("../../components/NewsCard", () => ({
-  __esModule: true,
-  default: ({ id }: { id: number }) => (
+vi.mock("../../components/NewsCard", () => {
+  const MockNewsCard = ({ id }: { id: number }) => (
     <div data-testid="news-card" data-news-id={id}>
       News {id}
     </div>
-  ),
-}))
+  )
+
+  MockNewsCard.displayName = "MockNewsCard"
+
+  return {
+    __esModule: true,
+    default: MockNewsCard,
+  }
+})
 
 vi.mock("../../contexts/AuthContext", () => ({
   useAuth: () => ({
@@ -46,13 +52,17 @@ const buildWrapper = (mode: "light" | "dark") => {
 
   const theme = createTheme({ palette: { mode } })
 
-  return ({ children }: { children: ReactNode }) => (
+  const NewsTestWrapper = ({ children }: { children: ReactNode }) => (
     <QueryClientProvider client={client}>
       <LanguageProvider>
         <ThemeProvider theme={theme}>{children}</ThemeProvider>
       </LanguageProvider>
     </QueryClientProvider>
   )
+
+  NewsTestWrapper.displayName = `NewsTestWrapper(${mode})`
+
+  return NewsTestWrapper
 }
 
 let matchMediaMock: ReturnType<typeof vi.fn>

--- a/root/frontend/src/pages/__tests__/News.performance.test.tsx
+++ b/root/frontend/src/pages/__tests__/News.performance.test.tsx
@@ -130,7 +130,8 @@ describe("News page feed rendering", () => {
         value: originalRequestIdleCallback,
       })
     } else {
-      delete (window as { requestIdleCallback?: typeof window.requestIdleCallback }).requestIdleCallback
+      delete (window as { requestIdleCallback?: typeof window.requestIdleCallback })
+        .requestIdleCallback
     }
 
     if (originalCancelIdleCallback) {
@@ -140,7 +141,8 @@ describe("News page feed rendering", () => {
         value: originalCancelIdleCallback,
       })
     } else {
-      delete (window as { cancelIdleCallback?: typeof window.cancelIdleCallback }).cancelIdleCallback
+      delete (window as { cancelIdleCallback?: typeof window.cancelIdleCallback })
+        .cancelIdleCallback
     }
   })
 
@@ -160,21 +162,21 @@ describe("News page feed rendering", () => {
     useNewsFeedMock.mockClear()
   })
 
-  it.each([
-    ["light"],
-    ["dark"],
-  ] as const)("renders a large news feed without blur in %s mode", async (mode) => {
-    currentMode = mode
-    const wrapper = buildWrapper(mode)
+  it.each([["light"], ["dark"]] as const)(
+    "renders a large news feed without blur in %s mode",
+    async (mode) => {
+      currentMode = mode
+      const wrapper = buildWrapper(mode)
 
-    const { container } = render(<News />, { wrapper })
+      const { container } = render(<News />, { wrapper })
 
-    const cards = await screen.findAllByTestId("news-card")
-    expect(cards.length).toBeGreaterThan(0)
+      const cards = await screen.findAllByTestId("news-card")
+      expect(cards.length).toBeGreaterThan(0)
 
-    const fadeContainer = container.querySelector<HTMLElement>("[data-page-fade]")
-    expect(fadeContainer).not.toBeNull()
-    expect(fadeContainer?.dataset.effect).toBeUndefined()
-    expect(useNewsFeedMock).toHaveBeenCalled()
-  })
+      const fadeContainer = container.querySelector<HTMLElement>("[data-page-fade]")
+      expect(fadeContainer).not.toBeNull()
+      expect(fadeContainer?.dataset.effect).toBeUndefined()
+      expect(useNewsFeedMock).toHaveBeenCalled()
+    }
+  )
 })

--- a/root/frontend/src/styles/tailwind.css
+++ b/root/frontend/src/styles/tailwind.css
@@ -100,26 +100,19 @@
     --page-fade-duration: 560ms;
     --page-fade-easing: cubic-bezier(0.33, 1, 0.68, 1);
     --page-fade-scale: 0.985;
-    --page-fade-blur: 16px;
     --page-fade-translate-y: 18px;
+    --page-fade-blur: 8px;
   }
 
   @keyframes ue-page-fade-shell {
     0% {
       opacity: 0;
       transform: translate3d(0, var(--page-fade-translate-y), 0) scale(var(--page-fade-scale));
-      filter: blur(var(--page-fade-blur));
-    }
-
-    55% {
-      opacity: 1;
-      filter: blur(calc(var(--page-fade-blur) * 0.35));
     }
 
     100% {
       opacity: 1;
       transform: translate3d(0, 0, 0) scale(1);
-      filter: blur(0px);
     }
   }
 
@@ -127,17 +120,11 @@
     0% {
       opacity: 0;
       transform: translate3d(var(--fade-x), var(--fade-y), 0) scale(var(--fade-scale));
-      filter: blur(var(--fade-blur));
-    }
-
-    45% {
-      filter: blur(calc(var(--fade-blur) * 0.4));
     }
 
     100% {
       opacity: 1;
       transform: translate3d(0, 0, 0) scale(1);
-      filter: blur(0px);
     }
   }
 
@@ -145,13 +132,12 @@
     --page-fade-delay: 80ms;
     --page-fade-duration: 560ms;
     --page-fade-easing: cubic-bezier(0.33, 1, 0.68, 1);
-    --page-fade-blur: 16px;
     --page-fade-scale: 0.985;
     --page-fade-translate-y: 18px;
     opacity: 0;
     transform: translate3d(0, var(--page-fade-translate-y), 0) scale(var(--page-fade-scale));
-    filter: blur(var(--page-fade-blur));
-    will-change: opacity, transform, filter;
+    filter: none;
+    will-change: opacity, transform;
     animation: none;
   }
 
@@ -164,17 +150,37 @@
     --fade-x: 0px;
     --fade-y: 22px;
     --fade-scale: 0.98;
-    --fade-blur: calc(var(--page-fade-blur) * 0.9);
     opacity: 0;
     transform: translate3d(var(--fade-x), var(--fade-y), 0) scale(var(--fade-scale));
-    filter: blur(var(--fade-blur));
-    will-change: opacity, transform, filter;
+    filter: none;
+    will-change: opacity, transform;
     animation: none;
   }
 
   [data-page-fade][data-ready="true"] [data-fade] {
     animation: ue-page-fade-item var(--page-fade-duration) var(--page-fade-easing)
       calc(var(--fade-delay, 120ms) + var(--page-fade-delay)) both;
+  }
+
+  [data-page-fade][data-effect="soft-blur"] {
+    filter: blur(var(--page-fade-blur));
+    will-change: opacity, transform, filter;
+    transition: filter calc(var(--page-fade-duration) * 0.85) var(--page-fade-easing);
+  }
+
+  [data-page-fade][data-effect="soft-blur"][data-ready="true"] {
+    filter: none;
+  }
+
+  [data-page-fade][data-effect="soft-blur"] [data-fade] {
+    --fade-blur: calc(var(--page-fade-blur) * 0.7);
+    filter: blur(var(--fade-blur));
+    will-change: opacity, transform, filter;
+    transition: filter calc(var(--page-fade-duration) * 0.85) var(--page-fade-easing);
+  }
+
+  [data-page-fade][data-effect="soft-blur"][data-ready="true"] [data-fade] {
+    filter: none;
   }
 
   [data-page-fade] [data-fade][data-direction="left"] {


### PR DESCRIPTION
## Summary
- lighten the page fade animations by removing default blur and adding an optional soft blur variant
- update PageFadeIn to support the new animation effect and respect reduced-motion preferences
- add a News page rendering test that exercises a large feed in both light and dark themes

## Testing
- npm --prefix root/frontend run test -- src/pages/__tests__/News.performance.test.tsx
- npm --prefix root/frontend run typecheck

------
https://chatgpt.com/codex/tasks/task_e_690399ef65148327b1930a63102802e0