### PR TITLE
Add cleanup service for stale email change tokens

### DIFF
--- a/root/app/core/config.py
+++ b/root/app/core/config.py
@@ -330,6 +330,8 @@ class Settings(BaseSettings):
     session_cleanup_interval_seconds: int = 900
     password_reset_cleanup_interval_seconds: int = 3_600
     password_reset_cleanup_retention_minutes: int = 45
+    email_change_cleanup_interval_seconds: int = 3_600
+    email_change_cleanup_retention_minutes: int = 45
     password_reset_max_active_tokens: int = 1
     stories_cleanup_enabled: bool = True
     stories_retention_cleanup_interval_seconds: int = 86_400

--- a/root/app/main.py
+++ b/root/app/main.py
@@ -29,6 +29,11 @@ from app.routers.notifications import legacy_router as legacy_push_router
 from app.routers.notifications import router as push_router
 from app.routers.schedule import router as schedule_router
 from app.services import notification_queue, webpush
+from app.services.email_change_cleanup import (
+    EmailChangeCleanupConfig,
+    cleanup_stale_email_change_tokens,
+    start_email_change_cleanup_scheduler,
+)
 from app.services.notifications import (
     cleanup_stale_notifications,
     start_notifications_scheduler,
@@ -36,11 +41,6 @@ from app.services.notifications import (
 from app.services.notifications_retention import (
     NotificationsRetentionConfig,
     start_notifications_retention_scheduler,
-)
-from app.services.email_change_cleanup import (
-    EmailChangeCleanupConfig,
-    cleanup_stale_email_change_tokens,
-    start_email_change_cleanup_scheduler,
 )
 from app.services.password_reset_cleanup import (
     PasswordResetCleanupConfig,

--- a/root/app/main.py
+++ b/root/app/main.py
@@ -37,6 +37,11 @@ from app.services.notifications_retention import (
     NotificationsRetentionConfig,
     start_notifications_retention_scheduler,
 )
+from app.services.email_change_cleanup import (
+    EmailChangeCleanupConfig,
+    cleanup_stale_email_change_tokens,
+    start_email_change_cleanup_scheduler,
+)
 from app.services.password_reset_cleanup import (
     PasswordResetCleanupConfig,
     cleanup_stale_password_reset_tokens,
@@ -72,6 +77,7 @@ async def lifespan(app: FastAPI):
     stop_session_cleanup = None
     stop_story_cleanup = None
     stop_password_reset_cleanup = None
+    stop_email_change_cleanup = None
     if settings.is_development and settings.notifications_scheduler_inline_enabled:
         stop_scheduler = await start_notifications_scheduler(
             poll_seconds=settings.notifications_scheduler_poll_seconds,
@@ -88,6 +94,9 @@ async def lifespan(app: FastAPI):
     await cleanup_expired_stories()
     await cleanup_stale_password_reset_tokens(
         retention_minutes=settings.password_reset_cleanup_retention_minutes
+    )
+    await cleanup_stale_email_change_tokens(
+        retention_minutes=settings.email_change_cleanup_retention_minutes
     )
     if (
         settings.notifications_retention_days > 0
@@ -124,6 +133,13 @@ async def lifespan(app: FastAPI):
                 retention_minutes=settings.password_reset_cleanup_retention_minutes,
             )
         )
+    if settings.email_change_cleanup_interval_seconds > 0:
+        stop_email_change_cleanup = await start_email_change_cleanup_scheduler(
+            config=EmailChangeCleanupConfig(
+                interval_seconds=settings.email_change_cleanup_interval_seconds,
+                retention_minutes=settings.email_change_cleanup_retention_minutes,
+            )
+        )
     if (
         settings.stories_cleanup_enabled
         and settings.stories_retention_cleanup_interval_seconds > 0
@@ -148,6 +164,8 @@ async def lifespan(app: FastAPI):
             await stop_story_cleanup()
         if stop_password_reset_cleanup is not None:
             await stop_password_reset_cleanup()
+        if stop_email_change_cleanup is not None:
+            await stop_email_change_cleanup()
         await notification_queue.shutdown_notification_queue()
         webpush.cleanup()
         await shutdown_cache()

--- a/root/app/services/email_change_cleanup.py
+++ b/root/app/services/email_change_cleanup.py
@@ -1,0 +1,138 @@
+"""Cleanup helpers for email change tokens."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from contextlib import suppress
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Awaitable, Callable
+
+from sqlalchemy import delete, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import async_session
+from app.core.observability import get_periodic_task_metrics
+from app.models.models import EmailChangeToken
+from app.utils.email import RESET_TOKEN_EXPIRY_MINUTES
+
+logger = logging.getLogger(__name__)
+
+
+_METRICS = get_periodic_task_metrics("email_change_cleanup")
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _normalize_retention_minutes(value: int | None) -> int:
+    if value is None:
+        return RESET_TOKEN_EXPIRY_MINUTES
+    return max(0, int(value))
+
+
+async def cleanup_stale_email_change_tokens(
+    *,
+    db: AsyncSession | None = None,
+    now: datetime | None = None,
+    retention_minutes: int | None = None,
+) -> int:
+    """Delete or deactivate stale email change tokens."""
+
+    owns_session = db is None
+    if now is None:
+        now = _now()
+    retention = _normalize_retention_minutes(retention_minutes)
+    cutoff = now - timedelta(minutes=retention)
+
+    if owns_session:
+        async with async_session() as session:
+            return await cleanup_stale_email_change_tokens(
+                db=session, now=now, retention_minutes=retention
+            )
+
+    removed = await db.execute(
+        delete(EmailChangeToken).where(EmailChangeToken.created_at <= cutoff)
+    )
+    marked = await db.execute(
+        update(EmailChangeToken)
+        .where(
+            EmailChangeToken.used.is_(False),
+            EmailChangeToken.expires_at <= now,
+            EmailChangeToken.created_at > cutoff,
+        )
+        .values(used=True)
+    )
+    await db.commit()
+
+    updated_count = int(marked.rowcount or 0)
+    removed_count = int(removed.rowcount or 0)
+    total = updated_count + removed_count
+    if total:
+        logger.info(
+            "Cleaned %s email change tokens (marked=%s, removed=%s)",
+            total,
+            updated_count,
+            removed_count,
+        )
+    return total
+
+
+@dataclass(slots=True)
+class EmailChangeCleanupConfig:
+    interval_seconds: int = 3_600
+    retention_minutes: int | None = None
+
+    def normalized_interval(self) -> int:
+        return max(30, int(self.interval_seconds))
+
+    def normalized_retention_minutes(self) -> int:
+        return _normalize_retention_minutes(self.retention_minutes)
+
+
+async def start_email_change_cleanup_scheduler(
+    *, config: EmailChangeCleanupConfig | None = None
+) -> Callable[[], Awaitable[None]]:
+    """Start a background task that cleans up stale email change tokens."""
+
+    cfg = config or EmailChangeCleanupConfig()
+    interval = cfg.normalized_interval()
+    retention = cfg.normalized_retention_minutes()
+
+    async def _loop() -> None:
+        try:
+            while True:
+                try:
+                    async with _METRICS.track_execution() as run:
+                        cleaned = await cleanup_stale_email_change_tokens(
+                            retention_minutes=retention
+                        )
+                        run.observe_deleted(cleaned)
+                except asyncio.CancelledError:
+                    raise
+                except Exception:  # pragma: no cover - defensive logging
+                    logger.exception("Failed to cleanup email change tokens")
+                await asyncio.sleep(interval)
+        except asyncio.CancelledError:
+            logger.info("Email change cleanup loop cancelled")
+            raise
+
+    loop = asyncio.get_running_loop()
+    task = loop.create_task(_loop())
+
+    async def _stop() -> None:
+        if task.done():
+            with suppress(Exception):
+                task.result()
+            return
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+
+    return _stop
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience entrypoint
+    asyncio.run(cleanup_stale_email_change_tokens())

--- a/root/tests/test_email_change_cleanup.py
+++ b/root/tests/test_email_change_cleanup.py
@@ -1,0 +1,132 @@
+import asyncio
+import datetime as dt
+
+import pytest
+from sqlalchemy import select
+
+from app.models.models import EmailChangeToken, User
+from app.services import email_change_cleanup
+from app.services.email_change_cleanup import (
+    EmailChangeCleanupConfig,
+    cleanup_stale_email_change_tokens,
+    start_email_change_cleanup_scheduler,
+)
+from app.utils.email import RESET_TOKEN_EXPIRY_MINUTES
+
+
+@pytest.mark.asyncio
+async def test_cleanup_stale_email_change_tokens_respects_retention(db_session):
+    now = dt.datetime.now(dt.UTC)
+
+    user = User(email="email-cleanup@example.com", hashed_password="x")
+    db_session.add(user)
+    await db_session.flush()
+
+    expired_recent = EmailChangeToken(
+        user_id=user.id,
+        new_email="expired@example.com",
+        token_hash="expired",
+        expires_at=now - dt.timedelta(minutes=1),
+        used=False,
+        created_at=now - dt.timedelta(minutes=20),
+    )
+    very_old_unused = EmailChangeToken(
+        user_id=user.id,
+        new_email="very-old@example.com",
+        token_hash="very-old",
+        expires_at=now + dt.timedelta(minutes=10),
+        used=False,
+        created_at=now - dt.timedelta(minutes=40),
+    )
+    old_used = EmailChangeToken(
+        user_id=user.id,
+        new_email="old-used@example.com",
+        token_hash="old-used",
+        expires_at=now + dt.timedelta(minutes=5),
+        used=True,
+        created_at=now - dt.timedelta(minutes=35),
+    )
+    recent_active = EmailChangeToken(
+        user_id=user.id,
+        new_email="recent@example.com",
+        token_hash="recent",
+        expires_at=now + dt.timedelta(minutes=30),
+        used=False,
+        created_at=now - dt.timedelta(minutes=5),
+    )
+
+    db_session.add_all([expired_recent, very_old_unused, old_used, recent_active])
+    await db_session.commit()
+
+    cleaned = await cleanup_stale_email_change_tokens(now=now, retention_minutes=30)
+    assert cleaned == 3
+
+    db_session.expire_all()
+    remaining = await db_session.execute(select(EmailChangeToken).order_by(EmailChangeToken.id))
+    tokens = remaining.scalars().all()
+    assert {token.token_hash for token in tokens} == {"expired", "recent"}
+
+    expired_record = next(token for token in tokens if token.token_hash == "expired")
+    assert expired_record.used is True
+
+    recent_record = next(token for token in tokens if token.token_hash == "recent")
+    assert recent_record.used is False
+
+
+@pytest.mark.asyncio
+async def test_cleanup_stale_email_change_tokens_default_retention(db_session):
+    now = dt.datetime.now(dt.UTC)
+
+    user = User(email="email-cleanup-default@example.com", hashed_password="x")
+    db_session.add(user)
+    await db_session.flush()
+
+    stale = EmailChangeToken(
+        user_id=user.id,
+        new_email="stale@example.com",
+        token_hash="stale",
+        expires_at=now - dt.timedelta(minutes=RESET_TOKEN_EXPIRY_MINUTES + 1),
+        used=False,
+        created_at=now - dt.timedelta(minutes=RESET_TOKEN_EXPIRY_MINUTES + 1),
+    )
+    db_session.add(stale)
+    await db_session.commit()
+
+    cleaned = await cleanup_stale_email_change_tokens(now=now)
+    assert cleaned == 1
+
+    db_session.expire_all()
+    remaining = await db_session.execute(select(EmailChangeToken.token_hash))
+    assert list(remaining) == []
+
+
+@pytest.mark.asyncio
+async def test_start_email_change_cleanup_scheduler(monkeypatch):
+    calls: list[int] = []
+    event = asyncio.Event()
+
+    async def fake_cleanup(*, retention_minutes: int, **_: object) -> int:
+        calls.append(retention_minutes)
+        event.set()
+        return 0
+
+    monkeypatch.setattr(
+        email_change_cleanup, "cleanup_stale_email_change_tokens", fake_cleanup
+    )
+
+    real_asyncio_sleep = asyncio.sleep
+
+    async def fast_sleep(_: float) -> None:
+        await real_asyncio_sleep(0)
+
+    monkeypatch.setattr(email_change_cleanup.asyncio, "sleep", fast_sleep)
+
+    config = EmailChangeCleanupConfig(
+        interval_seconds=1, retention_minutes=RESET_TOKEN_EXPIRY_MINUTES
+    )
+    stop = await start_email_change_cleanup_scheduler(config=config)
+    await asyncio.wait_for(event.wait(), timeout=0.1)
+    await stop()
+
+    assert calls
+    assert calls[0] == config.normalized_retention_minutes()

--- a/root/tests/test_email_change_cleanup.py
+++ b/root/tests/test_email_change_cleanup.py
@@ -62,7 +62,9 @@ async def test_cleanup_stale_email_change_tokens_respects_retention(db_session):
     assert cleaned == 3
 
     db_session.expire_all()
-    remaining = await db_session.execute(select(EmailChangeToken).order_by(EmailChangeToken.id))
+    remaining = await db_session.execute(
+        select(EmailChangeToken).order_by(EmailChangeToken.id)
+    )
     tokens = remaining.scalars().all()
     assert {token.token_hash for token in tokens} == {"expired", "recent"}
 


### PR DESCRIPTION
## Summary
- add a background service to remove or expire stale email change tokens
- expose configuration for the cleanup interval and retention window and wire it into the application lifespan
- cover email change token retention with dedicated tests

## Testing
- pytest tests/test_email_change_cleanup.py tests/test_user_profile_update.py

------
https://chatgpt.com/codex/tasks/task_e_6903c4d05cf08327b3f54575c750fbcf