### PR TITLE
Refactor events data fetching into query hooks

### DIFF
--- a/root/alembic/versions/202509010001_merge_push_topics_and_email_heads.py
+++ b/root/alembic/versions/202509010001_merge_push_topics_and_email_heads.py
@@ -1,0 +1,19 @@
+"""Merge push topic preferences and email normalization heads."""
+
+from __future__ import annotations
+
+# revision identifiers, used by Alembic.
+revision: str = "202509010001"
+down_revision: tuple[str, str] | None = ("202506250001", "202507310004")
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:  # noqa: D401 - Alembic migration hook.
+    """Consolidate the divergent migration branches."""
+
+
+
+def downgrade() -> None:  # noqa: D401 - Alembic migration hook.
+    """No downgrade steps for merge migration."""
+

--- a/root/alembic/versions/202509010001_merge_push_topics_and_email_heads.py
+++ b/root/alembic/versions/202509010001_merge_push_topics_and_email_heads.py
@@ -13,7 +13,5 @@ def upgrade() -> None:  # noqa: D401 - Alembic migration hook.
     """Consolidate the divergent migration branches."""
 
 
-
 def downgrade() -> None:  # noqa: D401 - Alembic migration hook.
     """No downgrade steps for merge migration."""
-

--- a/root/app/routers/notifications.py
+++ b/root/app/routers/notifications.py
@@ -264,9 +264,7 @@ def _aggregate_results(
     )
 
 
-async def _refresh_user_topic_preferences(
-    db: AsyncSession, *, user_id: int
-) -> None:
+async def _refresh_user_topic_preferences(db: AsyncSession, *, user_id: int) -> None:
     """Synchronize stored user topic preferences with subscription data."""
 
     topics_rows = (
@@ -284,9 +282,7 @@ async def _refresh_user_topic_preferences(
             aggregated.append(str(row))
     normalized = sort_topics(aggregated, settings_obj=settings)
     record = (
-        await db.execute(
-            select(UserPushTopic).where(UserPushTopic.user_id == user_id)
-        )
+        await db.execute(select(UserPushTopic).where(UserPushTopic.user_id == user_id))
     ).scalar_one_or_none()
     if normalized:
         topics_copy = list(normalized)

--- a/root/app/routers/notifications.py
+++ b/root/app/routers/notifications.py
@@ -264,6 +264,40 @@ def _aggregate_results(
     )
 
 
+async def _refresh_user_topic_preferences(
+    db: AsyncSession, *, user_id: int
+) -> None:
+    """Synchronize stored user topic preferences with subscription data."""
+
+    topics_rows = (
+        await db.execute(
+            select(PushSubscription.topics).where(PushSubscription.user_id == user_id)
+        )
+    ).scalars()
+    aggregated: list[str] = []
+    for row in topics_rows:
+        if not row:
+            continue
+        if isinstance(row, (list, tuple, set)):
+            aggregated.extend(str(item) for item in row if item)
+        else:
+            aggregated.append(str(row))
+    normalized = sort_topics(aggregated, settings_obj=settings)
+    record = (
+        await db.execute(
+            select(UserPushTopic).where(UserPushTopic.user_id == user_id)
+        )
+    ).scalar_one_or_none()
+    if normalized:
+        topics_copy = list(normalized)
+        if record is None:
+            db.add(UserPushTopic(user_id=user_id, topics=topics_copy))
+        else:
+            record.topics = topics_copy
+    elif record is not None:
+        await db.delete(record)
+
+
 async def _validate_subscription_payload(
     data: PushSubscriptionIn,
     *,
@@ -377,6 +411,10 @@ async def subscribe(
 
     now = datetime.now(UTC)
     try:
+        normalized_topics = resolve_topics(
+            payload.topics, existing.topics if existing else None
+        )
+        topics_copy = list(normalized_topics)
         if existing:
             if existing.user_id != user.id:
                 raise HTTPException(
@@ -388,12 +426,6 @@ async def subscribe(
                         ),
                     },
                 )
-            resolved_topics = resolve_topics(payload.topics, existing.topics)
-            normalized_topics = await synchronize_user_topics(
-                db,
-                user_id=user.id,
-                topics=resolved_topics,
-            )
             existing.p256dh = p256dh
             existing.auth = auth
             existing.user_id = user.id
@@ -401,17 +433,9 @@ async def subscribe(
             existing.last_seen_at = now
             if existing.created_at is None:
                 existing.created_at = now
-            existing.topics = list(normalized_topics)
-            await db.commit()
-            await db.refresh(existing)
+            existing.topics = topics_copy
             subscription = existing
         else:
-            resolved_topics = resolve_topics(payload.topics, None)
-            normalized_topics = await synchronize_user_topics(
-                db,
-                user_id=user.id,
-                topics=resolved_topics,
-            )
             subscription = PushSubscription(
                 endpoint=endpoint,
                 p256dh=p256dh,
@@ -419,13 +443,14 @@ async def subscribe(
                 user_id=user.id,
                 user_agent=user_agent or None,
                 last_seen_at=now,
-                topics=list(normalized_topics),
+                created_at=now,
+                topics=topics_copy,
             )
-            if subscription.created_at is None:
-                subscription.created_at = now
             db.add(subscription)
-            await db.commit()
-            await db.refresh(subscription)
+        await db.flush()
+        await _refresh_user_topic_preferences(db, user_id=user.id)
+        await db.commit()
+        await db.refresh(subscription)
     except IntegrityError:
         await db.rollback()
         raise HTTPException(
@@ -554,6 +579,8 @@ async def unsubscribe(
         return {"ok": True, "removed": False}
 
     await db.delete(existing)
+    await db.flush()
+    await _refresh_user_topic_preferences(db, user_id=user.id)
     await db.commit()
     return {"ok": True, "removed": True}
 

--- a/root/app/services/notifications.py
+++ b/root/app/services/notifications.py
@@ -553,7 +553,11 @@ async def create_notifications_for_users(
             (
                 await db.execute(
                     select(PushSubscription)
-                    .options(selectinload(PushSubscription.user))
+                    .options(
+                        selectinload(PushSubscription.user).selectinload(
+                            User.push_topic_preferences
+                        )
+                    )
                     .where(PushSubscription.user_id.in_(uids))
                 )
             )

--- a/root/app/services/push_topics.py
+++ b/root/app/services/push_topics.py
@@ -6,6 +6,7 @@ from collections.abc import Collection, Iterable, Sequence
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import attributes as orm_attributes
 
 from app.core.config import Settings
 from app.core.config import settings as app_settings
@@ -146,14 +147,22 @@ def subscription_supports_topic(
         return False
 
     user = getattr(subscription, "user", None)
-    preferences = getattr(user, "push_topic_preferences", None)
+    preferences = None
+    if user is not None:
+        try:
+            state = orm_attributes.instance_state(user)
+            if "push_topic_preferences" not in state.unloaded:
+                preferences = getattr(user, "push_topic_preferences", None)
+        except Exception:  # pragma: no cover - defensive guard
+            preferences = getattr(user, "push_topic_preferences", None)
+    allowed_by_user = True
     if preferences is not None:
         user_topics = normalize_topics(
             getattr(preferences, "topics", None),
             allowed_topics=allowed_topics,
             settings_obj=settings_obj,
         )
-        return normalized_topic in user_topics
+        allowed_by_user = normalized_topic in user_topics
 
     stored = getattr(subscription, "topics", None)
     normalized_existing = normalize_topics(
@@ -161,7 +170,9 @@ def subscription_supports_topic(
         allowed_topics=allowed_topics,
         settings_obj=settings_obj,
     )
-    return normalized_topic in normalized_existing
+    if normalized_existing:
+        return allowed_by_user and (normalized_topic in normalized_existing)
+    return allowed_by_user
 
 
 async def upsert_user_topics(

--- a/root/app/services/webpush.py
+++ b/root/app/services/webpush.py
@@ -22,7 +22,7 @@ from app.core.config import settings
 from app.core.database import async_session
 from app.core.rate_limit import RateLimitExceeded, RateLimitInfo, enforce_rate_limit
 from app.localization import resolve_locale, translate
-from app.models.models import PushSubscription
+from app.models.models import PushSubscription, User
 from app.services import push_schema
 from app.services.notification_templates import render_notification_template
 from app.services.push_topics import normalize_topic, subscription_supports_topic
@@ -705,7 +705,11 @@ async def send_to_user(
     async with async_session() as session:
         result = await session.execute(
             select(PushSubscription)
-            .options(selectinload(PushSubscription.user))
+            .options(
+                selectinload(PushSubscription.user).selectinload(
+                    User.push_topic_preferences
+                )
+            )
             .where(PushSubscription.user_id == user_id)
         )
         subscriptions = result.scalars().all()

--- a/root/frontend/src/api/__tests__/client.etag.test.ts
+++ b/root/frontend/src/api/__tests__/client.etag.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it } from "vitest"
+import { http, HttpResponse } from "msw"
+
+import api, { resetEtagCache } from "@/api/client"
+import { server } from "@/tests/mocks/server"
+
+describe("API ETag interceptor", () => {
+  beforeEach(() => {
+    resetEtagCache()
+  })
+
+  it("reuses cached ETags for subsequent requests when an etagCacheKey is provided", async () => {
+    const observedIfNoneMatch: Array<string | null> = []
+    let requestCount = 0
+
+    server.use(
+      http.get("*/events", ({ request }) => {
+        requestCount += 1
+        observedIfNoneMatch.push(request.headers.get("if-none-match"))
+
+        if (requestCount === 1) {
+          return HttpResponse.json(
+            {
+              items: [],
+              total: 0,
+              limit: 12,
+              cursor: null,
+              next_cursor: null,
+              has_more: false,
+            },
+            { headers: { ETag: '"etag-123"' } }
+          )
+        }
+
+        if (request.headers.get("if-none-match") === '"etag-123"') {
+          return new HttpResponse(null, { status: 304, headers: { ETag: '"etag-123"' } })
+        }
+
+        return HttpResponse.json({
+          items: [],
+          total: 0,
+          limit: 12,
+          cursor: null,
+          next_cursor: null,
+          has_more: false,
+        })
+      })
+    )
+
+    const config = {
+      etagCacheKey: "events:test",
+      validateStatus: (status: number) => status >= 200 && status < 400,
+    } as const
+
+    const firstResponse = await api.get("/events", config)
+    expect(firstResponse.status).toBe(200)
+
+    const secondResponse = await api.get("/events", config)
+    expect(secondResponse.status).toBe(304)
+
+    expect(observedIfNoneMatch).toEqual([null, '"etag-123"'])
+  })
+})

--- a/root/frontend/src/api/client.ts
+++ b/root/frontend/src/api/client.ts
@@ -28,6 +28,12 @@ export type ApiRequestConfig<D = unknown> = AxiosRequestConfig<D> & {
    * slot and should release it once finished.
    */
   __clientRateLimitAcquired?: boolean
+  /**
+   * Unique cache key used by the Axios ETag interceptor to persist the last
+   * received tag and automatically revalidate subsequent requests with
+   * `If-None-Match`.
+   */
+  etagCacheKey?: string
 }
 
 type ApiInstance = Omit<AxiosInstance, "get" | "delete" | "post" | "patch" | "put"> & {
@@ -103,6 +109,10 @@ const clientQueueWaiters: Array<() => void> = []
 const clientQueueTimestamps: number[] = []
 let clientQueueTimer: ReturnType<typeof setTimeout> | null = null
 let clientQueueResetAt = 0
+
+const etagCache = new Map<string, string>()
+
+export const resetEtagCache = () => etagCache.clear()
 
 const pruneClientQueueTimestamps = () => {
   const threshold = Date.now() - RATE_LIMIT_WINDOW_MS
@@ -362,6 +372,14 @@ api.interceptors.request.use(async (config) => {
     headers.set(acceptLanguageHeader, headerValue)
   }
 
+  const etagKey = candidate.etagCacheKey
+  if (etagKey && !headers.has("if-none-match")) {
+    const cachedTag = etagCache.get(etagKey)
+    if (cachedTag) {
+      headers.set("If-None-Match", cachedTag)
+    }
+  }
+
   config.headers = headers
 
   return config
@@ -369,23 +387,40 @@ api.interceptors.request.use(async (config) => {
 
 api.interceptors.response.use(
   (r) => {
+    const config = r.config as ApiRequestConfig | undefined
+    const etagKey = config?.etagCacheKey
+    if (etagKey) {
+      const responseHeaders = AxiosHeaders.from(r.headers ?? {})
+      const tag = responseHeaders.get("etag") ?? responseHeaders.get("ETag")
+      if (typeof tag === "string" && tag.trim()) {
+        etagCache.set(etagKey, tag)
+      } else {
+        etagCache.delete(etagKey)
+      }
+    }
     releaseClientQueueSlot(r.config as ApiRequestConfig | undefined)
     return r
   },
   async (err) => {
     releaseClientQueueSlot(err?.config as ApiRequestConfig | undefined)
 
+    const config = err?.config as ApiRequestConfig | undefined
+    const etagKey = config?.etagCacheKey
+    if (etagKey && err?.response?.status && err.response.status >= 400 && err.response.status !== 304) {
+      etagCache.delete(etagKey)
+    }
+
     if (err?.response?.status === 429 && err.config) {
-      const config = err.config as ApiRequestConfig
-      if (!config.skipRateLimitQueue) {
+      const retryConfig = err.config as ApiRequestConfig
+      if (!retryConfig.skipRateLimitQueue) {
         const delay = getRetryDelay(err.response?.headers)
         scheduleRateLimitWindow(delay)
 
-        const retryCount = config.__rateLimitRetryCount ?? 0
-        if (retryCount < RATE_LIMIT_MAX_RETRY && !config.signal?.aborted && !isAbortError(err)) {
-          config.__rateLimitRetryCount = retryCount + 1
+        const retryCount = retryConfig.__rateLimitRetryCount ?? 0
+        if (retryCount < RATE_LIMIT_MAX_RETRY && !retryConfig.signal?.aborted && !isAbortError(err)) {
+          retryConfig.__rateLimitRetryCount = retryCount + 1
           await waitForRateLimitWindow()
-          return api.request(config)
+          return api.request(retryConfig)
         }
       }
     }

--- a/root/frontend/src/api/client.ts
+++ b/root/frontend/src/api/client.ts
@@ -406,7 +406,12 @@ api.interceptors.response.use(
 
     const config = err?.config as ApiRequestConfig | undefined
     const etagKey = config?.etagCacheKey
-    if (etagKey && err?.response?.status && err.response.status >= 400 && err.response.status !== 304) {
+    if (
+      etagKey &&
+      err?.response?.status &&
+      err.response.status >= 400 &&
+      err.response.status !== 304
+    ) {
       etagCache.delete(etagKey)
     }
 
@@ -417,7 +422,11 @@ api.interceptors.response.use(
         scheduleRateLimitWindow(delay)
 
         const retryCount = retryConfig.__rateLimitRetryCount ?? 0
-        if (retryCount < RATE_LIMIT_MAX_RETRY && !retryConfig.signal?.aborted && !isAbortError(err)) {
+        if (
+          retryCount < RATE_LIMIT_MAX_RETRY &&
+          !retryConfig.signal?.aborted &&
+          !isAbortError(err)
+        ) {
           retryConfig.__rateLimitRetryCount = retryCount + 1
           await waitForRateLimitWindow()
           return api.request(retryConfig)

--- a/root/frontend/src/api/client.ts
+++ b/root/frontend/src/api/client.ts
@@ -390,7 +390,9 @@ api.interceptors.response.use(
     const config = r.config as ApiRequestConfig | undefined
     const etagKey = config?.etagCacheKey
     if (etagKey) {
-      const responseHeaders = AxiosHeaders.from(r.headers ?? {})
+      const responseHeaders = AxiosHeaders.from(
+        (r.headers ?? undefined) as AxiosHeaders | string | undefined
+      )
       const tag = responseHeaders.get("etag") ?? responseHeaders.get("ETag")
       if (typeof tag === "string" && tag.trim()) {
         etagCache.set(etagKey, tag)

--- a/root/frontend/src/api/generated/schema.ts
+++ b/root/frontend/src/api/generated/schema.ts
@@ -709,23 +709,6 @@ export interface paths {
     patch?: never
     trace?: never
   }
-  "/push/admin/disable-user": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Disable User Push */
-    post: operations["disable_user_push_push_admin_disable_user_post"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
   "/push/admin/topics/{user_id}": {
     parameters: {
       query?: never
@@ -740,6 +723,23 @@ export interface paths {
     /** Admin Update User Topics */
     put: operations["admin_update_user_topics_push_admin_topics__user_id__put"]
     post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/push/admin/disable-user": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Disable User Push */
+    post: operations["disable_user_push_push_admin_disable_user_post"]
     delete?: never
     options?: never
     head?: never
@@ -2289,13 +2289,6 @@ export interface components {
        */
       user_id?: number | null
     }
-    /** ResetPasswordIn */
-    ResetPasswordIn: {
-      /** Token */
-      token: string
-      /** Password */
-      password: string
-    }
     /** PushTopicsResponse */
     PushTopicsResponse: {
       /** Allowed */
@@ -2309,6 +2302,13 @@ export interface components {
       has_preferences: boolean
       /** Updated At */
       updated_at?: string | null
+    }
+    /** ResetPasswordIn */
+    ResetPasswordIn: {
+      /** Token */
+      token: string
+      /** Password */
+      password: string
     }
     /** ScheduleCreate */
     ScheduleCreate: {

--- a/root/frontend/src/api/generated/schema.ts
+++ b/root/frontend/src/api/generated/schema.ts
@@ -675,6 +675,23 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  "/push/topics": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** Get Push Topics */
+    get: operations["get_push_topics_push_topics_get"]
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   "/push/test": {
     parameters: {
       query?: never
@@ -703,6 +720,26 @@ export interface paths {
     put?: never
     /** Disable User Push */
     post: operations["disable_user_push_push_admin_disable_user_post"]
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/push/admin/topics/{user_id}": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: {
+        user_id: number
+      }
+      cookie?: never
+    }
+    /** Admin Get User Topics */
+    get: operations["admin_get_user_topics_push_admin_topics__user_id__get"]
+    /** Admin Update User Topics */
+    put: operations["admin_update_user_topics_push_admin_topics__user_id__put"]
+    post?: never
     delete?: never
     options?: never
     head?: never
@@ -1487,6 +1524,24 @@ export interface components {
        */
       is_current: boolean
     }
+    /** AdminUserTopicsResponse */
+    AdminUserTopicsResponse: {
+      /** User Id */
+      user_id: number
+      /** Email */
+      email: string
+      /** Topics */
+      topics: string[]
+      /** Allowed Topics */
+      allowed_topics: string[]
+      /** Updated At */
+      updated_at?: string | null
+    }
+    /** AdminUserTopicsUpdate */
+    AdminUserTopicsUpdate: {
+      /** Topics */
+      topics?: string[]
+    }
     /** Body_login_auth_login_post */
     Body_login_auth_login_post: {
       /** Grant Type */
@@ -2240,6 +2295,20 @@ export interface components {
       token: string
       /** Password */
       password: string
+    }
+    /** PushTopicsResponse */
+    PushTopicsResponse: {
+      /** Allowed */
+      allowed: string[]
+      /** Topics */
+      topics: string[]
+      /**
+       * Has Preferences
+       * @default false
+       */
+      has_preferences: boolean
+      /** Updated At */
+      updated_at?: string | null
     }
     /** ScheduleCreate */
     ScheduleCreate: {
@@ -3897,6 +3966,26 @@ export interface operations {
       }
     }
   }
+  get_push_topics_push_topics_get: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["PushTopicsResponse"]
+        }
+      }
+    }
+  }
   send_test_push_test_post: {
     parameters: {
       query?: never
@@ -3917,6 +4006,72 @@ export interface operations {
         }
         content: {
           "application/json": components["schemas"]["SendTestResponse"]
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  admin_get_user_topics_push_admin_topics__user_id__get: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        user_id: number
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["AdminUserTopicsResponse"]
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  admin_update_user_topics_push_admin_topics__user_id__put: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        user_id: number
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["AdminUserTopicsUpdate"]
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["AdminUserTopicsResponse"]
         }
       }
       /** @description Validation Error */

--- a/root/frontend/src/api/generated/schema.ts
+++ b/root/frontend/src/api/generated/schema.ts
@@ -713,9 +713,7 @@ export interface paths {
     parameters: {
       query?: never
       header?: never
-      path?: {
-        user_id: number
-      }
+      path?: never
       cookie?: never
     }
     /** Admin Get User Topics */

--- a/root/frontend/src/api/hooks/events.ts
+++ b/root/frontend/src/api/hooks/events.ts
@@ -1,0 +1,294 @@
+import {
+  useInfiniteQuery,
+  useQuery,
+  useQueryClient,
+  type InfiniteData,
+  type UseInfiniteQueryOptions,
+  type UseInfiniteQueryResult,
+  type UseQueryOptions,
+  type UseQueryResult,
+} from "@tanstack/react-query"
+import { useMemo } from "react"
+
+import api, { type ApiRequestConfig } from "../client"
+import type { Event } from "@/types/Event"
+import type { PaginatedResponse } from "@/types/Pagination"
+
+export const EVENTS_PAGE_SIZE = 12
+
+export type EventsListFilters = {
+  language: string
+  is_active?: boolean | null
+  search?: string
+  type?: string
+  location?: string
+  limit?: number
+}
+
+type NormalizedEventsListFilters = {
+  language: string
+  is_active: boolean | null
+  search: string
+  type: string
+  location: string
+  limit: number
+}
+
+const normalizeEventsListFilters = (filters: EventsListFilters): NormalizedEventsListFilters => {
+  const normalizeBoolean = (value: boolean | null | undefined) =>
+    typeof value === "boolean" ? value : null
+
+  const normalizeLimit = (value: number | undefined) => {
+    if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+      return Math.floor(value)
+    }
+    return EVENTS_PAGE_SIZE
+  }
+
+  return {
+    language: filters.language,
+    is_active: normalizeBoolean(filters.is_active ?? null),
+    search: filters.search?.trim() ?? "",
+    type: filters.type?.trim() ?? "",
+    location: filters.location?.trim() ?? "",
+    limit: normalizeLimit(filters.limit),
+  }
+}
+
+type EventsListQueryKeyTuple = readonly ["events", "list", NormalizedEventsListFilters]
+
+export type EventsListQueryKey = EventsListQueryKeyTuple
+
+const createEventsListEtagKey = (filters: NormalizedEventsListFilters) => {
+  const activity =
+    filters.is_active === null ? "all" : filters.is_active ? "active" : "archive"
+  return [
+    "events",
+    "list",
+    filters.language,
+    activity,
+    filters.search,
+    filters.type,
+    filters.location,
+    filters.limit,
+  ].join(":")
+}
+
+export const eventsListQueryKey = (filters: EventsListFilters) => {
+  const normalized = normalizeEventsListFilters(filters)
+  return ["events", "list", normalized] as EventsListQueryKey
+}
+
+const ensurePaginatedResponse = (
+  payload: PaginatedResponse<Event> | null | undefined,
+  fallbackLimit: number
+): PaginatedResponse<Event> => {
+  if (!payload) {
+    return {
+      items: [],
+      total: 0,
+      limit: fallbackLimit,
+      cursor: null,
+      next_cursor: null,
+      has_more: false,
+    }
+  }
+
+  const items = Array.isArray(payload.items) ? payload.items : []
+  const total = typeof payload.total === "number" ? payload.total : items.length
+  const limit = typeof payload.limit === "number" ? payload.limit : fallbackLimit
+
+  return {
+    items,
+    total,
+    limit,
+    cursor: payload.cursor ?? null,
+    next_cursor: payload.next_cursor ?? null,
+    has_more: Boolean(payload.has_more),
+  }
+}
+
+const mergeEventPages = (pages: PaginatedResponse<Event>[] | undefined): Event[] => {
+  if (!pages?.length) {
+    return []
+  }
+
+  const positions = new Map<number, number>()
+  const merged: Event[] = []
+
+  for (const page of pages) {
+    for (const item of page.items) {
+      const existingIndex = positions.get(item.id)
+      if (existingIndex != null) {
+        merged[existingIndex] = item
+      } else {
+        positions.set(item.id, merged.length)
+        merged.push(item)
+      }
+    }
+  }
+
+  return merged
+}
+
+type UseEventsListQueryOptions = Omit<
+  UseInfiniteQueryOptions<
+    PaginatedResponse<Event>,
+    Error,
+    PaginatedResponse<Event>,
+    PaginatedResponse<Event>,
+    EventsListQueryKey
+  >,
+  "queryKey" | "queryFn" | "initialPageParam" | "getNextPageParam"
+>
+
+export type UseEventsListQueryResult = UseInfiniteQueryResult<
+  PaginatedResponse<Event>,
+  Error
+> & {
+  events: Event[]
+  pagination: PaginatedResponse<Event> | null
+  queryKey: EventsListQueryKey
+}
+
+export const useEventsListQuery = (
+  filters: EventsListFilters,
+  options?: UseEventsListQueryOptions
+): UseEventsListQueryResult => {
+  const queryClient = useQueryClient()
+  const normalized = normalizeEventsListFilters(filters)
+  const queryKey: EventsListQueryKey = ["events", "list", normalized]
+  const { enabled = true, ...rest } = options ?? {}
+
+  const query = useInfiniteQuery<
+    PaginatedResponse<Event>,
+    Error,
+    PaginatedResponse<Event>,
+    EventsListQueryKey
+  >({
+    queryKey,
+    enabled,
+    initialPageParam: null,
+    getNextPageParam: (lastPage) => lastPage?.next_cursor ?? null,
+    queryFn: async ({ pageParam, signal }) => {
+      const etagKey = pageParam == null ? createEventsListEtagKey(normalized) : undefined
+      const params: Record<string, unknown> = {
+        limit: normalized.limit,
+        search: normalized.search,
+        type: normalized.type,
+        location: normalized.location,
+      }
+      if (normalized.is_active !== null) {
+        params.is_active = normalized.is_active
+      }
+      if (pageParam != null) {
+        params.cursor = pageParam
+      }
+
+      const requestConfig: ApiRequestConfig = {
+        params,
+        signal,
+        validateStatus: (status) => status >= 200 && status < 400,
+      }
+      if (etagKey) {
+        requestConfig.etagCacheKey = etagKey
+      }
+
+      const response = await api.get<PaginatedResponse<Event>>("/events", requestConfig)
+
+      if (response.status === 304) {
+        const cached = queryClient.getQueryData<
+          InfiniteData<PaginatedResponse<Event>>
+        >(queryKey)
+        return ensurePaginatedResponse(cached?.pages?.[0], normalized.limit)
+      }
+
+      return ensurePaginatedResponse(response.data, normalized.limit)
+    },
+    ...rest,
+  })
+
+  const events = useMemo(() => mergeEventPages(query.data?.pages), [query.data])
+  const pagination = query.data?.pages?.[query.data.pages.length - 1] ?? null
+
+  return {
+    ...query,
+    events,
+    pagination,
+    queryKey,
+  }
+}
+
+export type MyEventsQueryParams = {
+  language: string
+  userId?: number | string | null
+}
+
+type NormalizedMyEventsParams = {
+  language: string
+  userId: number | string | null
+}
+
+const normalizeMyEventsParams = (params: MyEventsQueryParams): NormalizedMyEventsParams => ({
+  language: params.language,
+  userId: params.userId ?? null,
+})
+
+type MyEventsQueryKeyTuple = readonly ["events", "my", NormalizedMyEventsParams]
+
+export type MyEventsQueryKey = MyEventsQueryKeyTuple
+
+const createMyEventsEtagKey = (params: NormalizedMyEventsParams) =>
+  ["events", "my", params.language, params.userId ?? "anon"].join(":")
+
+export const myEventsQueryKey = (params: MyEventsQueryParams) => {
+  const normalized = normalizeMyEventsParams(params)
+  return ["events", "my", normalized] as MyEventsQueryKey
+}
+
+type UseMyEventsQueryOptions = Omit<
+  UseQueryOptions<Event[], Error, Event[], MyEventsQueryKey>,
+  "queryKey" | "queryFn"
+>
+
+export type UseMyEventsQueryResult = UseQueryResult<Event[], Error> & {
+  queryKey: MyEventsQueryKey
+}
+
+export const useMyEventsQuery = (
+  params: MyEventsQueryParams,
+  options?: UseMyEventsQueryOptions
+): UseMyEventsQueryResult => {
+  const queryClient = useQueryClient()
+  const normalized = normalizeMyEventsParams(params)
+  const queryKey: MyEventsQueryKey = ["events", "my", normalized]
+  const { enabled = true, ...rest } = options ?? {}
+  const effectiveEnabled = enabled && normalized.userId != null
+
+  const query = useQuery<Event[], Error, Event[], MyEventsQueryKey>({
+    queryKey,
+    enabled: effectiveEnabled,
+    queryFn: async ({ signal }) => {
+      const etagKey = createMyEventsEtagKey(normalized)
+      const config: ApiRequestConfig = {
+        signal,
+        validateStatus: (status) => status >= 200 && status < 400,
+        etagCacheKey: etagKey,
+      }
+
+      const response = await api.get<Event[]>("/events/my", config)
+
+      if (response.status === 304) {
+        return queryClient.getQueryData<Event[]>(queryKey) ?? []
+      }
+
+      return Array.isArray(response.data) ? response.data : []
+    },
+    ...rest,
+  })
+
+  return {
+    ...query,
+    queryKey,
+  }
+}

--- a/root/frontend/src/api/hooks/events.ts
+++ b/root/frontend/src/api/hooks/events.ts
@@ -60,8 +60,7 @@ type EventsListQueryKeyTuple = readonly ["events", "list", NormalizedEventsListF
 export type EventsListQueryKey = EventsListQueryKeyTuple
 
 const createEventsListEtagKey = (filters: NormalizedEventsListFilters) => {
-  const activity =
-    filters.is_active === null ? "all" : filters.is_active ? "active" : "archive"
+  const activity = filters.is_active === null ? "all" : filters.is_active ? "active" : "archive"
   return [
     "events",
     "list",
@@ -142,10 +141,7 @@ type UseEventsListQueryOptions = Omit<
   "queryKey" | "queryFn" | "initialPageParam" | "getNextPageParam"
 >
 
-export type UseEventsListQueryResult = UseInfiniteQueryResult<
-  PaginatedResponse<Event>,
-  Error
-> & {
+export type UseEventsListQueryResult = UseInfiniteQueryResult<PaginatedResponse<Event>, Error> & {
   events: Event[]
   pagination: PaginatedResponse<Event> | null
   queryKey: EventsListQueryKey
@@ -197,9 +193,7 @@ export const useEventsListQuery = (
       const response = await api.get<PaginatedResponse<Event>>("/events", requestConfig)
 
       if (response.status === 304) {
-        const cached = queryClient.getQueryData<
-          InfiniteData<PaginatedResponse<Event>>
-        >(queryKey)
+        const cached = queryClient.getQueryData<InfiniteData<PaginatedResponse<Event>>>(queryKey)
         return ensurePaginatedResponse(cached?.pages?.[0], normalized.limit)
       }
 

--- a/root/frontend/src/api/hooks/events.ts
+++ b/root/frontend/src/api/hooks/events.ts
@@ -197,9 +197,8 @@ export const useEventsListQuery = (
       const response = await api.get<PaginatedResponse<Event>>("/events", requestConfig)
 
       if (response.status === 304) {
-        const cached = queryClient.getQueryData<
-          InfiniteData<PaginatedResponse<Event>, string | null>
-        >(queryKey)
+        const cached =
+          queryClient.getQueryData<InfiniteData<PaginatedResponse<Event>, string | null>>(queryKey)
         return ensurePaginatedResponse(cached?.pages?.[0], normalized.limit)
       }
 

--- a/root/frontend/src/api/hooks/events.ts
+++ b/root/frontend/src/api/hooks/events.ts
@@ -134,14 +134,17 @@ type UseEventsListQueryOptions = Omit<
   UseInfiniteQueryOptions<
     PaginatedResponse<Event>,
     Error,
-    PaginatedResponse<Event>,
-    PaginatedResponse<Event>,
-    EventsListQueryKey
+    InfiniteData<PaginatedResponse<Event>, string | null>,
+    EventsListQueryKey,
+    string | null
   >,
   "queryKey" | "queryFn" | "initialPageParam" | "getNextPageParam"
 >
 
-export type UseEventsListQueryResult = UseInfiniteQueryResult<PaginatedResponse<Event>, Error> & {
+export type UseEventsListQueryResult = UseInfiniteQueryResult<
+  InfiniteData<PaginatedResponse<Event>, string | null>,
+  Error
+> & {
   events: Event[]
   pagination: PaginatedResponse<Event> | null
   queryKey: EventsListQueryKey
@@ -159,8 +162,9 @@ export const useEventsListQuery = (
   const query = useInfiniteQuery<
     PaginatedResponse<Event>,
     Error,
-    PaginatedResponse<Event>,
-    EventsListQueryKey
+    InfiniteData<PaginatedResponse<Event>, string | null>,
+    EventsListQueryKey,
+    string | null
   >({
     queryKey,
     enabled,
@@ -193,7 +197,9 @@ export const useEventsListQuery = (
       const response = await api.get<PaginatedResponse<Event>>("/events", requestConfig)
 
       if (response.status === 304) {
-        const cached = queryClient.getQueryData<InfiniteData<PaginatedResponse<Event>>>(queryKey)
+        const cached = queryClient.getQueryData<
+          InfiniteData<PaginatedResponse<Event>, string | null>
+        >(queryKey)
         return ensurePaginatedResponse(cached?.pages?.[0], normalized.limit)
       }
 

--- a/root/frontend/src/api/notifications.ts
+++ b/root/frontend/src/api/notifications.ts
@@ -82,15 +82,9 @@ const adminTopicsSchema = z.object({
   updated_at: z.string().datetime().nullable().optional(),
 })
 
-export async function fetchAdminUserTopics(
-  userId: number
-): Promise<AdminUserTopicsResponse> {
+export async function fetchAdminUserTopics(userId: number): Promise<AdminUserTopicsResponse> {
   const { data } = await api.get<AdminUserTopicsResponse>(`/push/admin/topics/${userId}`)
-  return ensureValidResponse(
-    adminTopicsSchema,
-    data,
-    `GET /push/admin/topics/${userId}`
-  )
+  return ensureValidResponse(adminTopicsSchema, data, `GET /push/admin/topics/${userId}`)
 }
 
 export async function updateAdminUserTopics(
@@ -98,13 +92,6 @@ export async function updateAdminUserTopics(
   topics: string[]
 ): Promise<AdminUserTopicsResponse> {
   const payload = { topics }
-  const { data } = await api.put<AdminUserTopicsResponse>(
-    `/push/admin/topics/${userId}`,
-    payload
-  )
-  return ensureValidResponse(
-    adminTopicsSchema,
-    data,
-    `PUT /push/admin/topics/${userId}`
-  )
+  const { data } = await api.put<AdminUserTopicsResponse>(`/push/admin/topics/${userId}`, payload)
+  return ensureValidResponse(adminTopicsSchema, data, `PUT /push/admin/topics/${userId}`)
 }

--- a/root/frontend/src/api/notifications.ts
+++ b/root/frontend/src/api/notifications.ts
@@ -27,8 +27,8 @@ export async function saveSubscription(
   const payload: components["schemas"]["PushSubscriptionIn"] = {
     endpoint,
     keys: { p256dh, auth },
-    topics,
     user_agent: userAgent,
+    ...(Array.isArray(topics) ? { topics } : {}),
   }
 
   const { data } = await api.post<PushSubscriptionResponse>("/push/subscribe", payload)
@@ -68,7 +68,7 @@ export async function fetchPushTopics(): Promise<PushTopicsResponse> {
   const parsed = ensureValidResponse(pushTopicsSchema, data, "GET /push/topics")
   return {
     allowed: parsed.allowed,
-    topics: parsed.topics,
+    topics: parsed.topics ?? [],
     has_preferences: parsed.has_preferences ?? false,
     updated_at: parsed.updated_at ?? null,
   }

--- a/root/frontend/src/pages/AdminNotifications.tsx
+++ b/root/frontend/src/pages/AdminNotifications.tsx
@@ -101,9 +101,7 @@ export default function AdminNotifications() {
         new Set(allowed.map((topic) => normalizeTopicKey(topic)).filter(Boolean))
       )
       const selectedSet = new Set(
-        (selectedTopics ?? [])
-          .map((topic) => normalizeTopicKey(topic))
-          .filter(Boolean)
+        (selectedTopics ?? []).map((topic) => normalizeTopicKey(topic)).filter(Boolean)
       )
       const record: Record<string, boolean> = {}
       for (const topic of normalizedAllowed) {
@@ -224,20 +222,17 @@ export default function AdminNotifications() {
     } catch (error) {
       setTopicsData(null)
       setTopicsState({})
-      setTopicsError(
-        getErrorMessage(error, t("admin:notifications.topics.loadError"))
-      )
+      setTopicsError(getErrorMessage(error, t("admin:notifications.topics.loadError")))
     } finally {
       setTopicsBusy(false)
     }
   }, [buildTopicState, t, topicsUserIdInput])
 
   const handleTopicToggle = useCallback(
-    (topic: string) =>
-      (_event: ChangeEvent<HTMLInputElement>, checked: boolean) => {
-        const normalized = normalizeTopicKey(topic)
-        setTopicsState((prev) => ({ ...prev, [normalized]: checked }))
-      },
+    (topic: string) => (_event: ChangeEvent<HTMLInputElement>, checked: boolean) => {
+      const normalized = normalizeTopicKey(topic)
+      setTopicsState((prev) => ({ ...prev, [normalized]: checked }))
+    },
     []
   )
 
@@ -254,9 +249,7 @@ export default function AdminNotifications() {
       setTopicsState(buildTopicState(updated.allowed_topics, updated.topics))
       setTopicsMessage(t("admin:notifications.topics.saved"))
     } catch (error) {
-      setTopicsError(
-        getErrorMessage(error, t("admin:notifications.topics.saveError"))
-      )
+      setTopicsError(getErrorMessage(error, t("admin:notifications.topics.saveError")))
     } finally {
       setTopicsBusy(false)
     }
@@ -470,13 +463,9 @@ export default function AdminNotifications() {
                     sx={{ minWidth: { xs: "100%", sm: 200 } }}
                     disabled={topicsBusy}
                   />
-                  <Button
-                    variant="contained"
-                    onClick={handleLoadTopics}
-                    disabled={topicsBusy}
-                  >
+                  <Button variant="contained" onClick={handleLoadTopics} disabled={topicsBusy}>
                     {topicsBusy
-                      ? t("common:loading") ?? "Loading"
+                      ? (t("common:loading") ?? "Loading")
                       : t("admin:notifications.topics.load")}
                   </Button>
                 </Stack>
@@ -498,11 +487,7 @@ export default function AdminNotifications() {
                         id: topicsData.user_id,
                       })}
                     </Typography>
-                    <Stack
-                      direction={{ xs: "column", sm: "row" }}
-                      spacing={1}
-                      flexWrap="wrap"
-                    >
+                    <Stack direction={{ xs: "column", sm: "row" }} spacing={1} flexWrap="wrap">
                       {topicsData.allowed_topics.length === 0 ? (
                         <Typography variant="body2" color="text.secondary">
                           {t("admin:notifications.topics.empty")}
@@ -512,8 +497,7 @@ export default function AdminNotifications() {
                           const normalized = normalizeTopicKey(topic)
                           const translationKey = `notifications:topics.${normalized}`
                           const label = t(translationKey)
-                          const resolvedLabel =
-                            label === translationKey ? topic : (label as string)
+                          const resolvedLabel = label === translationKey ? topic : (label as string)
                           return (
                             <FormControlLabel
                               key={topic}
@@ -538,7 +522,7 @@ export default function AdminNotifications() {
                         disabled={topicsBusy || !topicsData.allowed_topics.length}
                       >
                         {topicsBusy
-                          ? t("common:loading") ?? "Loading"
+                          ? (t("common:loading") ?? "Loading")
                           : t("admin:notifications.topics.save")}
                       </Button>
                     </Box>

--- a/root/frontend/src/pages/Events.tsx
+++ b/root/frontend/src/pages/Events.tsx
@@ -38,11 +38,7 @@ import { useAuth } from "../contexts/AuthContext"
 import SmartImage from "@/components/SmartImage"
 import { useSearchParams } from "react-router-dom"
 import { useTranslation } from "react-i18next"
-import {
-  EVENTS_PAGE_SIZE,
-  useEventsListQuery,
-  useMyEventsQuery,
-} from "@/api/hooks/events"
+import { EVENTS_PAGE_SIZE, useEventsListQuery, useMyEventsQuery } from "@/api/hooks/events"
 
 type EventTabKey = "active" | "archive" | "my"
 type EventTab = { key: EventTabKey; is_active?: boolean }
@@ -182,7 +178,7 @@ const Events = () => {
   } = myEventsQuery
 
   const normalizedEvents = useMemo(() => {
-    return tab === "my" ? myEventsData ?? [] : listEvents
+    return tab === "my" ? (myEventsData ?? []) : listEvents
   }, [tab, listEvents, myEventsData])
 
   const loading = useMemo(() => {
@@ -190,7 +186,14 @@ const Events = () => {
       return myEventsLoading || (myEventsFetching && !myEventsLoading)
     }
     return listIsLoading || (listIsFetching && !listIsFetchingNextPage)
-  }, [tab, myEventsLoading, myEventsFetching, listIsLoading, listIsFetching, listIsFetchingNextPage])
+  }, [
+    tab,
+    myEventsLoading,
+    myEventsFetching,
+    listIsLoading,
+    listIsFetching,
+    listIsFetchingNextPage,
+  ])
 
   const loadingMore = tab !== "my" && Boolean(listIsFetchingNextPage)
   const hasMore = tab !== "my" && Boolean(listHasNextPage)

--- a/root/frontend/src/pages/Events.tsx
+++ b/root/frontend/src/pages/Events.tsx
@@ -6,13 +6,12 @@ import {
   useState,
   useCallback,
   useMemo,
-  useRef,
   type SyntheticEvent,
   type CSSProperties,
 } from "react"
+import { useQueryClient } from "@tanstack/react-query"
 import axios from "../api/client"
 import type { Event } from "@/types/Event"
-import type { PaginatedResponse } from "@/types/Pagination"
 import {
   Box,
   Tabs,
@@ -39,6 +38,11 @@ import { useAuth } from "../contexts/AuthContext"
 import SmartImage from "@/components/SmartImage"
 import { useSearchParams } from "react-router-dom"
 import { useTranslation } from "react-i18next"
+import {
+  EVENTS_PAGE_SIZE,
+  useEventsListQuery,
+  useMyEventsQuery,
+} from "@/api/hooks/events"
 
 type EventTabKey = "active" | "archive" | "my"
 type EventTab = { key: EventTabKey; is_active?: boolean }
@@ -48,8 +52,6 @@ const tabs = [
   { key: "archive", is_active: false },
   { key: "my" },
 ] as const satisfies readonly EventTab[]
-
-const PAGE_SIZE = 12
 
 type EventDraft = {
   title: string
@@ -100,7 +102,7 @@ const Events = () => {
   const { t, i18n } = useTranslation(["events", "common"])
   const language = i18n.language?.startsWith("en") ? "en" : "ru"
 
-  const [events, setEvents] = useState<Event[]>([])
+  const queryClient = useQueryClient()
   const [tab, setTab] = useState<EventTabKey>("active")
   const [search, setSearch] = useState("")
   const [type, setType] = useState("")
@@ -109,10 +111,6 @@ const Events = () => {
   const [createOpen, setCreateOpen] = useState(false)
   const [eventData, setEventData] = useState<EventDraft>(initialEvent)
   const [imageUploading, setImageUploading] = useState(false)
-  const [loading, setLoading] = useState(false)
-  const [loadingMore, setLoadingMore] = useState(false)
-  const [pagination, setPagination] = useState<PaginatedResponse<Event> | null>(null)
-
   const [createPreview, setCreatePreview] = useState<string | null>(null)
 
   const isMobile = useMediaQuery("(max-width:900px)")
@@ -120,10 +118,6 @@ const Events = () => {
   const [filterAnchor, setFilterAnchor] = useState<HTMLElement | null>(null)
   const filtersOpen = Boolean(filterAnchor)
   const filtersActive = Boolean(type?.trim() || location?.trim())
-  const etagCacheRef = useRef<Record<string, string>>({})
-  const eventsCacheRef = useRef<
-    Record<string, { events: Event[]; pagination: PaginatedResponse<Event> | null }>
-  >({})
 
   useEffect(() => {
     const t = (searchParams.get("tab") as typeof tab) || "active"
@@ -149,174 +143,63 @@ const Events = () => {
   const dType = useDebounced(type, 350)
   const dLocation = useDebounced(location, 350)
 
-  const cacheKey = useMemo(() => {
-    if (tab === "my") {
-      return `my:${language}`
+  const eventsListFilters = useMemo(() => {
+    const isActiveFilter = tab === "active" ? true : tab === "archive" ? false : null
+    return {
+      language,
+      is_active: isActiveFilter,
+      search: dSearch,
+      type: dType,
+      location: dLocation,
+      limit: EVENTS_PAGE_SIZE,
     }
-    const isActiveFilter = tab === "active" ? true : tab === "archive" ? false : undefined
-    return `${tab}:${language}:${String(isActiveFilter)}:${dSearch}:${dType}:${dLocation}:limit:${PAGE_SIZE}`
   }, [tab, language, dSearch, dType, dLocation])
 
-  const fetchEvents = useCallback(
-    async (signal?: AbortSignal) => {
-      setLoading(true)
-      if (tab !== "my") {
-        setPagination(null)
-      }
-      try {
-        const isActiveFilter = tab === "active" ? true : tab === "archive" ? false : undefined
-        const params =
-          tab === "my"
-            ? undefined
-            : {
-                is_active: isActiveFilter,
-                search: dSearch,
-                type: dType,
-                location: dLocation,
-                limit: PAGE_SIZE,
-              }
+  const eventsListQuery = useEventsListQuery(eventsListFilters, {
+    enabled: tab !== "my",
+  })
 
-        const keyBase = cacheKey
-        const headers = etagCacheRef.current[keyBase]
-          ? { "If-None-Match": etagCacheRef.current[keyBase] }
-          : undefined
-        const requestConfig = {
-          signal,
-          params,
-          headers,
-          validateStatus: (status: number) => status >= 200 && status < 400,
-        } as const
-
-        if (tab === "my") {
-          const res = await axios.get<Event[]>("/events/my", requestConfig)
-          const receivedEtag = res.headers?.etag
-          if (receivedEtag) {
-            etagCacheRef.current[keyBase] = receivedEtag
-          } else {
-            delete etagCacheRef.current[keyBase]
-          }
-          if (res.status === 304) {
-            const cached = eventsCacheRef.current[keyBase]
-            if (cached) {
-              setEvents(cached.events)
-            }
-            setPagination(null)
-            return
-          }
-          const nextEvents = Array.isArray(res.data) ? res.data : []
-          eventsCacheRef.current[keyBase] = { events: nextEvents, pagination: null }
-          setEvents(nextEvents)
-          setPagination(null)
-          return
-        }
-
-        const res = await axios.get<PaginatedResponse<Event>>("/events", requestConfig)
-        const receivedEtag = res.headers?.etag
-        if (receivedEtag) {
-          etagCacheRef.current[keyBase] = receivedEtag
-        } else {
-          delete etagCacheRef.current[keyBase]
-        }
-        if (res.status === 304) {
-          const cached = eventsCacheRef.current[keyBase]
-          if (cached) {
-            setEvents(cached.events)
-            setPagination(cached.pagination)
-          }
-          return
-        }
-
-        const data = res.data
-        const nextEvents = Array.isArray(data?.items) ? data.items : []
-        const nextPagination = data ?? null
-        eventsCacheRef.current[keyBase] = { events: nextEvents, pagination: nextPagination }
-        setEvents(nextEvents)
-        setPagination(nextPagination)
-      } catch (err: any) {
-        if (err?.name !== "CanceledError" && err?.code !== "ERR_CANCELED") {
-          setEvents([])
-          setPagination(null)
-        }
-      } finally {
-        setLoading(false)
-      }
-    },
-    [tab, dSearch, dType, dLocation, language, cacheKey]
+  const myEventsQuery = useMyEventsQuery(
+    { language, userId: user?.id ?? null },
+    { enabled: tab === "my" }
   )
 
-  useEffect(() => {
-    const ctrl = new AbortController()
-    fetchEvents(ctrl.signal)
-    return () => ctrl.abort()
-  }, [fetchEvents])
+  const {
+    events: listEvents,
+    isLoading: listIsLoading,
+    isFetching: listIsFetching,
+    isFetchingNextPage: listIsFetchingNextPage,
+    hasNextPage: listHasNextPage,
+    fetchNextPage: fetchNextEventsPage,
+    refetch: refetchEventsList,
+  } = eventsListQuery
+
+  const {
+    data: myEventsData,
+    isLoading: myEventsLoading,
+    isFetching: myEventsFetching,
+    refetch: refetchMyEvents,
+  } = myEventsQuery
+
+  const normalizedEvents = useMemo(() => {
+    return tab === "my" ? myEventsData ?? [] : listEvents
+  }, [tab, listEvents, myEventsData])
+
+  const loading = useMemo(() => {
+    if (tab === "my") {
+      return myEventsLoading || (myEventsFetching && !myEventsLoading)
+    }
+    return listIsLoading || (listIsFetching && !listIsFetchingNextPage)
+  }, [tab, myEventsLoading, myEventsFetching, listIsLoading, listIsFetching, listIsFetchingNextPage])
+
+  const loadingMore = tab !== "my" && Boolean(listIsFetchingNextPage)
+  const hasMore = tab !== "my" && Boolean(listHasNextPage)
 
   const loadMore = useCallback(async () => {
-    if (tab === "my" || loadingMore) return
-    const nextCursor = pagination?.next_cursor
-    if (nextCursor == null) return
-    setLoadingMore(true)
-    try {
-      const isActiveFilter = tab === "active" ? true : tab === "archive" ? false : undefined
-      const res = await axios.get<PaginatedResponse<Event>>("/events", {
-        params: {
-          is_active: isActiveFilter,
-          search: dSearch,
-          type: dType,
-          location: dLocation,
-          limit: PAGE_SIZE,
-          cursor: nextCursor,
-        },
-        validateStatus: (status: number) => status >= 200 && status < 300,
-      })
-      const data = res.data
-      const newItems = Array.isArray(data?.items) ? data.items : []
-      let mergedEvents: Event[] = []
-      setEvents((prev) => {
-        const existing = Array.isArray(prev) ? [...prev] : []
-        const seen = new Set(existing.map((item) => item.id))
-        newItems.forEach((item) => {
-          if (seen.has(item.id)) {
-            const index = existing.findIndex((evt) => evt.id === item.id)
-            if (index >= 0) existing[index] = item
-          } else {
-            existing.push(item)
-            seen.add(item.id)
-          }
-        })
-        mergedEvents = existing
-        return existing
-      })
-      setPagination((prev) => {
-        if (!data) {
-          const cached = eventsCacheRef.current[cacheKey]
-          eventsCacheRef.current[cacheKey] = {
-            events: mergedEvents,
-            pagination: prev ?? null,
-          }
-          return prev
-        }
-        if (!prev) {
-          eventsCacheRef.current[cacheKey] = { events: mergedEvents, pagination: data }
-          return data
-        }
-        const nextPagination = {
-          ...prev,
-          ...data,
-        }
-        eventsCacheRef.current[cacheKey] = {
-          events: mergedEvents,
-          pagination: nextPagination,
-        }
-        return nextPagination
-      })
-    } catch (err: any) {
-      if (err?.name !== "CanceledError" && err?.code !== "ERR_CANCELED") {
-        setPagination((prev) => (prev ? { ...prev, has_more: false, next_cursor: null } : prev))
-      }
-    } finally {
-      setLoadingMore(false)
+    if (tab !== "my" && listHasNextPage) {
+      await fetchNextEventsPage()
     }
-  }, [tab, loadingMore, pagination?.next_cursor, dSearch, dType, dLocation, cacheKey])
+  }, [fetchNextEventsPage, listHasNextPage, tab])
 
   const handleTabChange = (_event: SyntheticEvent, newValue: EventTabKey) => setTab(newValue)
 
@@ -365,18 +248,21 @@ const Events = () => {
         starts_at: eventData.starts_at,
         ends_at: eventData.ends_at,
       }
-      const res = await axios.post<Event>("/events", payload)
+      await axios.post<Event>("/events", payload)
       closeCreate()
       setTab("active")
-      setEvents((prev) => [res.data, ...prev])
-      setPagination((prev) => (prev ? { ...prev, total: prev.total + 1 } : prev))
+      void queryClient.invalidateQueries({ queryKey: ["events"] })
       window.scrollTo({ top: 0, behavior: "smooth" })
     } catch {}
   }
 
   const handleRefresh = useCallback(() => {
-    if (!loading) fetchEvents()
-  }, [fetchEvents, loading])
+    if (tab === "my") {
+      void refetchMyEvents()
+    } else {
+      void refetchEventsList()
+    }
+  }, [refetchEventsList, refetchMyEvents, tab])
 
   const starts = new Date(eventData.starts_at).getTime()
   const ends = new Date(eventData.ends_at).getTime()
@@ -396,8 +282,6 @@ const Events = () => {
       if (createPreview) URL.revokeObjectURL(createPreview)
     }
   }, [createPreview])
-
-  const normalizedEvents = useMemo(() => (Array.isArray(events) ? events : []), [events])
 
   const layoutConfig = useMemo(() => {
     if (isMobile) {
@@ -784,7 +668,7 @@ const Events = () => {
 
           {eventsContent}
 
-          {tab !== "my" && pagination?.has_more ? (
+          {hasMore ? (
             <Box display="flex" justifyContent="center" mt={4} mb={6}>
               <Button
                 variant="outlined"

--- a/root/frontend/src/setupTests.ts
+++ b/root/frontend/src/setupTests.ts
@@ -12,6 +12,7 @@ import {
   resetTestSessions,
 } from "./tests/mocks/handlers"
 import i18n from "./i18n/config"
+import { resetEtagCache } from "./api/client"
 
 expect.extend(toHaveNoViolations)
 
@@ -26,6 +27,7 @@ afterEach(() => {
   resetTestEvents()
   resetTestMfa()
   resetAdminDeadLetterJobs()
+  resetEtagCache()
 })
 afterAll(() => server.close())
 if (!(globalThis as any).TextEncoder) (globalThis as any).TextEncoder = TextEncoder

--- a/root/frontend/src/tests/pages/EventsCache.test.tsx
+++ b/root/frontend/src/tests/pages/EventsCache.test.tsx
@@ -4,6 +4,7 @@ import { MemoryRouter } from "react-router-dom"
 import { describe, expect, it, vi } from "vitest"
 import { HttpResponse, http } from "msw"
 import type { ContextType } from "react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 
 import Events from "@/pages/Events"
 import { AuthContext } from "@/contexts/AuthContext"
@@ -96,6 +97,14 @@ describe("Events caching", () => {
     const archiveEvents = [buildEvent(2, "Archived event 1", false)]
     let activeRequestCount = 0
 
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    })
+
     server.use(
       http.get("*/events", ({ request }) => {
         const url = new URL(request.url)
@@ -148,9 +157,11 @@ describe("Events caching", () => {
 
     render(
       <AuthContext.Provider value={authValue}>
-        <MemoryRouter>
-          <Events />
-        </MemoryRouter>
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <Events />
+          </MemoryRouter>
+        </QueryClientProvider>
       </AuthContext.Provider>
     )
 
@@ -169,5 +180,7 @@ describe("Events caching", () => {
     await waitFor(() => expect(activeRequestCount).toBe(2))
     expect(await screen.findByText("Active event 1")).toBeInTheDocument()
     expect(screen.queryByText("Archived event 1")).not.toBeInTheDocument()
+
+    queryClient.clear()
   })
 })

--- a/root/frontend/src/tests/pages/EventsPagination.test.tsx
+++ b/root/frontend/src/tests/pages/EventsPagination.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event"
 import { MemoryRouter } from "react-router-dom"
 import { describe, expect, it, beforeEach, vi } from "vitest"
 import type { ContextType } from "react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import Events from "@/pages/Events"
 import { AuthContext } from "@/contexts/AuthContext"
 import type { Event } from "@/types/Event"
@@ -104,12 +105,21 @@ describe("Events pagination UI", () => {
 
   it("loads additional pages when clicking load more", async () => {
     const user = userEvent.setup()
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    })
 
     render(
       <AuthContext.Provider value={authValue}>
-        <MemoryRouter>
-          <Events />
-        </MemoryRouter>
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <Events />
+          </MemoryRouter>
+        </QueryClientProvider>
       </AuthContext.Provider>
     )
 
@@ -121,5 +131,7 @@ describe("Events pagination UI", () => {
 
     await waitFor(() => expect(screen.getAllByTestId("event-card")).toHaveLength(15))
     expect(await screen.findByText("Paginated event 13")).toBeInTheDocument()
+
+    queryClient.clear()
   })
 })


### PR DESCRIPTION
## Summary
- add reusable React Query hooks for events and centralize ETag caching in axios interceptors
- refactor the Events page to consume the new hooks and rely on query caching for pagination
- expand unit and RTL coverage, including a new interceptor test and updated Events page tests

## Testing
- npm test -- src/tests/pages/EventsCache.test.tsx src/tests/pages/EventsPagination.test.tsx src/api/__tests__/client.etag.test.ts

------
https://chatgpt.com/codex/tasks/task_e_6903ef0c350483279128a1dcb7021f46