### PR TITLE
Add bootstrap fallback rendering on startup failures

### DIFF
--- a/root/frontend/src/app/__tests__/logger.test.ts
+++ b/root/frontend/src/app/__tests__/logger.test.ts
@@ -13,8 +13,8 @@ const originalConsoleWarn = console.warn
 
 beforeEach(async () => {
   const sentry = await import("@sentry/react")
-  captureException = sentry.captureException as unknown as vi.Mock
-  captureMessage = sentry.captureMessage as unknown as vi.Mock
+  captureException = sentry.captureException as unknown as Mock
+  captureMessage = sentry.captureMessage as unknown as Mock
   captureException.mockClear()
   captureMessage.mockClear()
   console.error = vi.fn()

--- a/root/frontend/src/main.tsx
+++ b/root/frontend/src/main.tsx
@@ -9,31 +9,45 @@ initGlobalErrorHandlers()
 initWebVitals()
 ensureTrustedTypesPolicies()
 
+declare global {
+  interface Window {
+    __APP_BOOTSTRAP_FORCE_ERROR__?: boolean
+  }
+}
+
 async function bootstrap() {
-  const ReactMod = await import("react")
-  const { StrictMode, useEffect } = ReactMod
-  const ReactDOMMod = await import("react-dom/client")
-  const { CssBaseline } = await import("@mui/material")
-  const StylesMod = await import("@mui/material/styles")
-  const { CssVarsProvider, useColorScheme } = StylesMod
-  const ReactQueryMod = await import("@tanstack/react-query")
-  const { QueryClientProvider } = ReactQueryMod
-  const AppMod = await import("./App")
-  const { default: App } = AppMod
-  const ErrorBoundaryMod = await import("./app/ErrorBoundary")
-  const { default: ErrorBoundary } = ErrorBoundaryMod
-  const QueryClientLocal = await import("./app/queryClient")
-  const { queryClient } = QueryClientLocal
-  const ThemeMod = await import("./theme")
-  const { default: theme } = ThemeMod
-  await import("./styles/tailwind.css")
-  await import("./assets/themes.css")
-  await import("./i18n/config")
-  await import("dayjs/locale/ru")
-  const SWMod = await import("./push/register-sw")
-  const { registerServiceWorker } = SWMod
-  const PushMod = await import("./push/subscribe")
-  const { ensurePushSubscription, hasPushConsent } = PushMod
+  try {
+    if (
+      typeof window !== "undefined" &&
+      window.__APP_BOOTSTRAP_FORCE_ERROR__
+    ) {
+      throw new Error("Forced bootstrap failure")
+    }
+
+    const ReactMod = await import("react")
+    const { StrictMode, useEffect } = ReactMod
+    const ReactDOMMod = await import("react-dom/client")
+    const { CssBaseline } = await import("@mui/material")
+    const StylesMod = await import("@mui/material/styles")
+    const { CssVarsProvider, useColorScheme } = StylesMod
+    const ReactQueryMod = await import("@tanstack/react-query")
+    const { QueryClientProvider } = ReactQueryMod
+    const AppMod = await import("./App")
+    const { default: App } = AppMod
+    const ErrorBoundaryMod = await import("./app/ErrorBoundary")
+    const { default: ErrorBoundary } = ErrorBoundaryMod
+    const QueryClientLocal = await import("./app/queryClient")
+    const { queryClient } = QueryClientLocal
+    const ThemeMod = await import("./theme")
+    const { default: theme } = ThemeMod
+    await import("./styles/tailwind.css")
+    await import("./assets/themes.css")
+    await import("./i18n/config")
+    await import("dayjs/locale/ru")
+    const SWMod = await import("./push/register-sw")
+    const { registerServiceWorker } = SWMod
+    const PushMod = await import("./push/subscribe")
+    const { ensurePushSubscription, hasPushConsent } = PushMod
 
   async function setupServiceWorker() {
     if (!import.meta.env.PROD) return
@@ -84,25 +98,121 @@ async function bootstrap() {
     ? (await import("@tanstack/react-query-devtools")).ReactQueryDevtools
     : null
 
-  ReactDOMMod.default.createRoot(document.getElementById("root")!).render(
-    <StrictMode>
-      <QueryClientProvider client={queryClient}>
-        <CssVarsProvider
-          theme={theme}
-          defaultMode="system"
-          modeStorageKey="theme"
-          disableTransitionOnChange
-        >
-          <CssBaseline enableColorScheme />
-          <BodyColorSchemeSync />
-          <ErrorBoundary>
-            <App />
-          </ErrorBoundary>
-        </CssVarsProvider>
-        {ReactQueryDevtools ? <ReactQueryDevtools buttonPosition="bottom-left" /> : null}
-      </QueryClientProvider>
-    </StrictMode>
-  )
+    ReactDOMMod.default.createRoot(document.getElementById("root")!).render(
+      <StrictMode>
+        <QueryClientProvider client={queryClient}>
+          <CssVarsProvider
+            theme={theme}
+            defaultMode="system"
+            modeStorageKey="theme"
+            disableTransitionOnChange
+          >
+            <CssBaseline enableColorScheme />
+            <BodyColorSchemeSync />
+            <ErrorBoundary>
+              <App />
+            </ErrorBoundary>
+          </CssVarsProvider>
+          {ReactQueryDevtools ? <ReactQueryDevtools buttonPosition="bottom-left" /> : null}
+        </QueryClientProvider>
+      </StrictMode>
+    )
+  } catch (error) {
+    logError("Failed to bootstrap application", error)
+
+    if (typeof document === "undefined") {
+      return
+    }
+
+    const rootElement = document.getElementById("root")
+    if (!rootElement) {
+      return
+    }
+
+    rootElement.innerHTML = ""
+
+    const container = document.createElement("div")
+    container.setAttribute("role", "alert")
+    container.style.display = "flex"
+    container.style.flexDirection = "column"
+    container.style.alignItems = "center"
+    container.style.justifyContent = "center"
+    container.style.minHeight = "100vh"
+    container.style.padding = "2rem"
+    container.style.gap = "1.5rem"
+    container.style.textAlign = "center"
+    container.style.backgroundColor = "#f5f5f5"
+
+    const title = document.createElement("h1")
+    title.textContent = "Не удалось загрузить приложение"
+    title.style.margin = "0"
+    title.style.fontSize = "1.75rem"
+
+    const description = document.createElement("p")
+    description.textContent =
+      "Попробуйте перезагрузить страницу или очистить кэш браузера. Если проблема сохраняется, обратитесь в поддержку."
+    description.style.margin = "0"
+    description.style.maxWidth = "32rem"
+    description.style.color = "#333"
+
+    const actions = document.createElement("div")
+    actions.style.display = "flex"
+    actions.style.flexWrap = "wrap"
+    actions.style.gap = "1rem"
+    actions.style.justifyContent = "center"
+
+    const reloadButton = document.createElement("button")
+    reloadButton.type = "button"
+    reloadButton.textContent = "Перезагрузить страницу"
+    reloadButton.style.padding = "0.75rem 1.5rem"
+    reloadButton.style.fontSize = "1rem"
+    reloadButton.style.borderRadius = "9999px"
+    reloadButton.style.border = "none"
+    reloadButton.style.cursor = "pointer"
+    reloadButton.style.backgroundColor = "#1976d2"
+    reloadButton.style.color = "#fff"
+    reloadButton.addEventListener("click", () => {
+      window.location.reload()
+    })
+
+    const clearCacheButton = document.createElement("button")
+    clearCacheButton.type = "button"
+    clearCacheButton.textContent = "Очистить кэш и перезагрузить"
+    clearCacheButton.style.padding = "0.75rem 1.5rem"
+    clearCacheButton.style.fontSize = "1rem"
+    clearCacheButton.style.borderRadius = "9999px"
+    clearCacheButton.style.border = "1px solid #1976d2"
+    clearCacheButton.style.cursor = "pointer"
+    clearCacheButton.style.backgroundColor = "transparent"
+    clearCacheButton.style.color = "#1976d2"
+    clearCacheButton.addEventListener("click", () => {
+      clearCacheButton.disabled = true
+      clearCacheButton.textContent = "Очищаем кэш..."
+
+      void (async () => {
+        try {
+          if ("serviceWorker" in navigator) {
+            const registrations = await navigator.serviceWorker.getRegistrations()
+            await Promise.all(registrations.map((registration) => registration.unregister()))
+          }
+          if ("caches" in window) {
+            const cacheKeys = await caches.keys()
+            await Promise.all(cacheKeys.map((cacheKey) => caches.delete(cacheKey)))
+          }
+        } catch (cleanupError) {
+          logError("Failed to clear caches after bootstrap error", cleanupError)
+        } finally {
+          window.location.reload()
+        }
+      })()
+    })
+
+    actions.append(reloadButton, clearCacheButton)
+
+    container.append(title, description, actions)
+
+    rootElement.append(container)
+  }
 }
 
 bootstrap()

--- a/root/frontend/src/main.tsx
+++ b/root/frontend/src/main.tsx
@@ -17,10 +17,7 @@ declare global {
 
 async function bootstrap() {
   try {
-    if (
-      typeof window !== "undefined" &&
-      window.__APP_BOOTSTRAP_FORCE_ERROR__
-    ) {
+    if (typeof window !== "undefined" && window.__APP_BOOTSTRAP_FORCE_ERROR__) {
       throw new Error("Forced bootstrap failure")
     }
 
@@ -49,54 +46,54 @@ async function bootstrap() {
     const PushMod = await import("./push/subscribe")
     const { ensurePushSubscription, hasPushConsent } = PushMod
 
-  async function setupServiceWorker() {
-    if (!import.meta.env.PROD) return
-    if (!("serviceWorker" in navigator)) return
-    try {
-      const registration = await registerServiceWorker("/sw.js")
-      if (!registration) return
-      if (!hasPushConsent()) return
+    async function setupServiceWorker() {
+      if (!import.meta.env.PROD) return
+      if (!("serviceWorker" in navigator)) return
       try {
-        await ensurePushSubscription({ registration, requestPermission: false })
+        const registration = await registerServiceWorker("/sw.js")
+        if (!registration) return
+        if (!hasPushConsent()) return
+        try {
+          await ensurePushSubscription({ registration, requestPermission: false })
+        } catch (error) {
+          logError("Failed to ensure push subscription", error)
+        }
       } catch (error) {
-        logError("Failed to ensure push subscription", error)
+        logError("Service worker registration failed", error)
       }
-    } catch (error) {
-      logError("Service worker registration failed", error)
     }
-  }
 
-  if (typeof window !== "undefined") {
-    if (document.readyState === "complete") {
-      void setupServiceWorker()
-    } else {
-      window.addEventListener(
-        "load",
-        () => {
-          void setupServiceWorker()
-        },
-        { once: true }
-      )
-    }
-  }
-
-  function BodyColorSchemeSync() {
-    const { mode, systemMode } = useColorScheme()
-    useEffect(() => {
-      const resolved = mode === "system" ? (systemMode ?? "light") : (mode ?? "light")
-      document.body.dataset.colorScheme = resolved
-      document.body.classList.toggle("dark", resolved === "dark")
-      return () => {
-        document.body.classList.remove("dark")
-        document.body.removeAttribute("data-color-scheme")
+    if (typeof window !== "undefined") {
+      if (document.readyState === "complete") {
+        void setupServiceWorker()
+      } else {
+        window.addEventListener(
+          "load",
+          () => {
+            void setupServiceWorker()
+          },
+          { once: true }
+        )
       }
-    }, [mode, systemMode])
-    return null
-  }
+    }
 
-  const ReactQueryDevtools = import.meta.env.DEV
-    ? (await import("@tanstack/react-query-devtools")).ReactQueryDevtools
-    : null
+    function BodyColorSchemeSync() {
+      const { mode, systemMode } = useColorScheme()
+      useEffect(() => {
+        const resolved = mode === "system" ? (systemMode ?? "light") : (mode ?? "light")
+        document.body.dataset.colorScheme = resolved
+        document.body.classList.toggle("dark", resolved === "dark")
+        return () => {
+          document.body.classList.remove("dark")
+          document.body.removeAttribute("data-color-scheme")
+        }
+      }, [mode, systemMode])
+      return null
+    }
+
+    const ReactQueryDevtools = import.meta.env.DEV
+      ? (await import("@tanstack/react-query-devtools")).ReactQueryDevtools
+      : null
 
     ReactDOMMod.default.createRoot(document.getElementById("root")!).render(
       <StrictMode>

--- a/root/frontend/tests/e2e/bootstrap-fallback.spec.ts
+++ b/root/frontend/tests/e2e/bootstrap-fallback.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from "@playwright/test"
+
+test.describe("bootstrap fallback", () => {
+  test("shows fallback UI when bootstrap fails", async ({ page }) => {
+    await page.addInitScript(() => {
+      ;(window as typeof window & { __APP_BOOTSTRAP_FORCE_ERROR__?: boolean }).__APP_BOOTSTRAP_FORCE_ERROR__ = true
+    })
+
+    await page.goto("/")
+
+    await expect(page.getByRole("heading", { name: "Не удалось загрузить приложение" })).toBeVisible()
+    await expect(
+      page.getByText("Попробуйте перезагрузить страницу или очистить кэш браузера", { exact: false })
+    ).toBeVisible()
+    await expect(page.getByRole("button", { name: "Перезагрузить страницу" })).toBeVisible()
+    await expect(page.getByRole("button", { name: "Очистить кэш и перезагрузить" })).toBeVisible()
+  })
+})

--- a/root/frontend/tests/e2e/bootstrap-fallback.spec.ts
+++ b/root/frontend/tests/e2e/bootstrap-fallback.spec.ts
@@ -3,14 +3,20 @@ import { test, expect } from "@playwright/test"
 test.describe("bootstrap fallback", () => {
   test("shows fallback UI when bootstrap fails", async ({ page }) => {
     await page.addInitScript(() => {
-      ;(window as typeof window & { __APP_BOOTSTRAP_FORCE_ERROR__?: boolean }).__APP_BOOTSTRAP_FORCE_ERROR__ = true
+      ;(
+        window as typeof window & { __APP_BOOTSTRAP_FORCE_ERROR__?: boolean }
+      ).__APP_BOOTSTRAP_FORCE_ERROR__ = true
     })
 
     await page.goto("/")
 
-    await expect(page.getByRole("heading", { name: "Не удалось загрузить приложение" })).toBeVisible()
     await expect(
-      page.getByText("Попробуйте перезагрузить страницу или очистить кэш браузера", { exact: false })
+      page.getByRole("heading", { name: "Не удалось загрузить приложение" })
+    ).toBeVisible()
+    await expect(
+      page.getByText("Попробуйте перезагрузить страницу или очистить кэш браузера", {
+        exact: false,
+      })
     ).toBeVisible()
     await expect(page.getByRole("button", { name: "Перезагрузить страницу" })).toBeVisible()
     await expect(page.getByRole("button", { name: "Очистить кэш и перезагрузить" })).toBeVisible()


### PR DESCRIPTION
## Summary
- wrap the frontend bootstrap process in a try/catch that reports failures to Sentry
- render a descriptive fallback with reload and cache-clearing actions when bootstrap fails
- add a Playwright spec that forces a bootstrap error and asserts the fallback UI appears

## Testing
- npm run test:e2e -- bootstrap-fallback.spec.ts *(fails: Playwright browser binaries are not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_6904da5cab548327b044bfd7a4f4fe34