### PR TITLE
feat: add typed API client and refactor news/events

### DIFF
--- a/root/frontend/src/api/__tests__/client.types.test.ts
+++ b/root/frontend/src/api/__tests__/client.types.test.ts
@@ -1,0 +1,46 @@
+import type { AxiosResponse } from "axios"
+import { describe, it, expectTypeOf } from "vitest"
+
+import type { paths } from "@/api/generated/schema"
+import { createEvent, uploadEventImage, type CreateEventPayload } from "@/api/events"
+import {
+  createNews,
+  fetchNews,
+  uploadNewsImage,
+  type CreateNewsPayload,
+} from "@/api/news"
+import {
+  fetchNotificationsList,
+  type NotificationsListResult,
+} from "@/api/notifications"
+
+describe("typed api client", () => {
+  it("fetchNews matches schema", () => {
+    type Expected = AxiosResponse<
+      paths["/news"]["get"]["responses"]["200"]["content"]["application/json"]
+    >
+    expectTypeOf<ReturnType<typeof fetchNews>>().toEqualTypeOf<Promise<Expected>>()
+  })
+
+  it("createNews payload aligns with schema", () => {
+    expectTypeOf<Parameters<typeof createNews>[0]>().toEqualTypeOf<CreateNewsPayload>()
+  })
+
+  it("uploadNewsImage returns a string", () => {
+    expectTypeOf<ReturnType<typeof uploadNewsImage>>().toEqualTypeOf<Promise<string>>()
+  })
+
+  it("createEvent payload aligns with schema", () => {
+    expectTypeOf<Parameters<typeof createEvent>[0]>().toEqualTypeOf<CreateEventPayload>()
+  })
+
+  it("uploadEventImage returns a string", () => {
+    expectTypeOf<ReturnType<typeof uploadEventImage>>().toEqualTypeOf<Promise<string>>()
+  })
+
+  it("notifications list matches schema", () => {
+    expectTypeOf<ReturnType<typeof fetchNotificationsList>>().toEqualTypeOf<
+      Promise<NotificationsListResult>
+    >()
+  })
+})

--- a/root/frontend/src/api/__tests__/client.types.test.ts
+++ b/root/frontend/src/api/__tests__/client.types.test.ts
@@ -3,16 +3,8 @@ import { describe, it, expectTypeOf } from "vitest"
 
 import type { paths } from "@/api/generated/schema"
 import { createEvent, uploadEventImage, type CreateEventPayload } from "@/api/events"
-import {
-  createNews,
-  fetchNews,
-  uploadNewsImage,
-  type CreateNewsPayload,
-} from "@/api/news"
-import {
-  fetchNotificationsList,
-  type NotificationsListResult,
-} from "@/api/notifications"
+import { createNews, fetchNews, uploadNewsImage, type CreateNewsPayload } from "@/api/news"
+import { fetchNotificationsList, type NotificationsListResult } from "@/api/notifications"
 
 describe("typed api client", () => {
   it("fetchNews matches schema", () => {

--- a/root/frontend/src/api/client.ts
+++ b/root/frontend/src/api/client.ts
@@ -577,8 +577,8 @@ const normalizeHeaders = <P extends ApiPath, M extends ApiMethod>(
     return headers
   }
 
-  const normalizedEntries = Object.entries(headers).filter(([, value]) =>
-    value !== undefined && value !== null
+  const normalizedEntries = Object.entries(headers).filter(
+    ([, value]) => value !== undefined && value !== null
   )
 
   if (normalizedEntries.length === 0) {

--- a/root/frontend/src/api/client.ts
+++ b/root/frontend/src/api/client.ts
@@ -457,31 +457,41 @@ type ApiPath = keyof paths
 
 type OperationFor<P extends ApiPath, M extends ApiMethod> = paths[P][M]
 
-type PathParamsOf<P extends ApiPath> = paths[P] extends {
-  parameters: { path: infer Params }
-}
-  ? Params extends Record<string, unknown>
-    ? Params
-    : Record<string, never>
-  : Record<string, never>
+type EmptyObject = Record<never, never>
+
+type ExtractPathParams<Op> = Op extends unknown
+  ? Op extends { parameters?: { path: infer Params } }
+    ? Params extends Record<string, unknown>
+      ? Params
+      : never
+    : never
+  : never
+
+type MethodsForPath<P extends ApiPath> = {
+  [M in ApiMethod]: paths[P][M]
+}[ApiMethod]
+
+type PathParamsOf<P extends ApiPath> = [ExtractPathParams<MethodsForPath<P>>] extends [never]
+  ? EmptyObject
+  : ExtractPathParams<MethodsForPath<P>>
 
 type QueryParamsOf<P extends ApiPath, M extends ApiMethod> =
   OperationFor<P, M> extends never
-    ? Record<string, never>
-    : OperationFor<P, M> extends { parameters: { query: infer Query } }
+    ? EmptyObject
+    : OperationFor<P, M> extends { parameters?: { query?: infer Query } }
       ? Query extends Record<string, unknown>
         ? Query
-        : Record<string, never>
-      : Record<string, never>
+        : EmptyObject
+      : EmptyObject
 
 type HeaderParamsOf<P extends ApiPath, M extends ApiMethod> =
   OperationFor<P, M> extends never
-    ? Record<string, never>
-    : OperationFor<P, M> extends { parameters: { header: infer Header } }
+    ? EmptyObject
+    : OperationFor<P, M> extends { parameters?: { header?: infer Header } }
       ? Header extends Record<string, unknown>
         ? Header
-        : Record<string, never>
-      : Record<string, never>
+        : EmptyObject
+      : EmptyObject
 
 type NormalizeContent<Content> =
   Content extends Record<string, unknown>
@@ -499,9 +509,11 @@ type NormalizeContent<Content> =
 type RequestBodyOf<P extends ApiPath, M extends ApiMethod> =
   OperationFor<P, M> extends never
     ? undefined
-    : OperationFor<P, M> extends { requestBody: { content: infer Content } }
+    : OperationFor<P, M> extends { requestBody?: { content: infer Content } }
       ? NormalizeContent<Content>
-      : undefined
+      : OperationFor<P, M> extends { requestBody: { content: infer Content } }
+        ? NormalizeContent<Content>
+        : undefined
 
 type SuccessStatus = 200 | 201 | 202 | 203 | 204 | 205 | 206
 
@@ -560,18 +572,20 @@ const buildPathWithParams = <P extends ApiPath>(path: P, params: PathParamsOf<P>
 
 const normalizeHeaders = <P extends ApiPath, M extends ApiMethod>(
   headers: ApiRequestHeaders<P, M> | undefined
-) => {
+): ApiRequestHeaders<P, M> | undefined => {
   if (!headers) {
     return headers
   }
 
-  const normalized: Record<string, unknown> = {}
-  for (const [key, value] of Object.entries(headers)) {
-    if (value !== undefined && value !== null) {
-      normalized[key] = value
-    }
+  const normalizedEntries = Object.entries(headers).filter(([, value]) =>
+    value !== undefined && value !== null
+  )
+
+  if (normalizedEntries.length === 0) {
+    return undefined
   }
-  return normalized
+
+  return Object.fromEntries(normalizedEntries) as ApiRequestHeaders<P, M>
 }
 
 const createTypedClient = (instance: ApiInstance) => {

--- a/root/frontend/src/api/client.ts
+++ b/root/frontend/src/api/client.ts
@@ -4,6 +4,7 @@ import axios, {
   type AxiosRequestConfig,
   type AxiosResponse,
 } from "axios"
+import type { paths } from "@/api/generated/schema"
 import i18n, { fallbackLng, supportedLngs } from "@/i18n/config"
 
 export const API_UNAUTHORIZED_EVENT = "auth:unauthorized"
@@ -449,5 +450,180 @@ api.interceptors.response.use(
     return Promise.reject(err)
   }
 )
+
+type ApiMethod = "get" | "post" | "put" | "patch" | "delete"
+
+type ApiPath = keyof paths
+
+type OperationFor<P extends ApiPath, M extends ApiMethod> = paths[P][M]
+
+type PathParamsOf<P extends ApiPath> = paths[P] extends {
+  parameters: { path: infer Params }
+}
+  ? Params extends Record<string, unknown>
+    ? Params
+    : Record<string, never>
+  : Record<string, never>
+
+type QueryParamsOf<P extends ApiPath, M extends ApiMethod> = OperationFor<P, M> extends never
+  ? Record<string, never>
+  : OperationFor<P, M> extends { parameters: { query: infer Query } }
+    ? Query extends Record<string, unknown>
+      ? Query
+      : Record<string, never>
+    : Record<string, never>
+
+type HeaderParamsOf<P extends ApiPath, M extends ApiMethod> = OperationFor<P, M> extends never
+  ? Record<string, never>
+  : OperationFor<P, M> extends { parameters: { header: infer Header } }
+    ? Header extends Record<string, unknown>
+      ? Header
+      : Record<string, never>
+    : Record<string, never>
+
+type NormalizeContent<Content> = Content extends Record<string, unknown>
+  ? {
+      [K in keyof Content]: K extends "application/json"
+        ? Content[K]
+        : K extends "multipart/form-data"
+          ? Content[K] | FormData
+          : K extends "application/x-www-form-urlencoded"
+            ? Content[K] | URLSearchParams
+            : Content[K]
+    }[keyof Content]
+  : never
+
+type RequestBodyOf<P extends ApiPath, M extends ApiMethod> = OperationFor<P, M> extends never
+  ? undefined
+  : OperationFor<P, M> extends { requestBody: { content: infer Content } }
+    ? NormalizeContent<Content>
+    : undefined
+
+type SuccessStatus = 200 | 201 | 202 | 203 | 204 | 205 | 206
+
+type ResponseContent<Response> = Response extends { content: infer Content }
+  ? Content extends Record<string, unknown>
+    ? "application/json" extends keyof Content
+      ? Content["application/json"]
+      : Content[keyof Content]
+    : unknown
+  : unknown
+
+type ResponseDataOf<P extends ApiPath, M extends ApiMethod> = OperationFor<P, M> extends never
+  ? unknown
+  : OperationFor<P, M> extends { responses: infer Responses }
+    ? {
+        [S in keyof Responses & (SuccessStatus | "default")]: ResponseContent<Responses[S]>
+      }[keyof Responses & (SuccessStatus | "default")] extends infer Result
+      ? Result extends never
+        ? unknown
+        : Result
+      : unknown
+    : unknown
+
+type ApiRequestHeaders<P extends ApiPath, M extends ApiMethod> =
+  HeaderParamsOf<P, M> &
+    Partial<Record<string, string | number | boolean | null | undefined>>
+
+type PathParamsOption<P extends ApiPath> = keyof PathParamsOf<P> extends never
+  ? { pathParams?: undefined }
+  : { pathParams: PathParamsOf<P> }
+
+type ApiRequestOptions<P extends ApiPath, M extends ApiMethod> = Omit<
+  ApiRequestConfig<RequestBodyOf<P, M>>,
+  "url" | "method" | "data" | "params" | "headers"
+> &
+  PathParamsOption<P> & {
+    params?: QueryParamsOf<P, M>
+    headers?: ApiRequestHeaders<P, M>
+  }
+
+type ApiResponseFor<P extends ApiPath, M extends ApiMethod> = AxiosResponse<
+  ResponseDataOf<P, M>
+>
+
+const buildPathWithParams = <P extends ApiPath>(path: P, params: PathParamsOf<P> | undefined) => {
+  if (!params || Object.keys(params).length === 0) {
+    return path
+  }
+
+  return (path as string).replace(/\{([^{}]+)\}/g, (segment, key: string) => {
+    const value = params[key as keyof typeof params]
+    if (value == null) {
+      throw new Error(`Missing value for path parameter "${key}"`)
+    }
+    return encodeURIComponent(String(value))
+  }) as P
+}
+
+const normalizeHeaders = <P extends ApiPath, M extends ApiMethod>(
+  headers: ApiRequestHeaders<P, M> | undefined
+) => {
+  if (!headers) {
+    return headers
+  }
+
+  const normalized: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(headers)) {
+    if (value !== undefined && value !== null) {
+      normalized[key] = value
+    }
+  }
+  return normalized
+}
+
+const createTypedClient = (instance: ApiInstance) => {
+  const request = async <P extends ApiPath, M extends ApiMethod>(
+    method: M,
+    path: P,
+    options?: ApiRequestOptions<P, M>,
+    body?: RequestBodyOf<P, M>
+  ): Promise<ApiResponseFor<P, M>> => {
+    const { pathParams, headers, params, ...rest } = options ?? {}
+    const url = buildPathWithParams(path, pathParams)
+    const config = rest as ApiRequestConfig<RequestBodyOf<P, M>>
+    const finalHeaders = normalizeHeaders(headers)
+    const requestConfig: ApiRequestConfig<RequestBodyOf<P, M>> = {
+      ...config,
+      method,
+      url,
+      params,
+      headers: finalHeaders,
+    }
+    if (body !== undefined) {
+      requestConfig.data = body
+    }
+    return instance.request<ResponseDataOf<P, M>>(requestConfig)
+  }
+
+  return {
+    request,
+    get: <P extends ApiPath>(path: P, options?: ApiRequestOptions<P, "get">) =>
+      request("get", path, options),
+    delete: <P extends ApiPath>(path: P, options?: ApiRequestOptions<P, "delete">) =>
+      request("delete", path, options),
+    post: <P extends ApiPath>(
+      path: P,
+      data?: RequestBodyOf<P, "post">,
+      options?: ApiRequestOptions<P, "post">
+    ) => request("post", path, options, data),
+    put: <P extends ApiPath>(
+      path: P,
+      data?: RequestBodyOf<P, "put">,
+      options?: ApiRequestOptions<P, "put">
+    ) => request("put", path, options, data),
+    patch: <P extends ApiPath>(
+      path: P,
+      data?: RequestBodyOf<P, "patch">,
+      options?: ApiRequestOptions<P, "patch">
+    ) => request("patch", path, options, data),
+  }
+}
+
+export type TypedApiClient = ReturnType<typeof createTypedClient>
+
+export type TypedRequestOptions<P extends ApiPath, M extends ApiMethod> = ApiRequestOptions<P, M>
+
+export const apiClient = createTypedClient(api)
 
 export default api

--- a/root/frontend/src/api/client.ts
+++ b/root/frontend/src/api/client.ts
@@ -465,39 +465,43 @@ type PathParamsOf<P extends ApiPath> = paths[P] extends {
     : Record<string, never>
   : Record<string, never>
 
-type QueryParamsOf<P extends ApiPath, M extends ApiMethod> = OperationFor<P, M> extends never
-  ? Record<string, never>
-  : OperationFor<P, M> extends { parameters: { query: infer Query } }
-    ? Query extends Record<string, unknown>
-      ? Query
+type QueryParamsOf<P extends ApiPath, M extends ApiMethod> =
+  OperationFor<P, M> extends never
+    ? Record<string, never>
+    : OperationFor<P, M> extends { parameters: { query: infer Query } }
+      ? Query extends Record<string, unknown>
+        ? Query
+        : Record<string, never>
       : Record<string, never>
-    : Record<string, never>
 
-type HeaderParamsOf<P extends ApiPath, M extends ApiMethod> = OperationFor<P, M> extends never
-  ? Record<string, never>
-  : OperationFor<P, M> extends { parameters: { header: infer Header } }
-    ? Header extends Record<string, unknown>
-      ? Header
+type HeaderParamsOf<P extends ApiPath, M extends ApiMethod> =
+  OperationFor<P, M> extends never
+    ? Record<string, never>
+    : OperationFor<P, M> extends { parameters: { header: infer Header } }
+      ? Header extends Record<string, unknown>
+        ? Header
+        : Record<string, never>
       : Record<string, never>
-    : Record<string, never>
 
-type NormalizeContent<Content> = Content extends Record<string, unknown>
-  ? {
-      [K in keyof Content]: K extends "application/json"
-        ? Content[K]
-        : K extends "multipart/form-data"
-          ? Content[K] | FormData
-          : K extends "application/x-www-form-urlencoded"
-            ? Content[K] | URLSearchParams
-            : Content[K]
-    }[keyof Content]
-  : never
+type NormalizeContent<Content> =
+  Content extends Record<string, unknown>
+    ? {
+        [K in keyof Content]: K extends "application/json"
+          ? Content[K]
+          : K extends "multipart/form-data"
+            ? Content[K] | FormData
+            : K extends "application/x-www-form-urlencoded"
+              ? Content[K] | URLSearchParams
+              : Content[K]
+      }[keyof Content]
+    : never
 
-type RequestBodyOf<P extends ApiPath, M extends ApiMethod> = OperationFor<P, M> extends never
-  ? undefined
-  : OperationFor<P, M> extends { requestBody: { content: infer Content } }
-    ? NormalizeContent<Content>
-    : undefined
+type RequestBodyOf<P extends ApiPath, M extends ApiMethod> =
+  OperationFor<P, M> extends never
+    ? undefined
+    : OperationFor<P, M> extends { requestBody: { content: infer Content } }
+      ? NormalizeContent<Content>
+      : undefined
 
 type SuccessStatus = 200 | 201 | 202 | 203 | 204 | 205 | 206
 
@@ -509,21 +513,21 @@ type ResponseContent<Response> = Response extends { content: infer Content }
     : unknown
   : unknown
 
-type ResponseDataOf<P extends ApiPath, M extends ApiMethod> = OperationFor<P, M> extends never
-  ? unknown
-  : OperationFor<P, M> extends { responses: infer Responses }
-    ? {
-        [S in keyof Responses & (SuccessStatus | "default")]: ResponseContent<Responses[S]>
-      }[keyof Responses & (SuccessStatus | "default")] extends infer Result
-      ? Result extends never
-        ? unknown
-        : Result
+type ResponseDataOf<P extends ApiPath, M extends ApiMethod> =
+  OperationFor<P, M> extends never
+    ? unknown
+    : OperationFor<P, M> extends { responses: infer Responses }
+      ? {
+          [S in keyof Responses & (SuccessStatus | "default")]: ResponseContent<Responses[S]>
+        }[keyof Responses & (SuccessStatus | "default")] extends infer Result
+        ? Result extends never
+          ? unknown
+          : Result
+        : unknown
       : unknown
-    : unknown
 
-type ApiRequestHeaders<P extends ApiPath, M extends ApiMethod> =
-  HeaderParamsOf<P, M> &
-    Partial<Record<string, string | number | boolean | null | undefined>>
+type ApiRequestHeaders<P extends ApiPath, M extends ApiMethod> = HeaderParamsOf<P, M> &
+  Partial<Record<string, string | number | boolean | null | undefined>>
 
 type PathParamsOption<P extends ApiPath> = keyof PathParamsOf<P> extends never
   ? { pathParams?: undefined }
@@ -538,9 +542,7 @@ type ApiRequestOptions<P extends ApiPath, M extends ApiMethod> = Omit<
     headers?: ApiRequestHeaders<P, M>
   }
 
-type ApiResponseFor<P extends ApiPath, M extends ApiMethod> = AxiosResponse<
-  ResponseDataOf<P, M>
->
+type ApiResponseFor<P extends ApiPath, M extends ApiMethod> = AxiosResponse<ResponseDataOf<P, M>>
 
 const buildPathWithParams = <P extends ApiPath>(path: P, params: PathParamsOf<P> | undefined) => {
   if (!params || Object.keys(params).length === 0) {

--- a/root/frontend/src/api/events.ts
+++ b/root/frontend/src/api/events.ts
@@ -16,6 +16,10 @@ export const uploadEventImage = async (file: File) => {
   const response = await apiClient.post("/events/upload_image", formData, {
     headers: { "Content-Type": "multipart/form-data" },
   })
-  const parsed = ensureValidResponse(uploadResponseSchema, response.data, "POST /events/upload_image")
+  const parsed = ensureValidResponse(
+    uploadResponseSchema,
+    response.data,
+    "POST /events/upload_image"
+  )
   return parsed.url
 }

--- a/root/frontend/src/api/events.ts
+++ b/root/frontend/src/api/events.ts
@@ -1,0 +1,21 @@
+import { z } from "zod"
+
+import type { components } from "@/api/generated/schema"
+import { apiClient } from "./client"
+import { ensureValidResponse } from "./validation"
+
+export type CreateEventPayload = components["schemas"]["EventCreate"]
+
+const uploadResponseSchema = z.object({ url: z.string().trim().min(1) })
+
+export const createEvent = (payload: CreateEventPayload) => apiClient.post("/events", payload)
+
+export const uploadEventImage = async (file: File) => {
+  const formData = new FormData()
+  formData.append("file", file)
+  const response = await apiClient.post("/events/upload_image", formData, {
+    headers: { "Content-Type": "multipart/form-data" },
+  })
+  const parsed = ensureValidResponse(uploadResponseSchema, response.data, "POST /events/upload_image")
+  return parsed.url
+}

--- a/root/frontend/src/api/hooks/events.ts
+++ b/root/frontend/src/api/hooks/events.ts
@@ -10,7 +10,7 @@ import {
 } from "@tanstack/react-query"
 import { useMemo } from "react"
 
-import api, { type ApiRequestConfig } from "../client"
+import { apiClient, type TypedRequestOptions } from "../client"
 import type { Event } from "@/types/Event"
 import type { PaginatedResponse } from "@/types/Pagination"
 
@@ -185,16 +185,14 @@ export const useEventsListQuery = (
         params.cursor = pageParam
       }
 
-      const requestConfig: ApiRequestConfig = {
+      const requestConfig: TypedRequestOptions<"/events", "get"> = {
         params,
         signal,
         validateStatus: (status) => status >= 200 && status < 400,
-      }
-      if (etagKey) {
-        requestConfig.etagCacheKey = etagKey
+        ...(etagKey ? { etagCacheKey: etagKey } : {}),
       }
 
-      const response = await api.get<PaginatedResponse<Event>>("/events", requestConfig)
+      const response = await apiClient.get("/events", requestConfig)
 
       if (response.status === 304) {
         const cached =
@@ -269,13 +267,13 @@ export const useMyEventsQuery = (
     enabled: effectiveEnabled,
     queryFn: async ({ signal }) => {
       const etagKey = createMyEventsEtagKey(normalized)
-      const config: ApiRequestConfig = {
+      const config: TypedRequestOptions<"/events/my", "get"> = {
         signal,
         validateStatus: (status) => status >= 200 && status < 400,
         etagCacheKey: etagKey,
       }
 
-      const response = await api.get<Event[]>("/events/my", config)
+      const response = await apiClient.get("/events/my", config)
 
       if (response.status === 304) {
         return queryClient.getQueryData<Event[]>(queryKey) ?? []

--- a/root/frontend/src/api/news.ts
+++ b/root/frontend/src/api/news.ts
@@ -23,11 +23,7 @@ export type UpdateNewsPayload = components["schemas"]["NewsUpdate"] | null
 
 const newsUploadResponseSchema = z.object({ url: z.string().trim().min(1) })
 
-const applyParsedData = <T>(
-  response: { data: unknown },
-  schema: z.ZodType<T>,
-  context: string
-) => {
+const applyParsedData = <T>(response: { data: unknown }, schema: z.ZodType<T>, context: string) => {
   const parsed = ensureValidResponse(schema, response.data, context)
   ;(response as { data: T }).data = parsed
 }
@@ -95,6 +91,10 @@ export const uploadNewsImage = async (file: File) => {
   const response = await apiClient.post("/news/upload_image", formData, {
     headers: { "Content-Type": "multipart/form-data" },
   })
-  const parsed = ensureValidResponse(newsUploadResponseSchema, response.data, "POST /news/upload_image")
+  const parsed = ensureValidResponse(
+    newsUploadResponseSchema,
+    response.data,
+    "POST /news/upload_image"
+  )
   return parsed.url
 }

--- a/root/frontend/src/api/news.ts
+++ b/root/frontend/src/api/news.ts
@@ -1,7 +1,7 @@
 import { z } from "zod"
 
 import type { components, paths } from "@/api/generated/schema"
-import api from "./client"
+import { apiClient } from "./client"
 import { ensureValidResponse } from "./validation"
 
 export type NewsItem = components["schemas"]["NewsOut"]
@@ -11,6 +11,25 @@ type NewsListResponse = paths["/news"]["get"]["responses"]["200"]["content"]["ap
 type FetchNewsOptions = {
   ifNoneMatch?: string | null
   signal?: AbortSignal
+}
+
+type FetchNewsItemOptions = {
+  ifNoneMatch?: string | null
+  signal?: AbortSignal
+}
+
+export type CreateNewsPayload = components["schemas"]["NewsCreate"]
+export type UpdateNewsPayload = components["schemas"]["NewsUpdate"] | null
+
+const newsUploadResponseSchema = z.object({ url: z.string().trim().min(1) })
+
+const applyParsedData = <T>(
+  response: { data: unknown },
+  schema: z.ZodType<T>,
+  context: string
+) => {
+  const parsed = ensureValidResponse(schema, response.data, context)
+  ;(response as { data: T }).data = parsed
 }
 
 const newsItemSchema: z.ZodType<NewsItem> = z.object({
@@ -29,8 +48,53 @@ export const parseNewsList = (data: unknown) =>
   ensureValidResponse(newsListSchema, data, "GET /news")
 
 export const fetchNews = ({ ifNoneMatch, signal }: FetchNewsOptions = {}) =>
-  api.get<NewsListResponse>("/news", {
-    headers: ifNoneMatch ? { "If-None-Match": ifNoneMatch } : undefined,
+  apiClient.get("/news", {
+    headers: ifNoneMatch ? { "if-none-match": ifNoneMatch } : undefined,
     signal,
     validateStatus: (status) => status === 304 || (status >= 200 && status < 300),
   })
+
+export const fetchNewsItem = async (
+  id: number,
+  { ifNoneMatch, signal }: FetchNewsItemOptions = {}
+) => {
+  const response = await apiClient.get("/news/{id}", {
+    pathParams: { id },
+    headers: ifNoneMatch ? { "if-none-match": ifNoneMatch } : undefined,
+    signal,
+    validateStatus: (status) => status === 304 || (status >= 200 && status < 300),
+  })
+  if (response.status !== 304) {
+    applyParsedData(response, newsItemSchema, "GET /news/{id}")
+  }
+  return response
+}
+
+export const createNews = async (payload: CreateNewsPayload) => {
+  const response = await apiClient.post("/news", payload)
+  applyParsedData(response, newsItemSchema, "POST /news")
+  return response
+}
+
+export const updateNews = async (id: number, payload: UpdateNewsPayload) => {
+  const response = await apiClient.patch("/news/{id}", payload ?? undefined, {
+    pathParams: { id },
+  })
+  applyParsedData(response, newsItemSchema, "PATCH /news/{id}")
+  return response
+}
+
+export const deleteNews = (id: number) =>
+  apiClient.delete("/news/{id}", {
+    pathParams: { id },
+  })
+
+export const uploadNewsImage = async (file: File) => {
+  const formData = new FormData()
+  formData.append("file", file)
+  const response = await apiClient.post("/news/upload_image", formData, {
+    headers: { "Content-Type": "multipart/form-data" },
+  })
+  const parsed = ensureValidResponse(newsUploadResponseSchema, response.data, "POST /news/upload_image")
+  return parsed.url
+}

--- a/root/frontend/src/api/notifications.ts
+++ b/root/frontend/src/api/notifications.ts
@@ -1,7 +1,7 @@
 import { z } from "zod"
 
 import { apiClient } from "@/api/client"
-import type { components, paths } from "@/api/generated/schema"
+import type { components } from "@/api/generated/schema"
 import type {
   AdminUserTopicsResponse,
   PushSubscriptionResponse,
@@ -108,8 +108,7 @@ export async function saveSubscription(
     user_agent: userAgent,
     ...(Array.isArray(topics) ? { topics } : {}),
   }
-
-  const { data } = await apiClient.post<PushSubscriptionResponse>("/push/subscribe", payload)
+  const { data } = await apiClient.post("/push/subscribe", payload)
   return data
 }
 
@@ -119,15 +118,14 @@ export async function deleteSubscription(endpoint: string): Promise<void> {
 }
 
 export async function sendTest(): Promise<SendTestNotificationResponse> {
-  const { data } = await apiClient.post<SendTestNotificationResponse>("/push/test")
+  const { data } = await apiClient.post("/push/test")
   return data
 }
 
 export async function getVapidPublicKey(): Promise<string | null> {
-  const { data } =
-    await apiClient.get<
-      paths["/push/vapid-public-key"]["get"]["responses"]["200"]["content"]["application/json"]
-    >("/push/vapid-public-key")
+  const { data } = await apiClient.get(
+    "/push/vapid-public-key"
+  )
   const schema = z.object({ publicKey: z.string().trim().min(1).optional() })
   const parsed = ensureValidResponse(schema, data, "GET /push/vapid-public-key")
   const normalized = parsed.publicKey?.trim()
@@ -142,7 +140,7 @@ const pushTopicsSchema = z.object({
 })
 
 export async function fetchPushTopics(): Promise<PushTopicsResponse> {
-  const { data } = await apiClient.get<PushTopicsResponse>("/push/topics")
+  const { data } = await apiClient.get("/push/topics")
   const parsed = ensureValidResponse(pushTopicsSchema, data, "GET /push/topics")
   return {
     allowed: parsed.allowed,
@@ -161,7 +159,7 @@ const adminTopicsSchema = z.object({
 })
 
 export async function fetchAdminUserTopics(userId: number): Promise<AdminUserTopicsResponse> {
-  const { data } = await apiClient.get<AdminUserTopicsResponse>("/push/admin/topics/{user_id}", {
+  const { data } = await apiClient.get("/push/admin/topics/{user_id}", {
     pathParams: { user_id: userId },
   })
   return ensureValidResponse(adminTopicsSchema, data, `GET /push/admin/topics/${userId}`)
@@ -172,7 +170,7 @@ export async function updateAdminUserTopics(
   topics: string[]
 ): Promise<AdminUserTopicsResponse> {
   const payload = { topics }
-  const { data } = await apiClient.put<AdminUserTopicsResponse>(
+  const { data } = await apiClient.put(
     "/push/admin/topics/{user_id}",
     payload,
     {

--- a/root/frontend/src/api/notifications.ts
+++ b/root/frontend/src/api/notifications.ts
@@ -1,6 +1,6 @@
 import { z } from "zod"
 
-import api from "@/api/client"
+import { apiClient } from "@/api/client"
 import type { components, paths } from "@/api/generated/schema"
 import type {
   AdminUserTopicsResponse,
@@ -9,6 +9,80 @@ import type {
   SendTestNotificationResponse,
 } from "@/types/notifications"
 import { ensureValidResponse } from "./validation"
+
+const notificationSchema = z.object({
+  id: z.number().int(),
+  title: z.string(),
+  body: z.string().nullable().optional(),
+  title_en: z.string().nullable().optional(),
+  body_en: z.string().nullable().optional(),
+  type: z.string().nullable().optional(),
+  url: z.string().nullable().optional(),
+  created_at: z.string(),
+  read: z.boolean(),
+  read_at: z.string().nullable().optional(),
+})
+
+const notificationsListSchema = z.object({
+  items: z.array(notificationSchema),
+  unread_count: z.number(),
+  has_more: z.boolean(),
+  next_cursor: z.string().nullable().optional(),
+})
+
+const deadLetterJobSchema = z.object({
+  id: z.number().int(),
+  kind: z.string(),
+  record_id: z.number().int(),
+  locale: z.string().nullable().optional(),
+  enqueued_at: z.string(),
+  claimed_at: z.string().nullable().optional(),
+  attempts: z.number().int(),
+  last_error: z.string().nullable().optional(),
+  next_retry_at: z.string().nullable().optional(),
+})
+
+const deadLetterListSchema = z.object({
+  items: z.array(deadLetterJobSchema),
+  total: z.number().int(),
+})
+
+export type NotificationEntry = z.infer<typeof notificationSchema>
+export type NotificationsListResult = z.infer<typeof notificationsListSchema>
+export type DeadLetterJob = z.infer<typeof deadLetterJobSchema>
+export type DeadLetterListResult = z.infer<typeof deadLetterListSchema>
+
+export const fetchNotificationsList = async (params?: {
+  cursor?: string | null
+  limit?: number
+}) => {
+  const response = await apiClient.get("/notifications", {
+    params,
+  })
+  return ensureValidResponse(notificationsListSchema, response.data, "GET /notifications")
+}
+
+export const markNotificationRead = (notificationId: number) =>
+  apiClient.patch("/notifications/{notif_id}/read", undefined, {
+    pathParams: { notif_id: notificationId },
+  })
+
+export const markAllNotificationsRead = () => apiClient.post("/notifications/read-all")
+
+export const clearNotifications = () => apiClient.delete("/notifications")
+
+export const fetchDeadLetterQueue = async (params?: { limit?: number; offset?: number }) => {
+  const response = await apiClient.get("/notifications/admin/dead-letter", {
+    params,
+  })
+  return ensureValidResponse(deadLetterListSchema, response.data, "GET /notifications/admin/dead-letter")
+}
+
+export const retryDeadLetterJobs = (jobIds: number[]) =>
+  apiClient.post("/notifications/admin/dead-letter/retry", { job_ids: jobIds })
+
+export const purgeDeadLetterJobs = (jobIds: number[]) =>
+  apiClient.post("/notifications/admin/dead-letter/purge", { job_ids: jobIds })
 
 export async function saveSubscription(
   sub: PushSubscriptionJSON,
@@ -31,23 +105,23 @@ export async function saveSubscription(
     ...(Array.isArray(topics) ? { topics } : {}),
   }
 
-  const { data } = await api.post<PushSubscriptionResponse>("/push/subscribe", payload)
+  const { data } = await apiClient.post<PushSubscriptionResponse>("/push/subscribe", payload)
   return data
 }
 
 export async function deleteSubscription(endpoint: string): Promise<void> {
   const payload: components["schemas"]["PushSubscriptionDelete"] = { endpoint }
-  await api.post("/push/unsubscribe", payload)
+  await apiClient.post("/push/unsubscribe", payload)
 }
 
 export async function sendTest(): Promise<SendTestNotificationResponse> {
-  const { data } = await api.post<SendTestNotificationResponse>("/push/test")
+  const { data } = await apiClient.post<SendTestNotificationResponse>("/push/test")
   return data
 }
 
 export async function getVapidPublicKey(): Promise<string | null> {
   const { data } =
-    await api.get<
+    await apiClient.get<
       paths["/push/vapid-public-key"]["get"]["responses"]["200"]["content"]["application/json"]
     >("/push/vapid-public-key")
   const schema = z.object({ publicKey: z.string().trim().min(1).optional() })
@@ -64,7 +138,7 @@ const pushTopicsSchema = z.object({
 })
 
 export async function fetchPushTopics(): Promise<PushTopicsResponse> {
-  const { data } = await api.get<PushTopicsResponse>("/push/topics")
+  const { data } = await apiClient.get<PushTopicsResponse>("/push/topics")
   const parsed = ensureValidResponse(pushTopicsSchema, data, "GET /push/topics")
   return {
     allowed: parsed.allowed,
@@ -83,7 +157,9 @@ const adminTopicsSchema = z.object({
 })
 
 export async function fetchAdminUserTopics(userId: number): Promise<AdminUserTopicsResponse> {
-  const { data } = await api.get<AdminUserTopicsResponse>(`/push/admin/topics/${userId}`)
+  const { data } = await apiClient.get<AdminUserTopicsResponse>("/push/admin/topics/{user_id}", {
+    pathParams: { user_id: userId },
+  })
   return ensureValidResponse(adminTopicsSchema, data, `GET /push/admin/topics/${userId}`)
 }
 
@@ -92,6 +168,8 @@ export async function updateAdminUserTopics(
   topics: string[]
 ): Promise<AdminUserTopicsResponse> {
   const payload = { topics }
-  const { data } = await api.put<AdminUserTopicsResponse>(`/push/admin/topics/${userId}`, payload)
+  const { data } = await apiClient.put<AdminUserTopicsResponse>("/push/admin/topics/{user_id}", payload, {
+    pathParams: { user_id: userId },
+  })
   return ensureValidResponse(adminTopicsSchema, data, `PUT /push/admin/topics/${userId}`)
 }

--- a/root/frontend/src/api/notifications.ts
+++ b/root/frontend/src/api/notifications.ts
@@ -75,7 +75,11 @@ export const fetchDeadLetterQueue = async (params?: { limit?: number; offset?: n
   const response = await apiClient.get("/notifications/admin/dead-letter", {
     params,
   })
-  return ensureValidResponse(deadLetterListSchema, response.data, "GET /notifications/admin/dead-letter")
+  return ensureValidResponse(
+    deadLetterListSchema,
+    response.data,
+    "GET /notifications/admin/dead-letter"
+  )
 }
 
 export const retryDeadLetterJobs = (jobIds: number[]) =>
@@ -168,8 +172,12 @@ export async function updateAdminUserTopics(
   topics: string[]
 ): Promise<AdminUserTopicsResponse> {
   const payload = { topics }
-  const { data } = await apiClient.put<AdminUserTopicsResponse>("/push/admin/topics/{user_id}", payload, {
-    pathParams: { user_id: userId },
-  })
+  const { data } = await apiClient.put<AdminUserTopicsResponse>(
+    "/push/admin/topics/{user_id}",
+    payload,
+    {
+      pathParams: { user_id: userId },
+    }
+  )
   return ensureValidResponse(adminTopicsSchema, data, `PUT /push/admin/topics/${userId}`)
 }

--- a/root/frontend/src/api/notifications.ts
+++ b/root/frontend/src/api/notifications.ts
@@ -123,9 +123,7 @@ export async function sendTest(): Promise<SendTestNotificationResponse> {
 }
 
 export async function getVapidPublicKey(): Promise<string | null> {
-  const { data } = await apiClient.get(
-    "/push/vapid-public-key"
-  )
+  const { data } = await apiClient.get("/push/vapid-public-key")
   const schema = z.object({ publicKey: z.string().trim().min(1).optional() })
   const parsed = ensureValidResponse(schema, data, "GET /push/vapid-public-key")
   const normalized = parsed.publicKey?.trim()
@@ -170,12 +168,8 @@ export async function updateAdminUserTopics(
   topics: string[]
 ): Promise<AdminUserTopicsResponse> {
   const payload = { topics }
-  const { data } = await apiClient.put(
-    "/push/admin/topics/{user_id}",
-    payload,
-    {
-      pathParams: { user_id: userId },
-    }
-  )
+  const { data } = await apiClient.put("/push/admin/topics/{user_id}", payload, {
+    pathParams: { user_id: userId },
+  })
   return ensureValidResponse(adminTopicsSchema, data, `PUT /push/admin/topics/${userId}`)
 }

--- a/root/frontend/src/hooks/useNotifications.ts
+++ b/root/frontend/src/hooks/useNotifications.ts
@@ -1,22 +1,18 @@
 import { useCallback } from "react"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
-import api from "@/api/client"
 
-export type NotificationItem = {
-  id: number
-  title: string
-  body?: string
-  created_at: string
-  read: boolean
-  link?: string
-}
+import {
+  clearNotifications as clearNotificationsRequest,
+  fetchNotificationsList,
+  markAllNotificationsRead as markAllNotificationsReadRequest,
+  markNotificationRead as markNotificationReadRequest,
+  type NotificationEntry,
+  type NotificationsListResult,
+} from "@/api/notifications"
 
-type NotificationsResponse = {
-  items?: NotificationItem[]
-  unread_count?: number
-  has_more?: boolean
-  next_cursor?: string | null
-}
+export type NotificationItem = NotificationEntry & { link?: string }
+
+type NotificationsResponse = NotificationsListResult
 
 type NormalizedNotificationsResponse = {
   items: NotificationItem[]
@@ -29,18 +25,18 @@ export function useNotifications() {
   const qc = useQueryClient()
   const queryKey = ["notifications", "list"] as const
   const normalize = (data: NotificationsResponse): NormalizedNotificationsResponse => ({
-    items: Array.isArray(data.items) ? data.items : [],
-    unread:
-      typeof data.unread_count === "number" && Number.isFinite(data.unread_count)
-        ? data.unread_count
-        : null,
-    hasMore: Boolean(data.has_more),
+    items: data.items.map((item) => ({
+      ...item,
+      link: item.url ?? undefined,
+    })),
+    unread: data.unread_count,
+    hasMore: data.has_more,
     nextCursor: data.next_cursor ?? null,
   })
   const list = useQuery<NormalizedNotificationsResponse>({
     queryKey,
     queryFn: async () => {
-      const { data } = await api.get<NotificationsResponse>("notifications")
+      const data = await fetchNotificationsList()
       return normalize(data)
     },
     refetchInterval: 60000,
@@ -48,19 +44,19 @@ export function useNotifications() {
   })
   const markRead = useMutation({
     mutationFn: async (id: number) => {
-      await api.patch(`notifications/${id}/read`)
+      await markNotificationReadRequest(id)
     },
     onSuccess: () => qc.invalidateQueries({ queryKey: ["notifications"] }),
   })
   const markAll = useMutation({
     mutationFn: async () => {
-      await api.post("notifications/read-all")
+      await markAllNotificationsReadRequest()
     },
     onSuccess: () => qc.invalidateQueries({ queryKey: ["notifications"] }),
   })
   const clearAll = useMutation({
     mutationFn: async () => {
-      await api.delete("notifications")
+      await clearNotificationsRequest()
     },
     onSuccess: () => qc.invalidateQueries({ queryKey: ["notifications"] }),
   })
@@ -71,9 +67,7 @@ export function useNotifications() {
     error: fetchMoreError,
   } = useMutation<NormalizedNotificationsResponse, unknown, string>({
     mutationFn: async (cursor: string) => {
-      const { data } = await api.get<NotificationsResponse>("notifications", {
-        params: { cursor },
-      })
+      const data = await fetchNotificationsList({ cursor })
       return normalize(data)
     },
     onSuccess: (nextPage) => {

--- a/root/frontend/src/pages/AdminNotifications.tsx
+++ b/root/frontend/src/pages/AdminNotifications.tsx
@@ -27,28 +27,16 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { isAxiosError } from "axios"
 import { useTranslation } from "react-i18next"
 
-import apiClient from "@/api/client"
-import { fetchAdminUserTopics, updateAdminUserTopics } from "@/api/notifications"
+import {
+  fetchAdminUserTopics,
+  fetchDeadLetterQueue,
+  purgeDeadLetterJobs,
+  retryDeadLetterJobs,
+  updateAdminUserTopics,
+} from "@/api/notifications"
 import Layout from "@/components/Layout"
 import PageFadeIn from "@/components/PageFadeIn"
 import { useLanguage } from "@/contexts/LanguageContext"
-
-type DeadLetterJob = {
-  id: number
-  kind: string
-  record_id: number
-  locale: string | null
-  enqueued_at: string
-  claimed_at: string | null
-  attempts: number
-  last_error: string | null
-  next_retry_at: string | null
-}
-
-type DeadLetterResponse = {
-  items: DeadLetterJob[]
-  total: number
-}
 
 const queryKey = ["admin", "notifications", "dead-letter"] as const
 
@@ -123,10 +111,7 @@ export default function AdminNotifications() {
 
   const listQuery = useQuery({
     queryKey,
-    queryFn: async () => {
-      const { data } = await apiClient.get<DeadLetterResponse>("/notifications/admin/dead-letter")
-      return data
-    },
+    queryFn: () => fetchDeadLetterQueue(),
   })
 
   const resetSelection = () => setSelected(new Set())
@@ -137,7 +122,7 @@ export default function AdminNotifications() {
 
   const retryMutation = useMutation({
     mutationFn: async (jobIds: number[]) => {
-      await apiClient.post("/notifications/admin/dead-letter/retry", { job_ids: jobIds })
+      await retryDeadLetterJobs(jobIds)
     },
     onMutate: () => {
       setActionError(null)
@@ -151,7 +136,7 @@ export default function AdminNotifications() {
 
   const purgeMutation = useMutation({
     mutationFn: async (jobIds: number[]) => {
-      await apiClient.post("/notifications/admin/dead-letter/purge", { job_ids: jobIds })
+      await purgeDeadLetterJobs(jobIds)
     },
     onMutate: () => {
       setActionError(null)

--- a/root/frontend/src/pages/Events.tsx
+++ b/root/frontend/src/pages/Events.tsx
@@ -10,7 +10,7 @@ import {
   type CSSProperties,
 } from "react"
 import { useQueryClient } from "@tanstack/react-query"
-import axios from "../api/client"
+import { createEvent, uploadEventImage } from "@/api/events"
 import type { Event } from "@/types/Event"
 import {
   Box,
@@ -214,12 +214,8 @@ const Events = () => {
       return localUrl
     })
     try {
-      const formData = new FormData()
-      formData.append("file", file)
-      const res = await axios.post<{ url: string }>("/events/upload_image", formData, {
-        headers: { "Content-Type": "multipart/form-data" },
-      })
-      setEventData((prev) => ({ ...prev, image_url: res.data.url }))
+      const imageUrl = await uploadEventImage(file)
+      setEventData((prev) => ({ ...prev, image_url: imageUrl }))
     } finally {
       setImageUploading(false)
     }
@@ -250,8 +246,8 @@ const Events = () => {
         location: locationValue,
         starts_at: eventData.starts_at,
         ends_at: eventData.ends_at,
-      }
-      await axios.post<Event>("/events", payload)
+      } satisfies Parameters<typeof createEvent>[0]
+      await createEvent(payload)
       closeCreate()
       setTab("active")
       void queryClient.invalidateQueries({ queryKey: ["events"] })

--- a/root/frontend/src/pages/News.tsx
+++ b/root/frontend/src/pages/News.tsx
@@ -11,7 +11,7 @@ import {
   useMemo,
   type CSSProperties,
 } from "react"
-import axios from "../api/client"
+import { createNews, uploadNewsImage } from "@/api/news"
 import {
   Box,
   Typography,
@@ -121,12 +121,8 @@ const News = () => {
     try {
       let image_url = ""
       if (imageFile) {
-        const data = new FormData()
-        data.append("file", imageFile)
-        const res = await axios.post<{ url: string }>("/news/upload_image", data, {
-          headers: { "Content-Type": "multipart/form-data" },
-        })
-        image_url = res.data?.url || ""
+        const uploadedUrl = await uploadNewsImage(imageFile)
+        image_url = uploadedUrl || ""
       }
 
       const payload = {
@@ -135,9 +131,9 @@ const News = () => {
         image_url,
         ...(newsData.title_en.trim() ? { title_en: newsData.title_en } : {}),
         ...(newsData.content_en.trim() ? { content_en: newsData.content_en } : {}),
-      }
+      } satisfies Parameters<typeof createNews>[0]
 
-      await axios.post("/news", payload)
+      await createNews(payload)
       setAddOpen(false)
       setNewsData(initialNews)
       setImageFile(null)

--- a/root/frontend/src/pages/NewsDetail.tsx
+++ b/root/frontend/src/pages/NewsDetail.tsx
@@ -28,7 +28,13 @@ import PhotoCamera from "@mui/icons-material/PhotoCamera"
 import dayjs from "dayjs"
 import utc from "dayjs/plugin/utc"
 import timezone from "dayjs/plugin/timezone"
-import api from "@/api/client"
+import {
+  deleteNews,
+  fetchNewsItem,
+  updateNews,
+  uploadNewsImage,
+  type NewsItem,
+} from "@/api/news"
 import Layout from "@/components/Layout"
 import SmartImage from "@/components/SmartImage"
 import { useAuth } from "@/contexts/AuthContext"
@@ -38,19 +44,16 @@ import { useTranslation } from "react-i18next"
 dayjs.extend(utc)
 dayjs.extend(timezone)
 
-type NewsItem = {
-  id: number
-  title: string
-  content: string
-  title_en?: string | null
-  content_en?: string | null
-  image_url?: string | null
-  created_at?: string
-}
-
 async function fetchNews(id: string) {
-  const { data } = await api.get<NewsItem>(`/news/${id}`)
-  return data
+  const numericId = Number(id)
+  if (!Number.isFinite(numericId)) {
+    throw new Error("Invalid news id")
+  }
+  const response = await fetchNewsItem(numericId)
+  if (response.status === 304) {
+    throw new Error("Not modified")
+  }
+  return response.data
 }
 
 const getMoscowDate = (dateStr: string) => {
@@ -151,12 +154,8 @@ export default function NewsDetail() {
     try {
       let imageUrl = editData.image_url
       if (newImage) {
-        const data = new FormData()
-        data.append("file", newImage)
-        const res = await api.post<{ url: string }>("/news/upload_image", data, {
-          headers: { "Content-Type": "multipart/form-data" },
-        })
-        imageUrl = res.data.url
+        const uploaded = await uploadNewsImage(newImage)
+        imageUrl = uploaded
       }
       const payload = {
         title: editData.title,
@@ -165,7 +164,7 @@ export default function NewsDetail() {
         content_en: editData.content_en,
         image_url: imageUrl,
       }
-      const { data } = await api.patch<NewsItem>(`/news/${query.data.id}`, payload)
+      const { data } = await updateNews(query.data.id, payload)
       queryClient.setQueryData(["news", id, language], data)
       await queryClient.invalidateQueries({ queryKey: ["news"] })
       setSnack(t("news:notifications.updated"))
@@ -182,7 +181,7 @@ export default function NewsDetail() {
     if (!query.data) return
     setDeleting(true)
     try {
-      await api.delete(`/news/${query.data.id}`)
+      await deleteNews(query.data.id)
       setSnack(t("news:notifications.deleted"))
       queryClient.removeQueries({ queryKey: ["news", id] })
       await queryClient.invalidateQueries({ queryKey: ["news"] })

--- a/root/frontend/src/pages/NewsDetail.tsx
+++ b/root/frontend/src/pages/NewsDetail.tsx
@@ -28,13 +28,7 @@ import PhotoCamera from "@mui/icons-material/PhotoCamera"
 import dayjs from "dayjs"
 import utc from "dayjs/plugin/utc"
 import timezone from "dayjs/plugin/timezone"
-import {
-  deleteNews,
-  fetchNewsItem,
-  updateNews,
-  uploadNewsImage,
-  type NewsItem,
-} from "@/api/news"
+import { deleteNews, fetchNewsItem, updateNews, uploadNewsImage, type NewsItem } from "@/api/news"
 import Layout from "@/components/Layout"
 import SmartImage from "@/components/SmartImage"
 import { useAuth } from "@/contexts/AuthContext"


### PR DESCRIPTION
## Summary
- extend the Axios client with OpenAPI-aware helpers that understand path params, request bodies, and typed responses
- add typed API utilities for news, events, and notifications that validate server payloads with Zod
- refactor news, events, and admin notification pages plus the notifications hook to use the new client instead of hard-coded URLs
- add compile-time tests that assert payloads and responses stay in sync with the generated schema

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_6904e465f6908327819cb7a935369c12