### PR TITLE
Remove dash list pseudo element stripe

### DIFF
--- a/root/frontend/src/styles/tailwind.css
+++ b/root/frontend/src/styles/tailwind.css
@@ -82,23 +82,6 @@
     background: var(--dash-panel-item-bg);
   }
 
-  .dash-list-item::before {
-    content: "";
-    position: absolute;
-    top: 12px;
-    bottom: 12px;
-    left: 10px;
-    width: 4px;
-    border-radius: 9999px;
-    background: linear-gradient(
-      180deg,
-      color-mix(in srgb, var(--dash-chip-time-text) 65%, transparent 35%) 0%,
-      color-mix(in srgb, var(--dash-chip-time-text) 35%, transparent 65%) 100%
-    );
-    opacity: 0.7;
-    pointer-events: none;
-  }
-
   .dash-highlight-veil {
     opacity: var(--dash-highlight-opacity, 0.6);
     mix-blend-mode: soft-light;


### PR DESCRIPTION
## Summary
- remove the `.dash-list-item::before` pseudo-element so the decorative vertical stripe no longer renders

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_69053eee012c832797de57e67a1a137c