### PR TITLE
Add themed gradients to dashboard panels

### DIFF
--- a/root/frontend/src/pages/Dashboard.tsx
+++ b/root/frontend/src/pages/Dashboard.tsx
@@ -564,7 +564,7 @@ export default function Dashboard() {
                 data-fade="left"
                 data-pop="true"
                 style={fadeDelayStyle("140ms")}
-                className={cn(panelBase, panelHover, "lg:col-span-4")}
+                className={cn(panelBase, panelHover, "dash-panel-schedule", "lg:col-span-4")}
                 padding="lg"
                 aria-busy={loadingSched}
               >
@@ -681,7 +681,7 @@ export default function Dashboard() {
                 data-fade="up"
                 data-pop="true"
                 style={fadeDelayStyle("200ms")}
-                className={cn(panelBase, panelHover, "lg:col-span-4")}
+                className={cn(panelBase, panelHover, "dash-panel-news", "lg:col-span-4")}
                 padding="lg"
                 aria-busy={loadingNews}
               >
@@ -783,7 +783,7 @@ export default function Dashboard() {
                 data-fade="right"
                 data-pop="true"
                 style={fadeDelayStyle("260ms")}
-                className={cn(panelBase, panelHover, "lg:col-span-4")}
+                className={cn(panelBase, panelHover, "dash-panel-events", "lg:col-span-4")}
                 padding="lg"
                 aria-busy={loadingEvents}
               >

--- a/root/frontend/src/styles/tailwind.css
+++ b/root/frontend/src/styles/tailwind.css
@@ -88,6 +88,59 @@
     transition: opacity 0.6s ease, filter 0.6s ease;
   }
 
+  .dash-panel-schedule,
+  .dash-panel-news,
+  .dash-panel-events {
+    position: relative;
+    isolation: isolate;
+  }
+
+  .dash-panel-schedule::before,
+  .dash-panel-news::before,
+  .dash-panel-events::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+    border-radius: inherit;
+    pointer-events: none;
+    opacity: 0.55;
+    mix-blend-mode: soft-light;
+    transition: opacity var(--dash-hover-duration) var(--dash-hover-ease);
+  }
+
+  .dash-panel-schedule:is(:hover, :focus-within)::before,
+  .dash-panel-news:is(:hover, :focus-within)::before,
+  .dash-panel-events:is(:hover, :focus-within)::before {
+    opacity: 0.85;
+  }
+
+  .dash-panel-schedule::before {
+    background:
+      radial-gradient(circle at 18% -8%, color-mix(in srgb, var(--dash-card-schedule-orb) 55%, transparent) 0%, transparent 65%),
+      radial-gradient(circle at 85% 120%, color-mix(in srgb, var(--dash-card-schedule-radial) 45%, transparent) 0%, transparent 78%);
+  }
+
+  .dash-panel-news::before {
+    background:
+      radial-gradient(circle at 82% 4%, color-mix(in srgb, var(--dash-card-news-orb) 52%, transparent) 0%, transparent 68%),
+      radial-gradient(circle at 10% 110%, color-mix(in srgb, var(--dash-card-news-radial) 46%, transparent) 0%, transparent 80%);
+  }
+
+  .dash-panel-events::before {
+    background:
+      radial-gradient(circle at 12% 6%, color-mix(in srgb, var(--dash-card-events-orb) 50%, transparent) 0%, transparent 68%),
+      radial-gradient(circle at 90% 115%, color-mix(in srgb, var(--dash-card-events-radial) 42%, transparent) 0%, transparent 82%);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .dash-panel-schedule::before,
+    .dash-panel-news::before,
+    .dash-panel-events::before {
+      transition: none;
+    }
+  }
+
   .skeleton {
     @apply relative overflow-hidden rounded-ue-md bg-skeleton text-transparent;
     animation: fade-in var(--anim-med, 0.3s ease) both;


### PR DESCRIPTION
## Summary
- add schedule, news, and events modifier classes to dashboard cards
- define soft gradient overlays for each panel using existing dashboard color tokens
- keep hover and focus treatments aligned with existing motion and accessibility affordances

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69053fd686c08327bd9ef9dd84e0d721