### PR TITLE
Fix invalid Tailwind group class

### DIFF
--- a/root/frontend/src/styles/tailwind.css
+++ b/root/frontend/src/styles/tailwind.css
@@ -77,7 +77,7 @@
   }
 
   .dash-list-item {
-    @apply relative block overflow-hidden rounded-ue-lg px-3 py-3 group/list;
+    @apply relative block overflow-hidden rounded-ue-lg px-3 py-3 group;
     list-style: none;
     background: transparent;
   }


### PR DESCRIPTION
## Summary
- replace the non-existent `group/list` class in the dashboard list item style with the standard `group` utility to satisfy Tailwind

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6905454d617483278d4f809166abb430