### PR TITLE
Fix Tailwind apply usage for dash list items

### DIFF
--- a/root/frontend/src/styles/tailwind.css
+++ b/root/frontend/src/styles/tailwind.css
@@ -77,7 +77,7 @@
   }
 
   .dash-list-item {
-    @apply relative block overflow-hidden rounded-ue-lg px-3 py-3 group;
+    @apply relative block overflow-hidden rounded-ue-lg px-3 py-3;
     list-style: none;
     background: transparent;
   }


### PR DESCRIPTION
## Summary
- remove the unsupported `group` utility from the `@apply` block for `.dash-list-item` to satisfy Tailwind's rules

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_690545ecd1e8832782fdeb3bf9703939