### PR TITLE
Refactor News page to use UI primitives

### DIFF
--- a/root/frontend/src/assets/themes.css
+++ b/root/frontend/src/assets/themes.css
@@ -72,7 +72,8 @@
   --dash-panel-bg-muted: color-mix(in srgb, white 97%, var(--nav-link) 3%);
   --dash-panel-border: color-mix(in srgb, white 62%, var(--nav-link) 38%);
   --dash-panel-shadow: 0 34px 110px -70px color-mix(in srgb, var(--nav-link-hover) 45%, transparent);
-  --dash-panel-shadow-soft: 0 28px 96px -68px color-mix(in srgb, var(--nav-link-hover) 32%, transparent);
+  --dash-panel-shadow-soft: 0 28px 96px -68px
+    color-mix(in srgb, var(--nav-link-hover) 32%, transparent);
   --dash-panel-item-bg: color-mix(in srgb, white 96%, var(--nav-link) 4%);
   --dash-panel-item-bg-alt: color-mix(in srgb, white 94%, var(--nav-link) 6%);
   --dash-panel-item-divider: color-mix(in srgb, white 76%, var(--nav-link) 24%);

--- a/root/frontend/src/components/ui/__tests__/primitives.test.tsx
+++ b/root/frontend/src/components/ui/__tests__/primitives.test.tsx
@@ -188,4 +188,3 @@ describe("UI primitives", () => {
     await waitFor(() => expect(screen.queryByRole("status")).not.toBeInTheDocument())
   })
 })
-

--- a/root/frontend/src/components/ui/dropdown-menu.tsx
+++ b/root/frontend/src/components/ui/dropdown-menu.tsx
@@ -10,7 +10,7 @@ import {
   useState,
   type ButtonHTMLAttributes,
   type HTMLAttributes,
-  type KeyboardEvent,
+  type KeyboardEvent as ReactKeyboardEvent,
   type MutableRefObject,
   type PropsWithChildren,
 } from "react"
@@ -290,7 +290,7 @@ export function DropdownMenuContent({
   }, [open, autoFocus, onOpenChange, triggerRef])
 
   const handleKeyDown = useCallback(
-    (event: KeyboardEvent<HTMLDivElement>) => {
+    (event: ReactKeyboardEvent<HTMLDivElement>) => {
       if (event.key === "ArrowDown") {
         event.preventDefault()
         focusNextItem(contentRef.current, 1)

--- a/root/frontend/src/components/ui/dropdown-menu.tsx
+++ b/root/frontend/src/components/ui/dropdown-menu.tsx
@@ -159,9 +159,7 @@ const focusFirstItem = (container: HTMLElement | null) => {
 const getFocusableItems = (container: HTMLElement | null) => {
   if (!container) return []
   return Array.from(
-    container.querySelectorAll<HTMLElement>(
-      '[data-ue-dropdown-item]:not([data-disabled="true"])'
-    )
+    container.querySelectorAll<HTMLElement>('[data-ue-dropdown-item]:not([data-disabled="true"])')
   )
 }
 
@@ -404,4 +402,3 @@ DropdownMenu.displayName = "DropdownMenu"
 DropdownMenuTrigger.displayName = "DropdownMenuTrigger"
 DropdownMenuContent.displayName = "DropdownMenuContent"
 DropdownMenuItem.displayName = "DropdownMenuItem"
-

--- a/root/frontend/src/components/ui/icon-button.tsx
+++ b/root/frontend/src/components/ui/icon-button.tsx
@@ -87,4 +87,3 @@ export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
 )
 
 IconButton.displayName = "IconButton"
-

--- a/root/frontend/src/components/ui/input.tsx
+++ b/root/frontend/src/components/ui/input.tsx
@@ -90,7 +90,9 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
           )}
         >
           {leadingIcon ? (
-            <span className="inline-flex items-center text-[color:var(--secondary-text)]">{leadingIcon}</span>
+            <span className="inline-flex items-center text-[color:var(--secondary-text)]">
+              {leadingIcon}
+            </span>
           ) : null}
           <input
             ref={ref}
@@ -187,7 +189,9 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
           )}
         >
           {leadingIcon ? (
-            <span className="mt-3 inline-flex items-start text-[color:var(--secondary-text)]">{leadingIcon}</span>
+            <span className="mt-3 inline-flex items-start text-[color:var(--secondary-text)]">
+              {leadingIcon}
+            </span>
           ) : null}
           <textarea
             ref={ref}
@@ -230,4 +234,3 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
 )
 
 TextArea.displayName = "TextArea"
-

--- a/root/frontend/src/components/ui/modal.tsx
+++ b/root/frontend/src/components/ui/modal.tsx
@@ -129,10 +129,7 @@ export function Modal({
   return createPortal(
     <ModalContext.Provider value={contextValue}>
       <div
-        className={cn(
-          "fixed inset-0 flex items-center justify-center p-4 sm:p-8",
-          className
-        )}
+        className={cn("fixed inset-0 flex items-center justify-center p-4 sm:p-8", className)}
         style={{ zIndex: "var(--ue-z-index-overlay)" }}
       >
         <div
@@ -164,7 +161,12 @@ export interface ModalContentProps extends HTMLAttributes<HTMLDivElement> {
   hideScrollbars?: boolean
 }
 
-export function ModalContent({ hideScrollbars = false, className, children, ...rest }: ModalContentProps) {
+export function ModalContent({
+  hideScrollbars = false,
+  className,
+  children,
+  ...rest
+}: ModalContentProps) {
   const { labelledBy, describedBy, trapRef } = useModalContext()
 
   return (
@@ -217,7 +219,10 @@ export function ModalTitle({ className, children, ...rest }: ComponentPropsWitho
   return (
     <h2
       id={titleId}
-      className={cn("text-2xl font-semibold tracking-tight text-[color:var(--page-text)]", className)}
+      className={cn(
+        "text-2xl font-semibold tracking-tight text-[color:var(--page-text)]",
+        className
+      )}
       {...rest}
     >
       {children}
@@ -310,4 +315,3 @@ ModalDescription.displayName = "ModalDescription"
 ModalBody.displayName = "ModalBody"
 ModalFooter.displayName = "ModalFooter"
 ModalCloseButton.displayName = "ModalCloseButton"
-

--- a/root/frontend/src/components/ui/toast.tsx
+++ b/root/frontend/src/components/ui/toast.tsx
@@ -39,7 +39,12 @@ export interface ToastViewportProps extends PropsWithChildren {
   container?: HTMLElement | null
 }
 
-export function ToastViewport({ position = "bottom-right", className, container, children }: ToastViewportProps) {
+export function ToastViewport({
+  position = "bottom-right",
+  className,
+  container,
+  children,
+}: ToastViewportProps) {
   const portalNode = useMemo(() => container ?? getToastRoot(), [container])
   if (!portalNode) return null
 
@@ -178,7 +183,9 @@ export function Toast({
         </div>
         <div className="flex flex-1 flex-col gap-1">
           {title ? <p className="text-sm font-semibold">{title}</p> : null}
-          {description ? <p className="text-sm text-[color:var(--secondary-text)]">{description}</p> : null}
+          {description ? (
+            <p className="text-sm text-[color:var(--secondary-text)]">{description}</p>
+          ) : null}
           <div className="mt-2 flex flex-wrap items-center gap-2">
             {actionLabel ? (
               <button
@@ -252,4 +259,3 @@ export const ToastActionButton = ({ className, ...rest }: ToastActionButtonProps
 ToastViewport.displayName = "ToastViewport"
 Toast.displayName = "Toast"
 ToastActionButton.displayName = "ToastActionButton"
-

--- a/root/frontend/src/pages/Dashboard.tsx
+++ b/root/frontend/src/pages/Dashboard.tsx
@@ -758,7 +758,7 @@ export default function Dashboard() {
                       {t("dashboard:viewAll")}
                     </Button>
                   </div>
-                  
+
                   {loadingNews && (
                     <div className="space-y-4" role="presentation">
                       <div className="flex items-center gap-3">
@@ -781,15 +781,15 @@ export default function Dashboard() {
                     <p className="text-sm text-secondary">{t("dashboard:news.empty")}</p>
                   )}
                   {!loadingNews && news.length > 0 && (
-                    <ul
-                      className="space-y-3"
-                      aria-label={t("dashboard:aria.newsList")}
-                    >
+                    <ul className="space-y-3" aria-label={t("dashboard:aria.newsList")}>
                       {news.map((n) => (
                         <li key={n.id} className="dash-list-item">
                           <button
                             type="button"
-                            className={cn(listActionBase, "flex items-start gap-4 text-left sm:gap-5")}
+                            className={cn(
+                              listActionBase,
+                              "flex items-start gap-4 text-left sm:gap-5"
+                            )}
                             onClick={() => navigate(`/news/${n.id}`)}
                             title={n.title}
                             aria-label={t("dashboard:aria.newsItem", { title: n.title })}
@@ -808,7 +808,11 @@ export default function Dashboard() {
                               aria-hidden="true"
                               className="ml-auto inline-flex h-9 w-9 flex-none items-center justify-center rounded-full border border-[color:var(--dash-arrow-pill-border)] bg-[color:var(--dash-arrow-pill-bg)] text-base text-[color:var(--dash-arrow-pill-text)] opacity-0 transition-[transform,opacity,background-color,border-color] duration-[var(--dash-hover-duration)] ease-[var(--dash-hover-ease)] group-hover:-translate-y-[calc(var(--dash-hover-lift)/2)] group-hover:opacity-100 group-hover:border-[color:var(--dash-arrow-pill-border-active)] group-hover:bg-[color:var(--dash-arrow-pill-bg-active)] group-hover:text-[color:var(--dash-arrow-pill-text-active)]"
                             >
-                              <ArrowForwardRoundedIcon aria-hidden="true" fontSize="inherit" className="h-4 w-4" />
+                              <ArrowForwardRoundedIcon
+                                aria-hidden="true"
+                                fontSize="inherit"
+                                className="h-4 w-4"
+                              />
                             </span>
                           </button>
                         </li>
@@ -880,7 +884,7 @@ export default function Dashboard() {
                       {t("dashboard:scope.week")}
                     </Button>
                   </div>
-                  
+
                   {loadingEvents && (
                     <div className="space-y-3" role="presentation">
                       <Skeleton height={24} />
@@ -906,7 +910,10 @@ export default function Dashboard() {
                           <li key={e.id} className="dash-list-item">
                             <button
                               type="button"
-                              className={cn(listActionBase, "flex flex-col items-start gap-3 text-left sm:gap-3")}
+                              className={cn(
+                                listActionBase,
+                                "flex flex-col items-start gap-3 text-left sm:gap-3"
+                              )}
                               onClick={() => navigate(`/events/${e.id}`)}
                               aria-label={t("dashboard:aria.eventItem", { title: e.title })}
                             >

--- a/root/frontend/src/pages/News.tsx
+++ b/root/frontend/src/pages/News.tsx
@@ -227,7 +227,10 @@ const News = () => {
               {Array.isArray(newsList) && showEmptyState && (
                 <div className="col-span-full">
                   <div className="flex flex-col items-center justify-center gap-3 rounded-ue-xl border border-dashed border-[color:var(--glass-border)]/70 bg-[color:var(--card-bg)]/60 px-6 py-16 text-center text-[color:var(--secondary-text)] shadow-surface">
-                    <ArticleIcon style={{ fontSize: "2rem", color: "var(--secondary-text)" }} aria-hidden="true" />
+                    <ArticleIcon
+                      style={{ fontSize: "2rem", color: "var(--secondary-text)" }}
+                      aria-hidden="true"
+                    />
                     <p className="text-lg font-medium tracking-tight">{t("news:states.empty")}</p>
                   </div>
                 </div>

--- a/root/frontend/src/pages/News.tsx
+++ b/root/frontend/src/pages/News.tsx
@@ -12,17 +12,19 @@ import {
   type CSSProperties,
 } from "react"
 import { createNews, uploadNewsImage } from "@/api/news"
+import { Button } from "@/components/ui/button"
 import {
-  Box,
-  Typography,
-  Button,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  Stack,
-  TextField,
-  useMediaQuery,
-} from "@mui/material"
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalTitle,
+  ModalCloseButton,
+} from "@/components/ui/modal"
+import { TextArea, TextInput } from "@/components/ui/input"
+import useMediaQuery from "@/hooks/useMediaQuery"
+import { cn } from "@/utils/cn"
 import ArticleIcon from "@mui/icons-material/Article"
 import PhotoCamera from "@mui/icons-material/PhotoCamera"
 import SmartImage from "@/components/SmartImage"
@@ -159,6 +161,11 @@ const News = () => {
     if (imageInputRef.current) imageInputRef.current.value = ""
   }, [imagePreview])
 
+  const openImagePicker = useCallback(() => {
+    if (adding) return
+    imageInputRef.current?.click()
+  }, [adding])
+
   const visibleList = useMemo(
     () => (visibleCount > 0 ? deferredList.slice(0, visibleCount) : deferredList),
     [deferredList, visibleCount]
@@ -167,217 +174,196 @@ const News = () => {
   return (
     <Layout>
       <PageFadeIn>
-        <Box
-          sx={{
-            width: "100vw",
-            minHeight: "100vh",
-            pl: { xs: 2, sm: 4, md: 5, lg: 8 },
-            pr: { xs: 4, sm: 6, md: 7, lg: 10 },
-            py: { xs: 0, sm: 0, md: 0, lg: 0 },
-            boxSizing: "border-box",
-            overflowX: "hidden",
-          }}
-        >
-          <Stack
-            data-fade
-            style={{ "--fade-delay": "80ms" } as CSSProperties}
-            direction="row"
-            alignItems="center"
-            gap={2}
-            mb={isMobile ? 1.5 : 3}
-            mt={isMobile ? 1.5 : 3}
-          >
-            <ArticleIcon color="primary" sx={{ fontSize: 34 }} />
-            <Typography
-              variant="h4"
-              fontWeight={700}
-              color="primary.main"
-              sx={{ fontSize: "clamp(0.8rem, 5vw, 2.7rem)" }}
-            >
-              {t("news:pageTitle")}
-            </Typography>
-          </Stack>
-
-          {user?.role === "admin" && (
-            <Box
+        <section className="relative w-full overflow-x-hidden bg-transparent">
+          <div className="mx-auto flex min-h-screen w-full max-w-6xl flex-col px-4 pb-16 pt-6 sm:px-6 md:px-10 lg:px-16">
+            <header
               data-fade
-              style={{ "--fade-delay": "140ms" } as CSSProperties}
-              sx={{ display: "flex", justifyContent: "flex-start", mb: 2 }}
+              style={{ "--fade-delay": "80ms" } as CSSProperties}
+              className="group mb-6 flex items-center gap-4 rounded-ue-xl border border-[color:var(--glass-border)] bg-[color:var(--card-bg)]/75 p-4 shadow-surface backdrop-blur supports-[backdrop-filter]:backdrop-blur-md"
             >
-              <Button
-                variant="contained"
-                sx={{
-                  fontWeight: 700,
-                  fontSize: "clamp(1rem, 2.1vw, 1.15rem)",
-                  px: { xs: 2.3, sm: 3 },
-                  py: 1.2,
-                  borderRadius: 3,
-                  letterSpacing: "0.02em",
-                }}
-                onClick={() => setAddOpen(true)}
-                disabled={adding}
+              <span className="flex h-12 w-12 items-center justify-center rounded-full bg-[color:var(--surface-accent,#111827)]/60 text-[color:var(--nav-link)] shadow-inner">
+                <ArticleIcon style={{ fontSize: "1.8rem" }} />
+              </span>
+              <h1 className="font-display text-[clamp(1.4rem,4vw,2.6rem)] font-semibold tracking-tight text-[color:var(--page-text)]">
+                {t("news:pageTitle")}
+              </h1>
+            </header>
+
+            {user?.role === "admin" && (
+              <div
+                data-fade
+                style={{ "--fade-delay": "140ms" } as CSSProperties}
+                className="mb-2 flex justify-start"
               >
-                {t("news:actions.add")}
-              </Button>
-            </Box>
-          )}
-
-          <Box
-            data-fade
-            style={{ "--fade-delay": "200ms" } as CSSProperties}
-            sx={{
-              display: "grid",
-              gridTemplateColumns: "repeat(auto-fit, minmax(320px, 1fr))",
-              gap: { xs: 2, sm: 3 },
-            }}
-          >
-            {Array.isArray(visibleList) &&
-              visibleList.map((news) => (
-                <Box key={news.id} sx={{ display: "flex", width: "100%", height: "100%" }}>
-                  <NewsCard
-                    {...news}
-                    image_url={news.image_url ?? undefined}
-                    onChange={() => {
-                      void refetchNews()
-                    }}
-                  />
-                </Box>
-              ))}
-
-            {Array.isArray(newsList) && showEmptyState && (
-              <Box sx={{ width: "100%", textAlign: "center", mt: 7, mb: 7 }}>
-                <Typography fontSize={24} className="events-empty-text">
-                  {t("news:states.empty")}
-                </Typography>
-              </Box>
+                <Button
+                  size="md"
+                  className="rounded-ue-lg px-5 font-semibold tracking-tight shadow-surface transition-transform duration-300 hover:-translate-y-[2px] focus-visible:shadow-focus"
+                  onClick={() => setAddOpen(true)}
+                  disabled={adding}
+                >
+                  {t("news:actions.add")}
+                </Button>
+              </div>
             )}
-          </Box>
 
-          <Dialog
+            <div
+              data-fade
+              style={{ "--fade-delay": "200ms" } as CSSProperties}
+              className="grid grid-cols-1 gap-5 sm:grid-cols-2 xl:grid-cols-3"
+            >
+              {Array.isArray(visibleList) &&
+                visibleList.map((news) => (
+                  <div key={news.id} className="flex">
+                    <NewsCard
+                      {...news}
+                      image_url={news.image_url ?? undefined}
+                      onChange={() => {
+                        void refetchNews()
+                      }}
+                    />
+                  </div>
+                ))}
+
+              {Array.isArray(newsList) && showEmptyState && (
+                <div className="col-span-full">
+                  <div className="flex flex-col items-center justify-center gap-3 rounded-ue-xl border border-dashed border-[color:var(--glass-border)]/70 bg-[color:var(--card-bg)]/60 px-6 py-16 text-center text-[color:var(--secondary-text)] shadow-surface">
+                    <ArticleIcon style={{ fontSize: "2rem", color: "var(--secondary-text)" }} aria-hidden="true" />
+                    <p className="text-lg font-medium tracking-tight">{t("news:states.empty")}</p>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+
+          <Modal
             open={addOpen}
-            onClose={handleCloseDialog}
-            fullScreen={isMobile}
-            PaperProps={{
-              sx: {
-                borderRadius: { xs: 0, sm: 4 },
-                width: { xs: "100vw", sm: 400 },
-                maxWidth: { xs: "100vw", sm: 440 },
-              },
+            onOpenChange={(open) => {
+              if (open) {
+                setAddOpen(true)
+                return
+              }
+              handleCloseDialog()
             }}
+            className={cn("p-4 sm:p-8", isMobile && "p-0")}
+            overlayClassName="backdrop-blur"
           >
-            <DialogTitle sx={{ fontWeight: 700, fontSize: "1.3rem" }}>
-              {t("news:dialogs.create.title")}
-            </DialogTitle>
-            <DialogContent>
-              <Stack spacing={2} mt={1} minWidth={isMobile ? "auto" : 340} mb={2}>
-                <TextField
+            <ModalContent
+              hideScrollbars={isMobile}
+              className={cn(
+                "w-full max-w-xl border border-[color:var(--glass-border)] bg-[color:var(--card-bg)]/98 shadow-surface-strong",
+                isMobile && "h-screen max-h-none rounded-none border-none"
+              )}
+            >
+              <ModalHeader className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                <ModalTitle className="text-[clamp(1.25rem,2.4vw,1.6rem)] font-semibold text-[color:var(--page-text)]">
+                  {t("news:dialogs.create.title")}
+                </ModalTitle>
+                <ModalCloseButton className="self-start sm:self-center">
+                  {t("common:buttons.close")}
+                </ModalCloseButton>
+              </ModalHeader>
+              <ModalBody className="gap-5">
+                <TextInput
                   label={t("news:form.title")}
                   value={newsData.title}
                   onChange={(e) => setNewsData({ ...newsData, title: e.target.value })}
-                  fullWidth
-                  inputProps={{ maxLength: 100 }}
-                  sx={{ fontSize: "1rem" }}
+                  maxLength={100}
                   disabled={adding}
+                  required
                 />
-                <TextField
+                <TextArea
                   label={t("news:form.content")}
                   value={newsData.content}
                   onChange={(e) => setNewsData({ ...newsData, content: e.target.value })}
-                  multiline
-                  minRows={5}
-                  fullWidth
-                  inputProps={{ maxLength: 3000 }}
-                  sx={{ fontSize: "1rem" }}
+                  rows={5}
+                  maxLength={3000}
                   disabled={adding}
+                  required
                 />
-                <TextField
+                <TextInput
                   label={t("news:form.title_en", { defaultValue: "Title (English)" })}
                   value={newsData.title_en}
                   onChange={(e) => setNewsData({ ...newsData, title_en: e.target.value })}
-                  fullWidth
-                  inputProps={{ maxLength: 100 }}
-                  sx={{ fontSize: "1rem" }}
+                  maxLength={100}
                   disabled={adding}
                 />
-                <TextField
+                <TextArea
                   label={t("news:form.content_en", { defaultValue: "News text (English)" })}
                   value={newsData.content_en}
                   onChange={(e) => setNewsData({ ...newsData, content_en: e.target.value })}
-                  multiline
-                  minRows={5}
-                  fullWidth
-                  inputProps={{ maxLength: 3000 }}
-                  sx={{ fontSize: "1rem" }}
+                  rows={5}
+                  maxLength={3000}
                   disabled={adding}
                 />
 
-                <Box display="flex" alignItems="center" gap={2}>
-                  <Button
-                    component="label"
-                    variant="outlined"
-                    startIcon={<PhotoCamera />}
-                    sx={{
-                      minWidth: 120,
-                      fontWeight: 600,
-                      fontSize: "1rem",
-                      borderRadius: 2,
-                    }}
-                    disabled={adding}
-                  >
-                    {imageFile ? t("common:buttons.changePhoto") : t("common:buttons.uploadPhoto")}
-                    <input
-                      type="file"
-                      accept="image/*"
-                      hidden
-                      ref={imageInputRef}
-                      onChange={handleImageChange}
-                    />
-                  </Button>
+                <div className="rounded-ue-xl border border-dashed border-[color:var(--glass-border)]/70 bg-[color:var(--card-bg)]/60 p-4">
+                  <input
+                    id="news-image-upload"
+                    type="file"
+                    accept="image/*"
+                    className="sr-only"
+                    ref={imageInputRef}
+                    onChange={handleImageChange}
+                    aria-label={t("news:form.imageUpload", { defaultValue: "Upload cover image" })}
+                  />
+                  <div className="flex flex-wrap items-center gap-4">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="cursor-pointer rounded-ue-lg px-4 font-semibold tracking-tight"
+                      disabled={adding}
+                      onClick={openImagePicker}
+                    >
+                      <span className="inline-flex items-center gap-2">
+                        <PhotoCamera fontSize="small" />
+                        <span>
+                          {imageFile
+                            ? t("common:buttons.changePhoto")
+                            : t("common:buttons.uploadPhoto")}
+                        </span>
+                      </span>
+                    </Button>
 
-                  {imagePreview && (
-                    <SmartImage
-                      srcRaw={imagePreview}
-                      alt={t("news:alt.newCover")}
-                      style={{
-                        width: 100,
-                        height: 60,
-                        objectFit: "cover",
-                        borderRadius: 8,
-                        border: "1px solid #eee",
-                        display: "block",
-                      }}
-                    />
-                  )}
-                </Box>
-
-                <Stack direction="row" gap={2} mt={2}>
-                  <Button
-                    variant="contained"
-                    onClick={handleAddNews}
-                    disabled={!newsData.title.trim() || !newsData.content.trim() || adding}
-                    sx={{
-                      fontWeight: 700,
-                      borderRadius: 2.2,
-                      px: 3,
-                      fontSize: "1.02rem",
-                    }}
-                  >
-                    {adding ? t("common:statuses.publishing") : t("news:actions.publish")}
-                  </Button>
-                  <Button
-                    variant="outlined"
-                    color="secondary"
-                    onClick={handleCloseDialog}
-                    disabled={adding}
-                    sx={{ borderRadius: 2.2, px: 2.5, fontSize: "1.02rem" }}
-                  >
-                    {t("common:buttons.cancel")}
-                  </Button>
-                </Stack>
-              </Stack>
-            </DialogContent>
-          </Dialog>
-        </Box>
+                    {imagePreview ? (
+                      <div className="relative h-20 w-32 overflow-hidden rounded-ue-lg border border-[color:var(--glass-border)] shadow-surface">
+                        <SmartImage
+                          srcRaw={imagePreview}
+                          alt={t("news:alt.newCover")}
+                          className="h-full w-full object-cover"
+                        />
+                      </div>
+                    ) : (
+                      <p className="text-sm text-[color:var(--secondary-text)]">
+                        {t("news:form.imageHelper", {
+                          defaultValue: "Upload a landscape image to feature alongside your post.",
+                        })}
+                      </p>
+                    )}
+                  </div>
+                </div>
+              </ModalBody>
+              <ModalFooter>
+                <Button
+                  variant="outline"
+                  onClick={handleCloseDialog}
+                  disabled={adding}
+                  className="rounded-ue-lg px-5"
+                >
+                  {t("common:buttons.cancel")}
+                </Button>
+                <Button
+                  onClick={handleAddNews}
+                  loading={adding}
+                  disabled={!newsData.title.trim() || !newsData.content.trim() || adding}
+                  className="rounded-ue-lg px-6"
+                >
+                  {adding ? t("common:statuses.publishing") : t("news:actions.publish")}
+                </Button>
+              </ModalFooter>
+            </ModalContent>
+          </Modal>
+        </section>
       </PageFadeIn>
     </Layout>
   )

--- a/root/frontend/src/styles/tailwind.css
+++ b/root/frontend/src/styles/tailwind.css
@@ -85,7 +85,9 @@
   .dash-highlight-veil {
     opacity: var(--dash-highlight-opacity, 0.6);
     mix-blend-mode: soft-light;
-    transition: opacity 0.6s ease, filter 0.6s ease;
+    transition:
+      opacity 0.6s ease,
+      filter 0.6s ease;
   }
 
   .dash-panel-schedule,
@@ -117,20 +119,44 @@
 
   .dash-panel-schedule::before {
     background:
-      radial-gradient(circle at 18% -8%, color-mix(in srgb, var(--dash-card-schedule-orb) 55%, transparent) 0%, transparent 65%),
-      radial-gradient(circle at 85% 120%, color-mix(in srgb, var(--dash-card-schedule-radial) 45%, transparent) 0%, transparent 78%);
+      radial-gradient(
+        circle at 18% -8%,
+        color-mix(in srgb, var(--dash-card-schedule-orb) 55%, transparent) 0%,
+        transparent 65%
+      ),
+      radial-gradient(
+        circle at 85% 120%,
+        color-mix(in srgb, var(--dash-card-schedule-radial) 45%, transparent) 0%,
+        transparent 78%
+      );
   }
 
   .dash-panel-news::before {
     background:
-      radial-gradient(circle at 82% 4%, color-mix(in srgb, var(--dash-card-news-orb) 52%, transparent) 0%, transparent 68%),
-      radial-gradient(circle at 10% 110%, color-mix(in srgb, var(--dash-card-news-radial) 46%, transparent) 0%, transparent 80%);
+      radial-gradient(
+        circle at 82% 4%,
+        color-mix(in srgb, var(--dash-card-news-orb) 52%, transparent) 0%,
+        transparent 68%
+      ),
+      radial-gradient(
+        circle at 10% 110%,
+        color-mix(in srgb, var(--dash-card-news-radial) 46%, transparent) 0%,
+        transparent 80%
+      );
   }
 
   .dash-panel-events::before {
     background:
-      radial-gradient(circle at 12% 6%, color-mix(in srgb, var(--dash-card-events-orb) 50%, transparent) 0%, transparent 68%),
-      radial-gradient(circle at 90% 115%, color-mix(in srgb, var(--dash-card-events-radial) 42%, transparent) 0%, transparent 82%);
+      radial-gradient(
+        circle at 12% 6%,
+        color-mix(in srgb, var(--dash-card-events-orb) 50%, transparent) 0%,
+        transparent 68%
+      ),
+      radial-gradient(
+        circle at 90% 115%,
+        color-mix(in srgb, var(--dash-card-events-radial) 42%, transparent) 0%,
+        transparent 82%
+      );
   }
 
   @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary
- replace Material UI layout and dialog elements on the News page with Tailwind-styled sections and the shared UI primitives
- restyle the heading, admin action, feed grid, empty state, and create-news modal to match the minimalist dashboard aesthetic while keeping the existing data loading logic intact
- adjust the dropdown menu keyboard event typing to work with the DOM listener helpers

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_69055d0c4aac8327b0a3f2ab5f346f8d