### PR TITLE
Refactor NewsCard to Tailwind UI primitives

### DIFF
--- a/root/frontend/src/components/NewsCard.tsx
+++ b/root/frontend/src/components/NewsCard.tsx
@@ -29,49 +29,25 @@ import { useTranslation } from "react-i18next"
 import useMediaQuery from "@/hooks/useMediaQuery"
 
 const DotsVerticalIcon = (props: SVGProps<SVGSVGElement>) => (
-  <svg
-    viewBox="0 0 20 20"
-    fill="currentColor"
-    aria-hidden
-    focusable="false"
-    {...props}
-  >
+  <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden focusable="false" {...props}>
     <path d="M10 4a1.5 1.5 0 110-3 1.5 1.5 0 010 3zm0 7a1.5 1.5 0 110-3 1.5 1.5 0 010 3zm0 7a1.5 1.5 0 110-3 1.5 1.5 0 010 3z" />
   </svg>
 )
 
 const PencilSquareIcon = (props: SVGProps<SVGSVGElement>) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="currentColor"
-    aria-hidden
-    focusable="false"
-    {...props}
-  >
+  <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden focusable="false" {...props}>
     <path d="M4 17.25V20h2.75l8.08-8.08-2.75-2.75L4 17.25zm13.71-9.04a1 1 0 000-1.41l-1.51-1.51a1 1 0 00-1.41 0l-1.34 1.34 2.75 2.75 1.51-1.17z" />
   </svg>
 )
 
 const TrashIcon = (props: SVGProps<SVGSVGElement>) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="currentColor"
-    aria-hidden
-    focusable="false"
-    {...props}
-  >
+  <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden focusable="false" {...props}>
     <path d="M9 3a1 1 0 00-1 1v1H4.5a1 1 0 000 2H5v11a3 3 0 003 3h8a3 3 0 003-3V7h.5a1 1 0 000-2H16V4a1 1 0 00-1-1H9zm1 2h4V4h-4v1zm-1 4a1 1 0 012 0v8a1 1 0 11-2 0V9zm6-1a1 1 0 00-1 1v8a1 1 0 102 0V9a1 1 0 00-1-1z" />
   </svg>
 )
 
 const CameraIcon = (props: SVGProps<SVGSVGElement>) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="currentColor"
-    aria-hidden
-    focusable="false"
-    {...props}
-  >
+  <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden focusable="false" {...props}>
     <path d="M9.5 4.5l-.72 1.44A1 1 0 017.89 6H6a3 3 0 00-3 3v8a3 3 0 003 3h12a3 3 0 003-3V9a3 3 0 00-3-3h-1.89a1 1 0 01-.89-.56L14.5 4.5h-5zm2.5 5.5a4 4 0 110 8 4 4 0 010-8zm0 2a2 2 0 100 4 2 2 0 000-4z" />
   </svg>
 )
@@ -464,9 +440,7 @@ const NewsCardComponent: FC<NewsCardProps> = ({
                   imageInputRef.current?.click()
                 }}
               >
-                {imageLoading
-                  ? t("common:statuses.uploading")
-                  : t("news:form.changePhoto")}
+                {imageLoading ? t("common:statuses.uploading") : t("news:form.changePhoto")}
               </Button>
               <input
                 type="file"
@@ -487,12 +461,7 @@ const NewsCardComponent: FC<NewsCardProps> = ({
             </div>
           </ModalBody>
           <ModalFooter className="flex flex-col gap-3 px-6 pb-6 sm:flex-row sm:justify-end">
-            <Button
-              variant="solid"
-              onClick={handleEdit}
-              loading={loading}
-              disabled={imageLoading}
-            >
+            <Button variant="solid" onClick={handleEdit} loading={loading} disabled={imageLoading}>
               {t("common:buttons.save")}
             </Button>
             <Button variant="outline" onClick={closeEditDialog} disabled={loading || imageLoading}>
@@ -518,7 +487,11 @@ const NewsCardComponent: FC<NewsCardProps> = ({
             <p>{t("news:dialogs.delete.description")}</p>
           </ModalBody>
           <ModalFooter className="flex flex-col gap-3 px-6 pb-6 sm:flex-row sm:justify-end">
-            <Button variant="outline" onClick={() => setConfirmDeleteOpen(false)} disabled={loading}>
+            <Button
+              variant="outline"
+              onClick={() => setConfirmDeleteOpen(false)}
+              disabled={loading}
+            >
               {t("common:buttons.cancel")}
             </Button>
             <Button

--- a/root/frontend/src/components/NewsCard.tsx
+++ b/root/frontend/src/components/NewsCard.tsx
@@ -1,23 +1,20 @@
-import { FC, memo, useState, useEffect, useRef, useCallback, useMemo } from "react"
+import { FC, memo, useState, useEffect, useRef, useCallback, useMemo, type SVGProps } from "react"
 import {
-  Box,
-  Typography,
-  IconButton,
-  Menu,
-  MenuItem,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
-  TextField,
-  Stack,
-  Button,
-  useMediaQuery,
-} from "@mui/material"
-import MoreVertIcon from "@mui/icons-material/MoreVert"
-import EditIcon from "@mui/icons-material/Edit"
-import DeleteIcon from "@mui/icons-material/Delete"
-import PhotoCamera from "@mui/icons-material/PhotoCamera"
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { Button } from "@/components/ui/button"
+import { TextArea, TextInput } from "@/components/ui/input"
+import {
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalTitle,
+} from "@/components/ui/modal"
 import { useAuth } from "../contexts/AuthContext"
 import { useLanguage } from "@/contexts/LanguageContext"
 import api from "../api/client"
@@ -29,6 +26,55 @@ import SmartImage from "@/components/SmartImage"
 import { cn } from "@/utils/cn"
 import { sanitizeNewsText } from "@/utils/sanitize"
 import { useTranslation } from "react-i18next"
+import useMediaQuery from "@/hooks/useMediaQuery"
+
+const DotsVerticalIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 20 20"
+    fill="currentColor"
+    aria-hidden
+    focusable="false"
+    {...props}
+  >
+    <path d="M10 4a1.5 1.5 0 110-3 1.5 1.5 0 010 3zm0 7a1.5 1.5 0 110-3 1.5 1.5 0 010 3zm0 7a1.5 1.5 0 110-3 1.5 1.5 0 010 3z" />
+  </svg>
+)
+
+const PencilSquareIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    aria-hidden
+    focusable="false"
+    {...props}
+  >
+    <path d="M4 17.25V20h2.75l8.08-8.08-2.75-2.75L4 17.25zm13.71-9.04a1 1 0 000-1.41l-1.51-1.51a1 1 0 00-1.41 0l-1.34 1.34 2.75 2.75 1.51-1.17z" />
+  </svg>
+)
+
+const TrashIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    aria-hidden
+    focusable="false"
+    {...props}
+  >
+    <path d="M9 3a1 1 0 00-1 1v1H4.5a1 1 0 000 2H5v11a3 3 0 003 3h8a3 3 0 003-3V7h.5a1 1 0 000-2H16V4a1 1 0 00-1-1H9zm1 2h4V4h-4v1zm-1 4a1 1 0 012 0v8a1 1 0 11-2 0V9zm6-1a1 1 0 00-1 1v8a1 1 0 102 0V9a1 1 0 00-1-1z" />
+  </svg>
+)
+
+const CameraIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    aria-hidden
+    focusable="false"
+    {...props}
+  >
+    <path d="M9.5 4.5l-.72 1.44A1 1 0 017.89 6H6a3 3 0 00-3 3v8a3 3 0 003 3h12a3 3 0 003-3V9a3 3 0 00-3-3h-1.89a1 1 0 01-.89-.56L14.5 4.5h-5zm2.5 5.5a4 4 0 110 8 4 4 0 010-8zm0 2a2 2 0 100 4 2 2 0 000-4z" />
+  </svg>
+)
 
 dayjs.extend(utc)
 dayjs.extend(timezone)
@@ -67,7 +113,7 @@ const NewsCardComponent: FC<NewsCardProps> = ({
   const { t } = useTranslation(["news", "common"])
   const { language } = useLanguage()
 
-  const [menuAnchor, setMenuAnchor] = useState<null | HTMLElement>(null)
+  const [menuOpen, setMenuOpen] = useState(false)
   const [editOpen, setEditOpen] = useState(false)
   const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false)
 
@@ -84,10 +130,10 @@ const NewsCardComponent: FC<NewsCardProps> = ({
   const [previewUrl, setPreviewUrl] = useState<string | null>(null)
   const [imageLoading, setImageLoading] = useState(false)
   const imageInputRef = useRef<HTMLInputElement>(null)
+  const editTitleRef = useRef<HTMLInputElement>(null)
   const [cardImageReady, setCardImageReady] = useState(!image_url)
 
   const isMobile = useMediaQuery("(max-width:600px)")
-  const menuId = `news-card-menu-${id}`
 
   const localizedTitle = useMemo(() => {
     const english = title_en ?? ""
@@ -159,6 +205,15 @@ const NewsCardComponent: FC<NewsCardProps> = ({
     if (imageInputRef.current) imageInputRef.current.value = ""
   }, [previewUrl])
 
+  const handleEditOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) {
+        closeEditDialog()
+      }
+    },
+    [closeEditDialog]
+  )
+
   const editImageUrl = useMemo(
     () => previewUrl || editData.image_url || "",
     [editData.image_url, previewUrl]
@@ -218,6 +273,10 @@ const NewsCardComponent: FC<NewsCardProps> = ({
     }
   }, [id, onChange])
 
+  const handleConfirmOpenChange = useCallback((open: boolean) => {
+    setConfirmDeleteOpen(open)
+  }, [])
+
   const handleCardClick = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
       if (editOpen) {
@@ -227,61 +286,32 @@ const NewsCardComponent: FC<NewsCardProps> = ({
       }
       const el = e.target as HTMLElement
       if (
-        el.closest("button") ||
-        el.closest("input") ||
-        el.closest(".MuiInputBase-root") ||
-        el.closest('[role="menu"]')
-      )
+        el.closest(
+          "button, a, input, textarea, [role='menu'], [role='dialog'], [data-news-card-interactive='true']"
+        )
+      ) {
         return
+      }
       navigate(`/news/${id}`)
     },
     [editOpen, id, navigate]
   )
 
-  const hoveringDisabled = editOpen || Boolean(menuAnchor)
-  const interactiveSx = useMemo(() => {
-    if (hoveringDisabled) {
-      return {}
-    }
-    return {
-      "&:hover": {
-        transform: "translateY(-2px) scale(1.02)",
-        boxShadow: "var(--shadow-2)",
-      },
-      "&:active": {
-        transform: "scale(0.997)",
-      },
-    }
-  }, [hoveringDisabled])
+  const hoveringDisabled = editOpen || menuOpen
 
   return (
-    <Box
-      className={cn("news-card")}
-      sx={{
-        width: "100%",
-        maxWidth: 700,
-        borderRadius: { xs: "1.1rem", sm: "1.2rem" },
-        background: "var(--card-bg)",
-        color: "var(--page-text)",
-        position: "relative",
-        cursor: hoveringDisabled ? "default" : "pointer",
-        boxShadow: 5,
-        p: 0,
-        overflow: "hidden",
-        display: "flex",
-        flexDirection: "column",
-        minHeight: 340,
-        "&:focus-visible": {
-          outline: "2px solid var(--nav-link)",
-          outlineOffset: "2px",
-        },
-        transition: "transform 0.25s ease, box-shadow 0.25s ease",
-        ...interactiveSx,
-      }}
+    <div
+      className={cn(
+        "news-card relative flex w-full max-w-[700px] min-h-[340px] flex-col overflow-hidden rounded-[1.2rem] border border-[color:var(--glass-border)] bg-[color:var(--card-bg)] text-[color:var(--page-text)] shadow-surface transition-[transform,box-shadow] duration-200 ease-out focus-visible:outline-none focus-visible:shadow-[var(--ue-focus-ring)]",
+        "motion-reduce:transition-[box-shadow]",
+        hoveringDisabled
+          ? "cursor-default"
+          : "cursor-pointer hover:-translate-y-[2px] hover:scale-[1.02] hover:shadow-surface-strong active:scale-[0.997] motion-reduce:hover:translate-y-0 motion-reduce:hover:scale-100 motion-reduce:active:scale-100"
+      )}
       role="button"
       tabIndex={0}
       onKeyDown={(e) => {
-        if (editOpen) return
+        if (editOpen || menuOpen) return
         if (e.currentTarget !== e.target) return
         if (e.key === "Enter" || e.key === " ") {
           e.preventDefault()
@@ -290,94 +320,59 @@ const NewsCardComponent: FC<NewsCardProps> = ({
       }}
       onClick={handleCardClick}
     >
-      {user?.role === "admin" && (
-        <>
-          <IconButton
-            aria-label={t("news:aria.cardActions")}
-            aria-controls={menuAnchor ? menuId : undefined}
-            aria-haspopup="true"
-            aria-expanded={Boolean(menuAnchor) ? "true" : undefined}
-            sx={{
-              position: "absolute",
-              top: 10,
-              right: 10,
-              zIndex: 2,
-              bgcolor: "rgba(255,255,255,0.82)",
-              "&:hover": { bgcolor: "#fff" },
-            }}
-            onClick={(e) => {
-              e.stopPropagation()
-              setMenuAnchor(e.currentTarget)
-            }}
-            size="small"
+      {user?.role === "admin" ? (
+        <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
+          <DropdownMenuTrigger
             disabled={loading}
-          >
-            <MoreVertIcon />
-          </IconButton>
-          <Menu
-            id={menuId}
-            anchorEl={menuAnchor}
-            open={Boolean(menuAnchor)}
-            onClose={(e) => {
-              if (e) (e as any).stopPropagation?.()
-              setMenuAnchor(null)
+            onClick={(event) => {
+              event.stopPropagation()
             }}
-            anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
-            transformOrigin={{ vertical: "top", horizontal: "right" }}
-            MenuListProps={{ "aria-labelledby": menuId }}
+            onPointerDown={(event) => {
+              event.stopPropagation()
+            }}
+            className="absolute right-3 top-3 z-10 flex h-10 w-10 items-center justify-center rounded-full border border-white/60 bg-white/90 text-[color:var(--nav-link)] shadow-surface transition-colors hover:bg-white focus-visible:shadow-[var(--ue-focus-ring)]"
+            aria-label={t("news:aria.cardActions")}
+            data-news-card-interactive="true"
           >
-            <MenuItem
-              onClick={(e) => {
-                e.stopPropagation()
+            <DotsVerticalIcon className="h-4 w-4" />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="min-w-[11.5rem]">
+            <DropdownMenuItem
+              onClick={(event) => {
+                event.stopPropagation()
+                setMenuOpen(false)
                 openEditDialog()
-                setMenuAnchor(null)
               }}
+              className="text-sm font-semibold text-[color:var(--nav-text)]"
+              data-news-card-interactive="true"
             >
-              <EditIcon fontSize="small" sx={{ mr: 1 }} />
-              {t("common:buttons.edit")}
-            </MenuItem>
-            <MenuItem
-              onClick={(e) => {
-                e.stopPropagation()
+              <span className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-[color:var(--nav-link)]/12 text-[color:var(--nav-link)]">
+                <PencilSquareIcon className="h-4 w-4" />
+              </span>
+              <span>{t("common:buttons.edit")}</span>
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onClick={(event) => {
+                event.stopPropagation()
+                setMenuOpen(false)
                 setConfirmDeleteOpen(true)
-                setMenuAnchor(null)
               }}
+              className="text-sm font-semibold text-[color:var(--badge-lab)]"
+              data-news-card-interactive="true"
             >
-              <DeleteIcon fontSize="small" sx={{ mr: 1 }} color="error" />
-              <span style={{ color: "#d32f2f" }}>{t("common:buttons.delete")}</span>
-            </MenuItem>
-          </Menu>
-        </>
-      )}
+              <span className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-[color:var(--badge-lab)]/12 text-[color:var(--badge-lab)]">
+                <TrashIcon className="h-4 w-4" />
+              </span>
+              <span>{t("common:buttons.delete")}</span>
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      ) : null}
 
-      <Box
-        sx={{
-          width: "100%",
-          height: { xs: 160, sm: 180, md: 220, lg: 240 },
-          borderTopLeftRadius: { xs: "1.1rem", sm: "1.2rem" },
-          borderTopRightRadius: { xs: "1.1rem", sm: "1.2rem" },
-          borderBottom: "1px solid #eee",
+      <div
+        className="relative h-[160px] w-full overflow-hidden border-b border-white/10 sm:h-[180px] md:h-[220px] lg:h-[240px]"
+        style={{
           background: "linear-gradient(135deg, rgba(13,71,161,0.18), rgba(63,81,181,0.08))",
-          position: "relative",
-          overflow: "hidden",
-          display: "flex",
-          alignItems: "stretch",
-          "& img": {
-            display: "block",
-            width: "100%",
-            height: "100%",
-            objectFit: "cover",
-            objectPosition: "center",
-          },
-          "&::after": {
-            content: '""',
-            position: "absolute",
-            inset: 0,
-            background: "linear-gradient(120deg, rgba(255,255,255,0.2), rgba(255,255,255,0.05))",
-            opacity: cardImageReady ? 0 : 1,
-            transition: "opacity 260ms ease",
-            pointerEvents: "none",
-          },
         }}
       >
         <SmartImage
@@ -388,198 +383,157 @@ const NewsCardComponent: FC<NewsCardProps> = ({
               : t("news:alt.heroFallback")
           }
           sizes="(min-width: 1200px) 640px, (min-width: 900px) 520px, 100vw"
-          style={{
-            width: "100%",
-            height: "100%",
-            display: "block",
-            objectFit: "cover",
-            objectPosition: "center",
-          }}
+          className="h-full w-full object-cover"
           onLoad={handleCardImageReady}
           onError={handleCardImageReady}
         />
-      </Box>
+        <span
+          aria-hidden
+          className={cn(
+            "pointer-events-none absolute inset-0 bg-[linear-gradient(120deg,rgba(255,255,255,0.2),rgba(255,255,255,0.05))]",
+            "transition-opacity duration-300 ease-out",
+            cardImageReady ? "opacity-0" : "opacity-100"
+          )}
+        />
+      </div>
 
-      <Box
-        sx={{
-          p: { xs: 2, sm: 3 },
-          flex: 1,
-          display: "flex",
-          flexDirection: "column",
-        }}
-      >
-        <Typography
-          fontWeight={700}
-          variant="h6"
-          mb={1}
-          sx={{
-            overflow: "hidden",
-            textOverflow: "ellipsis",
-            whiteSpace: "nowrap",
-            fontSize: "clamp(1.07rem, 3vw, 1.18rem)",
-          }}
-        >
+      <div className="flex flex-1 flex-col gap-3 px-5 py-4 sm:px-7 sm:py-6">
+        <h3 className="truncate font-display text-[clamp(1.07rem,3vw,1.18rem)] font-semibold text-[color:var(--page-text)]">
           {localizedTitle}
-        </Typography>
-
-        <Typography
-          mb={2}
-          variant="body2"
-          color="text.secondary"
-          sx={{
-            minHeight: { xs: 44, sm: 64 },
-            overflow: "hidden",
-            display: "-webkit-box",
-            WebkitLineClamp: 3,
-            WebkitBoxOrient: "vertical",
-            fontSize: "clamp(0.99rem, 2vw, 1.06rem)",
-          }}
-        >
+        </h3>
+        <p className="line-clamp-3 min-h-[2.75rem] text-[clamp(0.99rem,2vw,1.06rem)] text-[color:var(--secondary-text)] sm:min-h-[4rem]">
           {sanitizedPreview}
-        </Typography>
+        </p>
+        <div className="mt-auto text-sm text-[color:var(--secondary-text)]">
+          {createdAtIso ? <time dateTime={createdAtIso}>{createdAtLabel}</time> : null}
+        </div>
+      </div>
 
-        <Box flex={1} />
-
-        <Typography color="var(--secondary-text)" fontSize={14} sx={{ mt: "auto" }}>
-          {createdAtIso && <time dateTime={createdAtIso}>{createdAtLabel}</time>}
-        </Typography>
-      </Box>
-
-      {/* Edit dialog */}
-      <Dialog
+      <Modal
         open={editOpen}
-        onClose={closeEditDialog}
-        fullScreen={isMobile}
-        PaperProps={{
-          sx: {
-            borderRadius: { xs: 0, sm: 3 },
-            width: { xs: "100vw", sm: 420 },
-            maxWidth: { xs: "100vw", sm: 450 },
-          },
-        }}
+        onOpenChange={handleEditOpenChange}
+        closeOnOverlayClick={!loading && !imageLoading}
+        closeOnEscape={!loading && !imageLoading}
+        initialFocus={() => editTitleRef.current ?? undefined}
       >
-        <DialogTitle sx={{ fontWeight: 700, fontSize: "1.2rem" }}>
-          {t("news:dialogs.edit.title")}
-        </DialogTitle>
-        <DialogContent>
-          <Stack spacing={2} mt={1} minWidth={isMobile ? "auto" : 340} mb={2}>
-            <TextField
+        <ModalContent
+          className={cn(
+            "w-full max-w-2xl sm:max-w-xl",
+            isMobile ? "h-[calc(100vh-2rem)] max-h-[calc(100vh-2rem)] rounded-[1.25rem]" : ""
+          )}
+        >
+          <ModalHeader className="px-6 pt-6 pb-4">
+            <ModalTitle className="text-xl font-semibold">
+              {t("news:dialogs.edit.title")}
+            </ModalTitle>
+          </ModalHeader>
+          <ModalBody className="flex flex-col gap-4 px-6 pb-2">
+            <TextInput
+              ref={editTitleRef}
               label={t("news:form.title")}
               value={editData.title}
               onChange={(e) => setEditData({ ...editData, title: e.target.value })}
-              fullWidth
-              sx={{ fontSize: "1rem" }}
             />
-            <TextField
+            <TextArea
               label={t("news:form.text")}
               value={editData.content}
               onChange={(e) => setEditData({ ...editData, content: e.target.value })}
-              multiline
               rows={4}
-              fullWidth
-              sx={{ fontSize: "1rem" }}
             />
-            <TextField
+            <TextInput
               label={t("news:form.title_en", { defaultValue: "Title (English)" })}
               value={editData.title_en}
               onChange={(e) => setEditData({ ...editData, title_en: e.target.value })}
-              fullWidth
-              sx={{ fontSize: "1rem" }}
             />
-            <TextField
+            <TextArea
               label={t("news:form.content_en", { defaultValue: "News text (English)" })}
               value={editData.content_en}
               onChange={(e) => setEditData({ ...editData, content_en: e.target.value })}
-              multiline
               rows={4}
-              fullWidth
-              sx={{ fontSize: "1rem" }}
             />
-            <Box>
+            <div className="flex flex-col gap-3">
               <Button
-                component="label"
-                variant="contained"
+                type="button"
+                variant="outline"
+                leadingIcon={<CameraIcon className="h-4 w-4" />}
+                className="w-fit"
                 disabled={imageLoading}
-                startIcon={<PhotoCamera />}
-                sx={{
-                  minWidth: 120,
-                  fontWeight: 600,
-                  fontSize: "1rem",
-                  borderRadius: 2,
+                loading={imageLoading}
+                onClick={() => {
+                  if (imageLoading) return
+                  imageInputRef.current?.click()
                 }}
-                onClick={(e) => e.stopPropagation()}
               >
-                {imageLoading ? t("common:statuses.uploading") : t("news:form.changePhoto")}
-                <input
-                  type="file"
-                  accept="image/*"
-                  hidden
-                  ref={imageInputRef}
-                  onChange={handleImageChange}
-                  onClick={(e) => e.stopPropagation()}
-                />
+                {imageLoading
+                  ? t("common:statuses.uploading")
+                  : t("news:form.changePhoto")}
               </Button>
-              {editImageUrl && (
-                <Box mt={1}>
+              <input
+                type="file"
+                accept="image/*"
+                ref={imageInputRef}
+                onChange={handleImageChange}
+                className="sr-only"
+              />
+              {editImageUrl ? (
+                <div className="inline-flex overflow-hidden rounded-ue-md border border-[color:var(--glass-border)] bg-[color:var(--card-bg)]/90 p-1 shadow-surface">
                   <SmartImage
                     srcRaw={editImageUrl}
                     alt={t("news:alt.preview")}
-                    style={{
-                      width: 140,
-                      maxHeight: 90,
-                      objectFit: "cover",
-                      borderRadius: 8,
-                      border: "1px solid #eee",
-                      display: "block",
-                    }}
+                    className="h-[90px] w-[140px] rounded-[0.75rem] object-cover"
                   />
-                </Box>
-              )}
-            </Box>
+                </div>
+              ) : null}
+            </div>
+          </ModalBody>
+          <ModalFooter className="flex flex-col gap-3 px-6 pb-6 sm:flex-row sm:justify-end">
+            <Button
+              variant="solid"
+              onClick={handleEdit}
+              loading={loading}
+              disabled={imageLoading}
+            >
+              {t("common:buttons.save")}
+            </Button>
+            <Button variant="outline" onClick={closeEditDialog} disabled={loading || imageLoading}>
+              {t("common:buttons.cancel")}
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
 
-            <Stack direction="row" gap={2} mt={2}>
-              <Button
-                variant="contained"
-                onClick={handleEdit}
-                disabled={loading || imageLoading}
-                sx={{ fontWeight: 700, borderRadius: 2.2, px: 3, fontSize: "1.02rem" }}
-              >
-                {t("common:buttons.save")}
-              </Button>
-              <Button
-                variant="outlined"
-                color="secondary"
-                onClick={closeEditDialog}
-                sx={{ borderRadius: 2.2, px: 2.5, fontSize: "1.02rem" }}
-              >
-                {t("common:buttons.cancel")}
-              </Button>
-            </Stack>
-          </Stack>
-        </DialogContent>
-      </Dialog>
-
-      {/* Delete confirm */}
-      <Dialog open={confirmDeleteOpen} onClose={() => setConfirmDeleteOpen(false)}>
-        <DialogTitle>{t("news:dialogs.delete.title")}</DialogTitle>
-        <DialogContent>
-          <Typography>{t("news:dialogs.delete.description")}</Typography>
-        </DialogContent>
-        <DialogActions>
-          <Button
-            variant="outlined"
-            color="secondary"
-            onClick={() => setConfirmDeleteOpen(false)}
-            disabled={loading}
-          >
-            {t("common:buttons.cancel")}
-          </Button>
-          <Button variant="contained" color="error" onClick={handleDelete} disabled={loading}>
-            <DeleteIcon sx={{ mr: 1 }} /> {t("common:buttons.delete")}
-          </Button>
-        </DialogActions>
-      </Dialog>
-    </Box>
+      <Modal
+        open={confirmDeleteOpen}
+        onOpenChange={handleConfirmOpenChange}
+        closeOnOverlayClick={!loading}
+        closeOnEscape={!loading}
+      >
+        <ModalContent className="w-full max-w-md">
+          <ModalHeader className="px-6 pt-6">
+            <ModalTitle className="text-lg font-semibold">
+              {t("news:dialogs.delete.title")}
+            </ModalTitle>
+          </ModalHeader>
+          <ModalBody className="px-6 pb-2 text-[color:var(--secondary-text)]">
+            <p>{t("news:dialogs.delete.description")}</p>
+          </ModalBody>
+          <ModalFooter className="flex flex-col gap-3 px-6 pb-6 sm:flex-row sm:justify-end">
+            <Button variant="outline" onClick={() => setConfirmDeleteOpen(false)} disabled={loading}>
+              {t("common:buttons.cancel")}
+            </Button>
+            <Button
+              variant="solid"
+              onClick={handleDelete}
+              loading={loading}
+              leadingIcon={<TrashIcon className="h-4 w-4" />}
+              className="bg-[color:var(--badge-lab)] text-white hover:bg-[color-mix(in_srgb,var(--badge-lab) 85%,#ffffff 15%)]"
+            >
+              {t("common:buttons.delete")}
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </div>
   )
 }
 

--- a/root/frontend/src/styles/tailwind.css
+++ b/root/frontend/src/styles/tailwind.css
@@ -312,3 +312,12 @@
     }
   }
 }
+
+@layer utilities {
+  .line-clamp-3 {
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+}


### PR DESCRIPTION
## Summary
- reimplemented the NewsCard layout with Tailwind-based card, media frame, and typography while replacing Material UI controls
- added custom dropdown menu and modal flows that reuse shared Tailwind primitives and maintain focus trapping for edit/delete actions
- introduced a reusable line-clamp utility to preserve localized content preview truncation

## Testing
- npm run lint -- --max-warnings=0
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_69056ea9cd7c83279a98f4d9daad2d0d