### PR TITLE
Update News tests for Tailwind providers

### DIFF
--- a/root/frontend/src/pages/__tests__/News.performance.test.tsx
+++ b/root/frontend/src/pages/__tests__/News.performance.test.tsx
@@ -210,14 +210,12 @@ describe("News page feed rendering", () => {
     useMediaQueryMock.mockReset()
   })
 
-  it.each(
-    [
-      ["light", false],
-      ["light", true],
-      ["dark", false],
-      ["dark", true],
-    ] as const
-  )(
+  it.each([
+    ["light", false],
+    ["light", true],
+    ["dark", false],
+    ["dark", true],
+  ] as const)(
     "renders a large news feed without blur in %s mode (mobile=%s)",
     async (mode, isMobile) => {
       currentMode = mode

--- a/root/frontend/src/pages/__tests__/News.performance.test.tsx
+++ b/root/frontend/src/pages/__tests__/News.performance.test.tsx
@@ -1,8 +1,8 @@
-import type { ReactNode } from "react"
-import { render, screen } from "@testing-library/react"
+import { useEffect, type ReactNode } from "react"
+import { render, screen, waitFor } from "@testing-library/react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
-import { ThemeProvider, createTheme } from "@mui/material/styles"
 import { LanguageProvider } from "@/contexts/LanguageContext"
+import { AppShellProvider } from "@/contexts/AppShellContext"
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
 
 vi.mock("../../components/NewsCard", () => {
@@ -26,6 +26,13 @@ vi.mock("../../contexts/AuthContext", () => ({
   }),
 }))
 
+const useMediaQueryMock = vi.fn<(query: string) => boolean>(() => false)
+
+vi.mock("@/hooks/useMediaQuery", () => ({
+  __esModule: true,
+  default: (query: string) => useMediaQueryMock(query),
+}))
+
 vi.mock("@/hooks/useNewsFeed", () => ({
   useNewsFeed: vi.fn(),
 }))
@@ -43,6 +50,45 @@ const largeFeed = Array.from({ length: 96 }, (_, index) => ({
 
 const useNewsFeedMock = vi.mocked(useNewsFeed)
 
+type PortalRegistration = { node: HTMLElement | null; created: boolean }
+
+const ensurePortalElement = (id: string): PortalRegistration => {
+  if (typeof document === "undefined") return { node: null, created: false }
+  const existing = document.getElementById(id)
+  if (existing) return { node: existing, created: false }
+  const node = document.createElement("div")
+  node.setAttribute("id", id)
+  document.body.appendChild(node)
+  return { node, created: true }
+}
+
+const TailwindPortalProvider = ({ children }: { children: ReactNode }) => {
+  useEffect(() => {
+    const registrations: PortalRegistration[] = [
+      ensurePortalElement("ue-modal-root"),
+      ensurePortalElement("ue-toast-root"),
+    ]
+
+    return () => {
+      registrations.forEach(({ node, created }) => {
+        if (created && node?.parentNode) {
+          node.parentNode.removeChild(node)
+        }
+      })
+    }
+  }, [])
+
+  return <>{children}</>
+}
+
+TailwindPortalProvider.displayName = "TailwindPortalProvider"
+
+const setIsMobile = (isMobile: boolean) => {
+  useMediaQueryMock.mockImplementation((query) =>
+    query === "(max-width:600px)" ? isMobile : false
+  )
+}
+
 const buildWrapper = (mode: "light" | "dark") => {
   const client = new QueryClient({
     defaultOptions: {
@@ -50,13 +96,13 @@ const buildWrapper = (mode: "light" | "dark") => {
     },
   })
 
-  const theme = createTheme({ palette: { mode } })
-
   const NewsTestWrapper = ({ children }: { children: ReactNode }) => (
     <QueryClientProvider client={client}>
-      <LanguageProvider>
-        <ThemeProvider theme={theme}>{children}</ThemeProvider>
-      </LanguageProvider>
+      <AppShellProvider>
+        <LanguageProvider>
+          <TailwindPortalProvider>{children}</TailwindPortalProvider>
+        </LanguageProvider>
+      </AppShellProvider>
     </QueryClientProvider>
   )
 
@@ -154,19 +200,29 @@ describe("News page feed rendering", () => {
       refetch: vi.fn(),
     } as unknown as ReturnType<typeof useNewsFeed>)
     localStorage.setItem("ue:language", "en")
+    setIsMobile(false)
   })
 
   afterEach(() => {
     localStorage.clear()
     matchMediaMock.mockClear()
     useNewsFeedMock.mockClear()
+    useMediaQueryMock.mockReset()
   })
 
-  it.each([["light"], ["dark"]] as const)(
-    "renders a large news feed without blur in %s mode",
-    async (mode) => {
+  it.each(
+    [
+      ["light", false],
+      ["light", true],
+      ["dark", false],
+      ["dark", true],
+    ] as const
+  )(
+    "renders a large news feed without blur in %s mode (mobile=%s)",
+    async (mode, isMobile) => {
       currentMode = mode
       const wrapper = buildWrapper(mode)
+      setIsMobile(isMobile)
 
       const { container } = render(<News />, { wrapper })
 
@@ -176,6 +232,7 @@ describe("News page feed rendering", () => {
       const fadeContainer = container.querySelector<HTMLElement>("[data-page-fade]")
       expect(fadeContainer).not.toBeNull()
       expect(fadeContainer?.dataset.effect).toBeUndefined()
+      await waitFor(() => expect(fadeContainer?.dataset.ready).toBe("true"))
       expect(useNewsFeedMock).toHaveBeenCalled()
     }
   )

--- a/root/frontend/src/tests/pages/News/NewsFeed.test.tsx
+++ b/root/frontend/src/tests/pages/News/NewsFeed.test.tsx
@@ -1,4 +1,5 @@
 import { act, render, screen, waitFor } from "@testing-library/react"
+import { useEffect, type ReactNode } from "react"
 import { MemoryRouter } from "react-router-dom"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
@@ -7,6 +8,52 @@ import type { ContextType } from "react"
 
 import type { User } from "@/types/User"
 import { server } from "../../mocks/server"
+
+const useMediaQueryMock = vi.fn<(query: string) => boolean>(() => false)
+
+vi.mock("@/hooks/useMediaQuery", () => ({
+  __esModule: true,
+  default: (query: string) => useMediaQueryMock(query),
+}))
+
+const setIsMobile = (isMobile: boolean) => {
+  useMediaQueryMock.mockImplementation((query) =>
+    query === "(max-width:600px)" ? isMobile : false
+  )
+}
+
+type PortalRegistration = { node: HTMLElement | null; created: boolean }
+
+const ensurePortalElement = (id: string): PortalRegistration => {
+  if (typeof document === "undefined") return { node: null, created: false }
+  const existing = document.getElementById(id)
+  if (existing) return { node: existing, created: false }
+  const node = document.createElement("div")
+  node.setAttribute("id", id)
+  document.body.appendChild(node)
+  return { node, created: true }
+}
+
+const TailwindPortalProvider = ({ children }: { children: ReactNode }) => {
+  useEffect(() => {
+    const registrations: PortalRegistration[] = [
+      ensurePortalElement("ue-modal-root"),
+      ensurePortalElement("ue-toast-root"),
+    ]
+
+    return () => {
+      registrations.forEach(({ node, created }) => {
+        if (created && node?.parentNode) {
+          node.parentNode.removeChild(node)
+        }
+      })
+    }
+  }, [])
+
+  return <>{children}</>
+}
+
+TailwindPortalProvider.displayName = "TailwindPortalProvider"
 
 type CacheEntry = { key: string; response: Response }
 
@@ -124,9 +171,10 @@ const baseUser: User = {
 }
 
 const renderNewsPage = async (queryClient?: QueryClient) => {
-  const [{ AuthContext }, { LanguageProvider }] = await Promise.all([
+  const [{ AuthContext }, { LanguageProvider }, { AppShellProvider }] = await Promise.all([
     import("@/contexts/AuthContext"),
     import("@/contexts/LanguageContext"),
+    import("@/contexts/AppShellContext"),
   ])
 
   type AuthContextValue = ContextType<typeof AuthContext>
@@ -158,9 +206,13 @@ const renderNewsPage = async (queryClient?: QueryClient) => {
     <AuthContext.Provider value={authValue}>
       <LanguageProvider>
         <QueryClientProvider client={client}>
-          <MemoryRouter initialEntries={["/news"]}>
-            <News />
-          </MemoryRouter>
+          <AppShellProvider>
+            <TailwindPortalProvider>
+              <MemoryRouter initialEntries={["/news"]}>
+                <News />
+              </MemoryRouter>
+            </TailwindPortalProvider>
+          </AppShellProvider>
         </QueryClientProvider>
       </LanguageProvider>
     </AuthContext.Provider>
@@ -176,6 +228,8 @@ describe("News page feed integration", () => {
     delete (window as unknown as { caches?: CacheStorage }).caches
     window.localStorage.setItem("ue:language", "ru")
     server.resetHandlers()
+    setIsMobile(false)
+    useMediaQueryMock.mockClear()
   })
 
   it("persists API responses and revalidates using cached ETags", async () => {
@@ -199,6 +253,8 @@ describe("News page feed integration", () => {
     const { queryClient } = await renderNewsPage()
 
     expect(await screen.findByText("API headline")).toBeInTheDocument()
+    const fadeContainer = document.querySelector<HTMLElement>("[data-page-fade]")
+    await waitFor(() => expect(fadeContainer?.dataset.ready).toBe("true"))
     await waitFor(() => expect(requestCount).toBe(1))
     expect(put).toHaveBeenCalledTimes(1)
 
@@ -214,6 +270,7 @@ describe("News page feed integration", () => {
   })
 
   it("hydrates from service worker caches during network failures and clears legacy storage", async () => {
+    setIsMobile(true)
     const cachedItems = [createNewsItem(2, "Cached bulletin")]
     const cacheKey = buildCacheKey("ru")
     const cachedResponse = createNewsResponse(cachedItems, '"cached-tag"')
@@ -231,6 +288,8 @@ describe("News page feed integration", () => {
 
     expect(await screen.findByText("Cached bulletin")).toBeInTheDocument()
     expect(match).toHaveBeenCalled()
+    const fadeContainer = document.querySelector<HTMLElement>("[data-page-fade]")
+    await waitFor(() => expect(fadeContainer?.dataset.ready).toBe("true"))
     expect(window.localStorage.getItem("news:list")).toBeNull()
     expect(window.localStorage.getItem("news:etag")).toBeNull()
     expect(window.localStorage.getItem("news:list:ru")).toBeNull()


### PR DESCRIPTION
## Summary
- replace the News performance test's MUI theme wrapper with AppShell and Tailwind portal scaffolding while exercising both desktop and mobile layouts
- extend the News integration tests with Tailwind portal helpers, AppShell provider coverage, and updated page fade assertions for the new markup

## Testing
- pnpm vitest run News

------
https://chatgpt.com/codex/tasks/task_e_6905879c47308327b57ca21c2a5f1d60