### PR TITLE
Fix navbar visibility when reduced motion is enabled

### DIFF
--- a/root/frontend/src/assets/themes.css
+++ b/root/frontend/src/assets/themes.css
@@ -246,6 +246,13 @@ body.dark {
   --placeholder-fg: rgba(255, 255, 255, 0.58);
   --ue-focus-ring: 0 0 0 1px rgba(6, 11, 20, 0.92), 0 0 0 4px rgba(127, 182, 230, 0.45);
 }
+
+@media (prefers-reduced-motion: reduce) {
+  .navbar-root {
+    animation: none;
+    opacity: 1;
+  }
+}
 ::selection {
   background: var(--selection-bg);
   color: var(--selection-text);

--- a/root/frontend/src/components/Navbar.tsx
+++ b/root/frontend/src/components/Navbar.tsx
@@ -153,6 +153,7 @@ const Navbar = () => {
           zIndex: "var(--ue-z-index-nav)",
           transition: prefersReducedMotion ? "none" : undefined,
           animation: prefersReducedMotion ? "none" : undefined,
+          opacity: prefersReducedMotion ? 1 : undefined,
         }}
       >
         <div


### PR DESCRIPTION
## Summary
- ensure the navbar stays fully opaque when the user prefers reduced motion by guarding the inline opacity style
- keep CSS animations from reapplying by forcing opacity and disabling animation for the navbar under the prefers-reduced-motion media query

## Testing
- Manual - Verified the navbar renders at full opacity with reduced motion enabled via Playwright stubbed session

------
https://chatgpt.com/codex/tasks/task_e_69063536e9ec83279932a095af8b3ab6