### PR TITLE
refactor: restyle news pages with tailwind

### DIFF
--- a/root/frontend/src/components/Dialog.tsx
+++ b/root/frontend/src/components/Dialog.tsx
@@ -1,0 +1,186 @@
+import {
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react"
+import { createPortal } from "react-dom"
+import useFocusTrap, { type UseFocusTrapOptions } from "@/hooks/useFocusTrap"
+import { cn } from "@/utils/cn"
+
+const isBrowser = typeof document !== "undefined"
+
+type DialogSize = "sm" | "md" | "lg"
+
+const sizeClassMap: Record<DialogSize, string> = {
+  sm: "sm:max-w-sm",
+  md: "sm:max-w-lg",
+  lg: "sm:max-w-2xl",
+}
+
+export type DialogProps = {
+  open: boolean
+  onClose: () => void
+  title?: ReactNode
+  subtitle?: ReactNode
+  children: ReactNode
+  footer?: ReactNode
+  /** Defaults to `md`. */
+  size?: DialogSize
+  /** When true, the dialog takes the full screen height on narrow viewports. */
+  fullScreenOnMobile?: boolean
+  className?: string
+  bodyClassName?: string
+  footerClassName?: string
+  closeLabel?: string
+  initialFocus?: UseFocusTrapOptions["initialFocus"]
+}
+
+export function Dialog({
+  open,
+  onClose,
+  title,
+  subtitle,
+  children,
+  footer,
+  size = "md",
+  fullScreenOnMobile = false,
+  className,
+  bodyClassName,
+  footerClassName,
+  closeLabel = "Close",
+  initialFocus,
+}: DialogProps) {
+  const [portalNode, setPortalNode] = useState<HTMLElement | null>(null)
+  const [mounted, setMounted] = useState(false)
+  const dialogTitleId = useId()
+  const dialogSubtitleId = useId()
+  const closeButtonRef = useRef<HTMLButtonElement | null>(null)
+
+  useEffect(() => {
+    if (!isBrowser) return
+    const node = document.createElement("div")
+    node.dataset.dialogRoot = "true"
+    document.body.appendChild(node)
+    setPortalNode(node)
+    setMounted(true)
+    return () => {
+      document.body.removeChild(node)
+      setPortalNode(null)
+      setMounted(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!isBrowser || !open) return
+    const previousOverflow = document.body.style.overflow
+    document.body.style.overflow = "hidden"
+    return () => {
+      document.body.style.overflow = previousOverflow
+    }
+  }, [open])
+
+  const dialogRef = useFocusTrap<HTMLDivElement>({
+    active: open,
+    onDeactivate: onClose,
+    initialFocus: initialFocus ?? (() => closeButtonRef.current ?? undefined),
+    allowOutsideClick: true,
+  })
+
+  const labelledBy = useMemo(() => {
+    if (!title) return undefined
+    return dialogTitleId
+  }, [dialogTitleId, title])
+
+  const describedBy = useMemo(() => {
+    if (!subtitle) return undefined
+    return dialogSubtitleId
+  }, [dialogSubtitleId, subtitle])
+
+  if (!mounted || !portalNode || !open) {
+    return null
+  }
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[var(--ue-z-index-overlay)] flex items-start justify-center overflow-y-auto px-4 py-6 sm:px-6"
+      role="presentation"
+    >
+      <div
+        className="absolute inset-0 bg-[rgba(10,16,32,0.62)] backdrop-blur-[12px]"
+        aria-hidden="true"
+        onClick={onClose}
+      />
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={labelledBy}
+        aria-describedby={describedBy}
+        className={cn(
+          "relative z-10 w-full max-w-[min(100%,480px)]",
+          sizeClassMap[size],
+          fullScreenOnMobile
+            ? "h-[100dvh] max-h-[100dvh] overflow-y-auto rounded-none bg-[color:color-mix(in_srgb,var(--card-bg)_92%,white_8%)] px-5 pb-6 pt-5 text-page-foreground shadow-surface-strong ring-1 ring-white/10 sm:h-auto sm:max-h-[90vh] sm:rounded-ue-xl sm:px-6 sm:pb-7"
+            : "max-h-[92vh] overflow-y-auto rounded-ue-xl bg-[color:color-mix(in_srgb,var(--card-bg)_92%,white_8%)] px-5 pb-6 pt-5 text-page-foreground shadow-surface-strong ring-1 ring-white/10 backdrop-blur-xl sm:px-6 sm:pb-7",
+          "focus:outline-none",
+          className
+        )}
+      >
+        <div className="flex items-start justify-between gap-4">
+          <div className="space-y-1">
+            {title ? (
+              <h2
+                id={dialogTitleId}
+                className="text-[clamp(1.2rem,3vw,1.45rem)] font-semibold text-page-foreground"
+              >
+                {title}
+              </h2>
+            ) : null}
+            {subtitle ? (
+              <p
+                id={dialogSubtitleId}
+                className="text-sm font-medium text-[color:var(--secondary-text)]"
+              >
+                {subtitle}
+              </p>
+            ) : null}
+          </div>
+          <button
+            ref={closeButtonRef}
+            type="button"
+            onClick={onClose}
+            className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-white/10 bg-white/70 text-nav-link shadow-surface transition hover:bg-white focus-visible:outline-none focus-visible:shadow-focus"
+          >
+            <span className="sr-only">{closeLabel}</span>
+            <svg
+              viewBox="0 0 20 20"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+              className="h-4 w-4 text-[color:var(--nav-link)]"
+              aria-hidden
+            >
+              <path
+                d="M5.5 5.5l9 9m0-9l-9 9"
+                stroke="currentColor"
+                strokeWidth="1.6"
+                strokeLinecap="round"
+              />
+            </svg>
+          </button>
+        </div>
+        <div className={cn("mt-5 space-y-5", bodyClassName)}>{children}</div>
+        {footer ? (
+          <div className={cn("mt-6 flex flex-col gap-3 sm:flex-row sm:justify-end", footerClassName)}>
+            {footer}
+          </div>
+        ) : null}
+      </div>
+    </div>,
+    portalNode
+  )
+}
+
+export default Dialog

--- a/root/frontend/src/components/NewsCard.tsx
+++ b/root/frontend/src/components/NewsCard.tsx
@@ -1,19 +1,4 @@
-import { FC, memo, useState, useEffect, useRef, useCallback, useMemo } from "react"
-import {
-  Box,
-  Typography,
-  IconButton,
-  Menu,
-  MenuItem,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
-  TextField,
-  Stack,
-  Button,
-  useMediaQuery,
-} from "@mui/material"
+import { FC, memo, useState, useEffect, useRef, useCallback, useMemo, type ReactNode } from "react"
 import MoreVertIcon from "@mui/icons-material/MoreVert"
 import EditIcon from "@mui/icons-material/Edit"
 import DeleteIcon from "@mui/icons-material/Delete"
@@ -29,9 +14,24 @@ import SmartImage from "@/components/SmartImage"
 import { cn } from "@/utils/cn"
 import { sanitizeNewsText } from "@/utils/sanitize"
 import { useTranslation } from "react-i18next"
+import { Button } from "@/components/ui"
+import Dialog from "@/components/Dialog"
 
 dayjs.extend(utc)
 dayjs.extend(timezone)
+
+const inputClass =
+  "w-full rounded-ue-lg border border-white/12 bg-[color:color-mix(in_srgb,var(--card-bg)_94%,white_6%)] px-4 py-2.5 text-[0.98rem] text-[color:var(--page-text)] shadow-[inset_0_1px_0_rgba(15,23,42,0.08)] transition focus:border-[color:var(--nav-link)] focus:outline-none focus:shadow-focus placeholder:text-[color:var(--placeholder-fg)]"
+const textareaClass = `${inputClass} min-h-[128px] resize-y leading-relaxed`
+
+const iconButtonClass =
+  "inline-flex h-9 w-9 items-center justify-center rounded-full border border-white/15 bg-white/80 text-[color:var(--nav-link)] shadow-surface transition hover:bg-white focus-visible:outline-none focus-visible:shadow-focus"
+
+const menuPanelClass =
+  "absolute right-0 top-12 z-20 min-w-[180px] overflow-hidden rounded-ue-md border border-white/12 bg-[color:color-mix(in_srgb,var(--card-bg)_94%,white_6%)]/98 shadow-surface-strong backdrop-blur-xl"
+
+const menuItemClass =
+  "flex w-full items-center gap-2 px-4 py-2.5 text-left text-[0.95rem] font-medium text-[color:var(--page-text)] transition hover:bg-[color:var(--glass-bg)]/80 focus-visible:outline-none focus-visible:bg-[color:var(--glass-bg)]"
 
 type NewsCardProps = {
   id: number
@@ -42,6 +42,28 @@ type NewsCardProps = {
   created_at: string
   image_url?: string
   onChange?: () => void
+}
+
+type FieldProps = {
+  label: string
+  htmlFor: string
+  children: ReactNode
+  required?: boolean
+}
+
+function Field({ label, htmlFor, children, required = false }: FieldProps) {
+  return (
+    <div className="space-y-2">
+      <label
+        htmlFor={htmlFor}
+        className="text-sm font-semibold tracking-wide text-[color:color-mix(in_srgb,var(--secondary-text)_85%,white_15%)]"
+      >
+        {label}
+        {required ? <span className="ml-1 text-[#f87171]">*</span> : null}
+      </label>
+      {children}
+    </div>
+  )
 }
 
 const getMoscowDate = (dateStr: string) => {
@@ -67,9 +89,13 @@ const NewsCardComponent: FC<NewsCardProps> = ({
   const { t } = useTranslation(["news", "common"])
   const { language } = useLanguage()
 
-  const [menuAnchor, setMenuAnchor] = useState<null | HTMLElement>(null)
+  const [menuOpen, setMenuOpen] = useState(false)
+  const menuButtonRef = useRef<HTMLButtonElement | null>(null)
+  const menuRef = useRef<HTMLDivElement | null>(null)
+  const firstMenuItemRef = useRef<HTMLButtonElement | null>(null)
   const [editOpen, setEditOpen] = useState(false)
   const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false)
+  const editTitleRef = useRef<HTMLInputElement | null>(null)
 
   const [editData, setEditData] = useState({
     title,
@@ -86,8 +112,8 @@ const NewsCardComponent: FC<NewsCardProps> = ({
   const imageInputRef = useRef<HTMLInputElement>(null)
   const [cardImageReady, setCardImageReady] = useState(!image_url)
 
-  const isMobile = useMediaQuery("(max-width:600px)")
   const menuId = `news-card-menu-${id}`
+  const menuButtonId = `${menuId}-button`
 
   const localizedTitle = useMemo(() => {
     const english = title_en ?? ""
@@ -115,7 +141,6 @@ const NewsCardComponent: FC<NewsCardProps> = ({
 
   const handleCardImageReady = useCallback(() => setCardImageReady(true), [])
 
-  // preview URL lifecycle
   useEffect(() => {
     if (!newImage) {
       setPreviewUrl(null)
@@ -132,6 +157,34 @@ const NewsCardComponent: FC<NewsCardProps> = ({
     }
   }, [previewUrl])
 
+  useEffect(() => {
+    if (!menuOpen) return
+
+    const handleClick = (event: MouseEvent) => {
+      const target = event.target as Node
+      if (menuRef.current?.contains(target) || menuButtonRef.current?.contains(target)) return
+      setMenuOpen(false)
+    }
+
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setMenuOpen(false)
+        menuButtonRef.current?.focus()
+      }
+    }
+
+    document.addEventListener("mousedown", handleClick)
+    document.addEventListener("keydown", handleKey)
+    if (firstMenuItemRef.current) firstMenuItemRef.current.focus()
+
+    return () => {
+      document.removeEventListener("mousedown", handleClick)
+      document.removeEventListener("keydown", handleKey)
+    }
+  }, [menuOpen])
+
+  const closeMenu = useCallback(() => setMenuOpen(false), [])
+
   const openEditDialog = useCallback(() => {
     setEditData({
       title,
@@ -147,7 +200,8 @@ const NewsCardComponent: FC<NewsCardProps> = ({
       setPreviewUrl(null)
     }
     if (imageInputRef.current) imageInputRef.current.value = ""
-  }, [title, content, title_en, content_en, image_url, previewUrl])
+    closeMenu()
+  }, [title, content, title_en, content_en, image_url, previewUrl, closeMenu])
 
   const closeEditDialog = useCallback(() => {
     setEditOpen(false)
@@ -178,7 +232,6 @@ const NewsCardComponent: FC<NewsCardProps> = ({
         try {
           const data = new FormData()
           data.append("file", newImage)
-          // единый эндпоинт загрузки
           const res = await api.post<{ url: string }>(`/news/upload_image`, data, {
             headers: { "Content-Type": "multipart/form-data" },
           })
@@ -218,368 +271,282 @@ const NewsCardComponent: FC<NewsCardProps> = ({
     }
   }, [id, onChange])
 
-  const handleCardClick = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
-      if (editOpen) {
-        e.stopPropagation()
-        e.preventDefault()
-        return
-      }
-      const el = e.target as HTMLElement
-      if (
-        el.closest("button") ||
-        el.closest("input") ||
-        el.closest(".MuiInputBase-root") ||
-        el.closest('[role="menu"]')
-      )
-        return
-      navigate(`/news/${id}`)
-    },
-    [editOpen, id, navigate]
-  )
+  const handleCardClick = useCallback(() => {
+    if (editOpen) return
+    navigate(`/news/${id}`)
+  }, [editOpen, id, navigate])
 
-  const hoveringDisabled = editOpen || Boolean(menuAnchor)
-  const interactiveSx = useMemo(() => {
-    if (hoveringDisabled) {
-      return {}
-    }
-    return {
-      "&:hover": {
-        transform: "translateY(-2px) scale(1.02)",
-        boxShadow: "var(--shadow-2)",
-      },
-      "&:active": {
-        transform: "scale(0.997)",
-      },
-    }
-  }, [hoveringDisabled])
+  const hoveringDisabled = editOpen || menuOpen
 
   return (
-    <Box
-      className={cn("news-card")}
-      sx={{
-        width: "100%",
-        maxWidth: 700,
-        borderRadius: { xs: "1.1rem", sm: "1.2rem" },
-        background: "var(--card-bg)",
-        color: "var(--page-text)",
-        position: "relative",
-        cursor: hoveringDisabled ? "default" : "pointer",
-        boxShadow: 5,
-        p: 0,
-        overflow: "hidden",
-        display: "flex",
-        flexDirection: "column",
-        minHeight: 340,
-        "&:focus-visible": {
-          outline: "2px solid var(--nav-link)",
-          outlineOffset: "2px",
-        },
-        transition: "transform 0.25s ease, box-shadow 0.25s ease",
-        ...interactiveSx,
-      }}
-      role="button"
-      tabIndex={0}
-      onKeyDown={(e) => {
-        if (editOpen) return
-        if (e.currentTarget !== e.target) return
-        if (e.key === "Enter" || e.key === " ") {
-          e.preventDefault()
-          navigate(`/news/${id}`)
-        }
-      }}
-      onClick={handleCardClick}
+    <article
+      className={cn(
+        "group relative flex h-full w-full max-w-3xl flex-col overflow-hidden rounded-ue-xl border border-white/12 bg-[color:color-mix(in_srgb,var(--card-bg)_94%,white_6%)] text-[color:var(--page-text)] shadow-surface transition-[transform,box-shadow] duration-300 ease-out",
+        hoveringDisabled
+          ? "cursor-default"
+          : "cursor-pointer hover:-translate-y-[2px] hover:scale-[1.015] hover:shadow-surface-strong active:scale-[0.995]"
+      )}
     >
       {user?.role === "admin" && (
-        <>
-          <IconButton
-            aria-label={t("news:aria.cardActions")}
-            aria-controls={menuAnchor ? menuId : undefined}
+        <div className="absolute right-3 top-3 z-10">
+          <button
+            ref={menuButtonRef}
+            type="button"
+            id={menuButtonId}
+            aria-label={t("news:aria.cardActions") ?? ""}
+            aria-controls={menuOpen ? menuId : undefined}
             aria-haspopup="true"
-            aria-expanded={Boolean(menuAnchor) ? "true" : undefined}
-            sx={{
-              position: "absolute",
-              top: 10,
-              right: 10,
-              zIndex: 2,
-              bgcolor: "rgba(255,255,255,0.82)",
-              "&:hover": { bgcolor: "#fff" },
+            aria-expanded={menuOpen ? "true" : undefined}
+            className={iconButtonClass}
+            onClick={(event) => {
+              event.stopPropagation()
+              setMenuOpen((open) => !open)
             }}
-            onClick={(e) => {
-              e.stopPropagation()
-              setMenuAnchor(e.currentTarget)
-            }}
-            size="small"
             disabled={loading}
+            data-news-card-menu-button
           >
-            <MoreVertIcon />
-          </IconButton>
-          <Menu
-            id={menuId}
-            anchorEl={menuAnchor}
-            open={Boolean(menuAnchor)}
-            onClose={(e) => {
-              if (e) (e as any).stopPropagation?.()
-              setMenuAnchor(null)
-            }}
-            anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
-            transformOrigin={{ vertical: "top", horizontal: "right" }}
-            MenuListProps={{ "aria-labelledby": menuId }}
-          >
-            <MenuItem
-              onClick={(e) => {
-                e.stopPropagation()
-                openEditDialog()
-                setMenuAnchor(null)
-              }}
+            <MoreVertIcon fontSize="small" />
+          </button>
+          {menuOpen ? (
+            <div
+              ref={menuRef}
+              id={menuId}
+              role="menu"
+              aria-labelledby={menuButtonId}
+              data-news-card-menu
+              className={menuPanelClass}
             >
-              <EditIcon fontSize="small" sx={{ mr: 1 }} />
-              {t("common:buttons.edit")}
-            </MenuItem>
-            <MenuItem
-              onClick={(e) => {
-                e.stopPropagation()
-                setConfirmDeleteOpen(true)
-                setMenuAnchor(null)
-              }}
-            >
-              <DeleteIcon fontSize="small" sx={{ mr: 1 }} color="error" />
-              <span style={{ color: "#d32f2f" }}>{t("common:buttons.delete")}</span>
-            </MenuItem>
-          </Menu>
-        </>
+              <button
+                ref={firstMenuItemRef}
+                type="button"
+                className={menuItemClass}
+                onClick={(event) => {
+                  event.stopPropagation()
+                  openEditDialog()
+                }}
+              >
+                <EditIcon fontSize="small" className="text-[color:var(--nav-link)]" />
+                {t("common:buttons.edit")}
+              </button>
+              <button
+                type="button"
+                className={cn(menuItemClass, "text-[#e11d48]")}
+                onClick={(event) => {
+                  event.stopPropagation()
+                  setConfirmDeleteOpen(true)
+                  closeMenu()
+                }}
+              >
+                <DeleteIcon fontSize="small" className="text-[#e11d48]" />
+                {t("common:buttons.delete")}
+              </button>
+            </div>
+          ) : null}
+        </div>
       )}
 
-      <Box
-        sx={{
-          width: "100%",
-          height: { xs: 160, sm: 180, md: 220, lg: 240 },
-          borderTopLeftRadius: { xs: "1.1rem", sm: "1.2rem" },
-          borderTopRightRadius: { xs: "1.1rem", sm: "1.2rem" },
-          borderBottom: "1px solid #eee",
-          background: "linear-gradient(135deg, rgba(13,71,161,0.18), rgba(63,81,181,0.08))",
-          position: "relative",
-          overflow: "hidden",
-          display: "flex",
-          alignItems: "stretch",
-          "& img": {
-            display: "block",
-            width: "100%",
-            height: "100%",
-            objectFit: "cover",
-            objectPosition: "center",
-          },
-          "&::after": {
-            content: '""',
-            position: "absolute",
-            inset: 0,
-            background: "linear-gradient(120deg, rgba(255,255,255,0.2), rgba(255,255,255,0.05))",
-            opacity: cardImageReady ? 0 : 1,
-            transition: "opacity 260ms ease",
-            pointerEvents: "none",
-          },
-        }}
+      <button
+        type="button"
+        onClick={handleCardClick}
+        disabled={hoveringDisabled}
+        className="flex h-full flex-1 flex-col text-left focus-visible:outline-none disabled:cursor-default disabled:opacity-100"
       >
-        <SmartImage
-          srcRaw={cardImageUrl}
-          alt={
-            localizedTitle
-              ? t("news:alt.hero", { title: localizedTitle })
-              : t("news:alt.heroFallback")
-          }
-          sizes="(min-width: 1200px) 640px, (min-width: 900px) 520px, 100vw"
-          style={{
-            width: "100%",
-            height: "100%",
-            display: "block",
-            objectFit: "cover",
-            objectPosition: "center",
-          }}
-          onLoad={handleCardImageReady}
-          onError={handleCardImageReady}
-        />
-      </Box>
+        <div className="relative w-full border-b border-white/10 bg-[linear-gradient(135deg,rgba(29,78,216,0.18),rgba(59,130,246,0.08))]">
+          <div
+            className={cn(
+              "absolute inset-0 animate-pulse bg-[color:color-mix(in_srgb,var(--glass-bg)_70%,white_30%)] transition-opacity duration-300",
+              cardImageReady ? "opacity-0" : "opacity-100"
+            )}
+            aria-hidden
+          />
+          <SmartImage
+            srcRaw={cardImageUrl}
+            alt={
+              localizedTitle
+                ? t("news:alt.hero", { title: localizedTitle })
+                : t("news:alt.heroFallback")
+            }
+            sizes="(min-width: 1200px) 640px, (min-width: 900px) 520px, 100vw"
+            className="relative h-[180px] w-full object-cover sm:h-[220px]"
+            onLoad={handleCardImageReady}
+            onError={handleCardImageReady}
+          />
+        </div>
 
-      <Box
-        sx={{
-          p: { xs: 2, sm: 3 },
-          flex: 1,
-          display: "flex",
-          flexDirection: "column",
-        }}
-      >
-        <Typography
-          fontWeight={700}
-          variant="h6"
-          mb={1}
-          sx={{
-            overflow: "hidden",
-            textOverflow: "ellipsis",
-            whiteSpace: "nowrap",
-            fontSize: "clamp(1.07rem, 3vw, 1.18rem)",
-          }}
-        >
-          {localizedTitle}
-        </Typography>
+        <div className="flex flex-1 flex-col gap-3 px-4 py-5 sm:px-5 sm:py-6">
+          <h3 className="truncate text-[clamp(1.07rem,3vw,1.18rem)] font-semibold">
+            {localizedTitle}
+          </h3>
 
-        <Typography
-          mb={2}
-          variant="body2"
-          color="text.secondary"
-          sx={{
-            minHeight: { xs: 44, sm: 64 },
-            overflow: "hidden",
-            display: "-webkit-box",
-            WebkitLineClamp: 3,
-            WebkitBoxOrient: "vertical",
-            fontSize: "clamp(0.99rem, 2vw, 1.06rem)",
-          }}
-        >
-          {sanitizedPreview}
-        </Typography>
+          <p
+            className="min-h-[56px] text-[clamp(0.96rem,2vw,1.08rem)] text-[color:var(--secondary-text)]"
+            style={{
+              overflow: "hidden",
+              display: "-webkit-box",
+              WebkitLineClamp: 3,
+              WebkitBoxOrient: "vertical",
+            }}
+          >
+            {sanitizedPreview}
+          </p>
 
-        <Box flex={1} />
+          <div className="mt-auto pt-2 text-sm text-[color:var(--secondary-text)]">
+            {createdAtIso && <time dateTime={createdAtIso}>{createdAtLabel}</time>}
+          </div>
+        </div>
+      </button>
 
-        <Typography color="var(--secondary-text)" fontSize={14} sx={{ mt: "auto" }}>
-          {createdAtIso && <time dateTime={createdAtIso}>{createdAtLabel}</time>}
-        </Typography>
-      </Box>
-
-      {/* Edit dialog */}
       <Dialog
         open={editOpen}
         onClose={closeEditDialog}
-        fullScreen={isMobile}
-        PaperProps={{
-          sx: {
-            borderRadius: { xs: 0, sm: 3 },
-            width: { xs: "100vw", sm: 420 },
-            maxWidth: { xs: "100vw", sm: 450 },
-          },
-        }}
+        title={t("news:dialogs.edit.title")}
+        size="md"
+        fullScreenOnMobile
+        closeLabel={t("common:buttons.close")}
+        bodyClassName="space-y-4"
+        footerClassName="flex-col-reverse gap-3 sm:flex-row"
+        footer={
+          <>
+            <Button
+              variant="outline"
+              onClick={closeEditDialog}
+              disabled={loading || imageLoading}
+              className="w-full sm:w-auto"
+            >
+              {t("common:buttons.cancel")}
+            </Button>
+            <Button
+              onClick={() => {
+                void handleEdit()
+              }}
+              disabled={loading || imageLoading}
+              loading={loading}
+              className="w-full sm:w-auto"
+            >
+              {t("common:buttons.save")}
+            </Button>
+          </>
+        }
+        initialFocus={() => editTitleRef.current ?? undefined}
       >
-        <DialogTitle sx={{ fontWeight: 700, fontSize: "1.2rem" }}>
-          {t("news:dialogs.edit.title")}
-        </DialogTitle>
-        <DialogContent>
-          <Stack spacing={2} mt={1} minWidth={isMobile ? "auto" : 340} mb={2}>
-            <TextField
-              label={t("news:form.title")}
+        <form
+          className="space-y-4"
+          onSubmit={(event) => {
+            event.preventDefault()
+            void handleEdit()
+          }}
+        >
+          <Field label={t("news:form.title") ?? ""} htmlFor={`news-edit-title-${id}`} required>
+            <input
+              id={`news-edit-title-${id}`}
+              ref={editTitleRef}
+              type="text"
               value={editData.title}
               onChange={(e) => setEditData({ ...editData, title: e.target.value })}
-              fullWidth
-              sx={{ fontSize: "1rem" }}
+              className={inputClass}
             />
-            <TextField
-              label={t("news:form.text")}
+          </Field>
+
+          <Field label={t("news:form.text") ?? ""} htmlFor={`news-edit-content-${id}`} required>
+            <textarea
+              id={`news-edit-content-${id}`}
               value={editData.content}
               onChange={(e) => setEditData({ ...editData, content: e.target.value })}
-              multiline
+              className={textareaClass}
               rows={4}
-              fullWidth
-              sx={{ fontSize: "1rem" }}
             />
-            <TextField
-              label={t("news:form.title_en", { defaultValue: "Title (English)" })}
+          </Field>
+
+          <Field
+            label={t("news:form.title_en", { defaultValue: "Title (English)" }) ?? ""}
+            htmlFor={`news-edit-title-en-${id}`}
+          >
+            <input
+              id={`news-edit-title-en-${id}`}
+              type="text"
               value={editData.title_en}
               onChange={(e) => setEditData({ ...editData, title_en: e.target.value })}
-              fullWidth
-              sx={{ fontSize: "1rem" }}
+              className={inputClass}
             />
-            <TextField
-              label={t("news:form.content_en", { defaultValue: "News text (English)" })}
+          </Field>
+
+          <Field
+            label={t("news:form.content_en", { defaultValue: "News text (English)" }) ?? ""}
+            htmlFor={`news-edit-content-en-${id}`}
+          >
+            <textarea
+              id={`news-edit-content-en-${id}`}
               value={editData.content_en}
               onChange={(e) => setEditData({ ...editData, content_en: e.target.value })}
-              multiline
+              className={textareaClass}
               rows={4}
-              fullWidth
-              sx={{ fontSize: "1rem" }}
             />
-            <Box>
-              <Button
-                component="label"
-                variant="contained"
-                disabled={imageLoading}
-                startIcon={<PhotoCamera />}
-                sx={{
-                  minWidth: 120,
-                  fontWeight: 600,
-                  fontSize: "1rem",
-                  borderRadius: 2,
-                }}
-                onClick={(e) => e.stopPropagation()}
-              >
-                {imageLoading ? t("common:statuses.uploading") : t("news:form.changePhoto")}
-                <input
-                  type="file"
-                  accept="image/*"
-                  hidden
-                  ref={imageInputRef}
-                  onChange={handleImageChange}
-                  onClick={(e) => e.stopPropagation()}
-                />
-              </Button>
-              {editImageUrl && (
-                <Box mt={1}>
-                  <SmartImage
-                    srcRaw={editImageUrl}
-                    alt={t("news:alt.preview")}
-                    style={{
-                      width: 140,
-                      maxHeight: 90,
-                      objectFit: "cover",
-                      borderRadius: 8,
-                      border: "1px solid #eee",
-                      display: "block",
-                    }}
-                  />
-                </Box>
-              )}
-            </Box>
+          </Field>
 
-            <Stack direction="row" gap={2} mt={2}>
-              <Button
-                variant="contained"
-                onClick={handleEdit}
-                disabled={loading || imageLoading}
-                sx={{ fontWeight: 700, borderRadius: 2.2, px: 3, fontSize: "1.02rem" }}
-              >
-                {t("common:buttons.save")}
-              </Button>
-              <Button
-                variant="outlined"
-                color="secondary"
-                onClick={closeEditDialog}
-                sx={{ borderRadius: 2.2, px: 2.5, fontSize: "1.02rem" }}
-              >
-                {t("common:buttons.cancel")}
-              </Button>
-            </Stack>
-          </Stack>
-        </DialogContent>
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <Button
+              as="label"
+              variant="outline"
+              size="sm"
+              leadingIcon={<PhotoCamera className="text-[1.15rem]" />}
+              className="w-full sm:w-auto"
+              disabled={imageLoading}
+            >
+              {imageLoading ? t("common:statuses.uploading") : t("news:form.changePhoto")}
+              <input
+                type="file"
+                accept="image/*"
+                hidden
+                ref={imageInputRef}
+                onChange={handleImageChange}
+              />
+            </Button>
+
+            {editImageUrl ? (
+              <SmartImage
+                srcRaw={editImageUrl}
+                alt={t("news:alt.preview")}
+                className="h-20 w-full max-w-[180px] rounded-ue-md border border-white/10 object-cover shadow-surface"
+              />
+            ) : null}
+          </div>
+        </form>
       </Dialog>
 
-      {/* Delete confirm */}
-      <Dialog open={confirmDeleteOpen} onClose={() => setConfirmDeleteOpen(false)}>
-        <DialogTitle>{t("news:dialogs.delete.title")}</DialogTitle>
-        <DialogContent>
-          <Typography>{t("news:dialogs.delete.description")}</Typography>
-        </DialogContent>
-        <DialogActions>
-          <Button
-            variant="outlined"
-            color="secondary"
-            onClick={() => setConfirmDeleteOpen(false)}
-            disabled={loading}
-          >
-            {t("common:buttons.cancel")}
-          </Button>
-          <Button variant="contained" color="error" onClick={handleDelete} disabled={loading}>
-            <DeleteIcon sx={{ mr: 1 }} /> {t("common:buttons.delete")}
-          </Button>
-        </DialogActions>
+      <Dialog
+        open={confirmDeleteOpen}
+        onClose={() => setConfirmDeleteOpen(false)}
+        title={t("news:dialogs.delete.title")}
+        bodyClassName="space-y-4"
+        footer={
+          <>
+            <Button
+              variant="outline"
+              onClick={() => setConfirmDeleteOpen(false)}
+              disabled={loading}
+              className="w-full sm:w-auto"
+            >
+              {t("common:buttons.cancel")}
+            </Button>
+            <Button
+              onClick={() => {
+                void handleDelete()
+              }}
+              disabled={loading}
+              loading={loading}
+              className="w-full bg-[linear-gradient(98deg,#dc2626,#b91c1c)] text-white hover:bg-[linear-gradient(98deg,#b91c1c,#991b1b)] sm:w-auto"
+            >
+              <DeleteIcon fontSize="small" className="mr-1" />
+              {t("common:buttons.delete")}
+            </Button>
+          </>
+        }
+      >
+        <p className="text-[0.98rem] text-[color:var(--secondary-text)]">
+          {t("news:dialogs.delete.description")}
+        </p>
       </Dialog>
-    </Box>
+    </article>
   )
 }
 

--- a/root/frontend/src/pages/News.tsx
+++ b/root/frontend/src/pages/News.tsx
@@ -10,26 +10,22 @@ import {
   startTransition,
   useMemo,
   type CSSProperties,
+  type ReactNode,
 } from "react"
 import { createNews, uploadNewsImage } from "@/api/news"
-import {
-  Box,
-  Typography,
-  Button,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  Stack,
-  TextField,
-  useMediaQuery,
-} from "@mui/material"
 import ArticleIcon from "@mui/icons-material/Article"
 import PhotoCamera from "@mui/icons-material/PhotoCamera"
 import SmartImage from "@/components/SmartImage"
+import { Button } from "@/components/ui"
+import Dialog from "@/components/Dialog"
 import { useAuth } from "../contexts/AuthContext"
 import { useLanguage } from "../contexts/LanguageContext"
 import { useTranslation } from "react-i18next"
 import { useNewsFeed } from "@/hooks/useNewsFeed"
+
+const inputClass =
+  "w-full rounded-ue-lg border border-white/12 bg-[color:color-mix(in_srgb,var(--card-bg)_94%,white_6%)] px-4 py-2.5 text-[0.98rem] text-[color:var(--page-text)] shadow-[inset_0_1px_0_rgba(15,23,42,0.08)] transition focus:border-[color:var(--nav-link)] focus:outline-none focus:shadow-focus placeholder:text-[color:var(--placeholder-fg)]"
+const textareaClass = `${inputClass} min-h-[148px] resize-y leading-relaxed`
 
 type NewsFormState = {
   title: string
@@ -43,6 +39,28 @@ const initialNews: NewsFormState = {
   content: "",
   title_en: "",
   content_en: "",
+}
+
+type FieldProps = {
+  label: ReactNode
+  htmlFor: string
+  children: ReactNode
+  required?: boolean
+}
+
+function Field({ label, htmlFor, children, required = false }: FieldProps) {
+  return (
+    <div className="space-y-2">
+      <label
+        htmlFor={htmlFor}
+        className="text-sm font-semibold tracking-wide text-[color:color-mix(in_srgb,var(--secondary-text)_85%,white_15%)]"
+      >
+        {label}
+        {required ? <span className="ml-1 text-[#f87171]">*</span> : null}
+      </label>
+      {children}
+    </div>
+  )
 }
 
 const News = () => {
@@ -59,7 +77,7 @@ const News = () => {
   const [imageFile, setImageFile] = useState<File | null>(null)
   const [imagePreview, setImagePreview] = useState<string | null>(null)
   const imageInputRef = useRef<HTMLInputElement | null>(null)
-  const isMobile = useMediaQuery("(max-width:600px)")
+  const titleInputRef = useRef<HTMLInputElement | null>(null)
 
   const isInitialLoading = isPending && newsList.length === 0
   const showEmptyState = !isInitialLoading && !isFetching && newsList.length === 0
@@ -167,73 +185,45 @@ const News = () => {
   return (
     <Layout>
       <PageFadeIn>
-        <Box
-          sx={{
-            width: "100vw",
-            minHeight: "100vh",
-            pl: { xs: 2, sm: 4, md: 5, lg: 8 },
-            pr: { xs: 4, sm: 6, md: 7, lg: 10 },
-            py: { xs: 0, sm: 0, md: 0, lg: 0 },
-            boxSizing: "border-box",
-            overflowX: "hidden",
-          }}
-        >
-          <Stack
+        <div className="mx-auto flex w-full max-w-7xl flex-col px-4 pb-16 pt-6 sm:px-6 lg:px-12">
+          <div
             data-fade
             style={{ "--fade-delay": "80ms" } as CSSProperties}
-            direction="row"
-            alignItems="center"
-            gap={2}
-            mb={isMobile ? 1.5 : 3}
-            mt={isMobile ? 1.5 : 3}
+            className="mb-4 mt-4 flex flex-wrap items-center gap-3 text-nav-link sm:mb-8 sm:mt-6"
           >
-            <ArticleIcon color="primary" sx={{ fontSize: 34 }} />
-            <Typography
-              variant="h4"
-              fontWeight={700}
-              color="primary.main"
-              sx={{ fontSize: "clamp(0.8rem, 5vw, 2.7rem)" }}
-            >
+            <span className="inline-flex h-11 w-11 items-center justify-center rounded-full bg-[color:var(--glass-bg)]/70 text-[color:var(--nav-link)] shadow-surface">
+              <ArticleIcon className="text-[1.85rem]" />
+            </span>
+            <h1 className="text-[clamp(1.6rem,5vw,2.75rem)] font-bold tracking-tight text-[color:var(--page-text)]">
               {t("news:pageTitle")}
-            </Typography>
-          </Stack>
+            </h1>
+          </div>
 
           {user?.role === "admin" && (
-            <Box
+            <div
               data-fade
               style={{ "--fade-delay": "140ms" } as CSSProperties}
-              sx={{ display: "flex", justifyContent: "flex-start", mb: 2 }}
+              className="mb-6 flex justify-start"
             >
               <Button
-                variant="contained"
-                sx={{
-                  fontWeight: 700,
-                  fontSize: "clamp(1rem, 2.1vw, 1.15rem)",
-                  px: { xs: 2.3, sm: 3 },
-                  py: 1.2,
-                  borderRadius: 3,
-                  letterSpacing: "0.02em",
-                }}
+                size="lg"
                 onClick={() => setAddOpen(true)}
                 disabled={adding}
+                className="px-6 text-[clamp(1rem,2.2vw,1.1rem)]"
               >
                 {t("news:actions.add")}
               </Button>
-            </Box>
+            </div>
           )}
 
-          <Box
+          <div
             data-fade
             style={{ "--fade-delay": "200ms" } as CSSProperties}
-            sx={{
-              display: "grid",
-              gridTemplateColumns: "repeat(auto-fit, minmax(320px, 1fr))",
-              gap: { xs: 2, sm: 3 },
-            }}
+            className="grid grid-cols-[repeat(auto-fit,minmax(310px,1fr))] gap-5 sm:gap-6"
           >
             {Array.isArray(visibleList) &&
               visibleList.map((news) => (
-                <Box key={news.id} sx={{ display: "flex", width: "100%", height: "100%" }}>
+                <div key={news.id} className="flex h-full w-full">
                   <NewsCard
                     {...news}
                     image_url={news.image_url ?? undefined}
@@ -241,143 +231,141 @@ const News = () => {
                       void refetchNews()
                     }}
                   />
-                </Box>
+                </div>
               ))}
 
             {Array.isArray(newsList) && showEmptyState && (
-              <Box sx={{ width: "100%", textAlign: "center", mt: 7, mb: 7 }}>
-                <Typography fontSize={24} className="events-empty-text">
-                  {t("news:states.empty")}
-                </Typography>
-              </Box>
+              <div className="col-span-full mt-16 flex flex-col items-center text-center text-[color:var(--secondary-text)]">
+                <p className="text-lg font-semibold sm:text-xl">{t("news:states.empty")}</p>
+              </div>
             )}
-          </Box>
+          </div>
 
           <Dialog
             open={addOpen}
             onClose={handleCloseDialog}
-            fullScreen={isMobile}
-            PaperProps={{
-              sx: {
-                borderRadius: { xs: 0, sm: 4 },
-                width: { xs: "100vw", sm: 400 },
-                maxWidth: { xs: "100vw", sm: 440 },
-              },
-            }}
+            title={t("news:dialogs.create.title")}
+            size="md"
+            fullScreenOnMobile
+            closeLabel={t("common:buttons.close")}
+            bodyClassName="space-y-4"
+            footerClassName="flex-col-reverse gap-3 sm:flex-row"
+            footer={
+              <>
+                <Button
+                  variant="outline"
+                  onClick={handleCloseDialog}
+                  disabled={adding}
+                  className="w-full sm:w-auto"
+                >
+                  {t("common:buttons.cancel")}
+                </Button>
+                <Button
+                  onClick={() => {
+                    void handleAddNews()
+                  }}
+                  disabled={!newsData.title.trim() || !newsData.content.trim() || adding}
+                  loading={adding}
+                  className="w-full sm:w-auto"
+                >
+                  {adding ? t("common:statuses.publishing") : t("news:actions.publish")}
+                </Button>
+              </>
+            }
+            initialFocus={() => titleInputRef.current ?? undefined}
           >
-            <DialogTitle sx={{ fontWeight: 700, fontSize: "1.3rem" }}>
-              {t("news:dialogs.create.title")}
-            </DialogTitle>
-            <DialogContent>
-              <Stack spacing={2} mt={1} minWidth={isMobile ? "auto" : 340} mb={2}>
-                <TextField
-                  label={t("news:form.title")}
+            <form
+              className="space-y-4"
+              onSubmit={(event) => {
+                event.preventDefault()
+                void handleAddNews()
+              }}
+            >
+              <Field label={t("news:form.title") ?? ""} htmlFor="news-title" required>
+                <input
+                  id="news-title"
+                  ref={titleInputRef}
+                  type="text"
                   value={newsData.title}
                   onChange={(e) => setNewsData({ ...newsData, title: e.target.value })}
-                  fullWidth
-                  inputProps={{ maxLength: 100 }}
-                  sx={{ fontSize: "1rem" }}
+                  maxLength={100}
                   disabled={adding}
+                  className={inputClass}
                 />
-                <TextField
-                  label={t("news:form.content")}
+              </Field>
+
+              <Field label={t("news:form.content") ?? ""} htmlFor="news-content" required>
+                <textarea
+                  id="news-content"
                   value={newsData.content}
                   onChange={(e) => setNewsData({ ...newsData, content: e.target.value })}
-                  multiline
-                  minRows={5}
-                  fullWidth
-                  inputProps={{ maxLength: 3000 }}
-                  sx={{ fontSize: "1rem" }}
+                  maxLength={3000}
                   disabled={adding}
+                  className={textareaClass}
+                  rows={6}
                 />
-                <TextField
-                  label={t("news:form.title_en", { defaultValue: "Title (English)" })}
+              </Field>
+
+              <Field
+                label={t("news:form.title_en", { defaultValue: "Title (English)" }) ?? ""}
+                htmlFor="news-title-en"
+              >
+                <input
+                  id="news-title-en"
+                  type="text"
                   value={newsData.title_en}
                   onChange={(e) => setNewsData({ ...newsData, title_en: e.target.value })}
-                  fullWidth
-                  inputProps={{ maxLength: 100 }}
-                  sx={{ fontSize: "1rem" }}
+                  maxLength={100}
                   disabled={adding}
+                  className={inputClass}
                 />
-                <TextField
-                  label={t("news:form.content_en", { defaultValue: "News text (English)" })}
+              </Field>
+
+              <Field
+                label={t("news:form.content_en", { defaultValue: "News text (English)" }) ?? ""}
+                htmlFor="news-content-en"
+              >
+                <textarea
+                  id="news-content-en"
                   value={newsData.content_en}
                   onChange={(e) => setNewsData({ ...newsData, content_en: e.target.value })}
-                  multiline
-                  minRows={5}
-                  fullWidth
-                  inputProps={{ maxLength: 3000 }}
-                  sx={{ fontSize: "1rem" }}
+                  maxLength={3000}
                   disabled={adding}
+                  className={textareaClass}
+                  rows={6}
                 />
+              </Field>
 
-                <Box display="flex" alignItems="center" gap={2}>
-                  <Button
-                    component="label"
-                    variant="outlined"
-                    startIcon={<PhotoCamera />}
-                    sx={{
-                      minWidth: 120,
-                      fontWeight: 600,
-                      fontSize: "1rem",
-                      borderRadius: 2,
-                    }}
-                    disabled={adding}
-                  >
-                    {imageFile ? t("common:buttons.changePhoto") : t("common:buttons.uploadPhoto")}
-                    <input
-                      type="file"
-                      accept="image/*"
-                      hidden
-                      ref={imageInputRef}
-                      onChange={handleImageChange}
-                    />
-                  </Button>
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <Button
+                  as="label"
+                  variant="outline"
+                  size="sm"
+                  leadingIcon={<PhotoCamera className="text-[1.15rem]" />}
+                  className="w-full sm:w-auto"
+                  disabled={adding}
+                >
+                  {imageFile ? t("common:buttons.changePhoto") : t("common:buttons.uploadPhoto")}
+                  <input
+                    type="file"
+                    accept="image/*"
+                    hidden
+                    ref={imageInputRef}
+                    onChange={handleImageChange}
+                  />
+                </Button>
 
-                  {imagePreview && (
-                    <SmartImage
-                      srcRaw={imagePreview}
-                      alt={t("news:alt.newCover")}
-                      style={{
-                        width: 100,
-                        height: 60,
-                        objectFit: "cover",
-                        borderRadius: 8,
-                        border: "1px solid #eee",
-                        display: "block",
-                      }}
-                    />
-                  )}
-                </Box>
-
-                <Stack direction="row" gap={2} mt={2}>
-                  <Button
-                    variant="contained"
-                    onClick={handleAddNews}
-                    disabled={!newsData.title.trim() || !newsData.content.trim() || adding}
-                    sx={{
-                      fontWeight: 700,
-                      borderRadius: 2.2,
-                      px: 3,
-                      fontSize: "1.02rem",
-                    }}
-                  >
-                    {adding ? t("common:statuses.publishing") : t("news:actions.publish")}
-                  </Button>
-                  <Button
-                    variant="outlined"
-                    color="secondary"
-                    onClick={handleCloseDialog}
-                    disabled={adding}
-                    sx={{ borderRadius: 2.2, px: 2.5, fontSize: "1.02rem" }}
-                  >
-                    {t("common:buttons.cancel")}
-                  </Button>
-                </Stack>
-              </Stack>
-            </DialogContent>
+                {imagePreview ? (
+                  <SmartImage
+                    srcRaw={imagePreview}
+                    alt={t("news:alt.newCover")}
+                    className="h-20 w-full max-w-[160px] rounded-ue-md border border-white/10 object-cover shadow-surface"
+                  />
+                ) : null}
+              </div>
+            </form>
           </Dialog>
-        </Box>
+        </div>
       </PageFadeIn>
     </Layout>
   )

--- a/root/frontend/src/pages/NewsDetail.tsx
+++ b/root/frontend/src/pages/NewsDetail.tsx
@@ -1,24 +1,6 @@
-import type React from "react"
-import { useEffect, useMemo, useRef, useState } from "react"
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react"
 import { useNavigate, useParams } from "react-router-dom"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
-import {
-  Box,
-  Typography,
-  CircularProgress,
-  Paper,
-  Stack,
-  Button,
-  IconButton,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
-  TextField,
-  Divider,
-  Snackbar,
-  useMediaQuery,
-} from "@mui/material"
 import ArrowBackIcon from "@mui/icons-material/ArrowBack"
 import EditIcon from "@mui/icons-material/Edit"
 import DeleteIcon from "@mui/icons-material/Delete"
@@ -28,15 +10,46 @@ import PhotoCamera from "@mui/icons-material/PhotoCamera"
 import dayjs from "dayjs"
 import utc from "dayjs/plugin/utc"
 import timezone from "dayjs/plugin/timezone"
-import { deleteNews, fetchNewsItem, updateNews, uploadNewsImage, type NewsItem } from "@/api/news"
+import { deleteNews, fetchNewsItem, updateNews, uploadNewsImage } from "@/api/news"
 import Layout from "@/components/Layout"
 import SmartImage from "@/components/SmartImage"
+import { Button } from "@/components/ui"
+import Dialog from "@/components/Dialog"
 import { useAuth } from "@/contexts/AuthContext"
 import { useLanguage } from "@/contexts/LanguageContext"
 import { useTranslation } from "react-i18next"
+import { cn } from "@/utils/cn"
 
 dayjs.extend(utc)
 dayjs.extend(timezone)
+
+const inputClass =
+  "w-full rounded-ue-lg border border-white/12 bg-[color:color-mix(in_srgb,var(--card-bg)_94%,white_6%)] px-4 py-2.5 text-[0.98rem] text-[color:var(--page-text)] shadow-[inset_0_1px_0_rgba(15,23,42,0.08)] transition focus:border-[color:var(--nav-link)] focus:outline-none focus:shadow-focus placeholder:text-[color:var(--placeholder-fg)]"
+const textareaClass = `${inputClass} min-h-[160px] resize-y leading-relaxed`
+const iconButtonClass =
+  "inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/15 bg-white/85 text-[color:var(--nav-link)] shadow-surface transition hover:bg-white focus-visible:outline-none focus-visible:shadow-focus"
+
+type FieldProps = {
+  label: ReactNode
+  htmlFor: string
+  children: ReactNode
+  required?: boolean
+}
+
+function Field({ label, htmlFor, children, required = false }: FieldProps) {
+  return (
+    <div className="space-y-2">
+      <label
+        htmlFor={htmlFor}
+        className="text-sm font-semibold tracking-wide text-[color:color-mix(in_srgb,var(--secondary-text)_85%,white_15%)]"
+      >
+        {label}
+        {required ? <span className="ml-1 text-[#f87171]">*</span> : null}
+      </label>
+      {children}
+    </div>
+  )
+}
 
 async function fetchNews(id: string) {
   const numericId = Number(id)
@@ -63,7 +76,6 @@ export default function NewsDetail() {
   const { t } = useTranslation(["news", "common"])
   const { language } = useLanguage()
   const queryClient = useQueryClient()
-  const isMobile = useMediaQuery("(max-width:600px)")
 
   const [editOpen, setEditOpen] = useState(false)
   const [editData, setEditData] = useState({
@@ -80,6 +92,7 @@ export default function NewsDetail() {
   const [previewUrl, setPreviewUrl] = useState<string | null>(null)
   const [snack, setSnack] = useState("")
   const imageInputRef = useRef<HTMLInputElement>(null)
+  const editTitleRef = useRef<HTMLInputElement>(null)
   const [heroPos, setHeroPos] = useState<"50% 18%" | "50% 38%" | "50% 50%" | string>("50% 38%")
 
   const handleHeroLoad: React.ReactEventHandler<HTMLImageElement> = (e) => {
@@ -106,6 +119,12 @@ export default function NewsDetail() {
       if (previewUrl) URL.revokeObjectURL(previewUrl)
     }
   }, [previewUrl])
+
+  useEffect(() => {
+    if (!snack) return
+    const timeout = window.setTimeout(() => setSnack(""), 2400)
+    return () => window.clearTimeout(timeout)
+  }, [snack])
 
   const resetPreview = () => {
     if (previewUrl) {
@@ -229,258 +248,255 @@ export default function NewsDetail() {
   if (query.isLoading)
     return (
       <Layout>
-        <Box sx={{ minHeight: "60vh", display: "grid", placeItems: "center" }}>
-          <CircularProgress />
-        </Box>
+        <div className="flex min-h-[60vh] items-center justify-center">
+          <span className="h-12 w-12 animate-spin rounded-full border-2 border-white/30 border-t-[color:var(--nav-link)]" />
+        </div>
       </Layout>
     )
 
   if (query.isError || !query.data)
     return (
       <Layout>
-        <Box sx={{ p: 2 }}>
-          <Typography color="error">{t("news:states.loadError")}</Typography>
-        </Box>
+        <div className="px-4 py-10">
+          <p className="text-lg font-semibold text-[#f87171]">{t("news:states.loadError")}</p>
+        </div>
       </Layout>
     )
 
   return (
     <Layout>
-      <Paper
-        elevation={0}
-        sx={{
-          width: "100vw",
-          minHeight: "calc(100vh - 56px)",
-          bgcolor: "background.paper",
-          borderRadius: 0,
-          boxShadow: "none",
-          display: "flex",
-          flexDirection: "column",
-          pl: { xs: 2, sm: 4, md: 5, lg: 8 },
-          pr: { xs: 4, sm: 6, md: 7, lg: 10 },
-          py: { xs: 2, sm: 2, md: 2, lg: 2 },
-          boxSizing: "border-box",
-        }}
-      >
+      <div className="mx-auto flex w-full max-w-6xl flex-col px-4 pb-16 pt-6 sm:px-6 lg:px-10">
         <Button
+          variant="outline"
           onClick={handleBack}
-          startIcon={<ArrowBackIcon />}
-          sx={{
-            mb: 3,
-            alignSelf: "flex-start",
-            fontWeight: 700,
-            borderRadius: 2.5,
-            background: "linear-gradient(100deg, #1d5fff 20%, #65b2ff 100%)",
-            color: "#fff",
-            fontSize: "clamp(0.98rem, 2.1vw, 1.17rem)",
-            letterSpacing: "0.02em",
-            px: { xs: 1.6, sm: 2.3, md: 2.9, lg: 3.5 },
-            py: { xs: 0.9, sm: 1.12, md: 1.2, lg: 1.28 },
-            width: { xs: "100%", sm: "auto" },
-            minWidth: { xs: 0, sm: 0 },
-            boxShadow: "0 2px 18px #1976d238, 0 1.5px 8px #0001",
-            transition: "transform 0.16s, box-shadow 0.16s, background 0.19s, color 0.16s",
-            "&:hover": {
-              background: "linear-gradient(100deg, #1976d2 20%, #449aff 100%)",
-              color: "#eaf6ff",
-              transform: "scale(1.06)",
-              boxShadow: "0 6px 28px #1d5fff40, 0 2.5px 10px #0002",
-            },
-            "&:active": { transform: "scale(0.98)" },
-          }}
+          leadingIcon={<ArrowBackIcon className="text-[1.1rem]" />}
+          className="w-full max-w-[220px] justify-center border-white/20 text-[clamp(0.95rem,2vw,1.1rem)] sm:w-auto"
         >
           {t("common:buttons.back")}
         </Button>
 
-        <Stack spacing={2} width="100%" alignSelf="flex-start">
-          <Box display="flex" alignItems="center" flexWrap="wrap">
-            <Typography
-              variant="h3"
-              fontWeight={900}
-              sx={{ mr: 2, fontSize: "clamp(1.28rem,4vw,2.1rem)" }}
-            >
+        <div className="mt-6 flex flex-col gap-4">
+          <div className="flex flex-wrap items-center gap-3">
+            <h1 className="text-[clamp(1.55rem,4vw,2.4rem)] font-extrabold tracking-tight text-[color:var(--page-text)]">
               {displayTitle}
-            </Typography>
+            </h1>
 
             {user?.role === "admin" && (
-              <>
-                <IconButton
-                  color="primary"
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
                   onClick={openEdit}
-                  sx={{ mr: 1 }}
-                  aria-label={t("news:aria.editNews")}
+                  className={iconButtonClass}
+                  aria-label={t("news:aria.editNews") ?? ""}
                   disabled={saving || deleting}
                 >
-                  <EditIcon />
-                </IconButton>
-                <IconButton
-                  color="error"
+                  <EditIcon fontSize="small" />
+                </button>
+                <button
+                  type="button"
                   onClick={() => setConfirmDeleteOpen(true)}
-                  aria-label={t("news:aria.deleteNews")}
+                  className={cn(iconButtonClass, "text-[#e11d48]")}
+                  aria-label={t("news:aria.deleteNews") ?? ""}
                   disabled={deleting || saving}
                 >
-                  <DeleteIcon />
-                </IconButton>
-              </>
+                  <DeleteIcon fontSize="small" />
+                </button>
+              </div>
             )}
-          </Box>
+          </div>
 
           {createdAt && (
-            <Typography color="text.secondary" fontSize="clamp(0.92rem,1.5vw,1.12rem)">
+            <p className="text-sm font-medium text-[color:var(--secondary-text)]">
               {t("news:meta.published")} <time dateTime={createdAtIso}>{createdAtLabel}</time>
-            </Typography>
+            </p>
           )}
 
-          <Box
-            sx={{
-              width: "100%",
-              maxWidth: { xs: "100%", md: 800, lg: 1000 },
-              aspectRatio: { xs: "16 / 9", md: "21 / 9" },
-              position: "relative",
-              borderRadius: 4,
-              border: "1px solid #eee",
-              overflow: "hidden",
-              bgcolor: "rgba(0,0,0,0.04)",
-            }}
-          >
-            <SmartImage
-              srcRaw={imageUrl}
-              alt={
-                displayTitle
-                  ? t("news:alt.hero", { title: displayTitle })
-                  : t("news:alt.heroFallback")
-              }
-              onLoad={handleHeroLoad}
-              style={{
-                position: "absolute",
-                inset: 0,
-                width: "100%",
-                height: "100%",
-                display: "block",
-                objectFit: "cover",
-                objectPosition: heroPos,
-              }}
-            />
-          </Box>
+          <div className="mt-4 w-full max-w-4xl overflow-hidden rounded-ue-xl border border-white/12 bg-[color:var(--glass-bg)]/60 shadow-surface">
+            <div className="relative aspect-[16/9] w-full">
+              <SmartImage
+                srcRaw={imageUrl}
+                alt={
+                  displayTitle
+                    ? t("news:alt.hero", { title: displayTitle })
+                    : t("news:alt.heroFallback")
+                }
+                onLoad={handleHeroLoad}
+                className="absolute inset-0 h-full w-full object-cover"
+                style={{ objectPosition: heroPos }}
+              />
+            </div>
+          </div>
 
-          <Divider sx={{ my: 2 }} />
+          <div className="my-6 h-px w-full max-w-4xl bg-white/10" />
 
-          <Typography
-            variant="body1"
-            fontSize="clamp(1.07rem,2.3vw,1.24rem)"
-            sx={{ whiteSpace: "pre-line" }}
-          >
+          <p className="whitespace-pre-line text-[clamp(1.05rem,2.3vw,1.25rem)] leading-relaxed text-[color:var(--page-text)]">
             {content}
-          </Typography>
-        </Stack>
+          </p>
+        </div>
+      </div>
 
-        <Dialog open={editOpen} onClose={closeEdit} fullScreen={isMobile}>
-          <DialogTitle>{t("news:dialogs.edit.title")}</DialogTitle>
-          <DialogContent>
-            <Stack spacing={2} mt={1}>
-              <TextField
-                label={t("news:form.title")}
-                value={editData.title}
-                onChange={(e) => setEditData({ ...editData, title: e.target.value })}
-                fullWidth
-                disabled={saving}
-              />
-              <TextField
-                label={t("news:form.text")}
-                value={editData.content}
-                onChange={(e) => setEditData({ ...editData, content: e.target.value })}
-                multiline
-                rows={4}
-                fullWidth
-                disabled={saving}
-              />
-              <TextField
-                label={t("news:form.title_en", { defaultValue: "Title (English)" })}
-                value={editData.title_en}
-                onChange={(e) => setEditData({ ...editData, title_en: e.target.value })}
-                fullWidth
-                disabled={saving}
-              />
-              <TextField
-                label={t("news:form.content_en", { defaultValue: "News text (English)" })}
-                value={editData.content_en}
-                onChange={(e) => setEditData({ ...editData, content_en: e.target.value })}
-                multiline
-                rows={4}
-                fullWidth
-                disabled={saving}
-              />
-              <Box display="flex" gap={2} alignItems="center" mt={1}>
-                <Button
-                  component="label"
-                  variant="outlined"
-                  startIcon={<PhotoCamera />}
-                  sx={{ minWidth: 140 }}
-                  disabled={saving}
-                >
-                  {newImage ? t("news:form.changePhoto") : t("news:form.uploadPhoto")}
-                  <input
-                    type="file"
-                    accept="image/*"
-                    hidden
-                    ref={imageInputRef}
-                    onChange={handleImageChange}
-                  />
-                </Button>
-
-                {imageUrl && (
-                  <Box sx={{ width: 120, maxHeight: 70, borderRadius: 2, overflow: "hidden" }}>
-                    <SmartImage
-                      srcRaw={imageUrl}
-                      alt={t("news:alt.preview")}
-                      style={{ width: "100%", height: "100%", objectFit: "cover" }}
-                    />
-                  </Box>
-                )}
-              </Box>
-            </Stack>
-          </DialogContent>
-          <DialogActions>
-            <Button variant="contained" onClick={handleSave} disabled={saving}>
-              <SaveIcon sx={{ mr: 1 }} /> {t("common:buttons.save")}
-            </Button>
-            <Button variant="outlined" color="secondary" onClick={closeEdit} disabled={saving}>
-              <CloseIcon sx={{ mr: 1 }} /> {t("common:buttons.cancel")}
-            </Button>
-          </DialogActions>
-        </Dialog>
-
-        <Dialog
-          open={confirmDeleteOpen}
-          onClose={() => setConfirmDeleteOpen(false)}
-          fullScreen={isMobile}
-        >
-          <DialogTitle>{t("news:dialogs.delete.title")}</DialogTitle>
-          <DialogContent>
-            <Typography>{t("news:dialogs.delete.description")}</Typography>
-          </DialogContent>
-          <DialogActions>
+      <Dialog
+        open={editOpen}
+        onClose={closeEdit}
+        title={t("news:dialogs.edit.title")}
+        size="md"
+        fullScreenOnMobile
+        closeLabel={t("common:buttons.close")}
+        bodyClassName="space-y-4"
+        footerClassName="flex-col-reverse gap-3 sm:flex-row"
+        footer={
+          <>
             <Button
-              variant="outlined"
-              color="secondary"
-              onClick={() => setConfirmDeleteOpen(false)}
-              disabled={deleting}
+              variant="outline"
+              onClick={closeEdit}
+              disabled={saving}
+              className="w-full sm:w-auto"
+              leadingIcon={<CloseIcon fontSize="small" />}
             >
               {t("common:buttons.cancel")}
             </Button>
-            <Button variant="contained" color="error" onClick={handleDelete} disabled={deleting}>
-              <DeleteIcon sx={{ mr: 1 }} /> {t("common:buttons.delete")}
+            <Button
+              onClick={() => {
+                void handleSave()
+              }}
+              disabled={saving}
+              loading={saving}
+              className="w-full sm:w-auto"
+              leadingIcon={<SaveIcon fontSize="small" />}
+            >
+              {t("common:buttons.save")}
             </Button>
-          </DialogActions>
-        </Dialog>
+          </>
+        }
+        initialFocus={() => editTitleRef.current ?? undefined}
+      >
+        <form
+          className="space-y-4"
+          onSubmit={(event) => {
+            event.preventDefault()
+            void handleSave()
+          }}
+        >
+          <Field label={t("news:form.title") ?? ""} htmlFor="news-detail-title" required>
+            <input
+              id="news-detail-title"
+              ref={editTitleRef}
+              type="text"
+              value={editData.title}
+              onChange={(e) => setEditData({ ...editData, title: e.target.value })}
+              disabled={saving}
+              className={inputClass}
+            />
+          </Field>
 
-        <Snackbar
-          open={!!snack}
-          autoHideDuration={2400}
-          onClose={() => setSnack("")}
-          message={snack}
-        />
-      </Paper>
+          <Field label={t("news:form.text") ?? ""} htmlFor="news-detail-content" required>
+            <textarea
+              id="news-detail-content"
+              value={editData.content}
+              onChange={(e) => setEditData({ ...editData, content: e.target.value })}
+              disabled={saving}
+              className={textareaClass}
+              rows={5}
+            />
+          </Field>
+
+          <Field
+            label={t("news:form.title_en", { defaultValue: "Title (English)" }) ?? ""}
+            htmlFor="news-detail-title-en"
+          >
+            <input
+              id="news-detail-title-en"
+              type="text"
+              value={editData.title_en}
+              onChange={(e) => setEditData({ ...editData, title_en: e.target.value })}
+              disabled={saving}
+              className={inputClass}
+            />
+          </Field>
+
+          <Field
+            label={t("news:form.content_en", { defaultValue: "News text (English)" }) ?? ""}
+            htmlFor="news-detail-content-en"
+          >
+            <textarea
+              id="news-detail-content-en"
+              value={editData.content_en}
+              onChange={(e) => setEditData({ ...editData, content_en: e.target.value })}
+              disabled={saving}
+              className={textareaClass}
+              rows={5}
+            />
+          </Field>
+
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <Button
+              as="label"
+              variant="outline"
+              size="sm"
+              leadingIcon={<PhotoCamera className="text-[1.15rem]" />}
+              className="w-full sm:w-auto"
+              disabled={saving}
+            >
+              {newImage ? t("news:form.changePhoto") : t("news:form.uploadPhoto")}
+              <input
+                type="file"
+                accept="image/*"
+                hidden
+                ref={imageInputRef}
+                onChange={handleImageChange}
+              />
+            </Button>
+
+            {imageUrl ? (
+              <SmartImage
+                srcRaw={imageUrl}
+                alt={t("news:alt.preview")}
+                className="h-20 w-full max-w-[180px] rounded-ue-md border border-white/10 object-cover shadow-surface"
+              />
+            ) : null}
+          </div>
+        </form>
+      </Dialog>
+
+      <Dialog
+        open={confirmDeleteOpen}
+        onClose={() => setConfirmDeleteOpen(false)}
+        title={t("news:dialogs.delete.title")}
+        bodyClassName="space-y-4"
+        footer={
+          <>
+            <Button
+              variant="outline"
+              onClick={() => setConfirmDeleteOpen(false)}
+              disabled={deleting}
+              className="w-full sm:w-auto"
+            >
+              {t("common:buttons.cancel")}
+            </Button>
+            <Button
+              onClick={() => {
+                void handleDelete()
+              }}
+              disabled={deleting}
+              loading={deleting}
+              className="w-full bg-[linear-gradient(98deg,#dc2626,#b91c1c)] text-white hover:bg-[linear-gradient(98deg,#b91c1c,#991b1b)] sm:w-auto"
+              leadingIcon={<DeleteIcon fontSize="small" />}
+            >
+              {t("common:buttons.delete")}
+            </Button>
+          </>
+        }
+      >
+        <p className="text-[0.98rem] text-[color:var(--secondary-text)]">
+          {t("news:dialogs.delete.description")}
+        </p>
+      </Dialog>
+
+      {snack ? (
+        <div className="fixed bottom-6 left-1/2 z-[999] w-[min(90vw,360px)] -translate-x-1/2 rounded-ue-lg border border-white/12 bg-[color:color-mix(in_srgb,var(--card-bg)_94%,white_6%)]/95 px-4 py-3 text-center text-[0.95rem] font-semibold text-[color:var(--page-text)] shadow-surface-strong backdrop-blur-xl">
+          {snack}
+        </div>
+      ) : null}
     </Layout>
   )
 }


### PR DESCRIPTION
## Summary
- replace the news index layout with Tailwind-based containers, form styling helpers, and image preview handling
- rebuild the news card interactions with Tailwind menus and dialogs powered by a reusable focus-trapped dialog component
- restyle the news detail view with Tailwind controls, admin actions, and lightweight toast notifications while adopting the new dialog

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_690682cff5cc832780dc248fe0ea832d