### PR TITLE
Add skeleton loading and empty state improvements to news page

### DIFF
--- a/root/frontend/src/components/NewsCardSkeleton.tsx
+++ b/root/frontend/src/components/NewsCardSkeleton.tsx
@@ -1,0 +1,20 @@
+import { memo } from "react"
+
+const NewsCardSkeleton = () => {
+  return (
+    <article className="relative flex h-full w-full flex-col overflow-hidden rounded-ue-xl border border-white/12 bg-[color:color-mix(in_srgb,var(--card-bg)_94%,white_6%)] text-[color:var(--page-text)] shadow-surface">
+      <div className="h-[180px] w-full animate-skeleton-wave bg-skeleton sm:h-[220px]" aria-hidden />
+      <div className="flex flex-1 flex-col gap-4 px-4 py-5 sm:px-5 sm:py-6">
+        <div className="h-5 w-3/4 rounded-md animate-skeleton-wave bg-skeleton" aria-hidden />
+        <div className="space-y-3">
+          <div className="h-[14px] w-full rounded-md animate-skeleton-wave bg-skeleton" aria-hidden />
+          <div className="h-[14px] w-11/12 rounded-md animate-skeleton-wave bg-skeleton" aria-hidden />
+          <div className="h-[14px] w-5/6 rounded-md animate-skeleton-wave bg-skeleton" aria-hidden />
+        </div>
+        <div className="mt-auto h-4 w-1/3 rounded-md animate-skeleton-wave bg-skeleton" aria-hidden />
+      </div>
+    </article>
+  )
+}
+
+export default memo(NewsCardSkeleton)

--- a/root/frontend/src/components/NewsCardSkeleton.tsx
+++ b/root/frontend/src/components/NewsCardSkeleton.tsx
@@ -3,15 +3,30 @@ import { memo } from "react"
 const NewsCardSkeleton = () => {
   return (
     <article className="relative flex h-full w-full flex-col overflow-hidden rounded-ue-xl border border-white/12 bg-[color:color-mix(in_srgb,var(--card-bg)_94%,white_6%)] text-[color:var(--page-text)] shadow-surface">
-      <div className="h-[180px] w-full animate-skeleton-wave bg-skeleton sm:h-[220px]" aria-hidden />
+      <div
+        className="h-[180px] w-full animate-skeleton-wave bg-skeleton sm:h-[220px]"
+        aria-hidden
+      />
       <div className="flex flex-1 flex-col gap-4 px-4 py-5 sm:px-5 sm:py-6">
         <div className="h-5 w-3/4 rounded-md animate-skeleton-wave bg-skeleton" aria-hidden />
         <div className="space-y-3">
-          <div className="h-[14px] w-full rounded-md animate-skeleton-wave bg-skeleton" aria-hidden />
-          <div className="h-[14px] w-11/12 rounded-md animate-skeleton-wave bg-skeleton" aria-hidden />
-          <div className="h-[14px] w-5/6 rounded-md animate-skeleton-wave bg-skeleton" aria-hidden />
+          <div
+            className="h-[14px] w-full rounded-md animate-skeleton-wave bg-skeleton"
+            aria-hidden
+          />
+          <div
+            className="h-[14px] w-11/12 rounded-md animate-skeleton-wave bg-skeleton"
+            aria-hidden
+          />
+          <div
+            className="h-[14px] w-5/6 rounded-md animate-skeleton-wave bg-skeleton"
+            aria-hidden
+          />
         </div>
-        <div className="mt-auto h-4 w-1/3 rounded-md animate-skeleton-wave bg-skeleton" aria-hidden />
+        <div
+          className="mt-auto h-4 w-1/3 rounded-md animate-skeleton-wave bg-skeleton"
+          aria-hidden
+        />
       </div>
     </article>
   )

--- a/root/frontend/src/pages/News.tsx
+++ b/root/frontend/src/pages/News.tsx
@@ -1,6 +1,7 @@
 import Layout from "../components/Layout"
 import PageFadeIn from "../components/PageFadeIn"
 import NewsCard from "../components/NewsCard"
+import NewsCardSkeleton from "../components/NewsCardSkeleton"
 import {
   useEffect,
   useState,
@@ -81,6 +82,7 @@ const News = () => {
 
   const isInitialLoading = isPending && newsList.length === 0
   const showEmptyState = !isInitialLoading && !isFetching && newsList.length === 0
+  const skeletonCount = Math.max(visibleCount || 0, 6)
 
   useEffect(() => {
     return () => {
@@ -221,22 +223,44 @@ const News = () => {
             style={{ "--fade-delay": "200ms" } as CSSProperties}
             className="grid grid-cols-[repeat(auto-fit,minmax(310px,1fr))] gap-5 sm:gap-6"
           >
-            {Array.isArray(visibleList) &&
-              visibleList.map((news) => (
-                <div key={news.id} className="flex h-full w-full">
-                  <NewsCard
-                    {...news}
-                    image_url={news.image_url ?? undefined}
-                    onChange={() => {
-                      void refetchNews()
-                    }}
-                  />
-                </div>
-              ))}
+            {isInitialLoading
+              ? Array.from({ length: skeletonCount }).map((_, index) => (
+                  <div key={`news-skeleton-${index}`} className="flex h-full w-full">
+                    <NewsCardSkeleton />
+                  </div>
+                ))
+              : Array.isArray(visibleList) &&
+                visibleList.map((news) => (
+                  <div key={news.id} className="flex h-full w-full">
+                    <NewsCard
+                      {...news}
+                      image_url={news.image_url ?? undefined}
+                      onChange={() => {
+                        void refetchNews()
+                      }}
+                    />
+                  </div>
+                ))}
 
-            {Array.isArray(newsList) && showEmptyState && (
-              <div className="col-span-full mt-16 flex flex-col items-center text-center text-[color:var(--secondary-text)]">
-                <p className="text-lg font-semibold sm:text-xl">{t("news:states.empty")}</p>
+            {showEmptyState && (
+              <div className="col-span-full mt-16 flex justify-center">
+                <div className="flex w-full max-w-[420px] flex-col items-center gap-5 rounded-ue-xl border border-white/12 bg-glass/60 px-6 py-10 text-center text-[color:var(--secondary-text)] shadow-surface">
+                  <span className="flex h-16 w-16 items-center justify-center rounded-full bg-[color:var(--glass-bg)]/70 text-[color:var(--nav-link)] shadow-surface">
+                    <ArticleIcon className="text-[2.2rem]" />
+                  </span>
+                  <p className="text-lg font-semibold text-[color:var(--page-text)] sm:text-xl">
+                    {t("news:states.empty")}
+                  </p>
+                  {user?.role === "admin" && (
+                    <Button
+                      size="lg"
+                      onClick={() => setAddOpen(true)}
+                      className="px-6"
+                    >
+                      {t("news:actions.add")}
+                    </Button>
+                  )}
+                </div>
               </div>
             )}
           </div>

--- a/root/frontend/src/pages/News.tsx
+++ b/root/frontend/src/pages/News.tsx
@@ -252,11 +252,7 @@ const News = () => {
                     {t("news:states.empty")}
                   </p>
                   {user?.role === "admin" && (
-                    <Button
-                      size="lg"
-                      onClick={() => setAddOpen(true)}
-                      className="px-6"
-                    >
+                    <Button size="lg" onClick={() => setAddOpen(true)} className="px-6">
                       {t("news:actions.add")}
                     </Button>
                   )}


### PR DESCRIPTION
## Summary
- add a NewsCardSkeleton component that mimics the news card dimensions with animated placeholders
- render skeleton cards during the initial load to keep the grid layout stable and refresh the empty state with an action for admins

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690698b6dc6883279b48100f7164d4b9