### PR TITLE
Remove duplicated hero caption in news detail page

### DIFF
--- a/root/frontend/src/pages/NewsDetail.tsx
+++ b/root/frontend/src/pages/NewsDetail.tsx
@@ -341,9 +341,11 @@ export default function NewsDetail() {
                 style={{ objectFit: heroFit, objectPosition: heroPos }}
               />
             </div>
-            <figcaption className="border-t border-white/10 bg-[color:var(--glass-bg)]/70 px-5 py-3 text-sm font-medium text-[color:var(--secondary-text)]">
-              {displayTitle || t("news:alt.heroFallback")}
-            </figcaption>
+            {displayTitle ? null : (
+              <figcaption className="border-t border-white/10 bg-[color:var(--glass-bg)]/70 px-5 py-3 text-sm font-medium text-[color:var(--secondary-text)]">
+                {t("news:alt.heroFallback")}
+              </figcaption>
+            )}
           </figure>
 
           <section className="max-w-4xl space-y-6 text-[1.05rem] leading-8 text-secondary">


### PR DESCRIPTION
## Summary
- stop rendering the hero image caption when the news title is already visible
- keep the fallback caption for cases without a localized title

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_690768d246ac8327b7a799d166b8e31a