### PR TITLE
Align news pages with Tailwind styling

### DIFF
--- a/root/frontend/package-lock.json
+++ b/root/frontend/package-lock.json
@@ -43,6 +43,7 @@
         "@lhci/cli": "^0.15.1",
         "@playwright/test": "^1.50.1",
         "@sentry/vite-plugin": "^4.5.0",
+        "@tailwindcss/line-clamp": "^0.4.4",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.2.0",
         "@testing-library/user-event": "^14.5.2",
@@ -4861,6 +4862,16 @@
       "license": "MIT",
       "dependencies": {
         "sourcemap-codec": "^1.4.8"
+      }
+    },
+    "node_modules/@tailwindcss/line-clamp": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/line-clamp/-/line-clamp-0.4.4.tgz",
+      "integrity": "sha512-5U6SY5z8N42VtrCrKlsTAA35gy2VSyYtHWCsg1H87NU1SXnEfekTVlrga9fzUDrrHcGi2Lb5KenUWb4lRQT5/g==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "tailwindcss": ">=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1"
       }
     },
     "node_modules/@tanstack/query-core": {

--- a/root/frontend/package.json
+++ b/root/frontend/package.json
@@ -65,6 +65,7 @@
     "@lhci/cli": "^0.15.1",
     "@playwright/test": "^1.50.1",
     "@sentry/vite-plugin": "^4.5.0",
+    "@tailwindcss/line-clamp": "^0.4.4",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.2.0",
     "@testing-library/user-event": "^14.5.2",

--- a/root/frontend/src/components/NewsCard.tsx
+++ b/root/frontend/src/components/NewsCard.tsx
@@ -400,15 +400,7 @@ const NewsCardComponent: FC<NewsCardProps> = ({
             {localizedTitle}
           </h3>
 
-          <p
-            className="min-h-[56px] text-[clamp(0.96rem,2vw,1.08rem)] text-[color:var(--secondary-text)]"
-            style={{
-              overflow: "hidden",
-              display: "-webkit-box",
-              WebkitLineClamp: 3,
-              WebkitBoxOrient: "vertical",
-            }}
-          >
+          <p className="min-h-[56px] text-[clamp(0.96rem,2vw,1.08rem)] text-[color:var(--secondary-text)] line-clamp-3">
             {sanitizedPreview}
           </p>
 

--- a/root/frontend/src/pages/News.tsx
+++ b/root/frontend/src/pages/News.tsx
@@ -10,7 +10,6 @@ import {
   useDeferredValue,
   startTransition,
   useMemo,
-  type CSSProperties,
   type ReactNode,
 } from "react"
 import { createNews, uploadNewsImage } from "@/api/news"
@@ -187,11 +186,10 @@ const News = () => {
   return (
     <Layout>
       <PageFadeIn>
-        <div className="flex w-full flex-col px-4 pb-16 pt-6 sm:px-6 lg:px-10 xl:px-14 2xl:px-20">
+        <div className="flex w-full flex-col px-4 pb-16 pt-6 sm:px-6 lg:px-8">
           <div
             data-fade
-            style={{ "--fade-delay": "80ms" } as CSSProperties}
-            className="mb-4 mt-4 flex flex-wrap items-center gap-3 text-nav-link sm:mb-8 sm:mt-6"
+            className="mb-4 mt-4 flex flex-wrap items-center gap-3 text-nav-link [--fade-delay:80ms] sm:mb-8 sm:mt-6"
           >
             <span className="inline-flex h-11 w-11 items-center justify-center rounded-full bg-[color:var(--glass-bg)]/70 text-[color:var(--nav-link)] shadow-surface">
               <ArticleIcon className="text-[1.85rem]" />
@@ -204,8 +202,7 @@ const News = () => {
           {user?.role === "admin" && (
             <div
               data-fade
-              style={{ "--fade-delay": "140ms" } as CSSProperties}
-              className="mb-6 flex justify-start"
+              className="mb-6 flex justify-start [--fade-delay:140ms]"
             >
               <Button
                 size="lg"
@@ -220,8 +217,7 @@ const News = () => {
 
           <div
             data-fade
-            style={{ "--fade-delay": "200ms" } as CSSProperties}
-            className="grid grid-cols-[repeat(auto-fit,minmax(310px,1fr))] gap-5 sm:gap-6"
+            className="grid grid-cols-[repeat(auto-fit,minmax(310px,1fr))] gap-5 [--fade-delay:200ms] sm:gap-6"
           >
             {isInitialLoading
               ? Array.from({ length: skeletonCount }).map((_, index) => (
@@ -243,7 +239,7 @@ const News = () => {
                 ))}
 
             {showEmptyState && (
-              <div className="col-span-full mt-16 flex justify-center">
+              <div className="col-span-full mt-16 flex justify-start">
                 <div className="flex w-full max-w-[420px] flex-col items-center gap-5 rounded-ue-xl border border-white/12 bg-glass/60 px-6 py-10 text-center text-[color:var(--secondary-text)] shadow-surface">
                   <span className="flex h-16 w-16 items-center justify-center rounded-full bg-[color:var(--glass-bg)]/70 text-[color:var(--nav-link)] shadow-surface">
                     <ArticleIcon className="text-[2.2rem]" />

--- a/root/frontend/src/pages/News.tsx
+++ b/root/frontend/src/pages/News.tsx
@@ -200,10 +200,7 @@ const News = () => {
           </div>
 
           {user?.role === "admin" && (
-            <div
-              data-fade
-              className="mb-6 flex justify-start [--fade-delay:140ms]"
-            >
+            <div data-fade className="mb-6 flex justify-start [--fade-delay:140ms]">
               <Button
                 size="lg"
                 onClick={() => setAddOpen(true)}

--- a/root/frontend/src/pages/NewsDetail.tsx
+++ b/root/frontend/src/pages/NewsDetail.tsx
@@ -1,11 +1,4 @@
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  type ReactNode,
-} from "react"
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react"
 import { useNavigate, useParams } from "react-router-dom"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import ArrowBackIcon from "@mui/icons-material/ArrowBack"
@@ -366,7 +359,7 @@ export default function NewsDetail() {
               className={cn(
                 "flex w-full items-center justify-center overflow-hidden",
                 heroFrame.container,
-                heroFrame.backdrop,
+                heroFrame.backdrop
               )}
             >
               <SmartImage
@@ -387,7 +380,7 @@ export default function NewsDetail() {
             )}
           </figure>
 
-          <section className="max-w-4xl self-start space-y-6 text-[1.05rem] leading-8 text-secondary">
+          <section className="max-w-4xl self-start space-y-6 text-[1.05rem] leading-8 text-[color:var(--secondary-text)]">
             {content?.split(/\n{2,}/).map((chunk, index) => {
               const text = chunk.trim()
 

--- a/root/frontend/src/pages/NewsDetail.tsx
+++ b/root/frontend/src/pages/NewsDetail.tsx
@@ -4,7 +4,6 @@ import {
   useMemo,
   useRef,
   useState,
-  type CSSProperties,
   type ReactNode,
 } from "react"
 import { useNavigate, useParams } from "react-router-dom"
@@ -113,71 +112,44 @@ export default function NewsDetail() {
   }, [])
 
   const heroFrame = useMemo(() => {
-    const base = {
-      container: {
-        minHeight: "320px",
-        height: "clamp(320px, 56vh, 520px)",
-        maxHeight: "520px",
-      } satisfies CSSProperties,
-      objectFit: "cover" as const,
-      objectPosition: "50% 40%",
-      backdrop: "color-mix(in srgb, var(--glass-bg) 80%, black 20%)",
-    }
-
     if (!heroRatio || !Number.isFinite(heroRatio) || heroRatio <= 0) {
-      return base
+      return {
+        container: "min-h-[320px] h-[clamp(320px,56vh,520px)] max-h-[520px]",
+        image: "object-cover object-[50%_40%]",
+        backdrop: "bg-[color:color-mix(in_srgb,var(--glass-bg)_80%,black_20%)]",
+      }
     }
 
     const ratio = Math.min(Math.max(heroRatio, 0.35), 4)
 
     if (ratio < 0.82) {
       return {
-        container: {
-          aspectRatio: ratio,
-          minHeight: "440px",
-          maxHeight: "82vh",
-        } satisfies CSSProperties,
-        objectFit: "contain" as const,
-        objectPosition: "50% 50%",
-        backdrop: "color-mix(in srgb, var(--glass-bg) 75%, black 25%)",
+        container: "min-h-[440px] max-h-[82vh] aspect-[3/4]",
+        image: "object-contain object-center",
+        backdrop: "bg-[color:color-mix(in_srgb,var(--glass-bg)_75%,black_25%)]",
       }
     }
 
     if (ratio < 1.18) {
       return {
-        container: {
-          aspectRatio: ratio,
-          minHeight: "360px",
-          maxHeight: "76vh",
-        } satisfies CSSProperties,
-        objectFit: "cover" as const,
-        objectPosition: "50% 38%",
-        backdrop: "var(--glass-bg)",
+        container: "min-h-[360px] max-h-[76vh] aspect-[5/4]",
+        image: "object-cover object-[50%_38%]",
+        backdrop: "bg-[var(--glass-bg)]",
       }
     }
 
     if (ratio > 2.6) {
       return {
-        container: {
-          aspectRatio: ratio,
-          minHeight: "260px",
-          maxHeight: "60vh",
-        } satisfies CSSProperties,
-        objectFit: "cover" as const,
-        objectPosition: "50% 46%",
-        backdrop: "color-mix(in srgb, var(--glass-bg) 80%, black 20%)",
+        container: "min-h-[260px] max-h-[60vh] aspect-[21/9]",
+        image: "object-cover object-[50%_46%]",
+        backdrop: "bg-[color:color-mix(in_srgb,var(--glass-bg)_80%,black_20%)]",
       }
     }
 
     return {
-      container: {
-        aspectRatio: ratio,
-        minHeight: "300px",
-        maxHeight: "68vh",
-      } satisfies CSSProperties,
-      objectFit: "cover" as const,
-      objectPosition: "50% 40%",
-      backdrop: "var(--glass-bg)",
+      container: "min-h-[300px] max-h-[68vh] aspect-video",
+      image: "object-cover object-[50%_40%]",
+      backdrop: "bg-[var(--glass-bg)]",
     }
   }, [heroRatio])
 
@@ -340,7 +312,7 @@ export default function NewsDetail() {
 
   return (
     <Layout>
-      <div className="flex w-full flex-col gap-8 px-3 pb-16 pt-5 sm:px-8 md:px-12 lg:px-16 xl:px-20 2xl:px-28">
+      <div className="flex w-full flex-col gap-8 px-4 pb-16 pt-5 sm:px-6 lg:px-8">
         <Button
           variant="outline"
           onClick={handleBack}
@@ -350,7 +322,7 @@ export default function NewsDetail() {
           {t("common:buttons.back")}
         </Button>
 
-        <article className="flex w-full flex-col gap-8">
+        <article className="flex w-full flex-col items-start gap-8">
           <header className="flex w-full flex-col gap-4 text-left">
             <h1 className="max-w-5xl text-[clamp(1.6rem,4vw,2.4rem)] font-extrabold tracking-tight text-[color:var(--page-text)]">
               {displayTitle}
@@ -389,13 +361,13 @@ export default function NewsDetail() {
             ) : null}
           </header>
 
-          <figure className="w-full max-w-5xl overflow-hidden rounded-ue-xl border border-white/12 bg-[color:var(--glass-bg)]/60 shadow-surface">
+          <figure className="w-full max-w-5xl self-start overflow-hidden rounded-ue-xl border border-white/12 bg-[color:var(--glass-bg)]/60 shadow-surface">
             <div
-              className="flex w-full items-center justify-center overflow-hidden"
-              style={{
-                ...heroFrame.container,
-                background: heroFrame.backdrop,
-              }}
+              className={cn(
+                "flex w-full items-center justify-center overflow-hidden",
+                heroFrame.container,
+                heroFrame.backdrop,
+              )}
             >
               <SmartImage
                 srcRaw={imageUrl}
@@ -405,11 +377,7 @@ export default function NewsDetail() {
                     : t("news:alt.heroFallback")
                 }
                 onLoad={handleHeroLoad}
-                className="h-full w-full"
-                style={{
-                  objectFit: heroFrame.objectFit,
-                  objectPosition: heroFrame.objectPosition,
-                }}
+                className={cn("h-full w-full", heroFrame.image)}
               />
             </div>
             {displayTitle ? null : (
@@ -419,7 +387,7 @@ export default function NewsDetail() {
             )}
           </figure>
 
-          <section className="max-w-4xl space-y-6 text-[1.05rem] leading-8 text-secondary">
+          <section className="max-w-4xl self-start space-y-6 text-[1.05rem] leading-8 text-secondary">
             {content?.split(/\n{2,}/).map((chunk, index) => {
               const text = chunk.trim()
 

--- a/root/frontend/tailwind.config.ts
+++ b/root/frontend/tailwind.config.ts
@@ -1,4 +1,5 @@
 import plugin from "tailwindcss/plugin";
+import lineClamp from "@tailwindcss/line-clamp";
 import type { Config } from "tailwindcss";
 
 const attributeSelector = (attribute: "data" | "aria", value: string) => {
@@ -164,6 +165,7 @@ const config: Config = {
         return selector ? `.peer${selector} ~ &` : ".peer ~ &";
       });
     }),
+    lineClamp,
   ],
 };
 


### PR DESCRIPTION
## Summary
- adjust the News and NewsDetail layouts to sit flush left with Tailwind spacing utilities
- replace inline styling on both pages and their cards with Tailwind classes, including hero image framing
- add the Tailwind line clamp plugin to clamp news previews without custom styles

## Testing
- npm run lint --prefix root/frontend

------
https://chatgpt.com/codex/tasks/task_e_690771b2dcc8832782bea5b6b51b4a8e