### PR TITLE
Enhance news detail reading experience

### DIFF
--- a/root/frontend/src/pages/NewsDetail.tsx
+++ b/root/frontend/src/pages/NewsDetail.tsx
@@ -1,4 +1,12 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react"
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type ReactNode,
+} from "react"
 import { useNavigate, useParams } from "react-router-dom"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import ArrowBackIcon from "@mui/icons-material/ArrowBack"
@@ -7,6 +15,9 @@ import DeleteIcon from "@mui/icons-material/Delete"
 import SaveIcon from "@mui/icons-material/Save"
 import CloseIcon from "@mui/icons-material/Close"
 import PhotoCamera from "@mui/icons-material/PhotoCamera"
+import ShareIcon from "@mui/icons-material/Share"
+import LinkIcon from "@mui/icons-material/Link"
+import { IconButton, Tooltip } from "@mui/material"
 import dayjs from "dayjs"
 import utc from "dayjs/plugin/utc"
 import timezone from "dayjs/plugin/timezone"
@@ -28,6 +39,14 @@ const inputClass =
 const textareaClass = `${inputClass} min-h-[160px] resize-y leading-relaxed`
 const iconButtonClass =
   "inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/15 bg-white/85 text-[color:var(--nav-link)] shadow-surface transition hover:bg-white focus-visible:outline-none focus-visible:shadow-focus"
+
+type ToastStatus = "success" | "error" | "info"
+
+type ToastState = {
+  id: number
+  message: string
+  status: ToastStatus
+}
 
 type FieldProps = {
   label: ReactNode
@@ -90,19 +109,46 @@ export default function NewsDetail() {
   const [deleting, setDeleting] = useState(false)
   const [newImage, setNewImage] = useState<File | null>(null)
   const [previewUrl, setPreviewUrl] = useState<string | null>(null)
-  const [snack, setSnack] = useState("")
+  const [toast, setToast] = useState<ToastState | null>(null)
   const imageInputRef = useRef<HTMLInputElement>(null)
   const editTitleRef = useRef<HTMLInputElement>(null)
   const [heroRatio, setHeroRatio] = useState<number | null>(null)
+  const progressRef = useRef<HTMLDivElement>(null)
+  const toastTimerRef = useRef<number | null>(null)
 
-  const handleHeroLoad = useCallback<React.ReactEventHandler<HTMLImageElement>>((event) => {
-    const img = event.currentTarget
-    const width = img.naturalWidth || 0
-    const height = img.naturalHeight || 0
-    if (!width || !height) return
+  const TOAST_DURATION = 3600
 
-    setHeroRatio(width / height)
+  const showToast = useCallback(
+    (message: string, status: ToastStatus = "info") => {
+      setToast({ id: Date.now(), message, status })
+    },
+    []
+  )
+
+  const updateProgress = useCallback(() => {
+    const doc = document.documentElement
+    const scrollable = doc.scrollHeight - window.innerHeight
+    const progress = scrollable > 0 ? Math.min(Math.max(window.scrollY / scrollable, 0), 1) : 1
+    if (progressRef.current) {
+      progressRef.current.style.setProperty("--progress", progress.toString())
+      progressRef.current.style.opacity = progress > 0.005 ? "1" : "0"
+    }
   }, [])
+
+  const handleHeroLoad = useCallback<React.ReactEventHandler<HTMLImageElement>>(
+    (event) => {
+      const img = event.currentTarget
+      const width = img.naturalWidth || 0
+      const height = img.naturalHeight || 0
+      if (!width || !height) return
+
+      setHeroRatio(width / height)
+      window.requestAnimationFrame(() => {
+        updateProgress()
+      })
+    },
+    [updateProgress]
+  )
 
   const heroFrame = useMemo(() => {
     if (!heroRatio || !Number.isFinite(heroRatio) || heroRatio <= 0) {
@@ -161,10 +207,38 @@ export default function NewsDetail() {
   }, [previewUrl])
 
   useEffect(() => {
-    if (!snack) return
-    const timeout = window.setTimeout(() => setSnack(""), 2400)
-    return () => window.clearTimeout(timeout)
-  }, [snack])
+    updateProgress()
+    window.addEventListener("scroll", updateProgress, { passive: true })
+    window.addEventListener("resize", updateProgress)
+    return () => {
+      window.removeEventListener("scroll", updateProgress)
+      window.removeEventListener("resize", updateProgress)
+    }
+  }, [updateProgress])
+
+  useEffect(() => {
+    return () => {
+      if (toastTimerRef.current) {
+        window.clearTimeout(toastTimerRef.current)
+        toastTimerRef.current = null
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!toast) return
+    if (toastTimerRef.current) {
+      window.clearTimeout(toastTimerRef.current)
+    }
+    const timer = window.setTimeout(() => {
+      setToast(null)
+      toastTimerRef.current = null
+    }, TOAST_DURATION)
+    toastTimerRef.current = timer
+    return () => {
+      window.clearTimeout(timer)
+    }
+  }, [TOAST_DURATION, toast])
 
   const resetPreview = () => {
     if (previewUrl) {
@@ -220,11 +294,11 @@ export default function NewsDetail() {
       const { data } = await updateNews(query.data.id, payload)
       queryClient.setQueryData(["news", id, language], data)
       await queryClient.invalidateQueries({ queryKey: ["news"] })
-      setSnack(t("news:notifications.updated"))
+      showToast(t("news:notifications.updated"), "success")
       closeEdit()
     } catch (error) {
       console.error(error)
-      setSnack(t("news:notifications.savedError"))
+      showToast(t("news:notifications.savedError"), "error")
     } finally {
       setSaving(false)
     }
@@ -235,14 +309,14 @@ export default function NewsDetail() {
     setDeleting(true)
     try {
       await deleteNews(query.data.id)
-      setSnack(t("news:notifications.deleted"))
+      showToast(t("news:notifications.deleted"), "success")
       queryClient.removeQueries({ queryKey: ["news", id] })
       await queryClient.invalidateQueries({ queryKey: ["news"] })
       if (window.history.length > 1) navigate(-1)
       else navigate("/news")
     } catch (error) {
       console.error(error)
-      setSnack(t("news:notifications.deleteError"))
+      showToast(t("news:notifications.deleteError"), "error")
     } finally {
       setDeleting(false)
       setConfirmDeleteOpen(false)
@@ -285,6 +359,112 @@ export default function NewsDetail() {
   const createdAtIso = useMemo(() => (createdAt ? dayjs(createdAt).toISOString() : ""), [createdAt])
   const createdAtLabel = useMemo(() => (createdAt ? getMoscowDate(createdAt) : ""), [createdAt])
 
+  const contentNodes = useMemo<ReactNode[]>(() => {
+    if (!content) return []
+
+    return content
+      .split(/\n{2,}/)
+      .map((chunk, index) => {
+        const text = chunk.trim()
+        if (!text) return null
+
+        const lines = text.split(/\n/).map((line) => line.trim()).filter(Boolean)
+        if (!lines.length) return null
+
+        if (lines.every((line) => /^[-*]\s+/.test(line))) {
+          return (
+            <ul key={`news-detail-list-${index}`}>
+              {lines.map((line, itemIndex) => (
+                <li key={`news-detail-list-${index}-${itemIndex}`}>
+                  {line.replace(/^[-*]\s+/, "").trim()}
+                </li>
+              ))}
+            </ul>
+          )
+        }
+
+        if (lines.every((line) => /^\d+[.)]\s+/.test(line))) {
+          return (
+            <ol key={`news-detail-ordered-${index}`}>
+              {lines.map((line, itemIndex) => (
+                <li key={`news-detail-ordered-${index}-${itemIndex}`}>
+                  {line.replace(/^\d+[.)]\s+/, "").trim()}
+                </li>
+              ))}
+            </ol>
+          )
+        }
+
+        if (text.startsWith(">")) {
+          const quote = lines.map((line) => line.replace(/^>\s?/, "")).join("\n").trim()
+          return (
+            <blockquote key={`news-detail-quote-${index}`}>
+              {quote.split(/\n{2,}/).map((paragraph, quoteIndex) => (
+                <p key={`news-detail-quote-${index}-${quoteIndex}`}>{paragraph.trim()}</p>
+              ))}
+            </blockquote>
+          )
+        }
+
+        const segments = text.split(/\n/)
+
+        return (
+          <p key={`news-detail-paragraph-${index}`}>
+            {segments.map((segment, segmentIndex) => (
+              <span key={`news-detail-paragraph-${index}-${segmentIndex}`}>
+                {segment.trim()}
+                {segmentIndex < segments.length - 1 ? <br /> : null}
+              </span>
+            ))}
+          </p>
+        )
+      })
+      .filter(Boolean) as ReactNode[]
+  }, [content])
+
+  const actionsDescriptionId = useMemo(() => `news-actions-${id ?? "item"}`, [id])
+
+  const handleCopyLink = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(window.location.href)
+      showToast(
+        t("news:notifications.linkCopied", { defaultValue: "Link copied to clipboard" }),
+        "success"
+      )
+    } catch (error) {
+      console.error(error)
+      showToast(t("news:notifications.linkCopyError", { defaultValue: "Unable to copy link" }), "error")
+    }
+  }, [showToast, t])
+
+  const handleShare = useCallback(async () => {
+    const shareTitle = displayTitle || t("news:share.fallbackTitle", { defaultValue: "University news" })
+    const shareData = {
+      title: shareTitle,
+      text: shareTitle,
+      url: window.location.href,
+    }
+
+    if (navigator.share) {
+      try {
+        await navigator.share(shareData)
+        showToast(t("news:notifications.shareOpened", { defaultValue: "Share dialog opened" }), "success")
+      } catch (error) {
+        if ((error as DOMException)?.name === "AbortError") return
+        console.error(error)
+        showToast(t("news:notifications.shareError", { defaultValue: "Unable to share" }), "error")
+      }
+      return
+    }
+
+    await handleCopyLink()
+  }, [displayTitle, handleCopyLink, showToast, t])
+
+  const heroBackdropStyle = useMemo<CSSProperties | undefined>(
+    () => (imageUrl ? ({ "--hero-src": `url(${imageUrl})` } as CSSProperties) : undefined),
+    [imageUrl]
+  )
+
   if (query.isLoading)
     return (
       <Layout>
@@ -305,7 +485,15 @@ export default function NewsDetail() {
 
   return (
     <Layout>
-      <div className="flex w-full flex-col gap-8 px-4 pb-16 pt-5 sm:px-6 lg:px-8">
+      <div
+        ref={progressRef}
+        className="pointer-events-none fixed left-0 top-0 z-[1200] h-[3px] w-full overflow-hidden bg-transparent opacity-0 transition-opacity duration-300 ease-out"
+        aria-hidden="true"
+      >
+        <span className="block h-full w-full origin-left scale-x-[var(--progress,0)] bg-[linear-gradient(96deg,var(--nav-link),color-mix(in_srgb,var(--nav-link)_42%,#06b6d4_58%))] shadow-[0_0_14px_rgba(14,165,233,0.52)] transition-[transform] duration-200 ease-out will-change-transform" />
+      </div>
+
+      <div className="flex w-full flex-col gap-8 px-4 pb-24 pt-5 sm:px-6 lg:px-8">
         <Button
           variant="outline"
           onClick={handleBack}
@@ -354,40 +542,93 @@ export default function NewsDetail() {
             ) : null}
           </header>
 
-          <figure className="w-full max-w-5xl self-start overflow-hidden rounded-ue-xl border border-white/12 bg-[color:var(--glass-bg)]/60 shadow-surface">
+          <div className="relative flex w-full flex-col gap-6 lg:flex-row lg:items-start lg:gap-10">
             <div
               className={cn(
-                "flex w-full items-center justify-center overflow-hidden",
-                heroFrame.container,
-                heroFrame.backdrop
+                "relative isolate w-full max-w-5xl self-start before:pointer-events-none before:absolute before:-inset-x-[min(16vw,140px)] before:-top-[24vh] before:-bottom-[26vh] before:-z-10 before:bg-[image:var(--hero-src)] before:bg-cover before:bg-center before:bg-no-repeat before:opacity-0 before:blur-[120px] before:transition-opacity before:duration-[900ms] before:ease-out before:content-[''] motion-reduce:before:transition-none",
+                imageUrl ? "data-[has-image=true]:before:opacity-40" : "before:opacity-0"
               )}
+              data-has-image={Boolean(imageUrl)}
+              style={heroBackdropStyle}
             >
-              <SmartImage
-                srcRaw={imageUrl}
-                alt={
-                  displayTitle
-                    ? t("news:alt.hero", { title: displayTitle })
-                    : t("news:alt.heroFallback")
-                }
-                onLoad={handleHeroLoad}
-                className={cn("h-full w-full", heroFrame.image)}
-              />
+              <figure className="relative w-full overflow-hidden rounded-ue-xl border border-white/12 bg-[color:var(--glass-bg)]/60 shadow-surface backdrop-blur">
+                <div
+                  className={cn(
+                    "flex w-full items-center justify-center overflow-hidden",
+                    heroFrame.container,
+                    heroFrame.backdrop
+                  )}
+                >
+                  <SmartImage
+                    srcRaw={imageUrl}
+                    alt={
+                      displayTitle
+                        ? t("news:alt.hero", { title: displayTitle })
+                        : t("news:alt.heroFallback")
+                    }
+                    onLoad={handleHeroLoad}
+                    className={cn("h-full w-full", heroFrame.image)}
+                  />
+                </div>
+                {displayTitle ? null : (
+                  <figcaption className="border-t border-white/10 bg-[color:var(--glass-bg)]/70 px-5 py-3 text-sm font-medium text-[color:var(--secondary-text)]">
+                    {t("news:alt.heroFallback")}
+                  </figcaption>
+                )}
+              </figure>
             </div>
-            {displayTitle ? null : (
-              <figcaption className="border-t border-white/10 bg-[color:var(--glass-bg)]/70 px-5 py-3 text-sm font-medium text-[color:var(--secondary-text)]">
-                {t("news:alt.heroFallback")}
-              </figcaption>
-            )}
-          </figure>
 
-          <section className="max-w-4xl self-start space-y-6 text-[1.05rem] leading-8 text-[color:var(--secondary-text)]">
-            {content?.split(/\n{2,}/).map((chunk, index) => {
-              const text = chunk.trim()
+            <aside
+              role="region"
+              aria-label={t("news:aria.shareActions", { defaultValue: "Article actions" }) ?? ""}
+              aria-describedby={actionsDescriptionId}
+              className="pointer-events-auto fixed bottom-6 left-1/2 z-[1090] w-[min(92vw,360px)] -translate-x-1/2 rounded-ue-xl border border-white/15 bg-[color:color-mix(in_srgb,var(--card-bg)_78%,transparent_22%)]/85 p-4 text-[color:var(--page-text)] shadow-surface backdrop-blur-2xl transition-all duration-500 ease-out motion-reduce:transition-none md:static md:ml-auto md:w-auto md:translate-x-0 md:rounded-ue-lg md:border-white/12 md:bg-[color:color-mix(in_srgb,var(--glass-bg)_70%,black_30%)]/85 md:p-5 md:shadow-glass lg:sticky lg:top-28"
+            >
+              <p
+                id={actionsDescriptionId}
+                className="text-[0.72rem] font-semibold uppercase tracking-[0.28em] text-[color:var(--secondary-text)]"
+              >
+                {t("news:actions.title", { defaultValue: "Share this story" })}
+              </p>
+              <p className="mt-2 text-sm text-[color:color-mix(in_srgb,var(--secondary-text)_88%,white_12%)]">
+                {t("news:actions.helper", { defaultValue: "Spread the word or save the link" })}
+              </p>
+              <div className="mt-4 flex items-center justify-between gap-3">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  leadingIcon={<ShareIcon fontSize="small" />}
+                  className="flex-1 border-white/25 text-[0.95rem] font-semibold shadow-surface"
+                  onClick={() => {
+                    void handleShare()
+                  }}
+                >
+                  {t("news:actions.share", { defaultValue: "Share" })}
+                </Button>
+                <Tooltip
+                  title={t("news:actions.copyLink", { defaultValue: "Copy link" })}
+                  placement="top"
+                  arrow
+                >
+                  <IconButton
+                    onClick={() => {
+                      void handleCopyLink()
+                    }}
+                    aria-describedby={actionsDescriptionId}
+                    aria-label={t("news:actions.copyLink", { defaultValue: "Copy link" }) ?? ""}
+                    className="!h-11 !w-11 rounded-full border border-white/25 bg-white/10 text-[color:var(--page-text)] shadow-surface transition duration-200 ease-out hover:bg-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-0 focus-visible:ring-[color:var(--nav-link)]"
+                    size="large"
+                  >
+                    <LinkIcon fontSize="small" />
+                  </IconButton>
+                </Tooltip>
+              </div>
+            </aside>
+          </div>
 
-              if (!text) return null
-
-              return <p key={`news-detail-paragraph-${index}`}>{text}</p>
-            })}
+          <section className="prose-neutral">
+            {contentNodes.length ? contentNodes : null}
           </section>
         </article>
       </div>
@@ -549,9 +790,26 @@ export default function NewsDetail() {
         </p>
       </Dialog>
 
-      {snack ? (
-        <div className="fixed bottom-6 left-1/2 z-[999] w-[min(90vw,360px)] -translate-x-1/2 rounded-ue-lg border border-white/12 bg-[color:color-mix(in_srgb,var(--card-bg)_94%,white_6%)]/95 px-4 py-3 text-center text-[0.95rem] font-semibold text-[color:var(--page-text)] shadow-surface-strong backdrop-blur-xl">
-          {snack}
+      {toast ? (
+        <div className="pointer-events-none fixed inset-x-0 bottom-0 z-[1200] flex justify-center px-4 pb-5 pt-4">
+          <div
+            key={toast.id}
+            className={cn(
+              "toast-bubble",
+              toast.status === "success"
+                ? "toast-bubble--success"
+                : toast.status === "error"
+                  ? "toast-bubble--error"
+                  : "toast-bubble--info"
+            )}
+            data-status={toast.status}
+            role={toast.status === "error" ? "alert" : "status"}
+            aria-live={toast.status === "error" ? "assertive" : "polite"}
+            style={{ "--toast-duration": `${TOAST_DURATION}ms` } as CSSProperties}
+          >
+            {toast.message}
+            <span className="toast-bubble__progress" aria-hidden="true" />
+          </div>
         </div>
       ) : null}
     </Layout>

--- a/root/frontend/src/pages/NewsDetail.tsx
+++ b/root/frontend/src/pages/NewsDetail.tsx
@@ -118,12 +118,9 @@ export default function NewsDetail() {
 
   const TOAST_DURATION = 3600
 
-  const showToast = useCallback(
-    (message: string, status: ToastStatus = "info") => {
-      setToast({ id: Date.now(), message, status })
-    },
-    []
-  )
+  const showToast = useCallback((message: string, status: ToastStatus = "info") => {
+    setToast({ id: Date.now(), message, status })
+  }, [])
 
   const updateProgress = useCallback(() => {
     const doc = document.documentElement
@@ -368,7 +365,10 @@ export default function NewsDetail() {
         const text = chunk.trim()
         if (!text) return null
 
-        const lines = text.split(/\n/).map((line) => line.trim()).filter(Boolean)
+        const lines = text
+          .split(/\n/)
+          .map((line) => line.trim())
+          .filter(Boolean)
         if (!lines.length) return null
 
         if (lines.every((line) => /^[-*]\s+/.test(line))) {
@@ -396,7 +396,10 @@ export default function NewsDetail() {
         }
 
         if (text.startsWith(">")) {
-          const quote = lines.map((line) => line.replace(/^>\s?/, "")).join("\n").trim()
+          const quote = lines
+            .map((line) => line.replace(/^>\s?/, ""))
+            .join("\n")
+            .trim()
           return (
             <blockquote key={`news-detail-quote-${index}`}>
               {quote.split(/\n{2,}/).map((paragraph, quoteIndex) => (
@@ -433,12 +436,16 @@ export default function NewsDetail() {
       )
     } catch (error) {
       console.error(error)
-      showToast(t("news:notifications.linkCopyError", { defaultValue: "Unable to copy link" }), "error")
+      showToast(
+        t("news:notifications.linkCopyError", { defaultValue: "Unable to copy link" }),
+        "error"
+      )
     }
   }, [showToast, t])
 
   const handleShare = useCallback(async () => {
-    const shareTitle = displayTitle || t("news:share.fallbackTitle", { defaultValue: "University news" })
+    const shareTitle =
+      displayTitle || t("news:share.fallbackTitle", { defaultValue: "University news" })
     const shareData = {
       title: shareTitle,
       text: shareTitle,
@@ -448,7 +455,10 @@ export default function NewsDetail() {
     if (navigator.share) {
       try {
         await navigator.share(shareData)
-        showToast(t("news:notifications.shareOpened", { defaultValue: "Share dialog opened" }), "success")
+        showToast(
+          t("news:notifications.shareOpened", { defaultValue: "Share dialog opened" }),
+          "success"
+        )
       } catch (error) {
         if ((error as DOMException)?.name === "AbortError") return
         console.error(error)
@@ -627,9 +637,7 @@ export default function NewsDetail() {
             </aside>
           </div>
 
-          <section className="prose-neutral">
-            {contentNodes.length ? contentNodes : null}
-          </section>
+          <section className="prose-neutral">{contentNodes.length ? contentNodes : null}</section>
         </article>
       </div>
 

--- a/root/frontend/src/styles/tailwind.css
+++ b/root/frontend/src/styles/tailwind.css
@@ -180,7 +180,7 @@
   }
 
   .prose-neutral blockquote {
-    @apply relative overflow-hidden rounded-ue-lg border border-white/12 bg-[color:color-mix(in_srgb,var(--glass-bg)_82%,black_18%)]/70 px-6 py-5 font-medium italic text-[color:var(--page-text)] shadow-surface;
+    @apply relative overflow-hidden rounded-ue-lg border border-white/10 bg-[color:color-mix(in_srgb,var(--glass-bg)_82%,black_18%)] bg-opacity-70 px-6 py-5 font-medium italic text-[color:var(--page-text)] shadow-surface;
   }
 
   .prose-neutral blockquote::before {
@@ -232,7 +232,7 @@
   }
 
   .toast-bubble {
-    @apply relative w-[min(92vw,360px)] overflow-hidden rounded-ue-xl border border-white/16 bg-[color:color-mix(in_srgb,var(--card-bg)_78%,transparent_22%)]/85 px-5 py-4 text-center text-[0.95rem] font-semibold text-[color:var(--page-text)] shadow-surface backdrop-blur-xl;
+    @apply relative w-[min(92vw,360px)] overflow-hidden rounded-ue-xl border border-white/20 bg-[color:color-mix(in_srgb,var(--card-bg)_78%,transparent_22%)] bg-opacity-80 px-5 py-4 text-center text-[0.95rem] font-semibold text-[color:var(--page-text)] shadow-surface backdrop-blur-xl;
   }
 
   .toast-bubble--success {
@@ -244,7 +244,7 @@
   }
 
   .toast-bubble--info {
-    @apply border-white/18;
+    @apply border-white/20;
   }
 
   .toast-bubble__progress {

--- a/root/frontend/src/styles/tailwind.css
+++ b/root/frontend/src/styles/tailwind.css
@@ -167,6 +167,131 @@
     }
   }
 
+  .prose-neutral {
+    @apply relative w-full max-w-3xl self-start text-[1.05rem] leading-[1.85] text-[color:var(--secondary-text)] tracking-[0.01em];
+  }
+
+  .prose-neutral > * + * {
+    @apply mt-6;
+  }
+
+  .prose-neutral p {
+    @apply text-[1.02rem];
+  }
+
+  .prose-neutral blockquote {
+    @apply relative overflow-hidden rounded-ue-lg border border-white/12 bg-[color:color-mix(in_srgb,var(--glass-bg)_82%,black_18%)]/70 px-6 py-5 font-medium italic text-[color:var(--page-text)] shadow-surface;
+  }
+
+  .prose-neutral blockquote::before {
+    content: "\201C";
+    position: absolute;
+    top: -0.4em;
+    left: 0.35em;
+    font-size: 4rem;
+    line-height: 1;
+    color: color-mix(in srgb, var(--nav-link) 65%, white 35%);
+    opacity: 0.18;
+  }
+
+  .prose-neutral blockquote p + p {
+    @apply mt-3;
+  }
+
+  .prose-neutral ul,
+  .prose-neutral ol {
+    @apply my-6 list-outside space-y-2 pl-6;
+  }
+
+  .prose-neutral ul {
+    @apply list-disc;
+  }
+
+  .prose-neutral ol {
+    @apply list-decimal;
+  }
+
+  .prose-neutral li::marker {
+    color: color-mix(in srgb, var(--nav-link) 70%, white 30%);
+  }
+
+  .prose-neutral a {
+    @apply font-semibold text-[color:var(--nav-link)] underline decoration-[color:color-mix(in_srgb,var(--nav-link)_45%,white_55%)] decoration-2 underline-offset-4;
+  }
+
+  .prose-neutral p:first-of-type {
+    @apply relative;
+  }
+
+  .prose-neutral p:first-of-type::first-letter {
+    @apply float-left mr-3 font-display text-[3.4rem] uppercase leading-[0.85] text-[color:var(--page-text)];
+    padding-top: 0.2rem;
+    opacity: 0;
+    transform: translateY(12px);
+    animation: dropcap-fade 680ms ease forwards;
+  }
+
+  .toast-bubble {
+    @apply relative w-[min(92vw,360px)] overflow-hidden rounded-ue-xl border border-white/16 bg-[color:color-mix(in_srgb,var(--card-bg)_78%,transparent_22%)]/85 px-5 py-4 text-center text-[0.95rem] font-semibold text-[color:var(--page-text)] shadow-surface backdrop-blur-xl;
+  }
+
+  .toast-bubble--success {
+    @apply border-emerald-400/45 text-emerald-50;
+  }
+
+  .toast-bubble--error {
+    @apply border-[#f87171]/55 text-[#fee2e2];
+  }
+
+  .toast-bubble--info {
+    @apply border-white/18;
+  }
+
+  .toast-bubble__progress {
+    @apply absolute bottom-0 left-0 h-1 w-full origin-left bg-[linear-gradient(92deg,var(--nav-link),#38bdf8,rgba(255,255,255,0.9))];
+    animation: toast-progress var(--toast-duration, 3600ms) linear forwards;
+    transform: scaleX(1);
+  }
+
+  @keyframes toast-progress {
+    0% {
+      transform: scaleX(1);
+    }
+
+    100% {
+      transform: scaleX(0);
+    }
+  }
+
+  @keyframes dropcap-fade {
+    0% {
+      opacity: 0;
+      transform: translateY(12px);
+    }
+
+    100% {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .prose-neutral p:first-of-type::first-letter {
+      animation: none;
+      opacity: 1;
+      transform: none;
+    }
+
+    .toast-bubble {
+      transition: none;
+    }
+
+    .toast-bubble__progress {
+      animation: none;
+      transform: scaleX(1);
+    }
+  }
+
   .skeleton {
     @apply relative overflow-hidden rounded-ue-md bg-skeleton text-transparent;
     animation: fade-in var(--anim-med, 0.3s ease) both;


### PR DESCRIPTION
## Summary
- add a scroll-driven progress indicator and responsive action panel to the news detail page
- expand the hero presentation with blurred background layering and improved article typography
- replace the legacy snackbar with animated toast notifications supporting multiple statuses

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_6907ba1fe00c8327a9b8f5cd8988bda5