### PR TITLE
Enhance news pages with ambient visuals and interactions

### DIFF
--- a/root/frontend/src/components/NewsCard.tsx
+++ b/root/frontend/src/components/NewsCard.tsx
@@ -283,12 +283,24 @@ const NewsCardComponent: FC<NewsCardProps> = ({
   return (
     <article
       className={cn(
-        "group relative flex h-full w-full flex-col overflow-hidden rounded-ue-xl border border-white/12 bg-[color:color-mix(in_srgb,var(--card-bg)_94%,white_6%)] text-[color:var(--page-text)] shadow-surface transition-[transform,box-shadow] duration-300 ease-out",
+        "group relative isolate flex h-full w-full flex-col overflow-hidden rounded-ue-xl border border-white/12 bg-[color:color-mix(in_srgb,var(--card-bg)_94%,white_6%)] text-[color:var(--page-text)] shadow-surface transition-[transform,box-shadow] duration-300 ease-out",
         hoveringDisabled
           ? "cursor-default"
-          : "cursor-pointer hover:-translate-y-[2px] hover:scale-[1.015] hover:shadow-surface-strong active:scale-[0.995]"
+          : "cursor-pointer motion-safe:hover:-translate-y-[3px] motion-safe:hover:scale-[1.012] motion-safe:hover:shadow-surface-strong motion-safe:active:scale-[0.995]"
       )}
     >
+      <span
+        aria-hidden
+        className="pointer-events-none absolute inset-0 -z-[1] rounded-ue-xl bg-[radial-gradient(circle_at_top,rgba(148,163,255,0.22),transparent_65%)] opacity-0 transition duration-500 ease-out group-hover:opacity-100 group-focus-within:opacity-100"
+      />
+      <span
+        aria-hidden
+        className="pointer-events-none absolute -inset-px -z-[2] rounded-[inherit] bg-[conic-gradient(from_160deg_at_40%_20%,rgba(59,130,246,0.32),rgba(14,165,233,0.18),rgba(192,132,252,0.26),rgba(59,130,246,0.32))] opacity-0 transition duration-500 ease-out group-hover:opacity-100 group-focus-within:opacity-100"
+      />
+      <span
+        aria-hidden
+        className="pointer-events-none absolute inset-x-8 top-0 z-[1] h-px bg-gradient-to-r from-transparent via-white/45 to-transparent opacity-0 transition duration-500 ease-out group-hover:opacity-100 group-focus-within:opacity-100"
+      />
       {user?.role === "admin" && (
         <div className="absolute right-3 top-3 z-10">
           <button
@@ -353,7 +365,15 @@ const NewsCardComponent: FC<NewsCardProps> = ({
         disabled={hoveringDisabled}
         className="group/button relative flex h-full flex-1 flex-col text-left focus-visible:outline-none disabled:cursor-default disabled:opacity-100"
       >
-        <div className="relative w-full overflow-hidden border-b border-white/10 bg-[linear-gradient(135deg,rgba(29,78,216,0.18),rgba(59,130,246,0.08))]">
+        <div className="group/image relative w-full overflow-hidden border-b border-white/10 bg-[linear-gradient(135deg,rgba(29,78,216,0.18),rgba(59,130,246,0.08))]">
+          <span
+            aria-hidden
+            className="pointer-events-none absolute inset-0 z-[1] bg-[radial-gradient(circle_at_20%_-10%,rgba(255,255,255,0.22),transparent_65%)] opacity-0 transition duration-700 ease-out group-hover/image:opacity-100"
+          />
+          <span
+            aria-hidden
+            className="pointer-events-none absolute inset-y-0 left-[-40%] z-[2] w-1/2 bg-[linear-gradient(110deg,transparent,rgba(255,255,255,0.45),transparent)] opacity-0 transition duration-700 ease-out group-hover/image:translate-x-[220%] group-hover/image:opacity-80"
+          />
           <div
             className={cn(
               "absolute inset-0 animate-pulse bg-[color:color-mix(in_srgb,var(--glass-bg)_70%,white_30%)] transition-opacity duration-300",
@@ -371,7 +391,7 @@ const NewsCardComponent: FC<NewsCardProps> = ({
                     : t("news:alt.heroFallback")
                 }
                 sizes="(min-width: 1200px) 640px, (min-width: 900px) 520px, 100vw"
-                className="relative h-[180px] w-full object-cover transition duration-700 ease-out sm:h-[220px]"
+                className="relative z-[1] h-[180px] w-full object-cover transition duration-700 ease-out motion-safe:group-hover/image:scale-[1.04] sm:h-[220px]"
                 onLoad={handleCardImageReady}
                 onError={handleCardImageReady}
               />
@@ -388,7 +408,7 @@ const NewsCardComponent: FC<NewsCardProps> = ({
           {createdAtIso ? (
             <time
               dateTime={createdAtIso}
-              className="absolute bottom-3 left-3 z-[2] rounded-ue-pill bg-black/60 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-white/90 transition duration-300 ease-out group-hover/button:translate-y-[-2px] group-hover/button:bg-black/70"
+              className="absolute bottom-3 left-3 z-[3] rounded-ue-pill bg-black/60 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-white/90 transition duration-300 ease-out group-hover/button:translate-y-[-2px] group-hover/button:bg-black/70 group-hover/image:translate-y-[-2px] group-hover/image:bg-black/70"
             >
               {createdAtLabel}
             </time>
@@ -400,7 +420,7 @@ const NewsCardComponent: FC<NewsCardProps> = ({
             {localizedTitle}
           </h3>
 
-          <p className="min-h-[56px] text-[clamp(0.96rem,2vw,1.08rem)] text-[color:var(--secondary-text)] line-clamp-3">
+          <p className="min-h-[56px] text-[clamp(0.96rem,2vw,1.08rem)] text-[color:var(--secondary-text)] line-clamp-3 transition-colors duration-300 ease-out group-hover:text-[color:var(--page-text)]">
             {sanitizedPreview}
           </p>
 
@@ -414,6 +434,10 @@ const NewsCardComponent: FC<NewsCardProps> = ({
             />
           </div>
         </div>
+        <span
+          aria-hidden
+          className="pointer-events-none absolute inset-x-4 bottom-[-18%] h-24 translate-y-0 rounded-full bg-[radial-gradient(circle_at_center,rgba(14,165,233,0.18),transparent_70%)] opacity-0 transition duration-500 ease-out group-hover:translate-y-[-16%] group-hover:opacity-90"
+        />
       </button>
 
       <Dialog

--- a/root/frontend/src/pages/News.tsx
+++ b/root/frontend/src/pages/News.tsx
@@ -11,6 +11,7 @@ import {
   startTransition,
   useMemo,
   type ReactNode,
+  type CSSProperties,
 } from "react"
 import { createNews, uploadNewsImage } from "@/api/news"
 import ArticleIcon from "@mui/icons-material/Article"
@@ -186,27 +187,42 @@ const News = () => {
   return (
     <Layout>
       <PageFadeIn>
-        <div className="flex w-full flex-col px-4 pb-16 pt-6 sm:px-6 lg:px-8">
+        <div className="relative isolate flex w-full flex-col px-4 pb-16 pt-6 sm:px-6 lg:px-8">
+          <div aria-hidden className="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
+            <div className="absolute -left-[12%] top-[-18%] h-[420px] w-[420px] rounded-full bg-[radial-gradient(circle_at_center,rgba(59,130,246,0.28),transparent_70%)] blur-3xl opacity-70" />
+            <div className="absolute right-[-8%] top-[32%] h-[360px] w-[360px] rounded-full bg-[radial-gradient(circle_at_center,rgba(129,140,248,0.32),transparent_68%)] blur-3xl opacity-75 motion-safe:animate-[spin_28s_linear_infinite]" />
+            <div className="absolute bottom-[-24%] left-[18%] h-[320px] w-[320px] rounded-full bg-[radial-gradient(circle_at_center,rgba(14,165,233,0.22),transparent_70%)] blur-3xl opacity-60" />
+          </div>
+
           <div
             data-fade
-            className="mb-4 mt-4 flex flex-wrap items-center gap-3 text-nav-link [--fade-delay:80ms] sm:mb-8 sm:mt-6"
+            className="mb-3 mt-4 flex flex-wrap items-center gap-3 text-nav-link [--fade-delay:80ms] sm:mb-6 sm:mt-6"
           >
-            <span className="inline-flex h-11 w-11 items-center justify-center rounded-full bg-[color:var(--glass-bg)]/70 text-[color:var(--nav-link)] shadow-surface">
-              <ArticleIcon className="text-[1.85rem]" />
+            <span className="relative inline-flex h-11 w-11 items-center justify-center overflow-hidden rounded-full bg-[color:var(--glass-bg)]/75 text-[color:var(--nav-link)] shadow-surface">
+              <span className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_30%_20%,rgba(255,255,255,0.65),transparent_60%)] opacity-80" />
+              <ArticleIcon className="relative text-[1.85rem]" />
             </span>
-            <h1 className="text-[clamp(1.6rem,5vw,2.75rem)] font-bold tracking-tight text-[color:var(--page-text)]">
-              {t("news:pageTitle")}
-            </h1>
+            <div className="space-y-1">
+              <h1 className="text-[clamp(1.6rem,5vw,2.75rem)] font-bold tracking-tight text-[color:var(--page-text)]">
+                {t("news:pageTitle")}
+              </h1>
+              <p className="text-[0.9rem] font-medium uppercase tracking-[0.32em] text-[color:color-mix(in_srgb,var(--secondary-text)_75%,white_25%)]">
+                {t("news:pageTagline", {
+                  defaultValue: "Curated highlights and stories from the university ecosystem",
+                })}
+              </p>
+            </div>
           </div>
 
           {user?.role === "admin" && (
-            <div data-fade className="mb-6 flex justify-start [--fade-delay:140ms]">
+            <div data-fade className="mb-7 flex justify-start [--fade-delay:140ms]">
               <Button
                 size="lg"
                 onClick={() => setAddOpen(true)}
                 disabled={adding}
-                className="px-6 text-[clamp(1rem,2.2vw,1.1rem)]"
+                className="group relative overflow-hidden px-6 text-[clamp(1rem,2.2vw,1.1rem)]"
               >
+                <span className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_20%_20%,rgba(255,255,255,0.28),transparent_65%)] opacity-0 transition duration-300 group-hover:opacity-100 group-focus-visible:opacity-100" />
                 {t("news:actions.add")}
               </Button>
             </div>
@@ -214,17 +230,27 @@ const News = () => {
 
           <div
             data-fade
-            className="grid grid-cols-[repeat(auto-fit,minmax(310px,1fr))] gap-5 [--fade-delay:200ms] sm:gap-6"
+            className="grid grid-cols-[repeat(auto-fit,minmax(310px,1fr))] gap-5 [--fade-delay:220ms] sm:gap-6"
           >
             {isInitialLoading
               ? Array.from({ length: skeletonCount }).map((_, index) => (
-                  <div key={`news-skeleton-${index}`} className="flex h-full w-full">
+                  <div
+                    key={`news-skeleton-${index}`}
+                    className="flex h-full w-full"
+                    data-fade
+                    style={{ "--fade-delay": `${240 + index * 40}ms` } as CSSProperties}
+                  >
                     <NewsCardSkeleton />
                   </div>
                 ))
               : Array.isArray(visibleList) &&
-                visibleList.map((news) => (
-                  <div key={news.id} className="flex h-full w-full">
+                visibleList.map((news, index) => (
+                  <div
+                    key={news.id}
+                    className="flex h-full w-full"
+                    data-fade
+                    style={{ "--fade-delay": `${240 + index * 50}ms` } as CSSProperties}
+                  >
                     <NewsCard
                       {...news}
                       image_url={news.image_url ?? undefined}
@@ -237,7 +263,11 @@ const News = () => {
 
             {showEmptyState && (
               <div className="col-span-full mt-16 flex justify-start">
-                <div className="flex w-full max-w-[420px] flex-col items-center gap-5 rounded-ue-xl border border-white/12 bg-glass/60 px-6 py-10 text-center text-[color:var(--secondary-text)] shadow-surface">
+                <div
+                  data-fade
+                  className="relative flex w-full max-w-[420px] flex-col items-center gap-5 overflow-hidden rounded-ue-xl border border-white/12 bg-glass/60 px-6 py-10 text-center text-[color:var(--secondary-text)] shadow-surface"
+                >
+                  <span aria-hidden className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.18),transparent_65%)]" />
                   <span className="flex h-16 w-16 items-center justify-center rounded-full bg-[color:var(--glass-bg)]/70 text-[color:var(--nav-link)] shadow-surface">
                     <ArticleIcon className="text-[2.2rem]" />
                   </span>

--- a/root/frontend/src/pages/News.tsx
+++ b/root/frontend/src/pages/News.tsx
@@ -267,7 +267,10 @@ const News = () => {
                   data-fade
                   className="relative flex w-full max-w-[420px] flex-col items-center gap-5 overflow-hidden rounded-ue-xl border border-white/12 bg-glass/60 px-6 py-10 text-center text-[color:var(--secondary-text)] shadow-surface"
                 >
-                  <span aria-hidden className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.18),transparent_65%)]" />
+                  <span
+                    aria-hidden
+                    className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.18),transparent_65%)]"
+                  />
                   <span className="flex h-16 w-16 items-center justify-center rounded-full bg-[color:var(--glass-bg)]/70 text-[color:var(--nav-link)] shadow-surface">
                     <ArticleIcon className="text-[2.2rem]" />
                   </span>

--- a/root/frontend/src/pages/NewsDetail.tsx
+++ b/root/frontend/src/pages/NewsDetail.tsx
@@ -616,8 +616,14 @@ export default function NewsDetail() {
 
       {snack ? (
         <div className="fixed bottom-6 left-1/2 z-[999] w-[min(90vw,360px)] -translate-x-1/2 overflow-hidden rounded-ue-lg border border-white/12 bg-[color:color-mix(in_srgb,var(--card-bg)_94%,white_6%)]/95 px-4 py-3 text-center text-[0.95rem] font-semibold text-[color:var(--page-text)] shadow-surface-strong backdrop-blur-xl">
-          <span aria-hidden className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(148,163,255,0.16),transparent_65%)]" />
-          <span aria-hidden className="pointer-events-none absolute inset-x-6 top-0 h-px bg-gradient-to-r from-transparent via-white/45 to-transparent" />
+          <span
+            aria-hidden
+            className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(148,163,255,0.16),transparent_65%)]"
+          />
+          <span
+            aria-hidden
+            className="pointer-events-none absolute inset-x-6 top-0 h-px bg-gradient-to-r from-transparent via-white/45 to-transparent"
+          />
           <span className="relative block">{snack}</span>
         </div>
       ) : null}

--- a/root/frontend/src/pages/NewsDetail.tsx
+++ b/root/frontend/src/pages/NewsDetail.tsx
@@ -1,4 +1,12 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react"
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+  type CSSProperties,
+} from "react"
 import { useNavigate, useParams } from "react-router-dom"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import ArrowBackIcon from "@mui/icons-material/ArrowBack"
@@ -284,6 +292,19 @@ export default function NewsDetail() {
   const createdAt = query.data?.created_at
   const createdAtIso = useMemo(() => (createdAt ? dayjs(createdAt).toISOString() : ""), [createdAt])
   const createdAtLabel = useMemo(() => (createdAt ? getMoscowDate(createdAt) : ""), [createdAt])
+  const readingMinutes = useMemo(() => {
+    if (!content) return null
+    const words = content.split(/\s+/).filter((word) => word.trim().length > 0)
+    if (!words.length) return null
+    return Math.max(1, Math.round(words.length / 180))
+  }, [content])
+  const contentParagraphs = useMemo(() => {
+    if (!content) return []
+    return content
+      .split(/\n{2,}/)
+      .map((chunk) => chunk.trim())
+      .filter((chunk) => chunk.length > 0)
+  }, [content])
 
   if (query.isLoading)
     return (
@@ -305,91 +326,135 @@ export default function NewsDetail() {
 
   return (
     <Layout>
-      <div className="flex w-full flex-col gap-8 px-4 pb-16 pt-5 sm:px-6 lg:px-8">
-        <Button
-          variant="outline"
-          onClick={handleBack}
-          leadingIcon={<ArrowBackIcon className="text-[1.1rem]" />}
-          className="w-fit justify-start border-white/20 text-[clamp(0.95rem,2vw,1.1rem)]"
-        >
-          {t("common:buttons.back")}
-        </Button>
+      <div className="relative isolate">
+        <div aria-hidden className="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
+          <div className="absolute -left-[14%] top-[-12%] h-[520px] w-[520px] rounded-full bg-[radial-gradient(circle_at_center,rgba(59,130,246,0.24),transparent_68%)] blur-3xl opacity-75" />
+          <div className="absolute right-[-16%] top-[18%] h-[460px] w-[460px] rounded-full bg-[radial-gradient(circle_at_center,rgba(124,58,237,0.28),transparent_70%)] blur-3xl opacity-70" />
+          <div className="absolute bottom-[-22%] left-[10%] h-[380px] w-[380px] rounded-full bg-[radial-gradient(circle_at_center,rgba(14,165,233,0.2),transparent_70%)] blur-3xl opacity-60" />
+        </div>
 
-        <article className="flex w-full flex-col items-start gap-8">
-          <header className="flex w-full flex-col gap-4 text-left">
-            <h1 className="max-w-5xl text-[clamp(1.6rem,4vw,2.4rem)] font-extrabold tracking-tight text-[color:var(--page-text)]">
-              {displayTitle}
-            </h1>
+        <div className="flex w-full flex-col gap-8 px-4 pb-16 pt-5 sm:px-6 lg:px-8">
+          <Button
+            data-fade
+            variant="outline"
+            onClick={handleBack}
+            leadingIcon={<ArrowBackIcon className="text-[1.1rem]" />}
+            className="w-fit justify-start border-white/20 text-[clamp(0.95rem,2vw,1.1rem)] [--fade-delay:80ms]"
+          >
+            {t("common:buttons.back")}
+          </Button>
 
-            {createdAt ? (
-              <p className="text-sm font-medium uppercase tracking-[0.18em] text-[color:var(--secondary-text)]">
-                {t("news:meta.published")}
-                <span className="ml-2 font-semibold text-[color:var(--page-text)]">
-                  <time dateTime={createdAtIso}>{createdAtLabel}</time>
-                </span>
-              </p>
-            ) : null}
-
-            {user?.role === "admin" ? (
-              <div className="flex flex-wrap gap-2">
-                <button
-                  type="button"
-                  onClick={openEdit}
-                  className={iconButtonClass}
-                  aria-label={t("news:aria.editNews") ?? ""}
-                  disabled={saving || deleting}
-                >
-                  <EditIcon fontSize="small" />
-                </button>
-                <button
-                  type="button"
-                  onClick={() => setConfirmDeleteOpen(true)}
-                  className={cn(iconButtonClass, "text-[#e11d48]")}
-                  aria-label={t("news:aria.deleteNews") ?? ""}
-                  disabled={deleting || saving}
-                >
-                  <DeleteIcon fontSize="small" />
-                </button>
+          <article className="relative flex w-full flex-col items-start gap-8">
+            <header data-fade className="flex w-full flex-col gap-4 text-left [--fade-delay:140ms]">
+              <div className="max-w-5xl space-y-3">
+                <h1 className="text-balance text-[clamp(1.7rem,4.6vw,2.6rem)] font-extrabold tracking-tight text-[color:var(--page-text)]">
+                  {displayTitle}
+                </h1>
+                <p className="text-[0.95rem] font-medium uppercase tracking-[0.32em] text-[color:color-mix(in_srgb,var(--secondary-text)_80%,white_20%)]">
+                  {t("news:pageTagline", {
+                    defaultValue: "In-depth insights shaping our academic community",
+                  })}
+                </p>
               </div>
-            ) : null}
-          </header>
 
-          <figure className="w-full max-w-5xl self-start overflow-hidden rounded-ue-xl border border-white/12 bg-[color:var(--glass-bg)]/60 shadow-surface">
-            <div
-              className={cn(
-                "flex w-full items-center justify-center overflow-hidden",
-                heroFrame.container,
-                heroFrame.backdrop
-              )}
+              <div className="flex flex-wrap items-center gap-2">
+                {createdAt ? (
+                  <span className="inline-flex items-center gap-2 rounded-ue-pill border border-white/14 bg-[color:var(--glass-bg)]/70 px-3 py-1.5 text-[0.72rem] font-semibold uppercase tracking-[0.26em] text-[color:color-mix(in_srgb,var(--secondary-text)_85%,white_15%)]">
+                    {t("news:meta.published")}
+                    <time dateTime={createdAtIso} className="text-[color:var(--page-text)]">
+                      {createdAtLabel}
+                    </time>
+                  </span>
+                ) : null}
+
+                {readingMinutes ? (
+                  <span className="inline-flex items-center gap-2 rounded-ue-pill border border-white/14 bg-[color:var(--glass-bg)]/65 px-3 py-1.5 text-[0.72rem] font-semibold uppercase tracking-[0.26em] text-[color:color-mix(in_srgb,var(--secondary-text)_85%,white_15%)]">
+                    {t("news:meta.readingTime", {
+                      count: readingMinutes,
+                      defaultValue: `${readingMinutes} min read`,
+                    })}
+                  </span>
+                ) : null}
+              </div>
+
+              {user?.role === "admin" ? (
+                <div className="flex flex-wrap gap-2">
+                  <button
+                    type="button"
+                    onClick={openEdit}
+                    className={iconButtonClass}
+                    aria-label={t("news:aria.editNews") ?? ""}
+                    disabled={saving || deleting}
+                  >
+                    <EditIcon fontSize="small" />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setConfirmDeleteOpen(true)}
+                    className={cn(iconButtonClass, "text-[#e11d48]")}
+                    aria-label={t("news:aria.deleteNews") ?? ""}
+                    disabled={deleting || saving}
+                  >
+                    <DeleteIcon fontSize="small" />
+                  </button>
+                </div>
+              ) : null}
+            </header>
+
+            <figure
+              data-fade
+              className="group/hero relative w-full max-w-5xl self-start overflow-hidden rounded-ue-xl border border-white/12 bg-[color:var(--glass-bg)]/60 shadow-surface [--fade-delay:200ms]"
             >
-              <SmartImage
-                srcRaw={imageUrl}
-                alt={
-                  displayTitle
-                    ? t("news:alt.hero", { title: displayTitle })
-                    : t("news:alt.heroFallback")
-                }
-                onLoad={handleHeroLoad}
-                className={cn("h-full w-full", heroFrame.image)}
+              <span
+                aria-hidden
+                className="pointer-events-none absolute inset-0 z-[1] bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.28),transparent_75%)] opacity-0 transition duration-700 ease-out group-hover/hero:opacity-100"
               />
-            </div>
-            {displayTitle ? null : (
-              <figcaption className="border-t border-white/10 bg-[color:var(--glass-bg)]/70 px-5 py-3 text-sm font-medium text-[color:var(--secondary-text)]">
-                {t("news:alt.heroFallback")}
-              </figcaption>
-            )}
-          </figure>
+              <div
+                className={cn(
+                  "relative flex w-full items-center justify-center overflow-hidden",
+                  heroFrame.container,
+                  heroFrame.backdrop
+                )}
+              >
+                <SmartImage
+                  srcRaw={imageUrl}
+                  alt={
+                    displayTitle
+                      ? t("news:alt.hero", { title: displayTitle })
+                      : t("news:alt.heroFallback")
+                  }
+                  onLoad={handleHeroLoad}
+                  className={cn(
+                    "h-full w-full transition duration-700 ease-out motion-safe:group-hover/hero:scale-[1.03]",
+                    heroFrame.image
+                  )}
+                />
+              </div>
+              {displayTitle ? null : (
+                <figcaption className="relative border-t border-white/10 bg-[color:var(--glass-bg)]/70 px-5 py-3 text-sm font-medium text-[color:var(--secondary-text)]">
+                  {t("news:alt.heroFallback")}
+                </figcaption>
+              )}
+            </figure>
 
-          <section className="max-w-4xl self-start space-y-6 text-[1.05rem] leading-8 text-[color:var(--secondary-text)]">
-            {content?.split(/\n{2,}/).map((chunk, index) => {
-              const text = chunk.trim()
-
-              if (!text) return null
-
-              return <p key={`news-detail-paragraph-${index}`}>{text}</p>
-            })}
-          </section>
-        </article>
+            <section className="max-w-4xl self-start space-y-5 text-[1.05rem]">
+              {contentParagraphs.map((text, index) => (
+                <p
+                  key={`news-detail-paragraph-${index}`}
+                  data-fade
+                  style={{ "--fade-delay": `${260 + index * 50}ms` } as CSSProperties}
+                  className="group/paragraph relative overflow-hidden rounded-ue-xl border border-transparent bg-transparent px-5 py-4 text-[color:var(--secondary-text)] leading-[1.85] transition duration-300 ease-out hover:border-white/12 hover:bg-[color:color-mix(in_srgb,var(--card-bg)_86%,white_14%)] sm:px-6"
+                >
+                  <span className="relative z-[1] block">{text}</span>
+                  <span
+                    aria-hidden
+                    className="pointer-events-none absolute inset-0 rounded-ue-xl bg-[radial-gradient(circle_at_top,rgba(148,163,255,0.18),transparent_65%)] opacity-0 transition duration-500 ease-out group-hover/paragraph:opacity-100"
+                  />
+                </p>
+              ))}
+            </section>
+          </article>
+        </div>
       </div>
 
       <Dialog
@@ -550,8 +615,10 @@ export default function NewsDetail() {
       </Dialog>
 
       {snack ? (
-        <div className="fixed bottom-6 left-1/2 z-[999] w-[min(90vw,360px)] -translate-x-1/2 rounded-ue-lg border border-white/12 bg-[color:color-mix(in_srgb,var(--card-bg)_94%,white_6%)]/95 px-4 py-3 text-center text-[0.95rem] font-semibold text-[color:var(--page-text)] shadow-surface-strong backdrop-blur-xl">
-          {snack}
+        <div className="fixed bottom-6 left-1/2 z-[999] w-[min(90vw,360px)] -translate-x-1/2 overflow-hidden rounded-ue-lg border border-white/12 bg-[color:color-mix(in_srgb,var(--card-bg)_94%,white_6%)]/95 px-4 py-3 text-center text-[0.95rem] font-semibold text-[color:var(--page-text)] shadow-surface-strong backdrop-blur-xl">
+          <span aria-hidden className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(148,163,255,0.16),transparent_65%)]" />
+          <span aria-hidden className="pointer-events-none absolute inset-x-6 top-0 h-px bg-gradient-to-r from-transparent via-white/45 to-transparent" />
+          <span className="relative block">{snack}</span>
         </div>
       ) : null}
     </Layout>


### PR DESCRIPTION
## Summary
- refresh the News landing page with ambient gradients, animated entry timing, and elevated admin affordances
- upgrade NewsCard with glassmorphism-inspired hover states, dynamic imagery treatments, and richer typography transitions
- modernize the NewsDetail view with immersive hero framing, contextual meta badges, animated reading sections, and polished notifications

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_6907e0a08a64832793a75080504a18d9