### PR TITLE
Add E2E coverage for News share button

### DIFF
--- a/root/frontend/tests/e2e/news-share.spec.ts
+++ b/root/frontend/tests/e2e/news-share.spec.ts
@@ -1,0 +1,73 @@
+import { devices, expect, test } from "@playwright/test"
+import { useMockApi } from "./utils/mockApi"
+
+test.describe("News detail sharing (desktop)", () => {
+  test("falls back to copying link when the Web Share API is unavailable", async ({ page }) => {
+    await page.addInitScript(() => {
+      Object.defineProperty(navigator, "share", {
+        value: undefined,
+        configurable: true,
+      })
+
+      Object.defineProperty(navigator, "clipboard", {
+        value: {
+          writeText: (text: string) => {
+            ;(window as typeof window & { __copiedLink?: string }).__copiedLink = text
+            return Promise.resolve()
+          },
+        },
+        configurable: true,
+      })
+    })
+
+    const mock = await useMockApi(page)
+    await mock.login(page)
+
+    await page.goto("/news/1")
+    await expect(page.getByRole("heading", { name: /(Новость дня|News of the day)/i })).toBeVisible()
+
+    const shareButton = page.getByRole("button", { name: /(Поделиться|Share)/i })
+    await expect(shareButton).toBeVisible()
+    await shareButton.click()
+
+    await expect(page.getByText(/Ссылка скопирована|Link copied/i)).toBeVisible()
+    const copiedLink = await page.evaluate(() => (window as typeof window & { __copiedLink?: string }).__copiedLink)
+    expect(copiedLink).toContain("/news/1")
+  })
+})
+
+const { defaultBrowserType: _ignore, ...iPhone13Pro } = devices["iPhone 13 Pro"]
+
+test.describe("News detail sharing (mobile)", () => {
+  test.use(iPhone13Pro)
+
+  test("uses the Web Share API when available", async ({ page }) => {
+    await page.addInitScript(() => {
+      Object.defineProperty(navigator, "share", {
+        value: (data: ShareData) => {
+          const globalWindow = window as typeof window & { __sharedPayloads?: ShareData[] }
+          globalWindow.__sharedPayloads = [...(globalWindow.__sharedPayloads ?? []), data]
+          return Promise.resolve()
+        },
+        configurable: true,
+      })
+    })
+
+    const mock = await useMockApi(page)
+    await mock.login(page)
+
+    await page.goto("/news/1")
+    await expect(page.getByRole("heading", { name: /(Новость дня|News of the day)/i })).toBeVisible()
+
+    const shareButton = page.getByRole("button", { name: /(Поделиться|Share)/i })
+    await expect(shareButton).toBeVisible()
+    await shareButton.click()
+
+    await expect(page.getByText(/Окно отправки открыто|Share sheet opened/i)).toBeVisible()
+    const sharedPayload = await page.evaluate(
+      () => (window as typeof window & { __sharedPayloads?: ShareData[] }).__sharedPayloads?.at(0)
+    )
+    expect(sharedPayload?.url).toContain("/news/1")
+    expect(sharedPayload?.title).toBeTruthy()
+  })
+})

--- a/root/frontend/tests/e2e/news-share.spec.ts
+++ b/root/frontend/tests/e2e/news-share.spec.ts
@@ -24,14 +24,18 @@ test.describe("News detail sharing (desktop)", () => {
     await mock.login(page)
 
     await page.goto("/news/1")
-    await expect(page.getByRole("heading", { name: /(Новость дня|News of the day)/i })).toBeVisible()
+    await expect(
+      page.getByRole("heading", { name: /(Новость дня|News of the day)/i })
+    ).toBeVisible()
 
     const shareButton = page.getByRole("button", { name: /(Поделиться|Share)/i })
     await expect(shareButton).toBeVisible()
     await shareButton.click()
 
     await expect(page.getByText(/Ссылка скопирована|Link copied/i)).toBeVisible()
-    const copiedLink = await page.evaluate(() => (window as typeof window & { __copiedLink?: string }).__copiedLink)
+    const copiedLink = await page.evaluate(
+      () => (window as typeof window & { __copiedLink?: string }).__copiedLink
+    )
     expect(copiedLink).toContain("/news/1")
   })
 })
@@ -57,15 +61,17 @@ test.describe("News detail sharing (mobile)", () => {
     await mock.login(page)
 
     await page.goto("/news/1")
-    await expect(page.getByRole("heading", { name: /(Новость дня|News of the day)/i })).toBeVisible()
+    await expect(
+      page.getByRole("heading", { name: /(Новость дня|News of the day)/i })
+    ).toBeVisible()
 
     const shareButton = page.getByRole("button", { name: /(Поделиться|Share)/i })
     await expect(shareButton).toBeVisible()
     await shareButton.click()
 
     await expect(page.getByText(/Окно отправки открыто|Share sheet opened/i)).toBeVisible()
-    const sharedPayload = await page.evaluate(
-      () => (window as typeof window & { __sharedPayloads?: ShareData[] }).__sharedPayloads?.at(0)
+    const sharedPayload = await page.evaluate(() =>
+      (window as typeof window & { __sharedPayloads?: ShareData[] }).__sharedPayloads?.at(0)
     )
     expect(sharedPayload?.url).toContain("/news/1")
     expect(sharedPayload?.title).toBeTruthy()


### PR DESCRIPTION
## Summary
- add a Playwright spec that exercises the News detail share button on desktop and mobile
- verify both the clipboard fallback and Web Share API flows via mocked browser capabilities

## Testing
- npm run test:e2e -- --grep "News detail sharing"

------
https://chatgpt.com/codex/tasks/task_e_6908a230677c832798950866c164f38c