### PR TITLE
Center dialog overlay vertically

### DIFF
--- a/root/frontend/src/components/Dialog.tsx
+++ b/root/frontend/src/components/Dialog.tsx
@@ -98,7 +98,7 @@ export function Dialog({
 
   return createPortal(
     <div
-      className="fixed inset-0 z-[var(--ue-z-index-overlay)] flex items-start justify-center overflow-y-auto px-4 py-6 sm:px-6"
+      className="fixed inset-0 z-[var(--ue-z-index-overlay)] flex items-center justify-center overflow-y-auto px-4 py-8 sm:px-6 sm:py-12"
       role="presentation"
     >
       <div


### PR DESCRIPTION
## Summary
- adjust the dialog overlay container to center dialogs vertically with responsive padding

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6908b9745c9c832794cd672d8fa7e146