### PR TITLE
Adapt time period block for light theme

### DIFF
--- a/root/frontend/src/pages/Activity.tsx
+++ b/root/frontend/src/pages/Activity.tsx
@@ -651,7 +651,7 @@ export default function Activity() {
                       "rounded-full border-0 px-4 py-1.5 text-sm font-bold transition-all duration-150",
                       period === option.value
                         ? "bg-[color:var(--nav-link)] text-white shadow-[0_4px_12px_color-mix(in_srgb,var(--nav-link)_35%,transparent)] dark:shadow-[0_8px_24px_color-mix(in_srgb,var(--nav-link)_45%,transparent)]"
-                        : "bg-transparent !text-black hover:bg-[color:color-mix(in_srgb,var(--nav-link)_12%,transparent)] hover:text-[color:var(--nav-link)] dark:!text-white dark:bg-[color:color-mix(in_srgb,white_8%,transparent)] dark:hover:bg-[color:color-mix(in_srgb,white_12%,transparent)]"
+                        : "bg-transparent text-black hover:bg-[color:color-mix(in_srgb,var(--nav-link)_8%,transparent)] hover:text-[color:var(--nav-link)] dark:text-white dark:hover:bg-[color:color-mix(in_srgb,white_12%,transparent)]"
                     )}
                   >
                     {option.label}

--- a/root/frontend/src/pages/Activity.tsx
+++ b/root/frontend/src/pages/Activity.tsx
@@ -651,7 +651,7 @@ export default function Activity() {
                       "rounded-full border-0 px-4 py-1.5 text-sm font-bold transition-all duration-150",
                       period === option.value
                         ? "bg-[color:var(--nav-link)] text-white shadow-[0_4px_12px_color-mix(in_srgb,var(--nav-link)_35%,transparent)] dark:shadow-[0_8px_24px_color-mix(in_srgb,var(--nav-link)_45%,transparent)]"
-                        : "bg-transparent text-black hover:bg-[color:color-mix(in_srgb,var(--nav-link)_8%,transparent)] hover:text-[color:var(--nav-link)] dark:text-white dark:hover:bg-[color:color-mix(in_srgb,white_12%,transparent)]"
+                        : "bg-transparent text-[color:var(--page-text)] hover:bg-[color:color-mix(in_srgb,var(--nav-link)_8%,transparent)] hover:text-[color:var(--nav-link)]"
                     )}
                   >
                     {option.label}


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-2396f572-f0fe-4b05-8758-90a539b29c24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2396f572-f0fe-4b05-8758-90a539b29c24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

