### PR TITLE
Adjust profile panel width and avatar glow

### DIFF
--- a/root/frontend/src/pages/Profile.tsx
+++ b/root/frontend/src/pages/Profile.tsx
@@ -613,7 +613,7 @@ export default function Profile() {
             data-testid="profile-root"
             aria-label={t("profile:aria.page")}
           >
-            <div className="max-w-7xl mx-auto w-full relative z-0">
+            <div className="max-w-[95%] mx-auto w-full relative z-0">
               <motion.div
                 ref={containerRef}
                 className="glass profile-card px-6 sm:px-10 md:px-14 lg:px-16 py-10 sm:py-12 md:py-14 rounded-2xl md:rounded-3xl relative overflow-hidden backdrop-blur-md border border-glass-border bg-glass shadow-glass"
@@ -648,7 +648,7 @@ export default function Profile() {
 
                       {/* Avatar Container */}
                       <div
-                        className={`absolute left-1/2 top-12 sm:top-14 -translate-x-1/2 flex items-center justify-center p-1 ${reduceMotion ? "" : "animate-[aura-pulse_14s_ease-in-out_infinite]"}`}
+                        className="absolute left-1/2 top-12 sm:top-14 -translate-x-1/2 flex items-center justify-center p-1"
                         style={{ width: avatarSize, height: avatarSize }}
                       >
                         <div className="avatar-ring w-full h-full">


### PR DESCRIPTION
Stretch the profile panel wider and remove the pulsating avatar glow.

---
<a href="https://cursor.com/background-agent?bcId=bc-b2610944-644d-4792-97c4-11b2dea3d708"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b2610944-644d-4792-97c4-11b2dea3d708"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

