### PR TITLE
Fix username overlap on desktop profile

### DIFF
--- a/root/frontend/src/pages/Profile.tsx
+++ b/root/frontend/src/pages/Profile.tsx
@@ -453,7 +453,12 @@ export default function Profile() {
   const avatarSize = `${avatarPx}px`
   const avatarFloat = Math.round(avatarPx * 0.55)
   const heroPaddingBottom = `${Math.max(avatarFloat - 12, 28)}px`
-  const heroTextPaddingTop = `${Math.round(avatarPx * 0.65)}px`
+  // На десктопе увеличиваем отступ, чтобы имя не налегало на аватар
+  // Аватар находится на top-14 (56px) и имеет размер avatarPx, поэтому нужно
+  // добавить достаточно отступа, чтобы имя начиналось ниже аватара
+  const heroTextPaddingTop = isMobile 
+    ? `${Math.round(avatarPx * 0.65)}px`
+    : `${Math.round(56 + avatarPx + 16)}px` // top-14 (56px) + размер аватара + небольшой отступ
   const isOnline = ((user as any)?.is_online ?? (user as any)?.online ?? true) as boolean
   const statusSize = useMemo(() => Math.max(12, Math.round(avatarPx * 0.16)), [avatarPx])
   const statusOffset = useMemo(() => Math.max(6, Math.round(avatarPx * 0.08)), [avatarPx])

--- a/root/frontend/src/pages/Profile.tsx
+++ b/root/frontend/src/pages/Profile.tsx
@@ -453,7 +453,7 @@ export default function Profile() {
   const avatarSize = `${avatarPx}px`
   const avatarFloat = Math.round(avatarPx * 0.55)
   const heroPaddingBottom = `${Math.max(avatarFloat - 12, 28)}px`
-  const heroTextPaddingTop = isMobile 
+  const heroTextPaddingTop = isMobile
     ? `${Math.round(48 + avatarPx + 16)}px`
     : `${Math.round(56 + avatarPx + 16)}px`
   const isOnline = ((user as any)?.is_online ?? (user as any)?.online ?? true) as boolean

--- a/root/frontend/src/pages/Profile.tsx
+++ b/root/frontend/src/pages/Profile.tsx
@@ -453,12 +453,9 @@ export default function Profile() {
   const avatarSize = `${avatarPx}px`
   const avatarFloat = Math.round(avatarPx * 0.55)
   const heroPaddingBottom = `${Math.max(avatarFloat - 12, 28)}px`
-  // На десктопе увеличиваем отступ, чтобы имя не налегало на аватар
-  // Аватар находится на top-14 (56px) и имеет размер avatarPx, поэтому нужно
-  // добавить достаточно отступа, чтобы имя начиналось ниже аватара
   const heroTextPaddingTop = isMobile 
-    ? `${Math.round(avatarPx * 0.65)}px`
-    : `${Math.round(56 + avatarPx + 16)}px` // top-14 (56px) + размер аватара + небольшой отступ
+    ? `${Math.round(48 + avatarPx + 16)}px`
+    : `${Math.round(56 + avatarPx + 16)}px`
   const isOnline = ((user as any)?.is_online ?? (user as any)?.online ?? true) as boolean
   const statusSize = useMemo(() => Math.max(12, Math.round(avatarPx * 0.16)), [avatarPx])
   const statusOffset = useMemo(() => Math.max(6, Math.round(avatarPx * 0.08)), [avatarPx])


### PR DESCRIPTION
Adjust `heroTextPaddingTop` calculation to prevent username overlap with the avatar on desktop profile view.

---
<a href="https://cursor.com/background-agent?bcId=bc-cbc85ffa-640d-4ab3-ac25-6ad89e4520dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cbc85ffa-640d-4ab3-ac25-6ad89e4520dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

