### PR TITLE
Fix spotify progress bar length

### DIFF
--- a/root/frontend/src/pages/Profile.tsx
+++ b/root/frontend/src/pages/Profile.tsx
@@ -157,9 +157,13 @@ export const NowPlayingCard = memo(function NowPlayingCard({ data }: { data: Now
       const rest = String(seconds % 60).padStart(2, "0")
       return `${minutes}:${rest}`
     }
-    const maxProgress = fmtTime(duration)
-    const maxDuration = fmtTime(duration)
-    return `${Math.max(maxProgress.length, maxDuration.length) * 0.6 + 2}ch`
+    // Calculate maximum possible time format: "X:XX / Y:YY"
+    // Both progress and duration can be up to duration length
+    const maxTimeStr = fmtTime(duration)
+    // Format is "X:XX / Y:YY" (with spaces and slash)
+    const fullFormat = `${maxTimeStr} / ${maxTimeStr}`
+    // Use ch units for consistent width with tabular-nums font
+    return `${fullFormat.length * 0.6}ch`
   }, [duration])
 
   useEffect(() => {
@@ -266,7 +270,7 @@ export const NowPlayingCard = memo(function NowPlayingCard({ data }: { data: Now
             </div>
             <span
               className="np-time text-xs text-[#b3b3b3] whitespace-nowrap tabular-nums flex-shrink-0"
-              style={{ minWidth: maxTimeWidth }}
+              style={{ width: maxTimeWidth }}
             >
               {fmt(progress)} / {fmt(duration)}
             </span>

--- a/root/frontend/src/pages/Profile.tsx
+++ b/root/frontend/src/pages/Profile.tsx
@@ -157,12 +157,8 @@ export const NowPlayingCard = memo(function NowPlayingCard({ data }: { data: Now
       const rest = String(seconds % 60).padStart(2, "0")
       return `${minutes}:${rest}`
     }
-    // Calculate maximum possible time format: "X:XX / Y:YY"
-    // Both progress and duration can be up to duration length
     const maxTimeStr = fmtTime(duration)
-    // Format is "X:XX / Y:YY" (with spaces and slash)
     const fullFormat = `${maxTimeStr} / ${maxTimeStr}`
-    // Use ch units for consistent width with tabular-nums font
     return `${fullFormat.length * 0.6}ch`
   }, [duration])
 

--- a/root/frontend/src/pages/__tests__/__snapshots__/Profile.nowPlaying.test.tsx.snap
+++ b/root/frontend/src/pages/__tests__/__snapshots__/Profile.nowPlaying.test.tsx.snap
@@ -63,7 +63,7 @@ exports[`NowPlayingCard > matches snapshot when paused 1`] = `
         </div>
         <span
           class="np-time text-xs text-[#b3b3b3] whitespace-nowrap tabular-nums flex-shrink-0"
-          style="min-width: 4.4ch;"
+          style="width: 6.6ch;"
         >
           0:30
            / 
@@ -132,7 +132,7 @@ exports[`NowPlayingCard > matches snapshot when playing 1`] = `
         </div>
         <span
           class="np-time text-xs text-[#b3b3b3] whitespace-nowrap tabular-nums flex-shrink-0"
-          style="min-width: 4.4ch;"
+          style="width: 6.6ch;"
         >
           0:30
            / 


### PR DESCRIPTION
Fixes the "jumping" Spotify progress bar by setting a fixed width for the timer.

---
<a href="https://cursor.com/background-agent?bcId=bc-edce596a-23ba-4616-9504-8628d298134c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-edce596a-23ba-4616-9504-8628d298134c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

