### PR TITLE
Fix mobile gap between contacts and details

### DIFF
--- a/root/frontend/src/pages/Profile.tsx
+++ b/root/frontend/src/pages/Profile.tsx
@@ -939,10 +939,7 @@ export default function Profile() {
                   </div>
 
                   {/* Right Column - Profile Details / Edit Form */}
-                  <div
-                    className="w-full relative"
-                    style={{ marginTop: isMobile ? "0" : "0" }}
-                  >
+                  <div className="w-full relative" style={{ marginTop: isMobile ? "0" : "0" }}>
                     {edit ? (
                       <div className="profile-card profile-edit w-full rounded-xl sm:rounded-2xl p-4 sm:p-6 md:p-8 lg:p-10 border border-glass-border bg-surface dark:bg-card-bg shadow-surface dark:shadow-surface-strong">
                         <div className="flex flex-col gap-4 sm:gap-5">

--- a/root/frontend/src/pages/Profile.tsx
+++ b/root/frontend/src/pages/Profile.tsx
@@ -941,7 +941,7 @@ export default function Profile() {
                   {/* Right Column - Profile Details / Edit Form */}
                   <div
                     className="w-full relative"
-                    style={{ marginTop: isMobile ? `${Math.round(avatarPx * 0.55) + 36}px` : "0" }}
+                    style={{ marginTop: isMobile ? "0" : "0" }}
                   >
                     {edit ? (
                       <div className="profile-card profile-edit w-full rounded-xl sm:rounded-2xl p-4 sm:p-6 md:p-8 lg:p-10 border border-glass-border bg-surface dark:bg-card-bg shadow-surface dark:shadow-surface-strong">


### PR DESCRIPTION
Remove unnecessary `marginTop` from the right column on the mobile profile page to eliminate the gap between contact and details blocks.

---
<a href="https://cursor.com/background-agent?bcId=bc-ad7fdfe9-13c9-4911-af4d-919208155715"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ad7fdfe9-13c9-4911-af4d-919208155715"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

