### PR TITLE
Consolidate notifications worker failure logging

### DIFF
--- a/root/app/workers/notifications.py
+++ b/root/app/workers/notifications.py
@@ -58,19 +58,20 @@ class NotificationsScheduler:
                     raise
                 except Exception:
                     consecutive_failures += 1
-                    sleep_for = min(
+                    backoff_seconds = min(
                         self.poll_seconds * (2 ** min(consecutive_failures, 5)),
                         self.max_backoff_seconds,
                     )
+                    sleep_for = backoff_seconds
                     if self.metrics is not None:
                         self.metrics.record_failure()
-                    logger.exception(
-                        "Failed to generate schedule reminders (attempt %s)",
-                        consecutive_failures,
-                    )
-                    logging.getLogger().error(
-                        "Failed to generate schedule reminders (attempt %s)",
-                        consecutive_failures,
+                    logger.error(
+                        "Failed to generate schedule reminders",
+                        exc_info=True,
+                        extra={
+                            "attempt": consecutive_failures,
+                            "backoff_seconds": backoff_seconds,
+                        },
                     )
                 else:
                     consecutive_failures = 0

--- a/root/tests/test_notifications_service.py
+++ b/root/tests/test_notifications_service.py
@@ -419,6 +419,8 @@ async def test_generate_schedule_reminders_skips_inactive_users(
 
 @pytest.mark.anyio
 async def test_scheduler_loop_logs_failures(monkeypatch: pytest.MonkeyPatch, caplog):
+    from app.workers import notifications as worker_module
+
     class _DummySession:
         async def __aenter__(self):
             return object()
@@ -432,22 +434,45 @@ async def test_scheduler_loop_logs_failures(monkeypatch: pytest.MonkeyPatch, cap
     async def _cancel_sleep(_seconds: float):
         raise asyncio.CancelledError()
 
-    monkeypatch.setattr(notifications_module, "async_session", lambda: _DummySession())
-    monkeypatch.setattr(
-        notifications_module,
-        "generate_schedule_reminders",
-        _failing_generate,
+    class _DummyMetrics:
+        def __init__(self) -> None:
+            self.failures = 0
+
+        def record_failure(self) -> None:
+            self.failures += 1
+
+        def record_success(self, _created: int) -> None:
+            raise AssertionError("success should not be recorded")
+
+    metrics = _DummyMetrics()
+
+    monkeypatch.setattr(worker_module, "async_session", lambda: _DummySession())
+    monkeypatch.setattr(worker_module, "generate_schedule_reminders", _failing_generate)
+    monkeypatch.setattr(worker_module.asyncio, "sleep", _cancel_sleep)
+
+    scheduler = worker_module.NotificationsScheduler(
+        poll_seconds=3,
+        window_minutes=1,
+        max_backoff_seconds=30,
+        metrics=metrics,
     )
-    monkeypatch.setattr(notifications_module.asyncio, "sleep", _cancel_sleep)
 
-    caplog.set_level(logging.ERROR, logger=notifications_module.logger.name)
+    caplog.set_level(logging.ERROR, logger=worker_module.logger.name)
 
-    await notifications_module._scheduler_loop(poll_seconds=1, window_minutes=1)
+    with pytest.raises(asyncio.CancelledError):
+        await scheduler.run_forever()
 
-    assert any(
-        "Failed to generate schedule reminders" in record.getMessage()
+    failure_logs = [
+        record
         for record in caplog.records
-    )
+        if "Failed to generate schedule reminders" in record.getMessage()
+    ]
+
+    assert len(failure_logs) == 1
+    record = failure_logs[0]
+    assert getattr(record, "attempt", None) == 1
+    assert getattr(record, "backoff_seconds", None) == 6
+    assert metrics.failures == 1
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- consolidate notifications scheduler failure logging into a single structured entry that includes attempt and backoff context
- ensure worker failure metrics are still emitted and covered by tests
- update the notifications scheduler failure test to assert only one log entry is produced

## Testing
- pytest root/tests/test_notifications_service.py::test_scheduler_loop_logs_failures

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ed0d465b883278dcd36ef92ce1347)