### PR TITLE
Enhance health checks for dependent services

### DIFF
--- a/root/app/main.py
+++ b/root/app/main.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 from contextlib import asynccontextmanager
+import uuid
 
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, Request, status
+from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
-from sqlalchemy import text
+from sqlalchemy import func, select, text
+from sqlalchemy.exc import OperationalError
 
 from app.api.events import router as events_router
 from app.api.news import router as news_router
@@ -18,13 +21,13 @@ from app.api.stories import router as stories_router
 from app.api.users import router as users_router
 from app.auth.auth import router as auth_router
 from app.core.config import settings
-from app.core.database import Base, engine, wait_db
+from app.core.database import Base, async_session, engine, wait_db
 from app.core.metrics import configure_metrics
 from app.core.observability import configure_observability, shutdown_observability
 from app.core.rate_limit import RateLimitMiddleware, parse_rate_limit
 from app.core.schema_upgrade import ensure_webauthn_attestation_columns
 from app.core.security_headers import SecurityHeadersMiddleware
-from app.deps.cache import shutdown_cache
+from app.deps.cache import get_cache, shutdown_cache
 from app.routers.notifications import legacy_router as legacy_push_router
 from app.routers.notifications import router as push_router
 from app.routers.schedule import router as schedule_router
@@ -61,6 +64,9 @@ from app.services.story_cleanup import (
     cleanup_expired_stories,
     start_story_cleanup_scheduler,
 )
+from app.services.file_scanner import scan_for_malware
+from app.models.models import NotificationQueueJob
+from app.utils.files import _get_storage_backend
 
 try:
     from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
@@ -266,9 +272,89 @@ async def root():
 
 @app.get("/healthz")
 async def healthz():
-    async with engine.connect() as conn:
-        await conn.execute(text("SELECT 1"))
-    return {"status": "ok"}
+    statuses: dict[str, str] = {}
+
+    db_status = "ok"
+    try:
+        async with engine.connect() as conn:
+            await conn.execute(text("SELECT 1"))
+    except Exception:
+        db_status = "error"
+    statuses["db"] = db_status
+
+    cache_status = "disabled"
+    try:
+        cache_backend = get_cache()
+        if getattr(cache_backend, "enabled", False):
+            probe_key = f"healthz:{uuid.uuid4().hex}"
+            try:
+                await cache_backend.set(probe_key, {"status": "ok"}, ttl=5)
+                cache_status = "ok"
+            except Exception:
+                cache_status = "error"
+            finally:
+                try:
+                    await cache_backend.invalidate(probe_key)
+                except Exception:
+                    cache_status = "error"
+        else:
+            cache_status = "disabled"
+    except Exception:
+        cache_status = "error"
+    statuses["cache"] = cache_status
+
+    storage_status = "ok"
+    try:
+        backend = _get_storage_backend()
+        probe_name = f"healthz/{uuid.uuid4().hex}.txt"
+        try:
+            probe_url = await backend.save_file(
+                probe_name, b"", content_type="text/plain"
+            )
+        except Exception:
+            storage_status = "error"
+        else:
+            try:
+                await backend.delete_file(probe_url)
+            except Exception:
+                storage_status = "error"
+    except Exception:
+        storage_status = "error"
+    statuses["storage"] = storage_status
+
+    queue_status = "ok"
+    if getattr(settings, "notifications_queue_in_memory_only", False):
+        queue_status = "ok"
+    else:
+        try:
+            async with async_session() as session:
+                await session.execute(
+                    select(func.count()).select_from(NotificationQueueJob)
+                )
+        except OperationalError as exc:
+            message = str(exc).lower()
+            if "no such table" not in message:
+                queue_status = "error"
+        except Exception:
+            queue_status = "error"
+    statuses["notification_queue"] = queue_status
+
+    if getattr(settings, "event_file_scanner_enabled", False):
+        scanner_status = "ok"
+        try:
+            await scan_for_malware(b"healthz-probe")
+        except Exception:
+            scanner_status = "error"
+        statuses["file_scanner"] = scanner_status
+    else:
+        statuses["file_scanner"] = "disabled"
+
+    overall_ok = all(value != "error" for value in statuses.values())
+    http_status = (
+        status.HTTP_200_OK if overall_ok else status.HTTP_503_SERVICE_UNAVAILABLE
+    )
+    payload = {"status": "ok" if overall_ok else "error", **statuses}
+    return JSONResponse(status_code=http_status, content=payload)
 
 
 @app.get("/ready")

--- a/root/app/main.py
+++ b/root/app/main.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from contextlib import asynccontextmanager
 import uuid
+from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, Request, status
-from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 from sqlalchemy import func, select, text
 from sqlalchemy.exc import OperationalError
@@ -28,6 +28,7 @@ from app.core.rate_limit import RateLimitMiddleware, parse_rate_limit
 from app.core.schema_upgrade import ensure_webauthn_attestation_columns
 from app.core.security_headers import SecurityHeadersMiddleware
 from app.deps.cache import get_cache, shutdown_cache
+from app.models.models import NotificationQueueJob
 from app.routers.notifications import legacy_router as legacy_push_router
 from app.routers.notifications import router as push_router
 from app.routers.schedule import router as schedule_router
@@ -37,6 +38,7 @@ from app.services.email_change_cleanup import (
     cleanup_stale_email_change_tokens,
     start_email_change_cleanup_scheduler,
 )
+from app.services.file_scanner import scan_for_malware
 from app.services.notification_queue import (
     DeadLetterCleanupConfig,
     start_dead_letter_cleanup_scheduler,
@@ -64,8 +66,6 @@ from app.services.story_cleanup import (
     cleanup_expired_stories,
     start_story_cleanup_scheduler,
 )
-from app.services.file_scanner import scan_for_malware
-from app.models.models import NotificationQueueJob
 from app.utils.files import _get_storage_backend
 
 try:

--- a/root/tests/test_health_endpoint.py
+++ b/root/tests/test_health_endpoint.py
@@ -1,0 +1,149 @@
+import pytest
+from fastapi import status
+
+from app import main
+
+
+class _SuccessfulCache:
+    enabled = True
+
+    def __init__(self) -> None:
+        self._last_key: str | None = None
+
+    async def set(self, key: str, payload, ttl=None):
+        self._last_key = key
+
+    async def invalidate(self, key: str) -> None:
+        assert key == self._last_key
+
+
+class _FailingCache:
+    enabled = True
+
+    async def set(self, key: str, payload, ttl=None):
+        raise RuntimeError("cache set failed")
+
+    async def invalidate(self, key: str) -> None:
+        return None
+
+
+class _FailingSession:
+    async def __aenter__(self):
+        raise RuntimeError("queue unavailable")
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+@pytest.mark.anyio("asyncio")
+async def test_healthcheck_reports_dependency_statuses(async_client):
+    response = await async_client.get("/healthz")
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["status"] == "ok"
+    assert data["db"] == "ok"
+    assert data["storage"] == "ok"
+    assert data["notification_queue"] == "ok"
+    assert "cache" in data
+    assert "file_scanner" in data
+
+
+@pytest.mark.anyio("asyncio")
+async def test_healthcheck_database_failure_returns_503(async_client, monkeypatch):
+    class _FailingConnection:
+        async def __aenter__(self):
+            raise RuntimeError("db offline")
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class _FailingEngine:
+        def connect(self):
+            return _FailingConnection()
+
+    monkeypatch.setattr(main, "engine", _FailingEngine())
+
+    response = await async_client.get("/healthz")
+    data = response.json()
+    assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+    assert data["status"] == "error"
+    assert data["db"] == "error"
+
+
+@pytest.mark.anyio("asyncio")
+async def test_healthcheck_cache_success(async_client, monkeypatch):
+    cache = _SuccessfulCache()
+    monkeypatch.setattr(main, "get_cache", lambda: cache)
+
+    response = await async_client.get("/healthz")
+    data = response.json()
+    assert response.status_code == status.HTTP_200_OK
+    assert data["cache"] == "ok"
+
+
+@pytest.mark.anyio("asyncio")
+async def test_healthcheck_cache_failure(async_client, monkeypatch):
+    monkeypatch.setattr(main, "get_cache", lambda: _FailingCache())
+
+    response = await async_client.get("/healthz")
+    data = response.json()
+    assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+    assert data["cache"] == "error"
+
+
+@pytest.mark.anyio("asyncio")
+async def test_healthcheck_storage_failure(async_client, monkeypatch):
+    class _FailingStorage:
+        async def save_file(self, relative_path: str, data: bytes, *, content_type=None):
+            raise RuntimeError("storage down")
+
+        async def delete_file(self, file_url: str) -> None:
+            return None
+
+    monkeypatch.setattr(main, "_get_storage_backend", lambda: _FailingStorage())
+
+    response = await async_client.get("/healthz")
+    data = response.json()
+    assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+    assert data["storage"] == "error"
+
+
+@pytest.mark.anyio("asyncio")
+async def test_healthcheck_notification_queue_failure(async_client, monkeypatch):
+    monkeypatch.setattr(main, "async_session", lambda: _FailingSession())
+
+    response = await async_client.get("/healthz")
+    data = response.json()
+    assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+    assert data["notification_queue"] == "error"
+
+
+@pytest.mark.anyio("asyncio")
+async def test_healthcheck_file_scanner_success(async_client, monkeypatch):
+    monkeypatch.setattr(main.settings, "event_file_scanner_enabled", True)
+
+    async def _fake_scan(data: bytes, *, locale=None) -> None:
+        return None
+
+    monkeypatch.setattr(main, "scan_for_malware", _fake_scan)
+
+    response = await async_client.get("/healthz")
+    data = response.json()
+    assert response.status_code == status.HTTP_200_OK
+    assert data["file_scanner"] == "ok"
+
+
+@pytest.mark.anyio("asyncio")
+async def test_healthcheck_file_scanner_failure(async_client, monkeypatch):
+    monkeypatch.setattr(main.settings, "event_file_scanner_enabled", True)
+
+    async def _failing_scan(data: bytes, *, locale=None) -> None:
+        raise RuntimeError("scanner offline")
+
+    monkeypatch.setattr(main, "scan_for_malware", _failing_scan)
+
+    response = await async_client.get("/healthz")
+    data = response.json()
+    assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+    assert data["file_scanner"] == "error"
+

--- a/root/tests/test_health_endpoint.py
+++ b/root/tests/test_health_endpoint.py
@@ -94,7 +94,9 @@ async def test_healthcheck_cache_failure(async_client, monkeypatch):
 @pytest.mark.anyio("asyncio")
 async def test_healthcheck_storage_failure(async_client, monkeypatch):
     class _FailingStorage:
-        async def save_file(self, relative_path: str, data: bytes, *, content_type=None):
+        async def save_file(
+            self, relative_path: str, data: bytes, *, content_type=None
+        ):
             raise RuntimeError("storage down")
 
         async def delete_file(self, file_url: str) -> None:
@@ -146,4 +148,3 @@ async def test_healthcheck_file_scanner_failure(async_client, monkeypatch):
     data = response.json()
     assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
     assert data["file_scanner"] == "error"
-


### PR DESCRIPTION
## Summary
- extend the `/healthz` endpoint to probe the database, cache, static storage, notification queue, and file scanner services
- return detailed per-dependency statuses and 503 responses when a probe fails
- add comprehensive tests covering success and failure scenarios for each dependency check

## Testing
- `pytest root/tests/test_health_endpoint.py root/tests/test_smoke.py root/tests/test_rate_limit.py root/tests/test_metrics_endpoint.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fc72033c0832789d341f51f4293e3)