### PR TITLE
Prioritize detected MIME type for attachments

### DIFF
--- a/root/app/utils/files.py
+++ b/root/app/utils/files.py
@@ -248,7 +248,7 @@ async def save_attachment(
     declared_raw = (upload.content_type or "").strip()
     declared_type = _normalize_mime_type(declared_raw)
     allowed_types = settings.event_file_allowed_mime_types_set
-    if not declared_type or (allowed_types and declared_type not in allowed_types):
+    if declared_type and allowed_types and declared_type not in allowed_types:
         raise HTTPException(
             status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
             detail=translate("errors.files.unsupported_type", locale=locale),
@@ -269,17 +269,25 @@ async def save_attachment(
     data = await _read_limited(upload, limit, locale=locale)
 
     detected_type = detect_mime_type(data) or ""
-    if detected_type:
-        if allowed_types and detected_type not in allowed_types:
-            raise HTTPException(
-                status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
-                detail=translate("errors.files.unsupported_type", locale=locale),
-            )
-        if declared_type and detected_type != declared_type:
-            raise HTTPException(
-                status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
-                detail=translate("errors.files.content_type_mismatch", locale=locale),
-            )
+    if detected_type and allowed_types and detected_type not in allowed_types:
+        raise HTTPException(
+            status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+            detail=translate("errors.files.unsupported_type", locale=locale),
+        )
+
+    chosen_type = ""
+    chosen_type_source = ""
+    for source, candidate in (("detected", detected_type), ("declared", declared_type)):
+        if candidate and (not allowed_types or candidate in allowed_types):
+            chosen_type = candidate
+            chosen_type_source = source
+            break
+
+    if not chosen_type:
+        raise HTTPException(
+            status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+            detail=translate("errors.files.unsupported_type", locale=locale),
+        )
 
     def _ext_without_dot_from_mime(mime: str) -> str:
         candidate = _ext_from_mime(mime).lower()
@@ -291,39 +299,46 @@ async def save_attachment(
     declared_ext_without_dot = (
         _ext_without_dot_from_mime(declared_type) if declared_type else ""
     )
+    chosen_ext_without_dot = _ext_without_dot_from_mime(chosen_type)
 
-    if (
-        detected_ext_without_dot
-        and allowed_exts
-        and detected_ext_without_dot not in allowed_exts
-    ):
-        raise HTTPException(
-            status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
-            detail=translate("errors.files.unsupported_extension", locale=locale),
-        )
-
-    candidate_exts: tuple[str, ...] = (
-        ext_without_dot,
-        detected_ext_without_dot,
-        declared_ext_without_dot,
-    )
-    chosen_ext_without_dot = next(
-        (
-            candidate
-            for candidate in candidate_exts
-            if candidate and (not allowed_exts or candidate in allowed_exts)
-        ),
-        "",
-    )
-
-    if not chosen_ext_without_dot and allowed_exts:
-        raise HTTPException(
-            status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
-            detail=translate("errors.files.unsupported_extension", locale=locale),
-        )
-
-    if not chosen_ext_without_dot:
-        chosen_ext_without_dot = declared_ext_without_dot or detected_ext_without_dot
+    if allowed_exts:
+        if chosen_ext_without_dot:
+            if chosen_ext_without_dot not in allowed_exts:
+                raise HTTPException(
+                    status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+                    detail=translate("errors.files.unsupported_extension", locale=locale),
+                )
+        else:
+            fallback_exts: tuple[str, ...]
+            if chosen_type_source == "declared":
+                fallback_exts = (declared_ext_without_dot, ext_without_dot)
+            else:
+                fallback_exts = (detected_ext_without_dot,)
+            chosen_ext_without_dot = next(
+                (
+                    candidate
+                    for candidate in fallback_exts
+                    if candidate and candidate in allowed_exts
+                ),
+                "",
+            )
+            if not chosen_ext_without_dot:
+                raise HTTPException(
+                    status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+                    detail=translate("errors.files.unsupported_extension", locale=locale),
+                )
+    else:
+        if not chosen_ext_without_dot:
+            fallback_exts: tuple[str, ...]
+            if chosen_type_source == "declared":
+                fallback_exts = (declared_ext_without_dot, detected_ext_without_dot)
+            else:
+                fallback_exts = (detected_ext_without_dot, declared_ext_without_dot)
+            fallback_exts += (ext_without_dot,)
+            chosen_ext_without_dot = next(
+                (candidate for candidate in fallback_exts if candidate),
+                "",
+            )
 
     ext_for_name = f".{chosen_ext_without_dot}" if chosen_ext_without_dot else ""
     name = _gen_name(prefix, ext_for_name)
@@ -333,7 +348,7 @@ async def save_attachment(
     await _prepare_local_storage(backend, sanitized_subdir)
     relative_path = f"{sanitized_subdir}/{name}" if sanitized_subdir else name
     return await backend.save_file(
-        relative_path, data, content_type=declared_type or detected_type or None
+        relative_path, data, content_type=chosen_type or None
     )
 
 

--- a/root/app/utils/files.py
+++ b/root/app/utils/files.py
@@ -306,7 +306,9 @@ async def save_attachment(
             if chosen_ext_without_dot not in allowed_exts:
                 raise HTTPException(
                     status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
-                    detail=translate("errors.files.unsupported_extension", locale=locale),
+                    detail=translate(
+                        "errors.files.unsupported_extension", locale=locale
+                    ),
                 )
         else:
             fallback_exts: tuple[str, ...]
@@ -325,7 +327,9 @@ async def save_attachment(
             if not chosen_ext_without_dot:
                 raise HTTPException(
                     status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
-                    detail=translate("errors.files.unsupported_extension", locale=locale),
+                    detail=translate(
+                        "errors.files.unsupported_extension", locale=locale
+                    ),
                 )
     else:
         if not chosen_ext_without_dot:

--- a/root/tests/test_event_file_upload.py
+++ b/root/tests/test_event_file_upload.py
@@ -177,7 +177,7 @@ async def test_upload_event_file_rejects_forbidden_type(
 
 
 @pytest.mark.anyio("asyncio")
-async def test_upload_event_file_rejects_mismatched_magic_bytes(
+async def test_upload_event_file_prefers_detected_metadata(
     tmp_path, monkeypatch, db_session, user_factory
 ):
     admin = await user_factory(role="admin")
@@ -199,17 +199,14 @@ async def test_upload_event_file_rejects_mismatched_magic_bytes(
     monkeypatch.setattr(settings, "event_file_allowed_extensions", [".txt", ".pdf"])
     monkeypatch.setattr(settings, "event_file_max_size_bytes", 1024)
 
-    with pytest.raises(HTTPException) as excinfo:
-        await events.upload_event_file(
-            event.id, upload, request=None, db=db_session, user=admin
-        )
-
-    assert excinfo.value.status_code == status.HTTP_415_UNSUPPORTED_MEDIA_TYPE
-    assert excinfo.value.detail == translate(
-        "errors.files.content_type_mismatch", locale="en"
+    result = await events.upload_event_file(
+        event.id, upload, request=None, db=db_session, user=admin
     )
-    folder = tmp_path / "event_files"
-    assert not folder.exists()
+
+    stored_path = tmp_path / "event_files" / result.file_url.rsplit("/", 1)[-1]
+    assert stored_path.exists()
+    assert stored_path.suffix == ".pdf"
+    assert stored_path.read_bytes() == pdf_payload
 
 
 @pytest.mark.anyio("asyncio")
@@ -247,6 +244,38 @@ async def test_upload_event_file_rejects_infected_payload(
 
     assert excinfo.value.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
     assert excinfo.value.detail == translate("errors.files.infected", locale="en")
+    folder = tmp_path / "event_files"
+    assert not folder.exists()
+
+
+@pytest.mark.anyio("asyncio")
+async def test_upload_event_file_rejects_detected_type_not_allowed(
+    tmp_path, monkeypatch, db_session, user_factory
+):
+    admin = await user_factory(role="admin")
+    event = await _create_event(db_session, admin)
+
+    pdf_payload = b"%PDF-1.7\n" + b"0" * 100
+    upload = UploadFile(
+        filename="notes.txt",
+        file=io.BytesIO(pdf_payload),
+        headers=Headers({"content-type": "text/plain"}),
+    )
+
+    monkeypatch.setattr(settings, "static_dir_path", tmp_path)
+    monkeypatch.setattr(settings, "event_file_allowed_mime_types", ["text/plain"])
+    monkeypatch.setattr(settings, "event_file_allowed_extensions", [".txt"])
+    monkeypatch.setattr(settings, "event_file_max_size_bytes", 1024)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await events.upload_event_file(
+            event.id, upload, request=None, db=db_session, user=admin
+        )
+
+    assert excinfo.value.status_code == status.HTTP_415_UNSUPPORTED_MEDIA_TYPE
+    assert excinfo.value.detail == translate(
+        "errors.files.unsupported_type", locale="en"
+    )
     folder = tmp_path / "event_files"
     assert not folder.exists()
 

--- a/root/tests/test_file_utils.py
+++ b/root/tests/test_file_utils.py
@@ -174,3 +174,74 @@ async def test_save_image_preserves_transparency_with_png(tmp_path, monkeypatch)
         assert saved.width <= 300
         assert saved.height <= 200
         assert "exif" not in saved.info
+
+
+@pytest.mark.asyncio
+async def test_save_attachment_prefers_detected_type(monkeypatch):
+    payload = b"%PDF-1.7\n" + b"0" * 10
+    upload = UploadFile(
+        filename="notes.txt",
+        file=io.BytesIO(payload),
+        headers=Headers({"content-type": "text/plain"}),
+    )
+
+    backend = RecordingStorage()
+
+    async def fake_scan(data: bytes, *, locale: str | None = None) -> None:
+        assert data == payload
+
+    monkeypatch.setattr(files, "scan_for_malware", fake_scan)
+    monkeypatch.setattr(files, "storage_backend", backend)
+    monkeypatch.setattr(files, "_default_storage_backend", backend)
+    monkeypatch.setattr(files, "_get_storage_backend", lambda: backend)
+    monkeypatch.setattr(
+        settings,
+        "event_file_allowed_mime_types",
+        ["text/plain", "application/pdf"],
+    )
+    monkeypatch.setattr(settings, "event_file_allowed_extensions", [".txt", ".pdf"])
+    monkeypatch.setattr(settings, "event_file_max_size_bytes", 1024)
+
+    url = await files.save_attachment(upload, "event_files", "event_1")
+
+    assert url.startswith("https://cdn.example/event_files/")
+    assert url.endswith(".pdf")
+    assert backend.calls
+    method, (relative_path, data), kwargs = backend.calls[0]
+    assert method == "save"
+    assert relative_path.endswith(".pdf")
+    assert kwargs["content_type"] == "application/pdf"
+    assert data == payload
+
+
+@pytest.mark.asyncio
+async def test_save_attachment_falls_back_to_declared_type(monkeypatch):
+    payload = b"hello world"
+    upload = UploadFile(
+        filename="notes.txt",
+        file=io.BytesIO(payload),
+        headers=Headers({"content-type": "text/plain"}),
+    )
+
+    backend = RecordingStorage()
+
+    async def fake_scan(data: bytes, *, locale: str | None = None) -> None:
+        assert data == payload
+
+    monkeypatch.setattr(files, "scan_for_malware", fake_scan)
+    monkeypatch.setattr(files, "storage_backend", backend)
+    monkeypatch.setattr(files, "_default_storage_backend", backend)
+    monkeypatch.setattr(files, "_get_storage_backend", lambda: backend)
+    monkeypatch.setattr(files, "detect_mime_type", lambda _data: "")
+    monkeypatch.setattr(settings, "event_file_allowed_mime_types", ["text/plain"])
+    monkeypatch.setattr(settings, "event_file_allowed_extensions", [".txt"])
+    monkeypatch.setattr(settings, "event_file_max_size_bytes", 1024)
+
+    url = await files.save_attachment(upload, "event_files", "event_1")
+
+    assert url.startswith("https://cdn.example/event_files/")
+    assert url.endswith(".txt")
+    method, (relative_path, data), kwargs = backend.calls[0]
+    assert relative_path.endswith(".txt")
+    assert kwargs["content_type"] == "text/plain"
+    assert data == payload


### PR DESCRIPTION
## Summary
- prioritize detected MIME types when saving attachments and fall back to validated declared types only when necessary
- align generated filenames and stored metadata with the normalized MIME information
- expand attachment upload tests to cover mixed declared/detected scenarios and ensure metadata accuracy

## Testing
- pytest root/tests/test_file_utils.py::test_save_attachment_prefers_detected_type root/tests/test_file_utils.py::test_save_attachment_falls_back_to_declared_type -vv
- pytest root/tests/test_event_file_upload.py::test_upload_event_file_prefers_detected_metadata -vv
- pytest root/tests/test_event_file_upload.py::test_upload_event_file_rejects_detected_type_not_allowed -vv

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fdaa79dc08327a82f469a2e1a87f0)