### PR TITLE
feat: support jwt signing key rotation

### DIFF
--- a/root/app/auth/auth.py
+++ b/root/app/auth/auth.py
@@ -211,7 +211,14 @@ async def _mint_access_token(
     if extra:
         for key, value in extra.items():
             payload[key] = value
-    token = jwt.encode(payload, settings.secret_key, algorithm=settings.algorithm)
+    kid = settings.jwt_signing_active_kid
+    secret = settings.jwt_signing_active_secret
+    token = jwt.encode(
+        payload,
+        secret,
+        algorithm=settings.algorithm,
+        headers={"kid": kid},
+    )
     await db.commit()
     return token
 

--- a/root/app/auth/security.py
+++ b/root/app/auth/security.py
@@ -119,7 +119,14 @@ async def create_access_token(
     }
     if extra:
         payload.update(extra)
-    token = jwt.encode(payload, settings.secret_key, algorithm=settings.algorithm)
+    kid = settings.jwt_signing_active_kid
+    secret = settings.jwt_signing_active_secret
+    token = jwt.encode(
+        payload,
+        secret,
+        algorithm=settings.algorithm,
+        headers={"kid": kid},
+    )
     if db is not None:
         try:
             user_id = int(sub)
@@ -158,7 +165,31 @@ async def create_access_token(
 
 
 def decode_token(token: str) -> dict | None:
-    try:
-        return jwt.decode(token, settings.secret_key, algorithms=[settings.algorithm])
-    except JWTError:
+    registry = settings.jwt_signing_key_registry
+    if not registry:
         return None
+
+    candidates: list[str] = []
+    try:
+        header = jwt.get_unverified_header(token)
+    except JWTError:
+        header = {}
+
+    kid = header.get("kid") if isinstance(header, dict) else None
+    if isinstance(kid, str):
+        kid_secret = registry.get(kid)
+        if kid_secret:
+            candidates.append(kid_secret)
+
+    seen: set[str] = set(candidates)
+    for secret in registry.values():
+        if secret not in seen:
+            candidates.append(secret)
+            seen.add(secret)
+
+    for secret in candidates:
+        try:
+            return jwt.decode(token, secret, algorithms=[settings.algorithm])
+        except JWTError:
+            continue
+    return None

--- a/root/app/core/config.py
+++ b/root/app/core/config.py
@@ -205,6 +205,8 @@ class Settings(BaseSettings):
     database_pool_timeout: float = 30.0
     database_pool_recycle: int = 1_800
     secret_key: str
+    jwt_signing_keys: list[str] | str = ""
+    jwt_active_kid: str | None = None
     algorithm: str = "HS256"
     access_token_expire_minutes: int = 60
     frontend_origin: str = "http://localhost:5173"
@@ -496,9 +498,70 @@ class Settings(BaseSettings):
         case_sensitive=False,
     )
 
+    def _build_jwt_signing_key_entries(self) -> list[tuple[str, str]]:
+        entries: list[tuple[str, str]] = []
+        seen_kids: set[str] = set()
+        for raw_entry in _coerce_str_list(self.jwt_signing_keys):
+            if ":" not in raw_entry:
+                raise RuntimeError(
+                    "JWT_SIGNING_KEYS entries must be in '<kid>:<secret>' format"
+                )
+            kid, secret = raw_entry.split(":", 1)
+            kid = kid.strip()
+            secret = secret.strip()
+            if not kid:
+                raise RuntimeError(
+                    "JWT_SIGNING_KEYS entries must specify a non-empty kid value"
+                )
+            if not secret:
+                raise RuntimeError(
+                    "JWT_SIGNING_KEYS entries must specify a non-empty secret value"
+                )
+            if kid in seen_kids:
+                raise RuntimeError(
+                    "JWT_SIGNING_KEYS entries must use unique kid values"
+                )
+            entries.append((kid, secret))
+            seen_kids.add(kid)
+
+        if not entries:
+            fallback_kid = (self.jwt_active_kid or "primary").strip() or "primary"
+            entries.append((fallback_kid, self.secret_key))
+        return entries
+
+    @property
+    def jwt_signing_key_registry(self) -> dict[str, str]:
+        registry: dict[str, str] = {}
+        for kid, secret in self._build_jwt_signing_key_entries():
+            registry[kid] = secret
+        return registry
+
+    @property
+    def jwt_signing_active_kid(self) -> str:
+        registry = self.jwt_signing_key_registry
+        configured = self.jwt_active_kid.strip() if isinstance(self.jwt_active_kid, str) else None
+        if configured:
+            if configured not in registry:
+                raise RuntimeError(
+                    "JWT_ACTIVE_KID must match one of the configured JWT_SIGNING_KEYS"
+                )
+            return configured
+        return next(iter(registry))
+
+    @property
+    def jwt_signing_active_secret(self) -> str:
+        registry = self.jwt_signing_key_registry
+        active_kid = self.jwt_signing_active_kid
+        secret = registry.get(active_kid)
+        if secret is None:
+            raise RuntimeError(
+                "Configured JWT signing key registry does not contain the active kid"
+            )
+        return secret
+
     @cached_property
     def SECRET_KEY(self) -> str:
-        return self.secret_key
+        return self.jwt_signing_active_secret
 
     @cached_property
     def ALGORITHM(self) -> str:

--- a/root/app/core/config.py
+++ b/root/app/core/config.py
@@ -539,7 +539,11 @@ class Settings(BaseSettings):
     @property
     def jwt_signing_active_kid(self) -> str:
         registry = self.jwt_signing_key_registry
-        configured = self.jwt_active_kid.strip() if isinstance(self.jwt_active_kid, str) else None
+        configured = (
+            self.jwt_active_kid.strip()
+            if isinstance(self.jwt_active_kid, str)
+            else None
+        )
         if configured:
             if configured not in registry:
                 raise RuntimeError(

--- a/root/tests/test_auth_security.py
+++ b/root/tests/test_auth_security.py
@@ -1,18 +1,23 @@
 import uuid
+from datetime import UTC, datetime, timedelta
 
 import pytest
 from fastapi import status
+from jose import JWTError, jwt
 from passlib.hash import bcrypt
 from sqlalchemy import select
 
 from app.auth.security import (
     LEGACY_BCRYPT_MAX_BYTES,
     _truncate_for_bcrypt,
+    create_access_token,
+    decode_token,
     get_password_hash,
     verify_and_update_password,
     verify_password,
 )
 from app.models import models
+from app.core.config import settings
 
 
 def _make_legacy_hash(password: str) -> str:
@@ -106,6 +111,58 @@ def test_legacy_bcrypt_truncation_behavior():
 
     mutated_before_limit = "b" + long_password[1:]
     assert not verify_password(mutated_before_limit, legacy_hash)
+
+
+@pytest.mark.anyio
+async def test_create_access_token_uses_active_signing_key(monkeypatch):
+    monkeypatch.setattr(
+        settings,
+        "jwt_signing_keys",
+        ["new-key:new-secret", "legacy-key:old-secret"],
+    )
+    monkeypatch.setattr(settings, "jwt_active_kid", "new-key")
+
+    token = await create_access_token("user-123")
+
+    header = jwt.get_unverified_header(token)
+    assert header["kid"] == "new-key"
+
+    with pytest.raises(JWTError):
+        jwt.decode(token, "old-secret", algorithms=[settings.algorithm])
+
+    decoded = decode_token(token)
+    assert decoded is not None
+    assert decoded["sub"] == "user-123"
+
+
+@pytest.mark.anyio
+async def test_decode_token_accepts_legacy_and_active_secrets(monkeypatch):
+    monkeypatch.setattr(
+        settings,
+        "jwt_signing_keys",
+        ["active:new-secret", "legacy:old-secret"],
+    )
+    monkeypatch.setattr(settings, "jwt_active_kid", "active")
+
+    now = datetime.now(UTC)
+    legacy_payload = {
+        "sub": "legacy-user",
+        "iat": now,
+        "nbf": now,
+        "exp": now + timedelta(minutes=5),
+        "jti": "legacy-jti",
+    }
+    legacy_token = jwt.encode(legacy_payload, "old-secret", algorithm=settings.algorithm)
+
+    rotated_token = await create_access_token("current-user")
+
+    legacy_decoded = decode_token(legacy_token)
+    assert legacy_decoded is not None
+    assert legacy_decoded["sub"] == "legacy-user"
+
+    rotated_decoded = decode_token(rotated_token)
+    assert rotated_decoded is not None
+    assert rotated_decoded["sub"] == "current-user"
 
 
 @pytest.mark.anyio

--- a/root/tests/test_auth_security.py
+++ b/root/tests/test_auth_security.py
@@ -16,8 +16,8 @@ from app.auth.security import (
     verify_and_update_password,
     verify_password,
 )
-from app.models import models
 from app.core.config import settings
+from app.models import models
 
 
 def _make_legacy_hash(password: str) -> str:
@@ -152,7 +152,9 @@ async def test_decode_token_accepts_legacy_and_active_secrets(monkeypatch):
         "exp": now + timedelta(minutes=5),
         "jti": "legacy-jti",
     }
-    legacy_token = jwt.encode(legacy_payload, "old-secret", algorithm=settings.algorithm)
+    legacy_token = jwt.encode(
+        legacy_payload, "old-secret", algorithm=settings.algorithm
+    )
 
     rotated_token = await create_access_token("current-user")
 


### PR DESCRIPTION
## Summary
- introduce a signing key registry for JWT tokens, attaching the active key id to minted tokens and accepting legacy secrets during verification
- extend the settings object to load an ordered list of signing secrets and derive the active signing key
- add authentication security tests that cover token minting, validation, and rotation flows

## Testing
- pytest root/tests/test_auth_security.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fe84fa1f88327a338039d614ffe00)