### PR TITLE
Batch stale notification cleanup

### DIFF
--- a/root/app/core/config.py
+++ b/root/app/core/config.py
@@ -314,6 +314,7 @@ class Settings(BaseSettings):
     notifications_webpush_concurrency_limit: int = 10
     notifications_retention_days: int = 90
     notifications_retention_cleanup_interval_seconds: int = 86_400
+    notifications_retention_batch_size: int = 500
     notification_queue_dead_letter_retention_days: int = 30
     notification_queue_dead_letter_cleanup_interval_seconds: int = 86_400
     storage_backend: str = "static"
@@ -435,6 +436,13 @@ class Settings(BaseSettings):
                 "NOTIFICATIONS_ALLOWED_PUSH_TOPICS must include at least one topic"
             )
         return normalized
+
+    @field_validator("notifications_retention_batch_size")
+    @classmethod
+    def _validate_notifications_retention_batch_size(cls, value: int) -> int:
+        return _validate_positive_int(
+            int(value), label="NOTIFICATIONS_RETENTION_BATCH_SIZE"
+        )
 
     @field_validator("mfa_totp_issuer")
     @classmethod

--- a/root/app/services/notifications.py
+++ b/root/app/services/notifications.py
@@ -178,20 +178,62 @@ async def cleanup_stale_notifications(
 
     cutoff = now_value - dt.timedelta(days=int(retention_days))
 
-    deliveries_stmt = delete(NotificationDelivery).where(
-        NotificationDelivery.attempted_at < cutoff
-    )
-    notifications_stmt = delete(Notification).where(
-        Notification.created_at < cutoff,
-        or_(Notification.read.is_(True), Notification.read_at.is_not(None)),
-    )
+    batch_size = int(getattr(settings, "notifications_retention_batch_size", 0) or 0)
+    if batch_size <= 0:
+        batch_size = 500
 
-    deliveries_result = await db.execute(deliveries_stmt)
-    notifications_result = await db.execute(notifications_stmt)
+    deliveries_deleted = 0
+    while True:
+        deliveries_ids_stmt = (
+            select(NotificationDelivery.id)
+            .where(NotificationDelivery.attempted_at < cutoff)
+            .order_by(NotificationDelivery.id)
+            .limit(batch_size)
+        )
+        delivery_ids = [
+            int(value)
+            for value in (await db.scalars(deliveries_ids_stmt)).all()
+            if value is not None
+        ]
+        if not delivery_ids:
+            break
+        deliveries_stmt = delete(NotificationDelivery).where(
+            NotificationDelivery.id.in_(delivery_ids)
+        )
+        deliveries_result = await db.execute(deliveries_stmt)
+        deliveries_deleted += int(deliveries_result.rowcount or 0)
+        await db.commit()
+
+    # Commit to close the transaction created by the final select above.
     await db.commit()
 
-    deliveries_deleted = int(deliveries_result.rowcount or 0)
-    notifications_deleted = int(notifications_result.rowcount or 0)
+    notifications_deleted = 0
+    while True:
+        notifications_ids_stmt = (
+            select(Notification.id)
+            .where(
+                Notification.created_at < cutoff,
+                or_(Notification.read.is_(True), Notification.read_at.is_not(None)),
+            )
+            .order_by(Notification.id)
+            .limit(batch_size)
+        )
+        notification_ids = [
+            int(value)
+            for value in (await db.scalars(notifications_ids_stmt)).all()
+            if value is not None
+        ]
+        if not notification_ids:
+            break
+        notifications_stmt = delete(Notification).where(
+            Notification.id.in_(notification_ids)
+        )
+        notifications_result = await db.execute(notifications_stmt)
+        notifications_deleted += int(notifications_result.rowcount or 0)
+        await db.commit()
+
+    # Commit to close the transaction created by the final select above.
+    await db.commit()
 
     if notifications_deleted or deliveries_deleted:
         logger.info(

--- a/root/tests/test_notifications_retention.py
+++ b/root/tests/test_notifications_retention.py
@@ -89,7 +89,9 @@ async def test_cleanup_stale_notifications_respects_read_state(
         ),
     ]
 
-    db_session.add_all([old_read, another_old_read, old_unread, recent_read, *deliveries])
+    db_session.add_all(
+        [old_read, another_old_read, old_unread, recent_read, *deliveries]
+    )
     await db_session.flush()
     recent_read_id = recent_read.id
     await db_session.commit()

--- a/root/tests/test_notifications_retention.py
+++ b/root/tests/test_notifications_retention.py
@@ -3,14 +3,17 @@ import datetime as dt
 import pytest
 from sqlalchemy import select
 
+from app.core.config import settings
 from app.models.models import Notification, NotificationDelivery
 from app.services.notifications import cleanup_stale_notifications
 
 
 @pytest.mark.anyio
 async def test_cleanup_stale_notifications_respects_read_state(
-    db_session, user_factory
+    db_session, user_factory, monkeypatch
 ):
+    monkeypatch.setattr(settings, "notifications_retention_batch_size", 1)
+
     now = dt.datetime(2024, 1, 1, tzinfo=dt.UTC)
     user = await user_factory()
 
@@ -20,6 +23,16 @@ async def test_cleanup_stale_notifications_respects_read_state(
         body="body",
         type="info",
         url="/old-read",
+        created_at=now - dt.timedelta(days=120),
+        read=True,
+        read_at=now - dt.timedelta(days=119),
+    )
+    another_old_read = Notification(
+        user_id=user.id,
+        title="Old read 2",
+        body="body",
+        type="info",
+        url="/old-read-2",
         created_at=now - dt.timedelta(days=120),
         read=True,
         read_at=now - dt.timedelta(days=119),
@@ -54,6 +67,13 @@ async def test_cleanup_stale_notifications_respects_read_state(
             delivered_at=now - dt.timedelta(days=110),
         ),
         NotificationDelivery(
+            notification=another_old_read,
+            channel="webpush",
+            status="sent",
+            attempted_at=now - dt.timedelta(days=110),
+            delivered_at=now - dt.timedelta(days=110),
+        ),
+        NotificationDelivery(
             notification=old_unread,
             channel="webpush",
             status="sent",
@@ -69,7 +89,7 @@ async def test_cleanup_stale_notifications_respects_read_state(
         ),
     ]
 
-    db_session.add_all([old_read, old_unread, recent_read, *deliveries])
+    db_session.add_all([old_read, another_old_read, old_unread, recent_read, *deliveries])
     await db_session.flush()
     recent_read_id = recent_read.id
     await db_session.commit()
@@ -78,8 +98,8 @@ async def test_cleanup_stale_notifications_respects_read_state(
         db=db_session, retention_days=90, now=now
     )
 
-    assert deleted_notifications == 1
-    assert deleted_deliveries == 2
+    assert deleted_notifications == 2
+    assert deleted_deliveries == 3
 
     remaining_notifications = (
         (await db_session.execute(select(Notification).order_by(Notification.id)))


### PR DESCRIPTION
## Summary
- delete stale notifications and deliveries in batches using a configurable size
- add a validated notifications retention batch size setting
- expand the retention test to cover batched deletions and count reporting

## Testing
- pytest root/tests/test_notifications_retention.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ffe300af88327856474e1ec7146e4)