### PR TITLE
Optimize session cleanup deletions

### DIFF
--- a/root/app/core/config.py
+++ b/root/app/core/config.py
@@ -396,7 +396,8 @@ class Settings(BaseSettings):
         normalized = value.strip().lower()
         if normalized not in {"same-origin", "same-site", "cross-origin"}:
             raise ValueError(
-                "CORP_VALUE must be one of 'same-origin', 'same-site', or 'cross-origin'"
+                "CORP_VALUE must be one of 'same-origin', 'same-site', "
+                "or 'cross-origin'"
             )
         return normalized
 

--- a/root/app/services/session_cleanup.py
+++ b/root/app/services/session_cleanup.py
@@ -42,17 +42,33 @@ async def cleanup_expired_sessions(
         ActiveSession.expires_at <= now, ActiveSession.revoked_at <= now
     )
 
-    expired_session_exists = (
-        select(1)
-        .where(ActiveSession.id == MfaChallenge.session_id)
-        .where(expiry_condition)
-        .exists()
-    )
-    await db.execute(delete(MfaChallenge).where(expired_session_exists))
+    bind = db.get_bind()
+    dialect = bind.dialect
+
+    if dialect.name == "sqlite":
+        challenge_delete_stmt = delete(MfaChallenge).where(
+            MfaChallenge.session_id.in_(
+                select(ActiveSession.id).where(expiry_condition)
+            )
+        )
+    else:
+        challenge_delete_stmt = (
+            delete(MfaChallenge)
+            .where(MfaChallenge.session_id == ActiveSession.id)
+            .where(expiry_condition)
+            .execution_options(synchronize_session=False)
+        )
+    await db.execute(challenge_delete_stmt)
 
     delete_stmt = delete(ActiveSession).where(expiry_condition)
-    delete_result = await db.execute(delete_stmt)
-    deleted = int(delete_result.rowcount or 0)
+    supports_returning = bool(getattr(dialect, "delete_returning", False))
+    if supports_returning:
+        delete_stmt = delete_stmt.returning(ActiveSession.id)
+        delete_result = await db.execute(delete_stmt)
+        deleted = len(delete_result.scalars().all())
+    else:
+        delete_result = await db.execute(delete_stmt)
+        deleted = int(delete_result.rowcount or 0)
     await db.commit()
     if deleted:
         logger.info("Removed %s expired sessions", deleted)

--- a/root/app/services/session_cleanup.py
+++ b/root/app/services/session_cleanup.py
@@ -46,10 +46,9 @@ async def cleanup_expired_sessions(
     dialect = bind.dialect
 
     if dialect.name == "sqlite":
+        subquery = select(ActiveSession.id).where(expiry_condition)
         challenge_delete_stmt = delete(MfaChallenge).where(
-            MfaChallenge.session_id.in_(
-                select(ActiveSession.id).where(expiry_condition)
-            )
+            MfaChallenge.session_id.in_(subquery)
         )
     else:
         challenge_delete_stmt = (
@@ -62,10 +61,16 @@ async def cleanup_expired_sessions(
 
     delete_stmt = delete(ActiveSession).where(expiry_condition)
     supports_returning = bool(getattr(dialect, "delete_returning", False))
+    supports_rowcount_returning = bool(
+        getattr(dialect, "supports_sane_rowcount_returning", False)
+    )
     if supports_returning:
         delete_stmt = delete_stmt.returning(ActiveSession.id)
         delete_result = await db.execute(delete_stmt)
-        deleted = len(delete_result.scalars().all())
+        if supports_rowcount_returning and delete_result.rowcount is not None:
+            deleted = int(delete_result.rowcount)
+        else:
+            deleted = len(delete_result.fetchall())
     else:
         delete_result = await db.execute(delete_stmt)
         deleted = int(delete_result.rowcount or 0)

--- a/root/tests/test_session_cleanup.py
+++ b/root/tests/test_session_cleanup.py
@@ -94,6 +94,9 @@ async def test_cleanup_expired_sessions_removes_mfa_challenges(db_session):
         stmt for stmt in statements if stmt.lstrip().upper().startswith("DELETE")
     ]
     assert len(delete_statements) == 2
+    challenge_delete, session_delete = delete_statements
+    assert "mfa_challenge" in challenge_delete.lower()
+    assert "active_session" in session_delete.lower()
 
     async with async_session() as verify_session:
         result = await verify_session.execute(

--- a/root/tests/test_session_cleanup.py
+++ b/root/tests/test_session_cleanup.py
@@ -1,10 +1,10 @@
 import datetime as dt
 
 import pytest
-from sqlalchemy import select
+from sqlalchemy import event, select
 
 from app.auth import mfa
-from app.core.database import async_session
+from app.core.database import async_session, engine
 from app.models.models import ActiveSession, MfaChallenge, User
 from app.services.session_cleanup import cleanup_expired_sessions
 
@@ -75,9 +75,25 @@ async def test_cleanup_expired_sessions_removes_mfa_challenges(db_session):
     )
     await db_session.commit()
 
-    removed = await cleanup_expired_sessions(now=now)
+    statements: list[str] = []
+
+    def record_sql(
+        conn, cursor, statement, parameters, context, executemany
+    ):  # pragma: no cover - signature defined by SQLAlchemy
+        statements.append(statement)
+
+    event.listen(engine.sync_engine, "before_cursor_execute", record_sql)
+    try:
+        removed = await cleanup_expired_sessions(now=now)
+    finally:
+        event.remove(engine.sync_engine, "before_cursor_execute", record_sql)
 
     assert removed == 1
+
+    delete_statements = [
+        stmt for stmt in statements if stmt.lstrip().upper().startswith("DELETE")
+    ]
+    assert len(delete_statements) == 2
 
     async with async_session() as verify_session:
         result = await verify_session.execute(


### PR DESCRIPTION
## Summary
- replace the MFA challenge cleanup query with a bulk delete that joins expired sessions, while falling back for SQLite
- adjust the session delete to use RETURNING when available so row counts remain accurate across databases
- extend the cleanup tests to confirm the job removes challenges with just the two delete statements

## Testing
- pytest root/tests/test_session_cleanup.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910a8e77afc8327841411c720ae27d9)