### PR TITLE
Label notification queue metrics by job kind

### DIFF
--- a/root/app/core/observability.py
+++ b/root/app/core/observability.py
@@ -731,11 +731,13 @@ def create_notification_queue_metrics(
         dropped_jobs_total=Counter(
             "notification_queue_dropped_jobs_total",
             "Total notification jobs dropped due to queue saturation",
+            labelnames=("kind",),
             registry=target_registry,
         ),
         failed_jobs_total=Counter(
             "notification_queue_failed_jobs_total",
             "Total notification jobs permanently failed or dead-lettered",
+            labelnames=("kind",),
             registry=target_registry,
         ),
         processed_jobs_total=Counter(

--- a/root/app/services/notification_queue.py
+++ b/root/app/services/notification_queue.py
@@ -238,7 +238,8 @@ async def _enqueue_in_memory_job(job: NotificationJob) -> None:
     except asyncio.QueueFull:
         evicted = _evict_oldest(queue)
         if metrics is not None:
-            metrics.dropped_jobs_total.inc()
+            dropped_kind = evicted.kind if evicted is not None else job.kind
+            metrics.dropped_jobs_total.labels(kind=dropped_kind).inc()
             _update_in_memory_metrics(metrics, queue)
         logger.warning(
             "Notification queue full; dropped oldest job",
@@ -250,7 +251,7 @@ async def _enqueue_in_memory_job(job: NotificationJob) -> None:
                 enqueued = True
             except TimeoutError:
                 if metrics is not None:
-                    metrics.dropped_jobs_total.inc()
+                    metrics.dropped_jobs_total.labels(kind=job.kind).inc()
                     _update_in_memory_metrics(metrics, queue)
                 logger.warning(
                     "Notification queue saturated; dropping job after timeout",
@@ -857,7 +858,7 @@ async def _acknowledge_persistent_job(
                         record.dead_lettered = True
                         record.next_retry_at = None
                         if metrics is not None:
-                            metrics.failed_jobs_total.inc()
+                            metrics.failed_jobs_total.labels(kind=job.kind).inc()
                         logger.error(
                             (
                                 "Notification job exhausted retries; moving to "

--- a/root/tests/test_notification_queue_worker.py
+++ b/root/tests/test_notification_queue_worker.py
@@ -127,6 +127,10 @@ def _metric_value(name: str, labels: dict[str, str] | None = None) -> float | No
     return _METRICS_REGISTRY.get_sample_value(name, labels)
 
 
+def _metric_value_for_kind(name: str, kind: str) -> float | None:
+    return _metric_value(name, {"kind": kind})
+
+
 @pytest.mark.anyio
 async def test_reinitialize_notification_queue_metrics_replaces_registry() -> None:
     registry_one = CollectorRegistry()
@@ -199,13 +203,22 @@ async def test_notification_queue_records_drops_when_saturated(
 
     await notification_queue.enqueue_event_notification(1)
     await notification_queue.enqueue_event_notification(2)
+    await notification_queue.enqueue_news_notification(3)
+    await notification_queue.enqueue_news_notification(4)
 
     state = notification_queue._get_loop_state()
     assert state.queue.qsize() == 1
-    assert [job.record_id for job in list(state.queue._queue)] == [2]
+    remaining_jobs = list(state.queue._queue)
+    assert [job.record_id for job in remaining_jobs] == [4]
+    assert [job.kind for job in remaining_jobs] == ["news"]
 
     assert _metric_value("notification_queue_size") == pytest.approx(1.0)
-    assert _metric_value("notification_queue_dropped_jobs_total") == pytest.approx(1.0)
+    assert _metric_value_for_kind(
+        "notification_queue_dropped_jobs_total", "event"
+    ) == pytest.approx(2.0)
+    assert _metric_value_for_kind(
+        "notification_queue_dropped_jobs_total", "news"
+    ) == pytest.approx(1.0)
 
     await notification_queue.reset_testing_state()
     await notification_queue.shutdown_notification_queue()
@@ -283,7 +296,10 @@ async def test_reset_testing_state_resets_metrics(monkeypatch: pytest.MonkeyPatc
         "notification_queue_processed_jobs_total",
         {"kind": "news"},
     ) in (None, pytest.approx(0.0))
-    assert _metric_value("notification_queue_failed_jobs_total") == pytest.approx(0.0)
+    for kind in ("event", "news"):
+        assert _metric_value_for_kind(
+            "notification_queue_failed_jobs_total", kind
+        ) in (None, pytest.approx(0.0))
     assert _metric_value(
         "notification_queue_queue_wait_time_seconds_sum", {"kind": "news"}
     ) in (
@@ -435,7 +451,9 @@ async def test_persistent_queue_applies_exponential_backoff(
     assert len(attempt_times) == 2
     interval = attempt_times[1] - attempt_times[0]
     assert interval >= 0.04
-    assert _metric_value("notification_queue_failed_jobs_total") == pytest.approx(0.0)
+    assert _metric_value_for_kind(
+        "notification_queue_failed_jobs_total", "event"
+    ) in (None, pytest.approx(0.0))
 
     notification_queue._loop_states.clear()
 
@@ -496,7 +514,9 @@ async def test_persistent_queue_dead_letters_poison_jobs(
     await asyncio.sleep(0.05)
     assert len(attempts) == 3
 
-    assert _metric_value("notification_queue_failed_jobs_total") == pytest.approx(1.0)
+    assert _metric_value_for_kind(
+        "notification_queue_failed_jobs_total", "event"
+    ) == pytest.approx(1.0)
 
     await notification_queue.wait_for_all_jobs(timeout=1.0)
 

--- a/root/tests/test_notification_queue_worker.py
+++ b/root/tests/test_notification_queue_worker.py
@@ -297,9 +297,10 @@ async def test_reset_testing_state_resets_metrics(monkeypatch: pytest.MonkeyPatc
         {"kind": "news"},
     ) in (None, pytest.approx(0.0))
     for kind in ("event", "news"):
-        assert _metric_value_for_kind(
-            "notification_queue_failed_jobs_total", kind
-        ) in (None, pytest.approx(0.0))
+        assert _metric_value_for_kind("notification_queue_failed_jobs_total", kind) in (
+            None,
+            pytest.approx(0.0),
+        )
     assert _metric_value(
         "notification_queue_queue_wait_time_seconds_sum", {"kind": "news"}
     ) in (
@@ -451,9 +452,10 @@ async def test_persistent_queue_applies_exponential_backoff(
     assert len(attempt_times) == 2
     interval = attempt_times[1] - attempt_times[0]
     assert interval >= 0.04
-    assert _metric_value_for_kind(
-        "notification_queue_failed_jobs_total", "event"
-    ) in (None, pytest.approx(0.0))
+    assert _metric_value_for_kind("notification_queue_failed_jobs_total", "event") in (
+        None,
+        pytest.approx(0.0),
+    )
 
     notification_queue._loop_states.clear()
 


### PR DESCRIPTION
## Summary
- add `kind` labels to notification queue drop and failure counters
- tag drop and failure increments with the appropriate job kind across queue implementations
- extend queue worker tests to assert event/news specific drop counts and updated failure expectations

## Testing
- pytest root/tests/test_notification_queue_worker.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910b0be778c8327b8837110177b31a3)