### PR TITLE
Add cache control headers for events endpoints

### DIFF
--- a/root/app/api/events.py
+++ b/root/app/api/events.py
@@ -42,6 +42,7 @@ router = APIRouter(prefix="/events", tags=["events"])
 _EVENTS_LIST_CACHE_PREFIX = "events:list"
 _EVENTS_LIST_VERSION_KEY = f"{_EVENTS_LIST_CACHE_PREFIX}:version"
 _LOCAL_EVENTS_LIST_VERSION = 0
+_EVENTS_CACHE_CONTROL = "private, max-age=180"
 
 
 async def _reset_events_list_cache_version() -> None:
@@ -248,6 +249,7 @@ async def all_events(
 ):
     locale = resolve_locale(request=request, user=user)
     _set_language_headers(response, locale)
+    response.headers["Cache-Control"] = _EVENTS_CACHE_CONTROL
     cache = get_cache()
     cache_key: str | None = None
     cache_version: str | None = None
@@ -269,6 +271,7 @@ async def all_events(
             if etag_matches(cached.etag, if_none_match):
                 not_modified = Response(status_code=status.HTTP_304_NOT_MODIFIED)
                 not_modified.headers["ETag"] = etag_header
+                not_modified.headers["Cache-Control"] = _EVENTS_CACHE_CONTROL
                 _set_language_headers(not_modified, locale)
                 return not_modified
             response.headers["ETag"] = etag_header
@@ -294,6 +297,7 @@ async def all_events(
         if etag_matches(entry.etag, if_none_match):
             not_modified = Response(status_code=status.HTTP_304_NOT_MODIFIED)
             not_modified.headers["ETag"] = etag_header
+            not_modified.headers["Cache-Control"] = _EVENTS_CACHE_CONTROL
             _set_language_headers(not_modified, locale)
             return not_modified
         response.headers["ETag"] = etag_header
@@ -303,6 +307,7 @@ async def all_events(
     if etag_matches(digest, if_none_match):
         not_modified = Response(status_code=status.HTTP_304_NOT_MODIFIED)
         not_modified.headers["ETag"] = weak_header
+        not_modified.headers["Cache-Control"] = _EVENTS_CACHE_CONTROL
         _set_language_headers(not_modified, locale)
         return not_modified
     response.headers["ETag"] = weak_header
@@ -374,11 +379,13 @@ async def my_events(
 ):
     locale = resolve_locale(request=request, user=user)
     _set_language_headers(response, locale)
+    response.headers["Cache-Control"] = _EVENTS_CACHE_CONTROL
     payload = await crud.get_my_events(db, user_id=user.id, locale=locale)
     encoded, digest, weak_header = _encode_payload_with_etag(payload)
     if etag_matches(digest, if_none_match):
         not_modified = Response(status_code=status.HTTP_304_NOT_MODIFIED)
         not_modified.headers["ETag"] = weak_header
+        not_modified.headers["Cache-Control"] = _EVENTS_CACHE_CONTROL
         _set_language_headers(not_modified, locale)
         return not_modified
     response.headers["ETag"] = weak_header

--- a/root/tests/test_events_localization.py
+++ b/root/tests/test_events_localization.py
@@ -69,6 +69,7 @@ async def test_events_localization(async_client, db_session, user_factory):
         headers={**headers, "Accept-Language": "en"},
     )
     assert response_en.status_code == 200
+    assert response_en.headers.get("Cache-Control") == "private, max-age=180"
     assert response_en.headers.get("Content-Language") == "en"
     vary_en = response_en.headers.get("Vary", "")
     assert any(
@@ -103,6 +104,7 @@ async def test_events_localization(async_client, db_session, user_factory):
         headers={**headers, "Accept-Language": "ru"},
     )
     assert response_ru.status_code == 200
+    assert response_ru.headers.get("Cache-Control") == "private, max-age=180"
     assert response_ru.headers.get("Content-Language") == "ru"
     vary_ru = response_ru.headers.get("Vary", "")
     assert any(
@@ -170,6 +172,7 @@ async def test_events_etag_and_not_modified(
     assert list_response.status_code == status.HTTP_200_OK
     list_etag = list_response.headers.get("ETag")
     assert list_etag
+    assert list_response.headers.get("Cache-Control") == "private, max-age=180"
 
     list_not_modified = await async_client.get(
         "/events",
@@ -177,6 +180,7 @@ async def test_events_etag_and_not_modified(
     )
     assert list_not_modified.status_code == status.HTTP_304_NOT_MODIFIED
     assert list_not_modified.headers.get("Content-Language") == "en"
+    assert list_not_modified.headers.get("Cache-Control") == "private, max-age=180"
     vary_list = list_not_modified.headers.get("Vary", "")
     assert any(
         value.strip().lower() == "accept-language"
@@ -189,6 +193,7 @@ async def test_events_etag_and_not_modified(
     assert my_response.status_code == status.HTTP_200_OK
     my_etag = my_response.headers.get("ETag")
     assert my_etag
+    assert my_response.headers.get("Cache-Control") == "private, max-age=180"
 
     my_not_modified = await async_client.get(
         "/events/my",
@@ -197,6 +202,7 @@ async def test_events_etag_and_not_modified(
     assert my_not_modified.status_code == status.HTTP_304_NOT_MODIFIED
     assert my_not_modified.headers.get("Content-Language") == "en"
     assert my_not_modified.headers.get("ETag") == my_etag
+    assert my_not_modified.headers.get("Cache-Control") == "private, max-age=180"
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- add an explicit `Cache-Control` policy to the event listing endpoints, including 304 responses
- extend localization tests to cover the new caching headers on cache hits and misses

## Testing
- pytest root/tests/test_events_localization.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910b2f988dc83279db3062d74f53a79)