### PR TITLE
Fix event search index for PostgreSQL

### DIFF
--- a/root/alembic/versions/202509100001_add_event_search_indexes.py
+++ b/root/alembic/versions/202509100001_add_event_search_indexes.py
@@ -29,17 +29,17 @@ def upgrade() -> None:
             ON events
             USING gin (
                 to_tsvector(
-                    'simple',
+                    'simple'::regconfig,
                     concat_ws(
                         ' ',
-                        title,
-                        description,
-                        location,
-                        title_en,
-                        description_en,
-                        location_en,
-                        about,
-                        about_en
+                        coalesce(title, ''),
+                        coalesce(description, ''),
+                        coalesce(location, ''),
+                        coalesce(title_en, ''),
+                        coalesce(description_en, ''),
+                        coalesce(location_en, ''),
+                        coalesce(about, ''),
+                        coalesce(about_en, '')
                     )
                 )
             )


### PR DESCRIPTION
## Summary
- cast the text search configuration to regconfig to ensure the generated `to_tsvector` expression is immutable
- coalesce nullable event fields before building the concatenated search string for the GIN index

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910c25698c083279e017eb43c0771ae)