### PR TITLE
Fix event search index to use immutable expression

### DIFF
--- a/root/alembic/versions/202509100001_add_event_search_indexes.py
+++ b/root/alembic/versions/202509100001_add_event_search_indexes.py
@@ -30,17 +30,14 @@ def upgrade() -> None:
             USING gin (
                 to_tsvector(
                     'simple'::regconfig,
-                    concat_ws(
-                        ' ',
-                        coalesce(title, ''),
-                        coalesce(description, ''),
-                        coalesce(location, ''),
-                        coalesce(title_en, ''),
-                        coalesce(description_en, ''),
-                        coalesce(location_en, ''),
-                        coalesce(about, ''),
-                        coalesce(about_en, '')
-                    )
+                    coalesce(title, '')
+                    || ' ' || coalesce(description, '')
+                    || ' ' || coalesce(location, '')
+                    || ' ' || coalesce(title_en, '')
+                    || ' ' || coalesce(description_en, '')
+                    || ' ' || coalesce(location_en, '')
+                    || ' ' || coalesce(about, '')
+                    || ' ' || coalesce(about_en, '')
                 )
             )
             """


### PR DESCRIPTION
## Summary
- replace the concat_ws helper in the GIN index expression with direct text concatenation so PostgreSQL treats it as immutable

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910c32627308327bb485e8b2b613841)