### PR TITLE
feat: refresh schedule cache using TTL metadata

### DIFF
--- a/root/frontend/src/pages/Schedule.tsx
+++ b/root/frontend/src/pages/Schedule.tsx
@@ -42,21 +42,73 @@ type ActiveScheduleQueryKey = ReturnType<typeof scheduleQueryKey>
 const groupsStorageKey = "sched:groups"
 const scheduleStorageKey = (groupId: number) => `sched:${groupId}`
 
-const readFromStorage = <T,>(key: string): T | undefined => {
+const STORAGE_SCHEMA_VERSION = 1
+const GROUPS_STORAGE_TTL_MS = 5 * 60_000
+const SCHEDULE_STORAGE_TTL_MS = 5 * 60_000
+
+type StoredPayload<T> = {
+  version: number
+  timestamp: number
+  data: T
+}
+
+type StorageReadResult<T> = {
+  value: T
+  timestamp: number
+}
+
+type StorageReadOptions = {
+  maxAgeMs?: number
+  version?: number
+}
+
+type StorageWriteOptions = {
+  version?: number
+}
+
+const readFromStorage = <T,>(
+  key: string,
+  { maxAgeMs = SCHEDULE_STORAGE_TTL_MS, version = STORAGE_SCHEMA_VERSION }: StorageReadOptions = {}
+): StorageReadResult<T> | undefined => {
   if (typeof window === "undefined") return undefined
   try {
     const raw = window.localStorage.getItem(key)
     if (!raw) return undefined
-    return JSON.parse(raw) as T
+    const parsed = JSON.parse(raw) as Partial<StoredPayload<T>> | null
+    if (!parsed || typeof parsed !== "object") return undefined
+    if (parsed.version !== version) {
+      window.localStorage.removeItem(key)
+      return undefined
+    }
+    const ts = typeof parsed.timestamp === "number" ? parsed.timestamp : NaN
+    if (!Number.isFinite(ts)) {
+      window.localStorage.removeItem(key)
+      return undefined
+    }
+    if (Date.now() - ts > maxAgeMs) {
+      window.localStorage.removeItem(key)
+      return undefined
+    }
+    if (!("data" in parsed)) return undefined
+    return { value: parsed.data as T, timestamp: ts }
   } catch {
     return undefined
   }
 }
 
-const writeToStorage = (key: string, value: unknown) => {
+const writeToStorage = <T,>(
+  key: string,
+  value: T,
+  { version = STORAGE_SCHEMA_VERSION }: StorageWriteOptions = {}
+) => {
   if (typeof window === "undefined") return
   try {
-    window.localStorage.setItem(key, JSON.stringify(value))
+    const payload: StoredPayload<T> = {
+      version,
+      timestamp: Date.now(),
+      data: value,
+    }
+    window.localStorage.setItem(key, JSON.stringify(payload))
   } catch {
     /* noop */
   }
@@ -125,17 +177,6 @@ const minimalWeekdayFallback: WeekdayConfig[] = [
   { id: "fri", backend: ["Friday"], long: "Friday", short: "Fri" },
   { id: "sat", backend: ["Saturday"], long: "Saturday", short: "Sat" },
 ]
-
-const groupsPlaceholder = (previous?: ScheduleGroup[]) => {
-  if (previous !== undefined) return previous
-  return readFromStorage<ScheduleGroup[]>(groupsStorageKey)
-}
-
-const schedulePlaceholder = (groupId: number | null, previous?: Lesson[]) => {
-  if (previous !== undefined) return previous
-  if (groupId == null) return previous
-  return readFromStorage<Lesson[]>(scheduleStorageKey(groupId))
-}
 
 function getTimeStr(lesson: Lesson) {
   if (!lesson?.start_time) return ""
@@ -495,6 +536,14 @@ export default function Schedule() {
   }, [])
   const minutesNow = useMemo(() => nowTick.hour() * 60 + nowTick.minute(), [nowTick])
 
+  const groupsStorageSnapshot = useMemo(
+    () =>
+      readFromStorage<ScheduleGroup[]>(groupsStorageKey, {
+        maxAgeMs: GROUPS_STORAGE_TTL_MS,
+      }),
+    []
+  )
+
   const groupsQuery = useQuery<ScheduleGroup[], Error, ScheduleGroup[], ScheduleGroupsQueryKey>({
     queryKey: scheduleGroupsQueryKey,
     queryFn: async () => {
@@ -502,13 +551,40 @@ export default function Schedule() {
       return Array.isArray(res.data) ? res.data : []
     },
     enabled: Boolean(user),
-    placeholderData: groupsPlaceholder,
     staleTime: 60_000,
     gcTime: 5 * 60_000,
     networkMode: "online",
     retry: 1,
+    ...(groupsStorageSnapshot && {
+      initialData: groupsStorageSnapshot.value,
+      initialDataUpdatedAt: groupsStorageSnapshot.timestamp,
+    }),
   })
   const groups = groupsQuery.data ?? []
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+    if (!user) return
+    if (!groupsQuery.dataUpdatedAt) return
+    if (groupsQuery.isFetching) return
+    const age = Date.now() - groupsQuery.dataUpdatedAt
+    if (age >= GROUPS_STORAGE_TTL_MS) {
+      queryClient.invalidateQueries({
+        queryKey: scheduleGroupsQueryKey,
+        exact: true,
+        refetchType: "active",
+      })
+      return
+    }
+    const timeout = window.setTimeout(() => {
+      queryClient.invalidateQueries({
+        queryKey: scheduleGroupsQueryKey,
+        exact: true,
+        refetchType: "active",
+      })
+    }, GROUPS_STORAGE_TTL_MS - age)
+    return () => window.clearTimeout(timeout)
+  }, [groupsQuery.dataUpdatedAt, groupsQuery.isFetching, queryClient, user])
 
   useEffect(() => {
     if (!groupsQuery.isSuccess) return
@@ -517,6 +593,13 @@ export default function Schedule() {
 
   const activeGroupId = selectedGroup
   const scheduleKey = activeGroupId != null ? scheduleQueryKey(activeGroupId) : null
+
+  const scheduleStorageSnapshot = useMemo(() => {
+    if (activeGroupId == null) return undefined
+    return readFromStorage<Lesson[]>(scheduleStorageKey(activeGroupId), {
+      maxAgeMs: SCHEDULE_STORAGE_TTL_MS,
+    })
+  }, [activeGroupId])
 
   const scheduleQuery = useQuery<
     Lesson[],
@@ -533,13 +616,44 @@ export default function Schedule() {
       return Array.isArray(res.data) ? res.data : []
     },
     enabled: activeGroupId != null,
-    placeholderData: (previous) => schedulePlaceholder(activeGroupId, previous),
+    placeholderData: (previous) => {
+      if (previous !== undefined) return previous
+      return scheduleStorageSnapshot?.value
+    },
     staleTime: 60_000,
     gcTime: 5 * 60_000,
     networkMode: "online",
     retry: 1,
+    ...(scheduleStorageSnapshot && {
+      initialData: scheduleStorageSnapshot.value,
+      initialDataUpdatedAt: scheduleStorageSnapshot.timestamp,
+    }),
   })
   const groupScheduleRaw = scheduleQuery.data ?? []
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+    if (!scheduleKey) return
+    if (!scheduleQuery.dataUpdatedAt) return
+    if (scheduleQuery.isFetching) return
+    const age = Date.now() - scheduleQuery.dataUpdatedAt
+    if (age >= SCHEDULE_STORAGE_TTL_MS) {
+      queryClient.invalidateQueries({
+        queryKey: scheduleKey,
+        exact: true,
+        refetchType: "active",
+      })
+      return
+    }
+    const timeout = window.setTimeout(() => {
+      queryClient.invalidateQueries({
+        queryKey: scheduleKey,
+        exact: true,
+        refetchType: "active",
+      })
+    }, SCHEDULE_STORAGE_TTL_MS - age)
+    return () => window.clearTimeout(timeout)
+  }, [queryClient, scheduleKey, scheduleQuery.dataUpdatedAt, scheduleQuery.isFetching])
   const groupSchedule = useMemo(
     () => normalizeLessons(groupScheduleRaw),
     [groupScheduleRaw, normalizeLessons]

--- a/root/frontend/src/pages/__tests__/Schedule.cache.test.tsx
+++ b/root/frontend/src/pages/__tests__/Schedule.cache.test.tsx
@@ -1,0 +1,207 @@
+import { MemoryRouter } from "react-router-dom"
+import { cleanup, render, screen, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { LanguageProvider } from "@/contexts/LanguageContext"
+import Schedule from "@/pages/Schedule"
+import type { User } from "@/types/User"
+import type { ReactNode } from "react"
+
+type AuthState = {
+  isAuth: boolean
+  login: ReturnType<typeof vi.fn>
+  logout: ReturnType<typeof vi.fn>
+  refresh: ReturnType<typeof vi.fn>
+  user: User | null
+  loading: boolean
+  setUser: ReturnType<typeof vi.fn>
+}
+
+const apiMocks = vi.hoisted(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  patch: vi.fn(),
+  delete: vi.fn(),
+  put: vi.fn(),
+}))
+
+const baseUser: User = {
+  id: 1,
+  email: "student@example.com",
+  full_name: "Test Student",
+  role: "student",
+  group_id: 1,
+  avatar_url: null,
+  cover_url: null,
+  about: null,
+  record_book_number: null,
+  status: null,
+  institute: null,
+  course: null,
+  education_level: null,
+  track: null,
+  program: null,
+  telegram: null,
+  achievements: null,
+  department: null,
+  position: null,
+  spotify_connected: false,
+  spotify_display_name: null,
+  spotify_is_connected: false,
+  dnd_enabled: false,
+  dnd_start: null,
+  dnd_end: null,
+  is_active: true,
+  mfa_required: false,
+  mfa_default_method: null,
+  mfa_last_verified_at: null,
+  mfa_recovery_codes_generated_at: null,
+  totp_enrollments: [],
+  webauthn_credentials: [],
+  recovery_codes: [],
+  mfa_challenges: [],
+}
+
+const authState: AuthState = {
+  isAuth: true,
+  login: vi.fn(),
+  logout: vi.fn(),
+  refresh: vi.fn(),
+  user: baseUser,
+  loading: false,
+  setUser: vi.fn(),
+}
+
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => authState,
+  currentUserQueryKey: ["users", "me"] as const,
+}))
+
+vi.mock("@/api/client", () => ({
+  __esModule: true,
+  default: {
+    get: apiMocks.get,
+    post: apiMocks.post,
+    patch: apiMocks.patch,
+    delete: apiMocks.delete,
+    put: apiMocks.put,
+    interceptors: { response: { use: vi.fn() }, request: { use: vi.fn() } },
+  },
+}))
+
+vi.mock("@/components/PageFadeIn", () => ({
+  default: ({ children }: { children: ReactNode }) => <>{children}</>,
+}))
+
+const apiGetMock = apiMocks.get
+
+function renderSchedule() {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  })
+
+  const result = render(
+    <QueryClientProvider client={client}>
+      <LanguageProvider>
+        <MemoryRouter initialEntries={["/schedule"]}>
+          <Schedule />
+        </MemoryRouter>
+      </LanguageProvider>
+    </QueryClientProvider>
+  )
+
+  return { client, ...result }
+}
+
+describe("Schedule cache handling", () => {
+  beforeEach(() => {
+    localStorage.clear()
+    localStorage.setItem("ue:language", "en")
+    authState.user = { ...baseUser }
+    authState.loading = false
+    apiGetMock.mockReset()
+    apiMocks.post.mockReset()
+    apiMocks.patch.mockReset()
+    apiMocks.delete.mockReset()
+    apiMocks.put.mockReset()
+    if (!(Element.prototype as any).scrollTo) {
+      ;(Element.prototype as any).scrollTo = vi.fn()
+    }
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it("falls back to network fetch when cached schedule is stale", async () => {
+    const stalePayload = {
+      version: 1,
+      timestamp: 0,
+    }
+    localStorage.setItem(
+      "sched:groups",
+      JSON.stringify({ ...stalePayload, data: [{ id: 1, name: "Stale Group" }] })
+    )
+    localStorage.setItem(
+      "sched:1",
+      JSON.stringify({
+        ...stalePayload,
+        data: [
+          {
+            id: 100,
+            weekday: "Monday",
+            parity: "odd",
+            start_time: "2024-03-25T08:00:00",
+            end_time: "2024-03-25T09:30:00",
+            subject: "Stale Subject",
+            teacher: "Ada",
+            room: "101",
+            lesson_type: "Lecture",
+            group_id: 1,
+          },
+        ],
+      })
+    )
+
+    apiGetMock.mockImplementation(async (url: string) => {
+      if (url === "/groups") {
+        return { data: [{ id: 1, name: "Fresh Group" }] }
+      }
+      if (url === "/schedule/1") {
+        return {
+          data: [
+            {
+              id: 101,
+              weekday: "Monday",
+              parity: "odd",
+              start_time: "2024-03-25T08:00:00",
+              end_time: "2024-03-25T09:30:00",
+              subject: "Fresh Subject",
+              teacher: "Alan",
+              room: "202",
+              lesson_type: "Lecture",
+              group_id: 1,
+            },
+          ],
+        }
+      }
+      throw new Error(`Unhandled GET ${url}`)
+    })
+
+    const { client } = renderSchedule()
+
+    try {
+      await waitFor(() => {
+        expect(apiGetMock).toHaveBeenCalledWith("/groups")
+        expect(apiGetMock).toHaveBeenCalledWith("/schedule/1")
+      })
+
+      expect(await screen.findByText("Fresh Subject")).toBeInTheDocument()
+      expect(screen.queryByText("Stale Subject")).not.toBeInTheDocument()
+    } finally {
+      client.clear()
+    }
+  })
+})
+

--- a/root/frontend/src/pages/__tests__/Schedule.cache.test.tsx
+++ b/root/frontend/src/pages/__tests__/Schedule.cache.test.tsx
@@ -204,4 +204,3 @@ describe("Schedule cache handling", () => {
     }
   })
 })
-


### PR DESCRIPTION
## Summary
- add schema metadata and TTL validation to schedule localStorage caches
- hydrate React Query from cached payloads and invalidate them once the TTL expires
- cover stale cache fallback behaviour with a Schedule cache test

## Testing
- npm test -- Schedule.cache
- npm test -- Schedule.translations

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910c8227af083278f1fe36d701db723)