### PR TITLE
Record notification enqueue failures and add telemetry

### DIFF
--- a/root/app/api/events.py
+++ b/root/app/api/events.py
@@ -215,13 +215,21 @@ async def create_event(
         )
     record = await crud.create_event(db, data, user_id=user.id)
     await _invalidate_events_list_cache()
+    job = notification_queue.NotificationJob(
+        kind="event", record_id=record.id, locale=locale
+    )
     try:
         background.add_task(
             notification_queue.enqueue_event_notification,
             record.id,
             locale=locale,
         )
-    except Exception:
+    except Exception as exc:
+        await notification_queue.record_enqueue_failure(
+            job,
+            error=exc,
+            source="events.create_event",
+        )
         logger.exception(
             "Failed to enqueue event notification", extra={"event_id": record.id}
         )

--- a/root/app/core/observability.py
+++ b/root/app/core/observability.py
@@ -641,6 +641,7 @@ class NotificationQueueMetrics:
     queue_size: Gauge
     dropped_jobs_total: Counter
     failed_jobs_total: Counter
+    enqueue_failures_total: Counter
     processed_jobs_total: Counter
     processing_latency_seconds: Histogram
     queue_wait_time_seconds: Histogram
@@ -656,6 +657,7 @@ class NotificationQueueMetrics:
             self.queue_size,
             self.dropped_jobs_total,
             self.failed_jobs_total,
+            self.enqueue_failures_total,
             self.processed_jobs_total,
             self.processing_latency_seconds,
             self.queue_wait_time_seconds,
@@ -673,6 +675,7 @@ class NotificationQueueMetrics:
         self.queue_size = fresh.queue_size
         self.dropped_jobs_total = fresh.dropped_jobs_total
         self.failed_jobs_total = fresh.failed_jobs_total
+        self.enqueue_failures_total = fresh.enqueue_failures_total
         self.processed_jobs_total = fresh.processed_jobs_total
         self.processing_latency_seconds = fresh.processing_latency_seconds
         self.queue_wait_time_seconds = fresh.queue_wait_time_seconds
@@ -737,6 +740,12 @@ def create_notification_queue_metrics(
         failed_jobs_total=Counter(
             "notification_queue_failed_jobs_total",
             "Total notification jobs permanently failed or dead-lettered",
+            labelnames=("kind",),
+            registry=target_registry,
+        ),
+        enqueue_failures_total=Counter(
+            "notification_queue_enqueue_failures_total",
+            "Total notification jobs that failed to be enqueued",
             labelnames=("kind",),
             registry=target_registry,
         ),
@@ -838,6 +847,7 @@ def reinitialize_notification_queue_metrics(
             _notification_queue_metrics.queue_size,
             _notification_queue_metrics.dropped_jobs_total,
             _notification_queue_metrics.failed_jobs_total,
+            _notification_queue_metrics.enqueue_failures_total,
             _notification_queue_metrics.processed_jobs_total,
             _notification_queue_metrics.processing_latency_seconds,
             _notification_queue_metrics.queue_wait_time_seconds,

--- a/root/app/services/notification_queue.py
+++ b/root/app/services/notification_queue.py
@@ -150,9 +150,7 @@ async def record_enqueue_failure(
         try:
             metrics.enqueue_failures_total.labels(kind=job.kind).inc()
         except Exception:  # pragma: no cover - defensive metrics guard
-            logger.debug(
-                "Failed to increment enqueue failure metric", exc_info=True
-            )
+            logger.debug("Failed to increment enqueue failure metric", exc_info=True)
     record = FailedEnqueueRecord(
         job=job,
         error=_serialize_error(error),
@@ -184,7 +182,8 @@ async def retry_failed_enqueues(limit: int | None = None) -> int:
     async with _failed_enqueue_lock:
         if limit is None:
             pending: list[FailedEnqueueRecord] = [
-                _failed_enqueue_records.popleft() for _ in range(len(_failed_enqueue_records))
+                _failed_enqueue_records.popleft()
+                for _ in range(len(_failed_enqueue_records))
             ]
         else:
             count = max(int(limit), 0)

--- a/root/app/services/notification_queue.py
+++ b/root/app/services/notification_queue.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+from collections import deque
 from collections.abc import Awaitable, Callable, Iterable, Sequence
 from contextlib import suppress
 from dataclasses import dataclass, replace
@@ -47,6 +48,17 @@ class NotificationJob:
 
 
 @dataclass(slots=True)
+class FailedEnqueueRecord:
+    """Metadata describing an enqueue attempt that did not succeed."""
+
+    job: NotificationJob
+    error: str | None
+    source: str | None
+    occurred_at: datetime
+    attempts: int = 1
+
+
+@dataclass(slots=True)
 class _LoopState:
     """Per-event-loop resources for the notification queue."""
 
@@ -66,6 +78,11 @@ _queue_metrics: NotificationQueueMetrics | None = None
 _DEAD_LETTER_CLEANUP_METRICS = get_periodic_task_metrics(
     "notification_queue_dead_letter_cleanup"
 )
+
+
+_FAILED_ENQUEUE_HISTORY_LIMIT = 128
+_failed_enqueue_records: deque[FailedEnqueueRecord] = deque()
+_failed_enqueue_lock = asyncio.Lock()
 
 
 def _get_metrics() -> NotificationQueueMetrics | None:
@@ -110,6 +127,100 @@ def _get_loop_state() -> _LoopState:
 
 
 _WORKER_TASK_NAME = "notification-queue-worker"
+
+
+def _serialize_error(error: BaseException | str | None) -> str | None:
+    if error is None:
+        return None
+    if isinstance(error, BaseException):
+        return f"{error.__class__.__name__}: {error}"
+    return str(error)
+
+
+async def record_enqueue_failure(
+    job: NotificationJob,
+    *,
+    error: BaseException | str | None = None,
+    source: str | None = None,
+) -> None:
+    """Record telemetry and in-memory state for a failed enqueue attempt."""
+
+    metrics = _get_metrics()
+    if metrics is not None:
+        try:
+            metrics.enqueue_failures_total.labels(kind=job.kind).inc()
+        except Exception:  # pragma: no cover - defensive metrics guard
+            logger.debug(
+                "Failed to increment enqueue failure metric", exc_info=True
+            )
+    record = FailedEnqueueRecord(
+        job=job,
+        error=_serialize_error(error),
+        source=source,
+        occurred_at=datetime.now(UTC),
+    )
+    async with _failed_enqueue_lock:
+        _failed_enqueue_records.append(record)
+        while len(_failed_enqueue_records) > _FAILED_ENQUEUE_HISTORY_LIMIT:
+            dropped = _failed_enqueue_records.popleft()
+            logger.debug(
+                "Discarding oldest failed enqueue record", extra={"job": dropped.job}
+            )
+
+
+async def get_failed_enqueue_records() -> list[FailedEnqueueRecord]:
+    """Return a snapshot of recorded failed enqueue attempts."""
+
+    async with _failed_enqueue_lock:
+        return [replace(record) for record in _failed_enqueue_records]
+
+
+async def retry_failed_enqueues(limit: int | None = None) -> int:
+    """Retry previously failed enqueue attempts.
+
+    Returns the number of jobs successfully re-enqueued.
+    """
+
+    async with _failed_enqueue_lock:
+        if limit is None:
+            pending: list[FailedEnqueueRecord] = [
+                _failed_enqueue_records.popleft() for _ in range(len(_failed_enqueue_records))
+            ]
+        else:
+            count = max(int(limit), 0)
+            pending = [
+                _failed_enqueue_records.popleft()
+                for _ in range(min(count, len(_failed_enqueue_records)))
+            ]
+
+    successes = 0
+    failures: list[FailedEnqueueRecord] = []
+    for record in pending:
+        try:
+            await _enqueue_job(record.job)
+        except Exception as exc:  # pragma: no cover - defensive guard
+            record.error = _serialize_error(exc)
+            record.attempts += 1
+            record.occurred_at = datetime.now(UTC)
+            failures.append(record)
+            metrics = _get_metrics()
+            if metrics is not None:
+                try:
+                    metrics.enqueue_failures_total.labels(kind=record.job.kind).inc()
+                except Exception:  # pragma: no cover - defensive metrics guard
+                    logger.debug(
+                        "Failed to increment enqueue failure metric during retry",
+                        exc_info=True,
+                    )
+        else:
+            successes += 1
+
+    if failures:
+        async with _failed_enqueue_lock:
+            for record in failures:
+                _failed_enqueue_records.append(record)
+
+    return successes
 
 
 async def _ensure_worker() -> None:
@@ -354,13 +465,31 @@ async def enqueue_event_notification(
 ) -> None:
     """Queue an event notification job for asynchronous delivery."""
 
-    await _enqueue_job(NotificationJob(kind="event", record_id=event_id, locale=locale))
+    job = NotificationJob(kind="event", record_id=event_id, locale=locale)
+    try:
+        await _enqueue_job(job)
+    except Exception as exc:
+        await record_enqueue_failure(
+            job,
+            error=exc,
+            source="notification_queue.enqueue_event_notification",
+        )
+        raise
 
 
 async def enqueue_news_notification(news_id: int, *, locale: str | None = None) -> None:
     """Queue a news notification job for asynchronous delivery."""
 
-    await _enqueue_job(NotificationJob(kind="news", record_id=news_id, locale=locale))
+    job = NotificationJob(kind="news", record_id=news_id, locale=locale)
+    try:
+        await _enqueue_job(job)
+    except Exception as exc:
+        await record_enqueue_failure(
+            job,
+            error=exc,
+            source="notification_queue.enqueue_news_notification",
+        )
+        raise
 
 
 async def wait_for_all_jobs(timeout: float | None = None) -> None:
@@ -404,6 +533,8 @@ async def reset_testing_state() -> None:
     state.active_jobs = 0
     state.job_event.clear()
     await _clear_persistent_jobs()
+    async with _failed_enqueue_lock:
+        _failed_enqueue_records.clear()
     if metrics is not None:
         metrics.reset()
         if _use_persistent_backend():

--- a/root/tests/test_events_localization.py
+++ b/root/tests/test_events_localization.py
@@ -7,7 +7,10 @@ from app import crud
 from app.api import events
 from app.auth.security import get_password_hash
 from app.models import models
-from app.services import attendance_tokens
+from prometheus_client import CollectorRegistry
+
+from app.core import observability
+from app.services import attendance_tokens, notification_queue
 
 
 async def _login(async_client, email: str, password: str) -> dict[str, str]:
@@ -125,6 +128,59 @@ async def test_events_localization(async_client, db_session, user_factory):
     assert payload_ru[primary.id]["about"] == "Подробности"
     assert payload_ru[fallback.id]["title"] == "Только русский"
     assert payload_ru[fallback.id]["description"] == "Без перевода"
+
+
+@pytest.mark.anyio
+async def test_create_event_records_enqueue_failure(
+    async_client, db_session, user_factory, monkeypatch
+):
+    registry = CollectorRegistry()
+    metrics = observability.reinitialize_notification_queue_metrics(registry=registry)
+    notification_queue._queue_metrics = metrics
+    await notification_queue.reset_testing_state()
+
+    password = "TeacherPass123!"
+    teacher = await user_factory(
+        role="teacher", hashed_password=get_password_hash(password), is_active=True
+    )
+
+    headers = await _login(async_client, teacher.email, password)
+
+    def _failing_add_task(self, func, *args, **kwargs):  # pragma: no cover - test shim
+        raise RuntimeError("notification queue unavailable")
+
+    monkeypatch.setattr(events.BackgroundTasks, "add_task", _failing_add_task)
+
+    now = datetime.now(UTC)
+    payload = {
+        "title": "Queue Failure",
+        "description": "Test enqueue failure handling",
+        "starts_at": (now + timedelta(days=1)).isoformat(),
+        "ends_at": (now + timedelta(days=1, hours=1)).isoformat(),
+    }
+
+    response = await async_client.post("/events", headers=headers, json=payload)
+    assert response.status_code == status.HTTP_200_OK
+
+    body = response.json()
+    assert body["title"] == "Queue Failure"
+
+    counter_value = metrics.enqueue_failures_total.labels(kind="event")._value.get()
+    assert counter_value == pytest.approx(1.0)
+
+    failed_records = await notification_queue.get_failed_enqueue_records()
+    assert len(failed_records) == 1
+    failure = failed_records[0]
+    assert failure.job.record_id == body["id"]
+    assert failure.job.kind == "event"
+    assert failure.attempts == 1
+    assert failure.source == "events.create_event"
+    assert failure.error and "notification queue unavailable" in failure.error
+
+    stored = await db_session.get(models.Event, body["id"])
+    assert stored is not None
+
+    await notification_queue.reset_testing_state()
 
 
 @pytest.mark.anyio

--- a/root/tests/test_events_localization.py
+++ b/root/tests/test_events_localization.py
@@ -2,14 +2,13 @@ from datetime import UTC, datetime, timedelta
 
 import pytest
 from fastapi import status
+from prometheus_client import CollectorRegistry
 
 from app import crud
 from app.api import events
 from app.auth.security import get_password_hash
-from app.models import models
-from prometheus_client import CollectorRegistry
-
 from app.core import observability
+from app.models import models
 from app.services import attendance_tokens, notification_queue
 
 


### PR DESCRIPTION
## Summary
- record failed event notification enqueue attempts in the API using the notification queue audit helpers
- extend the notification queue service with telemetry, retry helpers, and Prometheus metrics for enqueue failures
- cover the enqueue failure path with a regression test that ensures telemetry is captured without breaking the API response

## Testing
- pytest root/tests/test_events_localization.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910ccab27f88327b80e49b5c5e58763)