### PR TITLE
Refactor bootstrap fallback with bilingual copy

### DIFF
--- a/root/frontend/src/main.tsx
+++ b/root/frontend/src/main.tsx
@@ -3,6 +3,7 @@ import { initGlobalErrorHandlers } from "./app/globalErrorHandlers"
 import { logError } from "./app/logger"
 import { initWebVitals } from "./app/webVitals"
 import { ensureTrustedTypesPolicies } from "./utils/trustedTypes"
+import { getBootstrapFallbackCopy, renderBootstrapFallback } from "./utils/bootstrapFallback"
 
 initObservability()
 initGlobalErrorHandlers()
@@ -135,87 +136,14 @@ async function bootstrap() {
 
     rootElement.innerHTML = ""
 
-    const container = document.createElement("div")
-    container.setAttribute("role", "alert")
-    container.style.display = "flex"
-    container.style.flexDirection = "column"
-    container.style.alignItems = "center"
-    container.style.justifyContent = "center"
-    container.style.minHeight = "100vh"
-    container.style.padding = "2rem"
-    container.style.gap = "1.5rem"
-    container.style.textAlign = "center"
-    container.style.backgroundColor = "#f5f5f5"
+    const copy = getBootstrapFallbackCopy(document)
 
-    const title = document.createElement("h1")
-    title.textContent = "Не удалось загрузить приложение"
-    title.style.margin = "0"
-    title.style.fontSize = "1.75rem"
-
-    const description = document.createElement("p")
-    description.textContent =
-      "Попробуйте перезагрузить страницу или очистить кэш браузера. Если проблема сохраняется, обратитесь в поддержку."
-    description.style.margin = "0"
-    description.style.maxWidth = "32rem"
-    description.style.color = "#333"
-
-    const actions = document.createElement("div")
-    actions.style.display = "flex"
-    actions.style.flexWrap = "wrap"
-    actions.style.gap = "1rem"
-    actions.style.justifyContent = "center"
-
-    const reloadButton = document.createElement("button")
-    reloadButton.type = "button"
-    reloadButton.textContent = "Перезагрузить страницу"
-    reloadButton.style.padding = "0.75rem 1.5rem"
-    reloadButton.style.fontSize = "1rem"
-    reloadButton.style.borderRadius = "9999px"
-    reloadButton.style.border = "none"
-    reloadButton.style.cursor = "pointer"
-    reloadButton.style.backgroundColor = "#1976d2"
-    reloadButton.style.color = "#fff"
-    reloadButton.addEventListener("click", () => {
-      window.location.reload()
+    renderBootstrapFallback({
+      documentRef: document,
+      rootElement,
+      copy,
+      logError,
     })
-
-    const clearCacheButton = document.createElement("button")
-    clearCacheButton.type = "button"
-    clearCacheButton.textContent = "Очистить кэш и перезагрузить"
-    clearCacheButton.style.padding = "0.75rem 1.5rem"
-    clearCacheButton.style.fontSize = "1rem"
-    clearCacheButton.style.borderRadius = "9999px"
-    clearCacheButton.style.border = "1px solid #1976d2"
-    clearCacheButton.style.cursor = "pointer"
-    clearCacheButton.style.backgroundColor = "transparent"
-    clearCacheButton.style.color = "#1976d2"
-    clearCacheButton.addEventListener("click", () => {
-      clearCacheButton.disabled = true
-      clearCacheButton.textContent = "Очищаем кэш..."
-
-      void (async () => {
-        try {
-          if ("serviceWorker" in navigator) {
-            const registrations = await navigator.serviceWorker.getRegistrations()
-            await Promise.all(registrations.map((registration) => registration.unregister()))
-          }
-          if ("caches" in window) {
-            const cacheKeys = await caches.keys()
-            await Promise.all(cacheKeys.map((cacheKey) => caches.delete(cacheKey)))
-          }
-        } catch (cleanupError) {
-          logError("Failed to clear caches after bootstrap error", cleanupError)
-        } finally {
-          window.location.reload()
-        }
-      })()
-    })
-
-    actions.append(reloadButton, clearCacheButton)
-
-    container.append(title, description, actions)
-
-    rootElement.append(container)
   }
 }
 

--- a/root/frontend/src/tests/bootstrapFallback.test.ts
+++ b/root/frontend/src/tests/bootstrapFallback.test.ts
@@ -1,9 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 
-import {
-  getBootstrapFallbackCopy,
-  renderBootstrapFallback,
-} from "../utils/bootstrapFallback"
+import { getBootstrapFallbackCopy, renderBootstrapFallback } from "../utils/bootstrapFallback"
 
 afterEach(() => {
   document.body.innerHTML = ""

--- a/root/frontend/src/tests/bootstrapFallback.test.ts
+++ b/root/frontend/src/tests/bootstrapFallback.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import {
+  getBootstrapFallbackCopy,
+  renderBootstrapFallback,
+} from "../utils/bootstrapFallback"
+
+afterEach(() => {
+  document.body.innerHTML = ""
+  document.documentElement.lang = ""
+  vi.restoreAllMocks()
+})
+
+describe("bootstrap fallback", () => {
+  it("renders English copy and keeps button behaviors", async () => {
+    document.documentElement.lang = "en"
+    const rootElement = document.createElement("div")
+    document.body.append(rootElement)
+
+    const copy = getBootstrapFallbackCopy(document)
+    const onReload = vi.fn()
+    const clearCachesAndReload = vi.fn().mockResolvedValue(undefined)
+    const logError = vi.fn()
+
+    const { reloadButton, clearCacheButton, container } = renderBootstrapFallback({
+      documentRef: document,
+      rootElement,
+      copy,
+      logError,
+      onReload,
+      clearCachesAndReload,
+    })
+
+    expect(container.querySelector("h1")?.textContent).toBe(copy.title)
+    expect(container.querySelector("p")?.textContent).toBe(copy.description)
+    expect(reloadButton.textContent).toBe(copy.reloadButtonLabel)
+    expect(clearCacheButton.textContent).toBe(copy.clearCacheButtonLabel)
+
+    reloadButton.click()
+    expect(onReload).toHaveBeenCalledTimes(1)
+
+    clearCacheButton.click()
+
+    expect(clearCacheButton.disabled).toBe(true)
+    expect(clearCacheButton.textContent).toBe(copy.clearingCacheLabel)
+    expect(clearCachesAndReload).toHaveBeenCalledTimes(1)
+
+    await Promise.resolve()
+
+    expect(onReload).toHaveBeenCalledTimes(2)
+    expect(logError).not.toHaveBeenCalled()
+  })
+
+  it("renders Russian copy when lang is ru", () => {
+    document.documentElement.lang = "ru"
+    const rootElement = document.createElement("div")
+    document.body.append(rootElement)
+
+    const copy = getBootstrapFallbackCopy(document)
+    const { container, reloadButton, clearCacheButton } = renderBootstrapFallback({
+      documentRef: document,
+      rootElement,
+      copy,
+      logError: vi.fn(),
+    })
+
+    expect(copy.title).toBe("Не удалось загрузить приложение")
+    expect(container.querySelector("h1")?.textContent).toBe(copy.title)
+    expect(container.querySelector("p")?.textContent).toBe(copy.description)
+    expect(reloadButton.textContent).toBe("Перезагрузить страницу")
+    expect(clearCacheButton.textContent).toBe("Очистить кэш и перезагрузить")
+  })
+})

--- a/root/frontend/src/utils/bootstrapFallback.ts
+++ b/root/frontend/src/utils/bootstrapFallback.ts
@@ -1,0 +1,182 @@
+export type BootstrapFallbackLanguage = "en" | "ru"
+
+export interface BootstrapFallbackCopy {
+  title: string
+  description: string
+  reloadButtonLabel: string
+  clearCacheButtonLabel: string
+  clearingCacheLabel: string
+}
+
+const FALLBACK_DICTIONARY: Record<BootstrapFallbackLanguage, BootstrapFallbackCopy> = {
+  en: {
+    title: "We couldn't load the application",
+    description:
+      "Try refreshing the page or clearing your browser cache. If the issue persists, contact support.",
+    reloadButtonLabel: "Reload page",
+    clearCacheButtonLabel: "Clear cache and reload",
+    clearingCacheLabel: "Clearing cache...",
+  },
+  ru: {
+    title: "Не удалось загрузить приложение",
+    description:
+      "Попробуйте перезагрузить страницу или очистить кэш браузера. Если проблема сохраняется, обратитесь в поддержку.",
+    reloadButtonLabel: "Перезагрузить страницу",
+    clearCacheButtonLabel: "Очистить кэш и перезагрузить",
+    clearingCacheLabel: "Очищаем кэш...",
+  },
+}
+
+function normalizeLanguage(value: string | null | undefined): BootstrapFallbackLanguage | null {
+  if (!value) {
+    return null
+  }
+
+  const normalized = value.toLowerCase().split("-")[0]
+  if (normalized === "en" || normalized === "ru") {
+    return normalized
+  }
+
+  return null
+}
+
+export function getBootstrapFallbackCopy(documentRef: Document): BootstrapFallbackCopy {
+  const detected = normalizeLanguage(documentRef.documentElement.lang) ??
+    normalizeLanguage(documentRef.body?.lang)
+
+  if (detected) {
+    return FALLBACK_DICTIONARY[detected]
+  }
+
+  return FALLBACK_DICTIONARY.en
+}
+
+interface RenderBootstrapFallbackOptions {
+  documentRef: Document
+  rootElement: HTMLElement
+  copy: BootstrapFallbackCopy
+  logError: (message: string, error: unknown) => void
+  onReload?: () => void
+  clearCachesAndReload?: () => Promise<void>
+}
+
+export interface RenderedBootstrapFallback {
+  container: HTMLDivElement
+  reloadButton: HTMLButtonElement
+  clearCacheButton: HTMLButtonElement
+}
+
+export function renderBootstrapFallback({
+  documentRef,
+  rootElement,
+  copy,
+  logError,
+  onReload,
+  clearCachesAndReload,
+}: RenderBootstrapFallbackOptions): RenderedBootstrapFallback {
+  const defaultWindow = documentRef.defaultView ?? window
+  const reload =
+    onReload ?? (() => {
+      defaultWindow.location.reload()
+    })
+
+  const clearCaches = clearCachesAndReload
+    ? clearCachesAndReload
+    : async () => {
+        if ("serviceWorker" in defaultWindow.navigator) {
+          const registrations = await defaultWindow.navigator.serviceWorker.getRegistrations()
+          await Promise.all(registrations.map((registration) => registration.unregister()))
+        }
+
+        if ("caches" in defaultWindow) {
+          const cacheKeys = await defaultWindow.caches.keys()
+          await Promise.all(cacheKeys.map((cacheKey) => defaultWindow.caches.delete(cacheKey)))
+        }
+      }
+
+  rootElement.innerHTML = ""
+
+  const container = documentRef.createElement("div")
+  container.setAttribute("role", "alert")
+  container.style.display = "flex"
+  container.style.flexDirection = "column"
+  container.style.alignItems = "center"
+  container.style.justifyContent = "center"
+  container.style.minHeight = "100vh"
+  container.style.padding = "2rem"
+  container.style.gap = "1.5rem"
+  container.style.textAlign = "center"
+  container.style.backgroundColor = "#f5f5f5"
+
+  const title = documentRef.createElement("h1")
+  title.textContent = copy.title
+  title.style.margin = "0"
+  title.style.fontSize = "1.75rem"
+
+  const description = documentRef.createElement("p")
+  description.textContent = copy.description
+  description.style.margin = "0"
+  description.style.maxWidth = "32rem"
+  description.style.color = "#333"
+
+  const actions = documentRef.createElement("div")
+  actions.style.display = "flex"
+  actions.style.flexWrap = "wrap"
+  actions.style.gap = "1rem"
+  actions.style.justifyContent = "center"
+
+  const reloadButton = documentRef.createElement("button")
+  reloadButton.type = "button"
+  reloadButton.textContent = copy.reloadButtonLabel
+  reloadButton.style.padding = "0.75rem 1.5rem"
+  reloadButton.style.fontSize = "1rem"
+  reloadButton.style.borderRadius = "9999px"
+  reloadButton.style.border = "none"
+  reloadButton.style.cursor = "pointer"
+  reloadButton.style.backgroundColor = "#1976d2"
+  reloadButton.style.color = "#fff"
+  reloadButton.addEventListener("click", () => {
+    reload()
+  })
+
+  const clearCacheButton = documentRef.createElement("button")
+  clearCacheButton.type = "button"
+  clearCacheButton.textContent = copy.clearCacheButtonLabel
+  clearCacheButton.style.padding = "0.75rem 1.5rem"
+  clearCacheButton.style.fontSize = "1rem"
+  clearCacheButton.style.borderRadius = "9999px"
+  clearCacheButton.style.border = "1px solid #1976d2"
+  clearCacheButton.style.cursor = "pointer"
+  clearCacheButton.style.backgroundColor = "transparent"
+  clearCacheButton.style.color = "#1976d2"
+  clearCacheButton.addEventListener("click", () => {
+    if (clearCacheButton.disabled) {
+      return
+    }
+
+    clearCacheButton.disabled = true
+    clearCacheButton.textContent = copy.clearingCacheLabel
+
+    void (async () => {
+      try {
+        await clearCaches()
+      } catch (cleanupError) {
+        logError("Failed to clear caches after bootstrap error", cleanupError)
+      } finally {
+        reload()
+      }
+    })()
+  })
+
+  actions.append(reloadButton, clearCacheButton)
+
+  container.append(title, description, actions)
+
+  rootElement.append(container)
+
+  return {
+    container,
+    reloadButton,
+    clearCacheButton,
+  }
+}

--- a/root/frontend/src/utils/bootstrapFallback.ts
+++ b/root/frontend/src/utils/bootstrapFallback.ts
@@ -41,8 +41,8 @@ function normalizeLanguage(value: string | null | undefined): BootstrapFallbackL
 }
 
 export function getBootstrapFallbackCopy(documentRef: Document): BootstrapFallbackCopy {
-  const detected = normalizeLanguage(documentRef.documentElement.lang) ??
-    normalizeLanguage(documentRef.body?.lang)
+  const detected =
+    normalizeLanguage(documentRef.documentElement.lang) ?? normalizeLanguage(documentRef.body?.lang)
 
   if (detected) {
     return FALLBACK_DICTIONARY[detected]
@@ -76,7 +76,8 @@ export function renderBootstrapFallback({
 }: RenderBootstrapFallbackOptions): RenderedBootstrapFallback {
   const defaultWindow = documentRef.defaultView ?? window
   const reload =
-    onReload ?? (() => {
+    onReload ??
+    (() => {
       defaultWindow.location.reload()
     })
 


### PR DESCRIPTION
## Summary
- move the bootstrap fallback UI into a helper backed by a bilingual dictionary
- detect the document language before rendering the fallback UI and default to English
- cover the helper with a Vitest to assert copy selection and button behaviors

## Testing
- npm run test -- bootstrapFallback

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910fa8bd7b88327989aa875957181a3)