### PR TITLE
Enforce environment-aware schema creation defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,28 @@ cp root/.env.example root/.env
 > process environment variables) with unique secrets before starting the
 > backend.
 
-### 2. Run the full stack with Docker (recommended)
+### 2. Run database migrations
+
+Apply the latest Alembic migrations before starting the API:
+
+```bash
+cd root
+# Reuse the same connection string you configure for DATABASE_URL
+export DATABASE_URL=postgresql+asyncpg://user:password@host:5432/university
+alembic upgrade head
+```
+
+Alembic reads the database URL from `root/alembic.ini`; when the bundled sample
+URL does not match your target database, set the `DATABASE_URL` environment
+variable before running the command. In Docker Compose, a one-off
+`migrations` service now executes `alembic upgrade head` automatically before
+the API and worker containers start. You can rerun migrations on demand with:
+
+```bash
+docker compose run --rm backend alembic upgrade head
+```
+
+### 3. Run the full stack with Docker (recommended)
 
 ```bash
 docker compose up --build
@@ -60,7 +81,7 @@ This command builds the backend, frontend, and notifications worker images, star
 - Frontend UI: http://localhost:8080
 - Worker metrics: http://localhost:9101/metrics
 
-### 3. Run services manually (alternative)
+### 4. Run services manually (alternative)
 
 #### Backend (FastAPI)
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
       ENABLE_METRICS_ENDPOINT: "true"
       METRICS_ALLOWLIST: 127.0.0.1,::1
     depends_on:
+      migrations:
+        condition: service_completed_successfully
       postgres:
         condition: service_healthy
     ports:
@@ -50,6 +52,8 @@ services:
       NOTIFICATIONS_WORKER_METRICS_HOST: 0.0.0.0
       NOTIFICATIONS_WORKER_METRICS_PORT: "9101"
     depends_on:
+      migrations:
+        condition: service_completed_successfully
       postgres:
         condition: service_healthy
     restart: unless-stopped
@@ -71,6 +75,21 @@ services:
       retries: 5
     ports:
       - "5432:5432"
+
+  migrations:
+    build:
+      context: .
+      dockerfile: root/backend.Dockerfile
+      target: runtime
+    command: alembic upgrade head
+    env_file:
+      - root/.env
+    environment:
+      DATABASE_URL: postgresql+psycopg://postgres:postgres@postgres:5432/university
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: "no"
 
 volumes:
   postgres-data:

--- a/docs/DEPLOY.en.md
+++ b/docs/DEPLOY.en.md
@@ -16,6 +16,27 @@ _[Russian version](DEPLOY.md) · [English version](DEPLOY.en.md)_
 - To expose Prometheus metrics, set `ENABLE_METRICS_ENDPOINT=true` and configure durable values for `METRICS_BASIC_AUTH_USERNAME` and `METRICS_BASIC_AUTH_PASSWORD` (docker-compose no longer injects placeholders). The backend refuses to serve `/metrics` if the password equals a known placeholder such as `changeme`.
 - To attach the `Cross-Origin-Resource-Policy` header, set `ENABLE_CORP=true`. Customize the value via `CORP_VALUE` (defaults to `same-site`; `same-origin` and `cross-origin` are also accepted).
 
+## Database migrations
+
+- Before launching a new release, run `alembic upgrade head`:
+
+  ```bash
+  cd root
+  export DATABASE_URL=postgresql+asyncpg://user:password@host:5432/university
+  alembic upgrade head
+  ```
+
+- Alembic reads the connection string from `root/alembic.ini`. If that sample URL
+  does not match your target database, provide the correct value through the
+  `DATABASE_URL` environment variable (reuse the same URL as the application).
+- Docker Compose now includes a one-off `migrations` service that runs
+  `alembic upgrade head` before the API and worker containers start. You can rerun
+  migrations manually when needed:
+
+  ```bash
+  docker compose run --rm backend alembic upgrade head
+  ```
+
 ### Database connection pool
 
 - In production environments use the SQLAlchemy pool: set `DATABASE_POOL_SIZE` (base pool size), `DATABASE_MAX_OVERFLOW` (additional connections above the pool), `DATABASE_POOL_TIMEOUT` (seconds to wait for a free connection), and `DATABASE_POOL_RECYCLE` (seconds before a forced connection close). Default values are `5`, `10`, `30`, and `1800` respectively.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -15,6 +15,27 @@ _[Русская версия](DEPLOY.md) · [English version](DEPLOY.en.md)_
 - Для экспонирования Prometheus-метрик установите `ENABLE_METRICS_ENDPOINT=true` и задайте собственные, стойкие значения `METRICS_BASIC_AUTH_USERNAME` и `METRICS_BASIC_AUTH_PASSWORD` (docker-compose больше не подставляет плейсхолдеры). Backend откажется отдавать `/metrics`, если пароль равен известному плейсхолдеру вроде `changeme`.
 - Для включения заголовка `Cross-Origin-Resource-Policy` установите `ENABLE_CORP=true`. Значение задаётся через `CORP_VALUE` (по умолчанию `same-site`; также поддерживаются `same-origin` и `cross-origin`).
 
+## Миграции базы данных
+
+- Перед первым запуском новой версии выполните `alembic upgrade head`:
+
+  ```bash
+  cd root
+  export DATABASE_URL=postgresql+asyncpg://user:password@host:5432/university
+  alembic upgrade head
+  ```
+
+- Alembic берёт строку подключения из `root/alembic.ini`. Если требуется другой
+  адрес, задайте его через переменную окружения `DATABASE_URL` (используйте то же
+  значение, что и для приложения).
+- В docker compose добавлен одноразовый сервис `migrations`, который выполняет
+  `alembic upgrade head` до запуска API и воркера. При необходимости повторите
+  миграции вручную:
+
+  ```bash
+  docker compose run --rm backend alembic upgrade head
+  ```
+
 ### Пул соединений базы данных
 
 - В production средах используйте пул SQLAlchemy: задайте `DATABASE_POOL_SIZE` (основной размер пула), `DATABASE_MAX_OVERFLOW` (дополнительные соединения поверх пула), `DATABASE_POOL_TIMEOUT` (секунды ожидания свободного соединения) и `DATABASE_POOL_RECYCLE` (период принудительного закрытия соединений, секунды). Значения по умолчанию — `5`, `10`, `30` и `1800` соответственно.

--- a/root/app/core/config.py
+++ b/root/app/core/config.py
@@ -382,9 +382,7 @@ class Settings(BaseSettings):
 
     @field_validator("auto_create_schema")
     @classmethod
-    def _warn_auto_create_schema(
-        cls, value: bool, info: ValidationInfo
-    ) -> bool:
+    def _warn_auto_create_schema(cls, value: bool, info: ValidationInfo) -> bool:
         if value:
             environment = str(info.data.get("environment") or "production").lower()
             if environment not in _DEVELOPMENT_ENVIRONMENTS:

--- a/root/app/core/config.py
+++ b/root/app/core/config.py
@@ -8,7 +8,7 @@ from functools import cached_property
 from pathlib import Path
 from urllib.parse import urlparse
 
-from pydantic import Field, ValidationError, field_validator
+from pydantic import Field, ValidationError, ValidationInfo, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 _PROJECT_ROOT = Path(__file__).resolve().parents[2]
@@ -128,6 +128,15 @@ def _validate_webauthn_origin(value: str) -> str:
 _logger = logging.getLogger(__name__)
 
 
+_DEVELOPMENT_ENVIRONMENTS = {
+    "dev",
+    "development",
+    "local",
+    "test",
+    "testing",
+}
+
+
 _DEVELOPMENT_FALLBACKS: dict[str, str] = {
     "database_url": "sqlite+aiosqlite:///./dev.db",
     "secret_key": "development-secret-key",  # pragma: allowlist secret
@@ -217,7 +226,7 @@ class Settings(BaseSettings):
     image_max_height: int = 1920
     trusted_hosts: str | list[str] = "localhost,127.0.0.1"
     environment: str = "development"
-    auto_create_schema: bool = True
+    auto_create_schema: bool | None = None
     smtp_host: str = ""
     smtp_port: int = 0
     smtp_user: str = ""
@@ -360,6 +369,35 @@ class Settings(BaseSettings):
     event_file_scanner_port: int = 3310
     event_file_scanner_socket: str = ""
     event_file_scanner_timeout: float = 30.0
+
+    @field_validator("auto_create_schema", mode="before")
+    @classmethod
+    def _default_auto_create_schema(
+        cls, value: bool | None, info: ValidationInfo
+    ) -> bool:
+        if value is not None:
+            return bool(value)
+        environment = str(info.data.get("environment") or "development").lower()
+        return environment in _DEVELOPMENT_ENVIRONMENTS
+
+    @field_validator("auto_create_schema")
+    @classmethod
+    def _warn_auto_create_schema(
+        cls, value: bool, info: ValidationInfo
+    ) -> bool:
+        if value:
+            environment = str(info.data.get("environment") or "production").lower()
+            if environment not in _DEVELOPMENT_ENVIRONMENTS:
+                _logger.warning(
+                    (
+                        "AUTO_CREATE_SCHEMA is enabled while ENVIRONMENT=%s. "
+                        "This should only be used for development or automated tests. "
+                        "Run 'alembic upgrade head' and set AUTO_CREATE_SCHEMA=false "
+                        "for production deployments."
+                    ),
+                    environment or "production",
+                )
+        return bool(value)
 
     @field_validator("database_pool_size")
     @classmethod
@@ -722,13 +760,7 @@ class Settings(BaseSettings):
 
     @cached_property
     def is_development(self) -> bool:
-        return str(self.environment).lower() in {
-            "dev",
-            "development",
-            "local",
-            "test",
-            "testing",
-        }
+        return str(self.environment).lower() in _DEVELOPMENT_ENVIRONMENTS
 
     @cached_property
     def cors_allow_methods_list(self) -> list[str]:

--- a/root/tests/test_core_config.py
+++ b/root/tests/test_core_config.py
@@ -128,3 +128,53 @@ def test_notifications_allowed_push_topics_parsed(monkeypatch):
         "schedule",
         "system",
     }
+
+
+def test_auto_create_schema_default_true_in_development(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "sqlite+aiosqlite:///./test.db")
+    monkeypatch.setenv("SECRET_KEY", "development-secret")
+    monkeypatch.setenv("ENVIRONMENT", "development")
+    monkeypatch.delenv("AUTO_CREATE_SCHEMA", raising=False)
+
+    with _temporary_env_file(None):
+        from app.core import config as config_module
+
+        config_module = importlib.reload(config_module)
+        settings = config_module.Settings()
+
+    assert settings.auto_create_schema is True
+
+
+def test_auto_create_schema_default_false_in_production(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "sqlite+aiosqlite:///./test.db")
+    monkeypatch.setenv("SECRET_KEY", "production-secret")
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.delenv("AUTO_CREATE_SCHEMA", raising=False)
+
+    with _temporary_env_file(None):
+        from app.core import config as config_module
+
+        config_module = importlib.reload(config_module)
+        settings = config_module.Settings()
+
+    assert settings.auto_create_schema is False
+
+
+def test_auto_create_schema_warns_when_enabled_in_production(monkeypatch, caplog):
+    monkeypatch.setenv("DATABASE_URL", "sqlite+aiosqlite:///./test.db")
+    monkeypatch.setenv("SECRET_KEY", "production-secret")
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("AUTO_CREATE_SCHEMA", "true")
+
+    with _temporary_env_file(None):
+        from app.core import config as config_module
+
+        with caplog.at_level("WARNING"):
+            config_module = importlib.reload(config_module)
+            settings = config_module.Settings()
+
+    assert settings.auto_create_schema is True
+    assert any(
+        "AUTO_CREATE_SCHEMA is enabled" in record.getMessage()
+        for record in caplog.records
+    )


### PR DESCRIPTION
## Summary
- ensure `AUTO_CREATE_SCHEMA` defaults to false outside development and log when forced on in production
- document the required Alembic migration workflow in the README and deployment guides
- add a migrations service to docker-compose so `alembic upgrade head` runs before app containers start and cover the behavior with tests

## Testing
- pytest tests/test_core_config.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69110176ec4083278381831ed7f4e048)