### PR TITLE
Propagate Sentry release metadata from Vite builds

### DIFF
--- a/docs/DEPLOY.en.md
+++ b/docs/DEPLOY.en.md
@@ -8,7 +8,8 @@ _[Russian version](DEPLOY.md) · [English version](DEPLOY.en.md)_
 - To render the interactive map, set `VITE_MAP_CONSTRUCTOR_ID` — the Yandex Maps constructor ID for the campus.
 - The `root/.env.example` file is only a template; set your own secrets via `.env` or environment variables in production.
 - All variables prefixed with `VITE_` are inlined into the code during `npm run build`; changing them after the build has no effect.
-- During CI/CD export `SERVICE_VERSION` (or `APP_VERSION`) before launching containers to propagate the build identifier to OpenTelemetry (`service.version`) and Sentry (`release`).
+- During CI/CD export `SERVICE_VERSION` (or `APP_VERSION`) before launching containers to propagate the build identifier to OpenTelemetry (`service.version`). The frontend build automatically reuses these variables — alongside common CI commit identifiers such as `SOURCE_VERSION`, `VERCEL_GIT_COMMIT`, or `GITHUB_SHA` — when `VITE_APP_RELEASE` is not explicitly provided.
+- Set `VITE_APP_RELEASE` to forward the release identifier to Sentry. Values are embedded at build time.
 - To enable client-side error monitoring, set `VITE_SENTRY_DSN` and, if needed, `VITE_ENVIRONMENT`. The SDK does not activate automatically in dev builds.
 - The frontend logger (`src/app/logger.ts`) automatically sends `logError`/`logWarning` to Sentry and mirrors the output in the console. Unhandled `Promise`/`axios` errors are captured by global handlers (`initGlobalErrorHandlers()` is invoked in `src/main.tsx`).
 - To collect Web Vitals, set `VITE_ENABLE_WEB_VITALS=true`. Optionally send metrics to your own endpoint through `VITE_WEB_VITALS_ENDPOINT` (otherwise they are printed to the console). The flag is ignored in dev/test environments, so CI will not fail even when the variable is enabled.
@@ -61,7 +62,8 @@ _[Russian version](DEPLOY.md) · [English version](DEPLOY.en.md)_
 # example
 cd frontend
 cp .env.production .env.local      # if needed
-VITE_BACKEND_ORIGIN=https://api.example.com npm run build
+VITE_APP_RELEASE=$(git rev-parse --short HEAD) \
+  VITE_BACKEND_ORIGIN=https://api.example.com npm run build
 ```
 
 - Localized PWA manifests are generated from `public/manifest.source.json`.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -7,7 +7,8 @@ _[Русская версия](DEPLOY.md) · [English version](DEPLOY.en.md)_
 - Перед сборкой фронтенда установите `VITE_BACKEND_ORIGIN` (например, через `frontend/.env.production`).
 - Файл `root/.env.example` служит только шаблоном; на продакшн-средах задайте собственные секреты через `.env` или переменные окружения.
 - Все переменные с префиксом `VITE_` подставляются в код на этапе `npm run build`; изменение значений после сборки эффекта не даст.
-- Во время CI/CD экспортируйте `SERVICE_VERSION` (или `APP_VERSION`) перед запуском контейнеров, чтобы пробросить идентификатор сборки в OpenTelemetry (`service.version`) и Sentry (`release`).
+- Во время CI/CD экспортируйте `SERVICE_VERSION` (или `APP_VERSION`) перед запуском контейнеров, чтобы пробросить идентификатор сборки в OpenTelemetry (`service.version`). Сборка фронтенда автоматически использует эти значения — а также распространённые CI-переменные вроде `SOURCE_VERSION`, `VERCEL_GIT_COMMIT` или `GITHUB_SHA` — если `VITE_APP_RELEASE` не задана явно.
+- Чтобы передать идентификатор релиза в Sentry, задайте `VITE_APP_RELEASE`. Значение подставляется на этапе сборки.
 - Для включения клиентского мониторинга ошибок задайте `VITE_SENTRY_DSN` и, при необходимости, `VITE_ENVIRONMENT`. В дев-сборке SDK автоматически не активируется.
 - Логгер на фронтенде (`src/app/logger.ts`) автоматически отправляет `logError`/`logWarning` в Sentry и дублирует вывод в консоль. Необработанные `Promise`/`axios` ошибки перехватываются глобальными хендлерами (`initGlobalErrorHandlers()` вызывается в `src/main.tsx`).
 - Чтобы собирать Web Vitals, установите `VITE_ENABLE_WEB_VITALS=true`. При необходимости отправляйте метрики на собственный эндпоинт через `VITE_WEB_VITALS_ENDPOINT` (иначе они пишутся в консоль). Флаг игнорируется в dev/test средах, поэтому CI не упадёт даже при включённой переменной.
@@ -60,7 +61,8 @@ _[Русская версия](DEPLOY.md) · [English version](DEPLOY.en.md)_
 # пример
 cd frontend
 cp .env.production .env.local      # при необходимости
-VITE_BACKEND_ORIGIN=https://api.example.com npm run build
+VITE_APP_RELEASE=$(git rev-parse --short HEAD) \
+  VITE_BACKEND_ORIGIN=https://api.example.com npm run build
 ```
 
 - Локализованные PWA-манифесты собираются из

--- a/root/frontend/src/app/observability.ts
+++ b/root/frontend/src/app/observability.ts
@@ -26,8 +26,7 @@ export function initObservability(env: ImportMetaEnv = import.meta.env): boolean
   }
 
   const environment = env.VITE_ENVIRONMENT ?? (env.PROD ? "production" : "development")
-  const release =
-    env.VITE_APP_RELEASE ?? env.VITE_RELEASE ?? env.VITE_SENTRY_RELEASE ?? undefined
+  const release = env.VITE_APP_RELEASE ?? env.VITE_RELEASE ?? env.VITE_SENTRY_RELEASE ?? undefined
   const tracesSampleRate = parseSampleRate(env.VITE_SENTRY_TRACES_SAMPLE_RATE)
   const profilesSampleRate = parseSampleRate(env.VITE_SENTRY_PROFILES_SAMPLE_RATE)
 

--- a/root/frontend/src/app/observability.ts
+++ b/root/frontend/src/app/observability.ts
@@ -26,16 +26,21 @@ export function initObservability(env: ImportMetaEnv = import.meta.env): boolean
   }
 
   const environment = env.VITE_ENVIRONMENT ?? (env.PROD ? "production" : "development")
+  const release =
+    env.VITE_APP_RELEASE ?? env.VITE_RELEASE ?? env.VITE_SENTRY_RELEASE ?? undefined
   const tracesSampleRate = parseSampleRate(env.VITE_SENTRY_TRACES_SAMPLE_RATE)
   const profilesSampleRate = parseSampleRate(env.VITE_SENTRY_PROFILES_SAMPLE_RATE)
 
-  Sentry.init({
+  const config = {
     dsn,
     environment,
     enabled: true,
     tracesSampleRate,
     profilesSampleRate,
-  })
+    ...(release ? { release } : {}),
+  }
+
+  Sentry.init(config)
 
   initialized = true
   return true

--- a/root/frontend/src/env.d.ts
+++ b/root/frontend/src/env.d.ts
@@ -3,6 +3,7 @@
 
 interface ImportMetaEnv {
   readonly VITE_BACKEND_ORIGIN?: string
+  readonly VITE_APP_RELEASE?: string
   readonly VITE_ENVIRONMENT?: string
   readonly VITE_SENTRY_DSN?: string
   readonly VITE_SENTRY_TRACES_SAMPLE_RATE?: string

--- a/root/frontend/src/tests/observability.test.ts
+++ b/root/frontend/src/tests/observability.test.ts
@@ -33,6 +33,25 @@ describe("initObservability", () => {
     )
   })
 
+  it("passes through the release identifier when provided", () => {
+    const result = initObservability({
+      DEV: false,
+      PROD: true,
+      BASE_URL: "http://localhost",
+      MODE: "production",
+      VITE_SENTRY_DSN: "https://examplePublicKey.ingest.sentry.io/123",
+      VITE_ENVIRONMENT: "production",
+      VITE_APP_RELEASE: "2024.04.15+sha.abcdef",
+    } as unknown as ImportMetaEnv)
+
+    expect(result).toBe(true)
+    expect(Sentry.init).toHaveBeenCalledWith(
+      expect.objectContaining({
+        release: "2024.04.15+sha.abcdef",
+      })
+    )
+  })
+
   it("skips initialization when DSN is missing", () => {
     const result = initObservability({
       DEV: false,

--- a/root/frontend/vite.config.mts
+++ b/root/frontend/vite.config.mts
@@ -32,6 +32,31 @@ const ensureMaskableIcons = () => {
 ensureMaskableIcons()
 generateManifests({ publicDir, sourcePath: manifestSourcePath })
 
+const ensureAppReleaseEnv = () => {
+  if (process.env.VITE_APP_RELEASE) return
+
+  const fallbackKeys = [
+    "SERVICE_VERSION",
+    "SOURCE_VERSION",
+    "APP_VERSION",
+    "HEROKU_SLUG_COMMIT",
+    "RENDER_GIT_COMMIT",
+    "VERCEL_GIT_COMMIT",
+    "GITHUB_SHA",
+    "COMMIT_SHA",
+  ] as const
+
+  for (const key of fallbackKeys) {
+    const candidate = process.env[key]
+    if (candidate) {
+      process.env.VITE_APP_RELEASE = candidate
+      return
+    }
+  }
+}
+
+ensureAppReleaseEnv()
+
 const withGeneratedManifests = (): PluginOption => ({
   name: "generate-localized-manifests",
   apply: () => true,


### PR DESCRIPTION
## Summary
- forward the VITE_APP_RELEASE value to Sentry when initializing observability
- hydrate VITE_APP_RELEASE during builds from common CI commit/version variables
- document the new variable and add a unit test that verifies the release is passed through

## Testing
- npm run test -- observability

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691109ee59e8832792d29a6206bec242)