### PR TITLE
Optimize event pagination counts

### DIFF
--- a/root/alembic/versions/202509200001_add_event_search_vector_column.py
+++ b/root/alembic/versions/202509200001_add_event_search_vector_column.py
@@ -25,7 +25,12 @@ def upgrade() -> None:
     if dialect != "postgresql":
         # SQLite keeps a plain column for compatibility even though full-text
         # search falls back to LIKE queries in application code.
-        op.add_column("events", sa.Column("search_vector", sa.Text(), nullable=True))
+        inspector = sa.inspect(bind)
+        existing = {column["name"] for column in inspector.get_columns("events")}
+        if "search_vector" not in existing:
+            op.add_column(
+                "events", sa.Column("search_vector", sa.Text(), nullable=True)
+            )
         return
 
     op.execute(sa.text(f"DROP INDEX IF EXISTS {_OLD_INDEX_NAME}"))

--- a/root/app/crud/__init__.py
+++ b/root/app/crud/__init__.py
@@ -435,7 +435,8 @@ async def get_all_events(
     cursor: str | None = None,
 ):
     now = datetime.now(UTC)
-    safe_limit = max(1, min(MAX_EVENTS_LIMIT, limit or DEFAULT_EVENTS_LIMIT))
+    raw_limit = DEFAULT_EVENTS_LIMIT if limit is None else limit
+    safe_limit = min(MAX_EVENTS_LIMIT, max(0, raw_limit))
     cursor_values = _decode_event_cursor(cursor)
 
     conditions = []
@@ -502,18 +503,27 @@ async def get_all_events(
         ordered_stmt = stmt.order_by(
             models.Event.starts_at.asc(), models.Event.id.asc()
         )
-    page_stmt = ordered_stmt.limit(safe_limit + 1)
+    fetch_limit = safe_limit + 1 if safe_limit > 0 else 1
+    page_stmt = ordered_stmt.limit(fetch_limit)
     rows = await db.execute(page_stmt)
     fetched_events = rows.scalars().all()
-    events = fetched_events[:safe_limit]
+    events = fetched_events[:safe_limit] if safe_limit else []
     ids = [e.id for e in events]
-    counts = await _attendance_counts(db, ids)
-    files_map = await _files_by_event(db, ids)
+    if ids:
+        counts = await _attendance_counts(db, ids)
+        files_map = await _files_by_event(db, ids)
+    else:
+        counts = {}
+        files_map = {}
 
-    total_stmt = select(func.count()).select_from(models.Event)
-    if conditions:
-        total_stmt = total_stmt.where(and_(*conditions))
-    total = (await db.execute(total_stmt)).scalar_one()
+    total: int | None
+    if cursor_values:
+        total = None
+    else:
+        total_stmt = select(func.count()).select_from(models.Event)
+        if conditions:
+            total_stmt = total_stmt.where(and_(*conditions))
+        total = (await db.execute(total_stmt)).scalar_one()
 
     registered_ids: set[int] = set()
     qr_map: dict[int, str | None] = {}

--- a/root/app/schemas/schemas.py
+++ b/root/app/schemas/schemas.py
@@ -450,7 +450,7 @@ class EventOut(OrmModel):
 
 class PaginatedEvents(BaseModel):
     items: list[EventOut]
-    total: int
+    total: int | None = None
     limit: int
     cursor: str | None = None
     next_cursor: str | None = None

--- a/root/frontend/src/api/generated/schema.ts
+++ b/root/frontend/src/api/generated/schema.ts
@@ -2134,7 +2134,7 @@ export interface components {
       /** Items */
       items: components["schemas"]["EventOut"][]
       /** Total */
-      total: number
+      total?: number | null
       /** Limit */
       limit: number
       /** Cursor */

--- a/root/tests/test_event_time_constraints.py
+++ b/root/tests/test_event_time_constraints.py
@@ -1,6 +1,8 @@
+from contextlib import contextmanager
 from datetime import UTC, datetime, timedelta
 
 import pytest
+from sqlalchemy import event
 from sqlalchemy.exc import IntegrityError
 
 from app import crud
@@ -10,6 +12,28 @@ from app.models import models
 from app.schemas import schemas
 
 pytestmark = pytest.mark.anyio("asyncio")
+
+
+@contextmanager
+def _capture_statements(session):
+    statements: list[str] = []
+    engine = session.bind
+    if engine is None:
+        yield statements
+        return
+
+    sync_engine = engine.sync_engine
+
+    def _before_cursor_execute(
+        _conn, _cursor, statement, _parameters, _context, _executemany
+    ) -> None:
+        statements.append(statement)
+
+    event.listen(sync_engine, "before_cursor_execute", _before_cursor_execute)
+    try:
+        yield statements
+    finally:
+        event.remove(sync_engine, "before_cursor_execute", _before_cursor_execute)
 
 
 async def _login(async_client, email: str, password: str) -> dict[str, str]:
@@ -186,6 +210,53 @@ async def test_get_all_events_cursor_respects_ordering_and_gaps(
     assert third_page.cursor == second_page.next_cursor
     assert [item.title for item in third_page.items] == ["Event D"]
     assert third_page.next_cursor is None
+
+
+async def test_get_all_events_cursor_skips_total_on_followup_pages(
+    db_session, user_factory
+):
+    admin = await user_factory(role="admin")
+    student = await user_factory()
+    base = datetime.now(UTC) + timedelta(days=1)
+
+    events = [
+        models.Event(
+            title=f"Event {idx}",
+            starts_at=base + timedelta(hours=idx),
+            ends_at=base + timedelta(hours=idx, minutes=30),
+            created_by=admin.id,
+            is_active=True,
+        )
+        for idx in range(5)
+    ]
+    db_session.add_all(events)
+    await db_session.commit()
+    for event_record in events:
+        await db_session.refresh(event_record)
+
+    first_page = await crud.get_all_events(
+        db_session,
+        user_id=student.id,
+        locale="en",
+        limit=2,
+    )
+    assert first_page.total == 5
+    assert first_page.next_cursor is not None
+
+    with _capture_statements(db_session) as statements:
+        second_page = await crud.get_all_events(
+            db_session,
+            user_id=student.id,
+            locale="en",
+            limit=2,
+            cursor=first_page.next_cursor,
+        )
+
+    assert second_page.total is None
+    lowered_statements = [stmt.lower() for stmt in statements]
+    assert not any(
+        "count" in stmt and " from events" in stmt for stmt in lowered_statements
+    )
 
 
 async def test_event_detail_returns_qr_code_after_registration(

--- a/root/tests/test_event_time_constraints.py
+++ b/root/tests/test_event_time_constraints.py
@@ -169,8 +169,8 @@ async def test_get_all_events_cursor_respects_ordering_and_gaps(
     ]
     db_session.add_all(initial_events)
     await db_session.commit()
-    for event in initial_events:
-        await db_session.refresh(event)
+    for event_record in initial_events:
+        await db_session.refresh(event_record)
 
     first_page = await crud.get_all_events(
         db_session,

--- a/root/tests/test_events_localization.py
+++ b/root/tests/test_events_localization.py
@@ -354,6 +354,7 @@ async def test_events_pagination_semantics(async_client, db_session, user_factor
     assert len(first_data["items"]) == 3
     assert first_data["has_more"] is True
     assert isinstance(first_data["next_cursor"], str)
+    assert first_data["total"] == 7
 
     second = await async_client.get(
         "/events",
@@ -367,6 +368,7 @@ async def test_events_pagination_semantics(async_client, db_session, user_factor
     assert second_data["has_more"] is True
     assert isinstance(second_data["next_cursor"], str)
     assert second_data["next_cursor"] != first_data["next_cursor"]
+    assert second_data["total"] is None
 
     third = await async_client.get(
         "/events",
@@ -379,11 +381,12 @@ async def test_events_pagination_semantics(async_client, db_session, user_factor
     assert len(third_data["items"]) == 1
     assert third_data["has_more"] is False
     assert third_data["next_cursor"] is None
-    assert third_data["total"] == 7
+    assert third_data["total"] is None
 
     default_response = await async_client.get("/events", headers=headers)
     assert default_response.status_code == status.HTTP_200_OK
     assert default_response.json()["limit"] == crud.DEFAULT_EVENTS_LIMIT
+    assert default_response.json()["total"] == 7
 
     capped = await async_client.get(
         "/events",


### PR DESCRIPTION
## Summary
- avoid recomputing total counts for paginated event cursors and support zero limits
- skip unnecessary attendance/file queries for empty pages and allow nullable totals in the API schema
- add a regression test covering the cursor branch to ensure no extra count query is executed

## Testing
- pytest root/tests/test_event_time_constraints.py::test_get_all_events_cursor_skips_total_on_followup_pages

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69111ff7da2c8327ad24baacf06c3db7)