### PR TITLE
Optimize attendance stats query and add indexes

### DIFF
--- a/root/alembic/versions/202506250001_add_indexes_for_attendance_stats.py
+++ b/root/alembic/versions/202506250001_add_indexes_for_attendance_stats.py
@@ -1,0 +1,39 @@
+"""Add indexes to support attendance stats query"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "202506250001"
+down_revision: str | None = "202506200001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _has_index(
+    inspector: sa.Inspector, table_name: str, column_names: Sequence[str]
+) -> bool:
+    normalized = tuple(column_names)
+    for index in inspector.get_indexes(table_name):
+        if tuple(index.get("column_names", [])) == normalized:
+            return True
+    return False
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if not _has_index(inspector, "events", ("starts_at",)):
+        op.create_index("ix_events_starts_at", "events", ["starts_at"])
+
+    if not _has_index(inspector, "event_attendance", ("user_id",)):
+        op.create_index(
+            "ix_event_attendance_user_id", "event_attendance", ["user_id"]
+        )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_event_attendance_user_id", table_name="event_attendance")
+    op.drop_index("ix_events_starts_at", table_name="events")

--- a/root/alembic/versions/202506250001_add_indexes_for_attendance_stats.py
+++ b/root/alembic/versions/202506250001_add_indexes_for_attendance_stats.py
@@ -3,6 +3,7 @@
 from collections.abc import Sequence
 
 import sqlalchemy as sa
+
 from alembic import op
 
 revision: str = "202506250001"
@@ -29,9 +30,7 @@ def upgrade() -> None:
         op.create_index("ix_events_starts_at", "events", ["starts_at"])
 
     if not _has_index(inspector, "event_attendance", ("user_id",)):
-        op.create_index(
-            "ix_event_attendance_user_id", "event_attendance", ["user_id"]
-        )
+        op.create_index("ix_event_attendance_user_id", "event_attendance", ["user_id"])
 
 
 def downgrade() -> None:

--- a/root/app/crud/__init__.py
+++ b/root/app/crud/__init__.py
@@ -3,9 +3,10 @@ from collections.abc import Sequence
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
-from sqlalchemy import and_, func, or_, select
+from sqlalchemy import and_, case, func, literal, or_, select, true
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import aliased
 
 from app.auth import mfa
 from app.auth.security import get_password_hash
@@ -923,77 +924,148 @@ async def get_attendance_stats(
     window_start = now - timedelta(days=period_days)
     previous_start = window_start - timedelta(days=period_days)
 
-    base_event_filter = (
-        models.Event.is_active.is_(True),
-        models.Event.starts_at >= window_start,
-        models.Event.starts_at < now,
-    )
-    total_events = await db.scalar(
-        select(func.count()).select_from(models.Event).where(*base_event_filter)
-    )
-    total_events = int(total_events or 0)
-
-    attendance_filter = (
-        models.EventAttendance.user_id == user_id,
-        models.EventAttendance.event_id == models.Event.id,
-        *base_event_filter,
-    )
-    attended_events = await db.scalar(
-        select(func.count())
-        .select_from(models.EventAttendance)
-        .join(models.Event, models.Event.id == models.EventAttendance.event_id)
-        .where(*attendance_filter)
-    )
-    attended_events = int(attended_events or 0)
-
-    percent = (attended_events / total_events * 100) if total_events else 0.0
-
-    previous_events = await db.scalar(
-        select(func.count())
-        .select_from(models.Event)
+    attendance_alias = aliased(models.EventAttendance)
+    filtered_events = (
+        select(
+            models.Event.id.label("event_id"),
+            case(
+                (models.Event.starts_at >= window_start, literal("current")),
+                else_=literal("previous"),
+            ).label("period"),
+        )
         .where(
             models.Event.is_active.is_(True),
             models.Event.starts_at >= previous_start,
-            models.Event.starts_at < window_start,
+            models.Event.starts_at < now,
         )
+        .cte("filtered_events")
     )
-    previous_events = int(previous_events or 0)
 
-    previous_attended = await db.scalar(
-        select(func.count())
-        .select_from(models.EventAttendance)
+    attendance_join = filtered_events.outerjoin(
+        attendance_alias,
+        and_(
+            attendance_alias.event_id == filtered_events.c.event_id,
+            attendance_alias.user_id == user_id,
+        ),
+    )
+
+    stats_subquery = (
+        select(
+            func.coalesce(
+                func.sum(
+                    case((filtered_events.c.period == "current", 1), else_=0)
+                ),
+                0,
+            ).label("current_total"),
+            func.coalesce(
+                func.sum(
+                    case((filtered_events.c.period == "previous", 1), else_=0)
+                ),
+                0,
+            ).label("previous_total"),
+            func.coalesce(
+                func.sum(
+                    case(
+                        (
+                            and_(
+                                filtered_events.c.period == "current",
+                                attendance_alias.id.isnot(None),
+                            ),
+                            1,
+                        ),
+                        else_=0,
+                    )
+                ),
+                0,
+            ).label("current_attended"),
+            func.coalesce(
+                func.sum(
+                    case(
+                        (
+                            and_(
+                                filtered_events.c.period == "previous",
+                                attendance_alias.id.isnot(None),
+                            ),
+                            1,
+                        ),
+                        else_=0,
+                    )
+                ),
+                0,
+            ).label("previous_attended"),
+        )
+        .select_from(attendance_join)
+    ).subquery()
+
+    recent_attendance_base = (
+        select(
+            models.EventAttendance.registered_at.label("registered_at"),
+            models.Event.starts_at.label("starts_at"),
+            models.Event.title.label("title"),
+            func.row_number()
+            .over(order_by=models.EventAttendance.registered_at.desc())
+            .label("rn"),
+        )
         .join(models.Event, models.Event.id == models.EventAttendance.event_id)
         .where(
             models.EventAttendance.user_id == user_id,
-            models.Event.starts_at >= previous_start,
-            models.Event.starts_at < window_start,
             models.Event.is_active.is_(True),
+            models.Event.starts_at >= window_start,
+            models.Event.starts_at < now,
         )
+    ).subquery()
+
+    top_recent = (
+        select(
+            recent_attendance_base.c.registered_at,
+            recent_attendance_base.c.starts_at,
+            recent_attendance_base.c.title,
+            recent_attendance_base.c.rn,
+        )
+        .where(recent_attendance_base.c.rn <= 5)
+    ).subquery()
+
+    stats_rows = await db.execute(
+        select(
+            stats_subquery.c.current_total,
+            stats_subquery.c.previous_total,
+            stats_subquery.c.current_attended,
+            stats_subquery.c.previous_attended,
+            top_recent.c.registered_at,
+            top_recent.c.starts_at,
+            top_recent.c.title,
+            top_recent.c.rn,
+        )
+        .select_from(stats_subquery.outerjoin(top_recent, true()))
+        .order_by(top_recent.c.rn)
     )
-    previous_attended = int(previous_attended or 0)
+
+    rows = stats_rows.all()
+
+    if rows:
+        first_row = rows[0]
+        total_events = int(first_row.current_total or 0)
+        attended_events = int(first_row.current_attended or 0)
+        previous_events = int(first_row.previous_total or 0)
+        previous_attended = int(first_row.previous_attended or 0)
+    else:
+        total_events = attended_events = previous_events = previous_attended = 0
+
+    percent = (attended_events / total_events * 100) if total_events else 0.0
     previous_percent = (
         previous_attended / previous_events * 100 if previous_events else 0.0
     )
 
-    recent_rows = await db.execute(
-        select(
-            models.EventAttendance.registered_at,
-            models.Event.starts_at,
-            models.Event.title,
-        )
-        .join(models.Event, models.Event.id == models.EventAttendance.event_id)
-        .where(*attendance_filter)
-        .order_by(models.EventAttendance.registered_at.desc())
-        .limit(5)
-    )
-    recent = []
-    for registered_at, starts_at, title in recent_rows.all():
-        date_source = starts_at or registered_at
+    recent: list[dict[str, Any]] = []
+    for row in rows:
+        if getattr(row, "rn", None) is None:
+            continue
+        date_source = row.starts_at or row.registered_at
         recent.append(
             {
                 "date": _dt_to_iso(date_source),
                 "status": "present",
-                "course": title or None,
+                "course": row.title or None,
             }
         )
 

--- a/root/app/crud/__init__.py
+++ b/root/app/crud/__init__.py
@@ -952,15 +952,11 @@ async def get_attendance_stats(
     stats_subquery = (
         select(
             func.coalesce(
-                func.sum(
-                    case((filtered_events.c.period == "current", 1), else_=0)
-                ),
+                func.sum(case((filtered_events.c.period == "current", 1), else_=0)),
                 0,
             ).label("current_total"),
             func.coalesce(
-                func.sum(
-                    case((filtered_events.c.period == "previous", 1), else_=0)
-                ),
+                func.sum(case((filtered_events.c.period == "previous", 1), else_=0)),
                 0,
             ).label("previous_total"),
             func.coalesce(
@@ -993,8 +989,7 @@ async def get_attendance_stats(
                 ),
                 0,
             ).label("previous_attended"),
-        )
-        .select_from(attendance_join)
+        ).select_from(attendance_join)
     ).subquery()
 
     recent_attendance_base = (
@@ -1021,8 +1016,7 @@ async def get_attendance_stats(
             recent_attendance_base.c.starts_at,
             recent_attendance_base.c.title,
             recent_attendance_base.c.rn,
-        )
-        .where(recent_attendance_base.c.rn <= 5)
+        ).where(recent_attendance_base.c.rn <= 5)
     ).subquery()
 
     stats_rows = await db.execute(

--- a/root/tests/test_stats_api.py
+++ b/root/tests/test_stats_api.py
@@ -41,7 +41,9 @@ async def test_attendance_stats_returns_expected_payload(
     hashed = get_password_hash(password)
     student = await user_factory(hashed_password=hashed, is_active=True)
 
-    def build_event(title: str, delta: timedelta, duration_hours: int = 2) -> models.Event:
+    def build_event(
+        title: str, delta: timedelta, duration_hours: int = 2
+    ) -> models.Event:
         starts_at = now - delta
         return models.Event(
             title=title,
@@ -67,8 +69,7 @@ async def test_attendance_stats_returns_expected_payload(
     previous_missed = build_event("Computer Science", timedelta(days=50))
 
     db_session.add_all(
-        current_attended_events
-        + [current_missed, previous_attended, previous_missed]
+        current_attended_events + [current_missed, previous_attended, previous_missed]
     )
     await db_session.commit()
 

--- a/root/tests/test_stats_api.py
+++ b/root/tests/test_stats_api.py
@@ -41,84 +41,60 @@ async def test_attendance_stats_returns_expected_payload(
     hashed = get_password_hash(password)
     student = await user_factory(hashed_password=hashed, is_active=True)
 
-    current_attended = models.Event(
-        title="Functional Analysis",
-        description="Lecture",
-        location="Auditorium A",
-        event_type="lecture",
-        starts_at=now - timedelta(days=5),
-        ends_at=now - timedelta(days=5) + timedelta(hours=2),
-        created_by=admin.id,
-        is_active=True,
-    )
-    current_attended_2 = models.Event(
-        title="Modern Physics",
-        description="Seminar",
-        location="Room 204",
-        event_type="seminar",
-        starts_at=now - timedelta(days=2),
-        ends_at=now - timedelta(days=2) + timedelta(hours=3),
-        created_by=admin.id,
-        is_active=True,
-    )
-    current_missed = models.Event(
-        title="Statistics",
-        description="Workshop",
-        location="Room 101",
-        event_type="workshop",
-        starts_at=now - timedelta(days=8),
-        ends_at=now - timedelta(days=8) + timedelta(hours=2),
-        created_by=admin.id,
-        is_active=True,
-    )
-    previous_attended = models.Event(
-        title="Linear Algebra",
-        description="Lecture",
-        location="Auditorium B",
-        event_type="lecture",
-        starts_at=now - timedelta(days=35),
-        ends_at=now - timedelta(days=35) + timedelta(hours=2),
-        created_by=admin.id,
-        is_active=True,
-    )
-    previous_missed = models.Event(
-        title="Computer Science",
-        description="Seminar",
-        location="Lab 5",
-        event_type="seminar",
-        starts_at=now - timedelta(days=50),
-        ends_at=now - timedelta(days=50) + timedelta(hours=2),
-        created_by=admin.id,
-        is_active=True,
-    )
+    def build_event(title: str, delta: timedelta, duration_hours: int = 2) -> models.Event:
+        starts_at = now - delta
+        return models.Event(
+            title=title,
+            description=f"Session for {title}",
+            location="Auditorium A",
+            event_type="lecture",
+            starts_at=starts_at,
+            ends_at=starts_at + timedelta(hours=duration_hours),
+            created_by=admin.id,
+            is_active=True,
+        )
+
+    current_attended_events = [
+        build_event("Functional Analysis", timedelta(days=5)),
+        build_event("Modern Physics", timedelta(days=4)),
+        build_event("Organic Chemistry", timedelta(days=3)),
+        build_event("Biology Lab", timedelta(days=2)),
+        build_event("Contemporary History", timedelta(days=1)),
+        build_event("Philosophy of Science", timedelta(hours=12)),
+    ]
+    current_missed = build_event("Applied Statistics", timedelta(days=8))
+    previous_attended = build_event("Linear Algebra", timedelta(days=35))
+    previous_missed = build_event("Computer Science", timedelta(days=50))
 
     db_session.add_all(
-        [
-            current_attended,
-            current_attended_2,
-            current_missed,
-            previous_attended,
-            previous_missed,
-        ]
+        current_attended_events
+        + [current_missed, previous_attended, previous_missed]
     )
     await db_session.commit()
 
     attendances = []
-    for event_id, registered_at in [
-        (current_attended.id, now - timedelta(days=5, hours=1)),
-        (current_attended_2.id, now - timedelta(days=2, hours=2)),
-        (previous_attended.id, now - timedelta(days=34)),
-    ]:
+    for event in current_attended_events:
         secret = attendance_tokens.generate_secret()
         attendances.append(
             models.EventAttendance(
                 user_id=student.id,
-                event_id=event_id,
-                registered_at=registered_at,
+                event_id=event.id,
+                registered_at=event.starts_at - timedelta(minutes=30),
                 qr_secret=secret,
                 qr_hmac=attendance_tokens.compute_secret_hmac(secret),
             )
         )
+
+    secret = attendance_tokens.generate_secret()
+    attendances.append(
+        models.EventAttendance(
+            user_id=student.id,
+            event_id=previous_attended.id,
+            registered_at=previous_attended.starts_at - timedelta(hours=1),
+            qr_secret=secret,
+            qr_hmac=attendance_tokens.compute_secret_hmac(secret),
+        )
+    )
     db_session.add_all(attendances)
     await db_session.commit()
 
@@ -128,15 +104,16 @@ async def test_attendance_stats_returns_expected_payload(
     assert response.status_code == 200
     payload = response.json()
 
-    assert payload["present"] == 2
-    assert payload["total"] == 3
-    assert payload["percent"] == pytest.approx(66.67, rel=1e-2)
-    assert payload["trend"] == pytest.approx(16.67, rel=1e-2)
+    assert payload["present"] == 6
+    assert payload["total"] == 7
+    assert payload["percent"] == pytest.approx(85.71, rel=1e-2)
+    assert payload["trend"] == pytest.approx(35.71, rel=1e-2)
     assert payload["period_key"] == "30d"
     assert payload["period_label"] == "Last 30 days"
-    assert len(payload["recent"]) == 2
-    assert payload["recent"][0]["status"] == "present"
-    assert payload["recent"][0]["course"] == "Modern Physics"
+    assert len(payload["recent"]) == 5
+    assert [entry["status"] for entry in payload["recent"]] == ["present"] * 5
+    assert payload["recent"][0]["course"] == "Philosophy of Science"
+    assert payload["recent"][4]["course"] == "Modern Physics"
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- rewrite the attendance stats query to use a single CTE-based statement that returns period metrics and recent attendances
- add a migration that ensures indexes on events.starts_at and event_attendance.user_id exist for the optimized query
- extend the attendance stats test to cover the new dataset and verify the recent attendance ordering

## Testing
- pytest root/tests/test_stats_api.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691131cecc60832789107ef33c405b65)