### PR TITLE
Align portal content pages with schedule layout

### DIFF
--- a/root/app/main.py
+++ b/root/app/main.py
@@ -39,7 +39,10 @@ from app.services.email_change_cleanup import (
     cleanup_stale_email_change_tokens,
     start_email_change_cleanup_scheduler,
 )
-from app.services.file_scanner import check_file_scanner_health
+from app.services.file_scanner import (
+    check_file_scanner_health,
+    scan_for_malware as _scan_for_malware,
+)
 from app.services.notification_queue import (
     DeadLetterCleanupConfig,
     start_dead_letter_cleanup_scheduler,
@@ -185,6 +188,10 @@ app = FastAPI(lifespan=lifespan)
 
 configure_observability(app, engine=engine)
 configure_metrics(app)
+
+# Re-export the malware scanning helper so health checks can be monkeypatched in tests
+# without importing the heavy scanning module directly.
+scan_for_malware = _scan_for_malware
 
 _RESPONSE_COMPRESSION_MINIMUM_SIZE = 512
 

--- a/root/app/main.py
+++ b/root/app/main.py
@@ -41,6 +41,8 @@ from app.services.email_change_cleanup import (
 )
 from app.services.file_scanner import (
     check_file_scanner_health,
+)
+from app.services.file_scanner import (
     scan_for_malware as _scan_for_malware,
 )
 from app.services.notification_queue import (

--- a/root/frontend/src/pages/Activity.tsx
+++ b/root/frontend/src/pages/Activity.tsx
@@ -610,132 +610,420 @@ export default function Activity() {
   return (
     <Layout>
       <PageFadeIn>
-        <motion.div
-          initial="hidden"
-          animate="show"
-          variants={headerVariants}
-          className="mx-auto w-full max-w-full px-4 py-6 pb-16 sm:px-6 md:px-8 md:py-8 xl:px-12 xl:pb-8"
-          style={
-            reduce ? undefined : { willChange: "transform, opacity", transform: "translateZ(0)" }
-          }
-        >
-          <div
-            data-fade
-            style={fadeDelayStyle("80ms")}
-            className="mb-4 flex flex-wrap items-center justify-between gap-4 md:mb-6"
+        <div className="w-screen min-h-screen bg-[color:var(--page-bg)] text-[color:var(--page-text)] py-8 sm:py-10">
+          <motion.div
+            initial="hidden"
+            animate="show"
+            variants={headerVariants}
+            className="mx-auto max-w-6xl px-2 pb-16 sm:px-4"
+            style={
+              reduce ? undefined : { willChange: "transform, opacity", transform: "translateZ(0)" }
+            }
           >
-            <div className="flex items-center gap-3">
-              <span className="inline-flex h-[34px] w-[34px] items-center justify-center rounded-xl border border-[color:color-mix(in_srgb,white_12%,var(--nav-link)_88%)] bg-[color:color-mix(in_srgb,var(--card-bg)_92%,var(--nav-link)_8%)] text-[color:var(--nav-link)] shadow-surface dark:bg-[color:color-mix(in_srgb,var(--card-bg)_88%,var(--nav-link)_12%)]">
-                <TimelineIcon className="text-[20px]" />
-              </span>
-              <h1 className="text-[clamp(1.5rem,2.6vw,2.4rem)] font-black tracking-tight text-[color:var(--page-text)]">
+            <div
+              data-fade
+              style={fadeDelayStyle("80ms")}
+              className="mb-8 flex flex-wrap items-center gap-4 sm:gap-5"
+            >
+              <div className="flex h-12 w-12 items-center justify-center rounded-full bg-[color:color-mix(in_srgb,var(--glass-bg)_70%,var(--nav-link)_30%)] text-[color:var(--nav-link)] shadow-[0_6px_20px_color-mix(in_srgb,var(--nav-link)_24%,transparent)] transition-transform duration-200 hover:scale-105 dark:bg-[color:color-mix(in_srgb,var(--glass-bg)_65%,var(--nav-link)_35%)] dark:shadow-[0_8px_24px_color-mix(in_srgb,var(--nav-link)_28%,transparent)] backdrop-blur-sm [-webkit-backdrop-filter:blur(12px)]">
+                <TimelineIcon className="text-[2rem]" />
+              </div>
+              <h1 className="text-[clamp(1.6rem,5vw,2.75rem)] font-bold tracking-tight text-[color:var(--page-text)]">
                 {t("activity:title")}
               </h1>
             </div>
             <motion.div
+              data-fade
               initial={{ opacity: 0, y: reduce ? 0 : 8 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: reduce ? 0 : 0.35 }}
+              style={{
+                ...(reduce ? {} : { willChange: "transform, opacity", transform: "translateZ(0)" }),
+                ...fadeDelayStyle("140ms"),
+              }}
+              className="mb-6 inline-flex items-center gap-1 rounded-full border border-[color:color-mix(in_srgb,white_12%,var(--nav-link)_88%)] bg-[color:color-mix(in_srgb,var(--card-bg)_96%,white_4%)] p-1 shadow-[0_4px_12px_rgba(0,0,0,0.08),0_2px_4px_rgba(0,0,0,0.04)] backdrop-blur-xl [-webkit-backdrop-filter:blur(12px)] dark:border-[color:color-mix(in_srgb,white_8%,var(--nav-link)_92%)] dark:bg-[color:color-mix(in_srgb,var(--card-bg)_94%,transparent_6%)] dark:shadow-[0_12px_34px_rgba(0,0,0,0.46)]"
+            >
+              {periodOptions.map((option) => (
+                <button
+                  key={option.value}
+                  onClick={() => setPeriod(option.value)}
+                  className={cn(
+                    "rounded-full border-0 px-4 py-1.5 text-sm font-bold transition-all duration-150",
+                    period === option.value
+                      ? "bg-[color:var(--nav-link)] text-white shadow-[0_4px_12px_color-mix(in_srgb,var(--nav-link)_35%,transparent)] dark:shadow-[0_8px_24px_color-mix(in_srgb,var(--nav-link)_45%,transparent)]"
+                      : "bg-transparent text-[color:var(--page-text)] hover:bg-[color:color-mix(in_srgb,var(--nav-link)_8%,transparent)] hover:text-[color:var(--nav-link)]"
+                  )}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </motion.div>
+
+            <motion.div
+              variants={gridVariants}
+              initial="hidden"
+              animate="show"
+              className="mb-4 grid grid-cols-1 gap-4 sm:grid-cols-2 md:mb-6 md:grid-cols-3 md:gap-6"
               style={
                 reduce
                   ? undefined
                   : { willChange: "transform, opacity", transform: "translateZ(0)" }
               }
             >
-              <div className="inline-flex items-center gap-1 rounded-full border border-[color:color-mix(in_srgb,white_12%,var(--nav-link)_88%)] bg-[color:color-mix(in_srgb,var(--card-bg)_96%,white_4%)] p-1 shadow-[0_4px_12px_rgba(0,0,0,0.08),0_2px_4px_rgba(0,0,0,0.04)] backdrop-blur-xl [-webkit-backdrop-filter:blur(12px)] dark:border-[color:color-mix(in_srgb,white_8%,var(--nav-link)_92%)] dark:bg-[color:color-mix(in_srgb,var(--card-bg)_94%,transparent_6%)] dark:shadow-[0_12px_34px_rgba(0,0,0,0.46)]">
-                {periodOptions.map((option) => (
-                  <button
-                    key={option.value}
-                    onClick={() => setPeriod(option.value)}
-                    className={cn(
-                      "rounded-full border-0 px-4 py-1.5 text-sm font-bold transition-all duration-150",
-                      period === option.value
-                        ? "bg-[color:var(--nav-link)] text-white shadow-[0_4px_12px_color-mix(in_srgb,var(--nav-link)_35%,transparent)] dark:shadow-[0_8px_24px_color-mix(in_srgb,var(--nav-link)_45%,transparent)]"
-                        : "bg-transparent text-[color:var(--page-text)] hover:bg-[color:color-mix(in_srgb,var(--nav-link)_8%,transparent)] hover:text-[color:var(--nav-link)]"
-                    )}
-                  >
-                    {option.label}
-                  </button>
-                ))}
-              </div>
-            </motion.div>
-          </div>
-
-          <motion.div
-            variants={gridVariants}
-            initial="hidden"
-            animate="show"
-            className="mb-4 grid grid-cols-1 gap-4 sm:grid-cols-2 md:mb-6 md:grid-cols-3 md:gap-6"
-            style={
-              reduce ? undefined : { willChange: "transform, opacity", transform: "translateZ(0)" }
-            }
-          >
-            <CardShell tone="success" onClick={() => setDetail("attendance")}>
-              <div className="flex items-center gap-4">
-                <AnimatedRing value={attendance?.percent ?? 0} size={ringSize} tone="success" />
-                <div className="flex min-w-0 flex-1 flex-col gap-1">
-                  <p className="text-[0.65rem] font-semibold uppercase tracking-wider text-[color:color-mix(in_srgb,var(--secondary-text)_55%,transparent)]">
-                    {t("activity:sections.attendance.title")}
-                  </p>
-                  <div className="flex flex-wrap items-center gap-2">
-                    <span className="text-[clamp(1.75rem,2vw,2.25rem)] font-black tracking-tighter tabular-nums lining-nums text-[color:var(--page-text)]">
-                      {attendancePctAnimated}%
-                    </span>
-                    <TrendChip value={attendance?.trend} />
+              <CardShell tone="success" onClick={() => setDetail("attendance")}>
+                <div className="flex items-center gap-4">
+                  <AnimatedRing value={attendance?.percent ?? 0} size={ringSize} tone="success" />
+                  <div className="flex min-w-0 flex-1 flex-col gap-1">
+                    <p className="text-[0.65rem] font-semibold uppercase tracking-wider text-[color:color-mix(in_srgb,var(--secondary-text)_55%,transparent)]">
+                      {t("activity:sections.attendance.title")}
+                    </p>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="text-[clamp(1.75rem,2vw,2.25rem)] font-black tracking-tighter tabular-nums lining-nums text-[color:var(--page-text)]">
+                        {attendancePctAnimated}%
+                      </span>
+                      <TrendChip value={attendance?.trend} />
+                    </div>
+                    <ProgressBar
+                      value={progressAttendance}
+                      className="h-2 rounded-full"
+                      barClassName="bg-[#10b981] dark:bg-[#34d399] rounded-full transition-[width] duration-600"
+                    />
+                    <p className="truncate text-sm text-[color:color-mix(in_srgb,var(--secondary-text)_65%,transparent)]">
+                      {t("activity:sections.attendance.summary", {
+                        present: attendance?.present ?? 0,
+                        total: attendance?.total ?? 0,
+                        period: attendance?.periodLabel || labelByPeriod(period),
+                      })}
+                    </p>
                   </div>
-                  <ProgressBar
-                    value={progressAttendance}
-                    className="h-2 rounded-full"
-                    barClassName="bg-[#10b981] dark:bg-[#34d399] rounded-full transition-[width] duration-600"
-                  />
-                  <p className="truncate text-sm text-[color:color-mix(in_srgb,var(--secondary-text)_65%,transparent)]">
-                    {t("activity:sections.attendance.summary", {
-                      present: attendance?.present ?? 0,
-                      total: attendance?.total ?? 0,
-                      period: attendance?.periodLabel || labelByPeriod(period),
-                    })}
+                </div>
+              </CardShell>
+
+              <CardShell tone="info" onClick={() => setDetail("grades")}>
+                <div className="flex flex-col gap-1">
+                  <p className="text-[0.65rem] font-semibold uppercase tracking-wider text-[color:color-mix(in_srgb,var(--secondary-text)_55%,transparent)]">
+                    {t("activity:sections.grades.title")}
+                  </p>
+                  <div className="flex items-center gap-2">
+                    <span className="text-[clamp(1.75rem,2vw,2.25rem)] font-black tracking-tighter tabular-nums lining-nums text-[color:var(--page-text)]">
+                      {grades?.scale === "gpa"
+                        ? `GPA ${gradesAnimated}`
+                        : grades?.scale === "100"
+                          ? `${gradesAnimated}/100`
+                          : `${gradesAnimated}/5`}
+                    </span>
+                    <TrendChip value={grades?.trend} />
+                  </div>
+                  <p className="text-sm text-[color:color-mix(in_srgb,var(--secondary-text)_65%,transparent)]">
+                    {t("activity:sections.grades.averageLabel")}
                   </p>
                 </div>
-              </div>
-            </CardShell>
+              </CardShell>
 
-            <CardShell tone="info" onClick={() => setDetail("grades")}>
-              <div className="flex flex-col gap-1">
-                <p className="text-[0.65rem] font-semibold uppercase tracking-wider text-[color:color-mix(in_srgb,var(--secondary-text)_55%,transparent)]">
-                  {t("activity:sections.grades.title")}
-                </p>
-                <div className="flex items-center gap-2">
-                  <span className="text-[clamp(1.75rem,2vw,2.25rem)] font-black tracking-tighter tabular-nums lining-nums text-[color:var(--page-text)]">
-                    {grades?.scale === "gpa"
-                      ? `GPA ${gradesAnimated}`
-                      : grades?.scale === "100"
-                        ? `${gradesAnimated}/100`
-                        : `${gradesAnimated}/5`}
-                  </span>
-                  <TrendChip value={grades?.trend} />
+              <CardShell tone="warning" onClick={() => setDetail("participation")}>
+                <div className="flex flex-col gap-1">
+                  <p className="text-[0.65rem] font-semibold uppercase tracking-wider text-[color:color-mix(in_srgb,var(--secondary-text)_55%,transparent)]">
+                    {t("activity:sections.participation.title")}
+                  </p>
+                  <div className="flex items-center gap-2">
+                    <span className="text-[clamp(1.75rem,2vw,2.25rem)] font-black tracking-tighter tabular-nums lining-nums text-[color:var(--page-text)]">
+                      {t("activity:sections.participation.eventsCount", {
+                        value: partEventsAnimated,
+                        count: participation?.events ?? 0,
+                      })}
+                    </span>
+                    <TrendChip value={participation?.trend} />
+                  </div>
+                  <p className="text-sm text-[color:color-mix(in_srgb,var(--secondary-text)_65%,transparent)]">
+                    {[
+                      participation?.hours != null
+                        ? t("activity:sections.participation.summaryHours", {
+                            count: participation.hours ?? 0,
+                          })
+                        : null,
+                      participation?.groups != null
+                        ? t("activity:sections.participation.summaryGroups", {
+                            count: participation.groups ?? 0,
+                          })
+                        : null,
+                    ]
+                      .filter(Boolean)
+                      .join(separator)}
+                  </p>
                 </div>
-                <p className="text-sm text-[color:color-mix(in_srgb,var(--secondary-text)_65%,transparent)]">
-                  {t("activity:sections.grades.averageLabel")}
-                </p>
-              </div>
-            </CardShell>
+              </CardShell>
+            </motion.div>
 
-            <CardShell tone="warning" onClick={() => setDetail("participation")}>
-              <div className="flex flex-col gap-1">
-                <p className="text-[0.65rem] font-semibold uppercase tracking-wider text-[color:color-mix(in_srgb,var(--secondary-text)_55%,transparent)]">
-                  {t("activity:sections.participation.title")}
-                </p>
-                <div className="flex items-center gap-2">
-                  <span className="text-[clamp(1.75rem,2vw,2.25rem)] font-black tracking-tighter tabular-nums lining-nums text-[color:var(--page-text)]">
-                    {t("activity:sections.participation.eventsCount", {
-                      value: partEventsAnimated,
-                      count: participation?.events ?? 0,
-                    })}
-                  </span>
-                  <TrendChip value={participation?.trend} />
+            <div className="my-4 border-t border-[color:color-mix(in_srgb,white_12%,var(--nav-link)_88%)] md:my-6 dark:border-[color:color-mix(in_srgb,white_8%,var(--nav-link)_92%)]" />
+
+            <motion.div
+              variants={gridVariants}
+              initial="hidden"
+              animate="show"
+              className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 md:gap-6"
+            >
+              <CardShell onClick={() => setDetail("attendance_recent")}>
+                <div className="flex flex-col">
+                  <div className="mb-2 flex items-center gap-2">
+                    <EventAvailableIcon className="text-base text-[color:var(--nav-link)]" />
+                    <h3 className="font-black text-[color:var(--page-text)]">
+                      {t("activity:sections.attendance.recent")}
+                    </h3>
+                  </div>
+                  <div className="space-y-1">
+                    <AnimatePresence initial={true}>
+                      {(attendance?.recent ?? []).slice(0, 6).map((r, i) => {
+                        const color =
+                          r.status === "present"
+                            ? "#10b981"
+                            : r.status === "late"
+                              ? "#f59e0b"
+                              : "#ef4444"
+                        const darkColor =
+                          r.status === "present"
+                            ? "#34d399"
+                            : r.status === "late"
+                              ? "#fbbf24"
+                              : "#f87171"
+                        const attendanceRecord = r as Partial<{
+                          id?: number | string
+                          lesson_id?: number | string
+                        }>
+                        const itemKey =
+                          pickKeyCandidate(attendanceRecord.id) ??
+                          pickKeyCandidate(attendanceRecord.lesson_id) ??
+                          attendanceItemKey(r, i)
+                        return (
+                          <motion.div
+                            key={itemKey}
+                            variants={listItemVariants}
+                            initial="hidden"
+                            animate="show"
+                            exit={{ opacity: 0 }}
+                            transition={{ delay: reduce ? 0 : i * 0.04 }}
+                            className="py-1"
+                            style={
+                              reduce
+                                ? undefined
+                                : { willChange: "transform, opacity", transform: "translateZ(0)" }
+                            }
+                          >
+                            <div className="flex items-center gap-2">
+                              <div
+                                className="h-2 w-2 rounded-full dark:hidden"
+                                style={{
+                                  background: color,
+                                  boxShadow: `0 0 0 3px ${color}18`,
+                                }}
+                              />
+                              <div
+                                className="hidden h-2 w-2 rounded-full dark:block"
+                                style={{
+                                  background: darkColor,
+                                  boxShadow: `0 0 0 3px ${darkColor}18`,
+                                }}
+                              />
+                              <div className="flex min-w-0 flex-1 flex-wrap items-baseline gap-1.5">
+                                <span className="font-bold text-[color:var(--page-text)]">
+                                  {r.course || attendanceLessonFallback}
+                                </span>
+                                <span className="text-sm text-[color:color-mix(in_srgb,var(--secondary-text)_55%,transparent)]">
+                                  {attendanceStatusLabel(r.status)}
+                                </span>
+                              </div>
+                            </div>
+                            <p className="ml-4 text-xs text-[color:color-mix(in_srgb,var(--secondary-text)_55%,transparent)]">
+                              {formatDate(r.date)}
+                            </p>
+                          </motion.div>
+                        )
+                      })}
+                    </AnimatePresence>
+                    {!loading && (!attendance?.recent || attendance.recent.length === 0) && (
+                      <p className="px-1 py-1 text-sm text-[color:color-mix(in_srgb,var(--secondary-text)_55%,transparent)]">
+                        {noDataText}
+                      </p>
+                    )}
+                  </div>
                 </div>
-                <p className="text-sm text-[color:color-mix(in_srgb,var(--secondary-text)_65%,transparent)]">
+              </CardShell>
+
+              <CardShell onClick={() => setDetail("grades_recent")}>
+                <div className="flex flex-col">
+                  <div className="mb-2 flex items-center gap-2">
+                    <SchoolIcon className="text-base text-[color:var(--nav-link)]" />
+                    <h3 className="font-black text-[color:var(--page-text)]">
+                      {t("activity:sections.grades.recent")}
+                    </h3>
+                  </div>
+                  <div className="space-y-1">
+                    <AnimatePresence initial={true}>
+                      {(grades?.recent ?? []).slice(0, 6).map((r, i) => {
+                        const gradeRecord = r as Partial<{ id?: number | string }>
+                        const itemKey = pickKeyCandidate(gradeRecord.id) ?? gradeItemKey(r, i)
+                        return (
+                          <motion.div
+                            key={itemKey}
+                            variants={listItemVariants}
+                            initial="hidden"
+                            animate="show"
+                            exit={{ opacity: 0 }}
+                            transition={{ delay: reduce ? 0 : i * 0.04 }}
+                            className="py-1"
+                            style={
+                              reduce
+                                ? undefined
+                                : { willChange: "transform, opacity", transform: "translateZ(0)" }
+                            }
+                          >
+                            <div className="flex items-center gap-2">
+                              <div className="h-2 w-2 rounded-full bg-[#3b82f6]/90 shadow-[0_0_0_3px_#3b82f618] dark:bg-[#60a5fa]/90 dark:shadow-[0_0_0_3px_#60a5fa18]" />
+                              <div className="flex min-w-0 flex-1 flex-wrap items-baseline gap-1.5">
+                                <span className="font-bold text-[color:var(--page-text)]">
+                                  {r.course}
+                                </span>
+                                <span className="text-sm text-[color:color-mix(in_srgb,var(--secondary-text)_55%,transparent)]">
+                                  {r.score}
+                                  {r.max ? "/" + r.max : ""}
+                                </span>
+                              </div>
+                            </div>
+                            <p className="ml-4 text-xs text-[color:color-mix(in_srgb,var(--secondary-text)_55%,transparent)]">
+                              {formatDate(r.date)}
+                            </p>
+                          </motion.div>
+                        )
+                      })}
+                    </AnimatePresence>
+                    {!loading && (!grades?.recent || grades.recent.length === 0) && (
+                      <p className="px-1 py-1 text-sm text-[color:color-mix(in_srgb,var(--secondary-text)_55%,transparent)]">
+                        {noDataText}
+                      </p>
+                    )}
+                  </div>
+                </div>
+              </CardShell>
+
+              <CardShell onClick={() => setDetail("participation_recent")}>
+                <div className="flex flex-col">
+                  <div className="mb-2 flex items-center gap-2">
+                    <EmojiEventsIcon className="text-base text-[color:var(--nav-link)]" />
+                    <h3 className="font-black text-[color:var(--page-text)]">
+                      {t("activity:sections.participation.recent")}
+                    </h3>
+                  </div>
+                  <div className="space-y-1">
+                    <AnimatePresence initial={true}>
+                      {(participation?.recent ?? []).slice(0, 6).map((r, i) => {
+                        const participationRecord = r as Partial<{ id?: number | string }>
+                        const itemKey =
+                          pickKeyCandidate(participationRecord.id) ?? participationItemKey(r, i)
+                        return (
+                          <motion.div
+                            key={itemKey}
+                            variants={listItemVariants}
+                            initial="hidden"
+                            animate="show"
+                            exit={{ opacity: 0 }}
+                            transition={{ delay: reduce ? 0 : i * 0.04 }}
+                            className="py-1"
+                            style={
+                              reduce
+                                ? undefined
+                                : { willChange: "transform, opacity", transform: "translateZ(0)" }
+                            }
+                          >
+                            <div className="flex items-center gap-2">
+                              <div className="h-2 w-2 rounded-full bg-[#f59e0b]/90 shadow-[0_0_0_3px_#f59e0b18] dark:bg-[#fbbf24]/90 dark:shadow-[0_0_0_3px_#fbbf2418]" />
+                              <div className="flex min-w-0 flex-1 flex-wrap items-baseline gap-1.5">
+                                <span className="font-bold text-[color:var(--page-text)]">
+                                  {r.title}
+                                </span>
+                                <span className="text-sm text-[color:color-mix(in_srgb,var(--secondary-text)_55%,transparent)]">
+                                  {[formatDate(r.date), r.role].filter(Boolean).join(separator)}
+                                </span>
+                              </div>
+                            </div>
+                          </motion.div>
+                        )
+                      })}
+                    </AnimatePresence>
+                    {!loading && (!participation?.recent || participation.recent.length === 0) && (
+                      <p className="px-1 py-1 text-sm text-[color:color-mix(in_srgb,var(--secondary-text)_55%,transparent)]">
+                        {noDataText}
+                      </p>
+                    )}
+                  </div>
+                </div>
+              </CardShell>
+            </motion.div>
+          </motion.div>
+
+          <Dialog
+            open={detail !== ""}
+            onClose={() => setDetail("")}
+            title={detailSection ? t(`activity:sections.${detailSection}.dialogTitle`) : ""}
+            size="md"
+          >
+            {detail === "attendance" && (
+              <div className="space-y-4">
+                <p className="text-base text-[color:var(--page-text)]">
+                  {t("activity:sections.attendance.dialogTotal", {
+                    present: attendance?.present ?? 0,
+                    total: attendance?.total ?? 0,
+                    period: attendance?.periodLabel || labelByPeriod(period),
+                  })}
+                </p>
+                <ProgressBar
+                  value={Math.max(0, Math.min(100, attendance?.percent ?? 0))}
+                  className="h-2.5 rounded-lg"
+                  barClassName="bg-[#10b981] dark:bg-[#34d399] rounded-lg"
+                />
+                <div className="space-y-2">
+                  {(attendance?.recent ?? []).map((r, i) => (
+                    <div key={attendanceItemKey(r, i)} className="space-y-0.5">
+                      <p className="text-sm font-semibold text-[color:var(--page-text)]">
+                        {`${r.course || attendanceLessonFallback} — ${attendanceStatusLabel(r.status)}`}
+                      </p>
+                      <p className="text-xs text-[color:color-mix(in_srgb,var(--secondary-text)_65%,transparent)]">
+                        {formatDate(r.date)}
+                      </p>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+            {detail === "grades" && (
+              <div className="space-y-4">
+                <p className="text-base font-semibold text-[color:var(--page-text)]">
+                  {grades?.scale === "gpa"
+                    ? `GPA ${(grades?.average ?? 0).toFixed(2)}`
+                    : grades?.scale === "100"
+                      ? `${Math.round(grades?.average ?? 0)}/100`
+                      : `${(grades?.average ?? 0).toFixed(1)}/5`}
+                </p>
+                <div className="space-y-2">
+                  {(grades?.recent ?? []).map((r, i) => (
+                    <div key={gradeItemKey(r, i)} className="space-y-0.5">
+                      <p className="text-sm font-semibold text-[color:var(--page-text)]">
+                        {`${r.course} — ${r.score}${r.max ? "/" + r.max : ""}`}
+                      </p>
+                      <p className="text-xs text-[color:color-mix(in_srgb,var(--secondary-text)_65%,transparent)]">
+                        {formatDate(r.date)}
+                      </p>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+            {detail === "participation" && (
+              <div className="space-y-4">
+                <p className="text-base text-[color:var(--page-text)]">
                   {[
+                    t("activity:sections.participation.eventsCount", {
+                      value: String(participation?.events ?? 0),
+                      count: participation?.events ?? 0,
+                    }),
                     participation?.hours != null
                       ? t("activity:sections.participation.summaryHours", {
                           count: participation.hours ?? 0,
@@ -750,235 +1038,21 @@ export default function Activity() {
                     .filter(Boolean)
                     .join(separator)}
                 </p>
-              </div>
-            </CardShell>
-          </motion.div>
-
-          <div className="my-4 border-t border-[color:color-mix(in_srgb,white_12%,var(--nav-link)_88%)] md:my-6 dark:border-[color:color-mix(in_srgb,white_8%,var(--nav-link)_92%)]" />
-
-          <motion.div
-            variants={gridVariants}
-            initial="hidden"
-            animate="show"
-            className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 md:gap-6"
-          >
-            <CardShell onClick={() => setDetail("attendance_recent")}>
-              <div className="flex flex-col">
-                <div className="mb-2 flex items-center gap-2">
-                  <EventAvailableIcon className="text-base text-[color:var(--nav-link)]" />
-                  <h3 className="font-black text-[color:var(--page-text)]">
-                    {t("activity:sections.attendance.recent")}
-                  </h3>
-                </div>
-                <div className="space-y-1">
-                  <AnimatePresence initial={true}>
-                    {(attendance?.recent ?? []).slice(0, 6).map((r, i) => {
-                      const color =
-                        r.status === "present"
-                          ? "#10b981"
-                          : r.status === "late"
-                            ? "#f59e0b"
-                            : "#ef4444"
-                      const darkColor =
-                        r.status === "present"
-                          ? "#34d399"
-                          : r.status === "late"
-                            ? "#fbbf24"
-                            : "#f87171"
-                      const attendanceRecord = r as Partial<{
-                        id?: number | string
-                        lesson_id?: number | string
-                      }>
-                      const itemKey =
-                        pickKeyCandidate(attendanceRecord.id) ??
-                        pickKeyCandidate(attendanceRecord.lesson_id) ??
-                        attendanceItemKey(r, i)
-                      return (
-                        <motion.div
-                          key={itemKey}
-                          variants={listItemVariants}
-                          initial="hidden"
-                          animate="show"
-                          exit={{ opacity: 0 }}
-                          transition={{ delay: reduce ? 0 : i * 0.04 }}
-                          className="py-1"
-                          style={
-                            reduce
-                              ? undefined
-                              : { willChange: "transform, opacity", transform: "translateZ(0)" }
-                          }
-                        >
-                          <div className="flex items-center gap-2">
-                            <div
-                              className="h-2 w-2 rounded-full dark:hidden"
-                              style={{
-                                background: color,
-                                boxShadow: `0 0 0 3px ${color}18`,
-                              }}
-                            />
-                            <div
-                              className="hidden h-2 w-2 rounded-full dark:block"
-                              style={{
-                                background: darkColor,
-                                boxShadow: `0 0 0 3px ${darkColor}18`,
-                              }}
-                            />
-                            <div className="flex min-w-0 flex-1 flex-wrap items-baseline gap-1.5">
-                              <span className="font-bold text-[color:var(--page-text)]">
-                                {r.course || attendanceLessonFallback}
-                              </span>
-                              <span className="text-sm text-[color:color-mix(in_srgb,var(--secondary-text)_55%,transparent)]">
-                                {attendanceStatusLabel(r.status)}
-                              </span>
-                            </div>
-                          </div>
-                          <p className="ml-4 text-xs text-[color:color-mix(in_srgb,var(--secondary-text)_55%,transparent)]">
-                            {formatDate(r.date)}
-                          </p>
-                        </motion.div>
-                      )
-                    })}
-                  </AnimatePresence>
-                  {!loading && (!attendance?.recent || attendance.recent.length === 0) && (
-                    <p className="px-1 py-1 text-sm text-[color:color-mix(in_srgb,var(--secondary-text)_55%,transparent)]">
-                      {noDataText}
-                    </p>
-                  )}
+                <div className="space-y-2">
+                  {(participation?.recent ?? []).map((r, i) => (
+                    <div key={participationItemKey(r, i)} className="space-y-0.5">
+                      <p className="text-sm font-semibold text-[color:var(--page-text)]">
+                        {r.title}
+                      </p>
+                      <p className="text-xs text-[color:color-mix(in_srgb,var(--secondary-text)_65%,transparent)]">
+                        {[formatDate(r.date), r.role].filter(Boolean).join(separator)}
+                      </p>
+                    </div>
+                  ))}
                 </div>
               </div>
-            </CardShell>
-
-            <CardShell onClick={() => setDetail("grades_recent")}>
-              <div className="flex flex-col">
-                <div className="mb-2 flex items-center gap-2">
-                  <SchoolIcon className="text-base text-[color:var(--nav-link)]" />
-                  <h3 className="font-black text-[color:var(--page-text)]">
-                    {t("activity:sections.grades.recent")}
-                  </h3>
-                </div>
-                <div className="space-y-1">
-                  <AnimatePresence initial={true}>
-                    {(grades?.recent ?? []).slice(0, 6).map((r, i) => {
-                      const gradeRecord = r as Partial<{ id?: number | string }>
-                      const itemKey = pickKeyCandidate(gradeRecord.id) ?? gradeItemKey(r, i)
-                      return (
-                        <motion.div
-                          key={itemKey}
-                          variants={listItemVariants}
-                          initial="hidden"
-                          animate="show"
-                          exit={{ opacity: 0 }}
-                          transition={{ delay: reduce ? 0 : i * 0.04 }}
-                          className="py-1"
-                          style={
-                            reduce
-                              ? undefined
-                              : { willChange: "transform, opacity", transform: "translateZ(0)" }
-                          }
-                        >
-                          <div className="flex items-center gap-2">
-                            <div className="h-2 w-2 rounded-full bg-[#3b82f6]/90 shadow-[0_0_0_3px_#3b82f618] dark:bg-[#60a5fa]/90 dark:shadow-[0_0_0_3px_#60a5fa18]" />
-                            <div className="flex min-w-0 flex-1 flex-wrap items-baseline gap-1.5">
-                              <span className="font-bold text-[color:var(--page-text)]">
-                                {r.course}
-                              </span>
-                              <span className="text-sm text-[color:color-mix(in_srgb,var(--secondary-text)_55%,transparent)]">
-                                {r.score}
-                                {r.max ? "/" + r.max : ""}
-                              </span>
-                            </div>
-                          </div>
-                          <p className="ml-4 text-xs text-[color:color-mix(in_srgb,var(--secondary-text)_55%,transparent)]">
-                            {formatDate(r.date)}
-                          </p>
-                        </motion.div>
-                      )
-                    })}
-                  </AnimatePresence>
-                  {!loading && (!grades?.recent || grades.recent.length === 0) && (
-                    <p className="px-1 py-1 text-sm text-[color:color-mix(in_srgb,var(--secondary-text)_55%,transparent)]">
-                      {noDataText}
-                    </p>
-                  )}
-                </div>
-              </div>
-            </CardShell>
-
-            <CardShell onClick={() => setDetail("participation_recent")}>
-              <div className="flex flex-col">
-                <div className="mb-2 flex items-center gap-2">
-                  <EmojiEventsIcon className="text-base text-[color:var(--nav-link)]" />
-                  <h3 className="font-black text-[color:var(--page-text)]">
-                    {t("activity:sections.participation.recent")}
-                  </h3>
-                </div>
-                <div className="space-y-1">
-                  <AnimatePresence initial={true}>
-                    {(participation?.recent ?? []).slice(0, 6).map((r, i) => {
-                      const participationRecord = r as Partial<{ id?: number | string }>
-                      const itemKey =
-                        pickKeyCandidate(participationRecord.id) ?? participationItemKey(r, i)
-                      return (
-                        <motion.div
-                          key={itemKey}
-                          variants={listItemVariants}
-                          initial="hidden"
-                          animate="show"
-                          exit={{ opacity: 0 }}
-                          transition={{ delay: reduce ? 0 : i * 0.04 }}
-                          className="py-1"
-                          style={
-                            reduce
-                              ? undefined
-                              : { willChange: "transform, opacity", transform: "translateZ(0)" }
-                          }
-                        >
-                          <div className="flex items-center gap-2">
-                            <div className="h-2 w-2 rounded-full bg-[#f59e0b]/90 shadow-[0_0_0_3px_#f59e0b18] dark:bg-[#fbbf24]/90 dark:shadow-[0_0_0_3px_#fbbf2418]" />
-                            <div className="flex min-w-0 flex-1 flex-wrap items-baseline gap-1.5">
-                              <span className="font-bold text-[color:var(--page-text)]">
-                                {r.title}
-                              </span>
-                              <span className="text-sm text-[color:color-mix(in_srgb,var(--secondary-text)_55%,transparent)]">
-                                {[formatDate(r.date), r.role].filter(Boolean).join(separator)}
-                              </span>
-                            </div>
-                          </div>
-                        </motion.div>
-                      )
-                    })}
-                  </AnimatePresence>
-                  {!loading && (!participation?.recent || participation.recent.length === 0) && (
-                    <p className="px-1 py-1 text-sm text-[color:color-mix(in_srgb,var(--secondary-text)_55%,transparent)]">
-                      {noDataText}
-                    </p>
-                  )}
-                </div>
-              </div>
-            </CardShell>
-          </motion.div>
-        </motion.div>
-
-        <Dialog
-          open={detail !== ""}
-          onClose={() => setDetail("")}
-          title={detailSection ? t(`activity:sections.${detailSection}.dialogTitle`) : ""}
-          size="md"
-        >
-          {detail === "attendance" && (
-            <div className="space-y-4">
-              <p className="text-base text-[color:var(--page-text)]">
-                {t("activity:sections.attendance.dialogTotal", {
-                  present: attendance?.present ?? 0,
-                  total: attendance?.total ?? 0,
-                  period: attendance?.periodLabel || labelByPeriod(period),
-                })}
-              </p>
-              <ProgressBar
-                value={Math.max(0, Math.min(100, attendance?.percent ?? 0))}
-                className="h-2.5 rounded-lg"
-                barClassName="bg-[#10b981] dark:bg-[#34d399] rounded-lg"
-              />
+            )}
+            {detail === "attendance_recent" && (
               <div className="space-y-2">
                 {(attendance?.recent ?? []).map((r, i) => (
                   <div key={attendanceItemKey(r, i)} className="space-y-0.5">
@@ -991,17 +1065,8 @@ export default function Activity() {
                   </div>
                 ))}
               </div>
-            </div>
-          )}
-          {detail === "grades" && (
-            <div className="space-y-4">
-              <p className="text-base font-semibold text-[color:var(--page-text)]">
-                {grades?.scale === "gpa"
-                  ? `GPA ${(grades?.average ?? 0).toFixed(2)}`
-                  : grades?.scale === "100"
-                    ? `${Math.round(grades?.average ?? 0)}/100`
-                    : `${(grades?.average ?? 0).toFixed(1)}/5`}
-              </p>
+            )}
+            {detail === "grades_recent" && (
               <div className="space-y-2">
                 {(grades?.recent ?? []).map((r, i) => (
                   <div key={gradeItemKey(r, i)} className="space-y-0.5">
@@ -1014,30 +1079,8 @@ export default function Activity() {
                   </div>
                 ))}
               </div>
-            </div>
-          )}
-          {detail === "participation" && (
-            <div className="space-y-4">
-              <p className="text-base text-[color:var(--page-text)]">
-                {[
-                  t("activity:sections.participation.eventsCount", {
-                    value: String(participation?.events ?? 0),
-                    count: participation?.events ?? 0,
-                  }),
-                  participation?.hours != null
-                    ? t("activity:sections.participation.summaryHours", {
-                        count: participation.hours ?? 0,
-                      })
-                    : null,
-                  participation?.groups != null
-                    ? t("activity:sections.participation.summaryGroups", {
-                        count: participation.groups ?? 0,
-                      })
-                    : null,
-                ]
-                  .filter(Boolean)
-                  .join(separator)}
-              </p>
+            )}
+            {detail === "participation_recent" && (
               <div className="space-y-2">
                 {(participation?.recent ?? []).map((r, i) => (
                   <div key={participationItemKey(r, i)} className="space-y-0.5">
@@ -1048,54 +1091,14 @@ export default function Activity() {
                   </div>
                 ))}
               </div>
+            )}
+            <div className="mt-6 flex justify-end">
+              <Button variant="outline" onClick={() => setDetail("")}>
+                {t("activity:dialog.close")}
+              </Button>
             </div>
-          )}
-          {detail === "attendance_recent" && (
-            <div className="space-y-2">
-              {(attendance?.recent ?? []).map((r, i) => (
-                <div key={attendanceItemKey(r, i)} className="space-y-0.5">
-                  <p className="text-sm font-semibold text-[color:var(--page-text)]">
-                    {`${r.course || attendanceLessonFallback} — ${attendanceStatusLabel(r.status)}`}
-                  </p>
-                  <p className="text-xs text-[color:color-mix(in_srgb,var(--secondary-text)_65%,transparent)]">
-                    {formatDate(r.date)}
-                  </p>
-                </div>
-              ))}
-            </div>
-          )}
-          {detail === "grades_recent" && (
-            <div className="space-y-2">
-              {(grades?.recent ?? []).map((r, i) => (
-                <div key={gradeItemKey(r, i)} className="space-y-0.5">
-                  <p className="text-sm font-semibold text-[color:var(--page-text)]">
-                    {`${r.course} — ${r.score}${r.max ? "/" + r.max : ""}`}
-                  </p>
-                  <p className="text-xs text-[color:color-mix(in_srgb,var(--secondary-text)_65%,transparent)]">
-                    {formatDate(r.date)}
-                  </p>
-                </div>
-              ))}
-            </div>
-          )}
-          {detail === "participation_recent" && (
-            <div className="space-y-2">
-              {(participation?.recent ?? []).map((r, i) => (
-                <div key={participationItemKey(r, i)} className="space-y-0.5">
-                  <p className="text-sm font-semibold text-[color:var(--page-text)]">{r.title}</p>
-                  <p className="text-xs text-[color:color-mix(in_srgb,var(--secondary-text)_65%,transparent)]">
-                    {[formatDate(r.date), r.role].filter(Boolean).join(separator)}
-                  </p>
-                </div>
-              ))}
-            </div>
-          )}
-          <div className="mt-6 flex justify-end">
-            <Button variant="outline" onClick={() => setDetail("")}>
-              {t("activity:dialog.close")}
-            </Button>
-          </div>
-        </Dialog>
+          </Dialog>
+        </div>
       </PageFadeIn>
     </Layout>
   )

--- a/root/frontend/src/pages/Events.tsx
+++ b/root/frontend/src/pages/Events.tsx
@@ -289,401 +289,398 @@ const Events = () => {
   return (
     <Layout>
       <PageFadeIn>
-        <div className="relative w-full min-h-screen bg-[color:var(--page-bg)] text-[color:var(--page-text)] px-4 py-6 sm:px-6 md:px-8 lg:px-12 overflow-hidden">
-          {/* Background gradients */}
-          <div className="pointer-events-none absolute inset-0 -z-10 opacity-60" aria-hidden="true">
-            <div className="absolute -inset-[40%_-20%_10%_-20%] bg-[radial-gradient(60%_60%_at_80%_10%,rgba(0,118,255,0.22),transparent),radial-gradient(45%_45%_at_10%_80%,rgba(46,213,166,0.18),transparent)]" />
-          </div>
-          <div className="pointer-events-none absolute inset-0 -z-[1]" aria-hidden="true">
-            <div className="absolute inset-0 bg-[linear-gradient(180deg,rgba(7,18,39,0.22)_0%,rgba(7,18,39,0)_45%),linear-gradient(140deg,rgba(255,255,255,0.04)_0%,rgba(255,255,255,0)_55%)]" />
-          </div>
-
-          {/* Header */}
-          <div
-            data-fade
-            style={fadeDelayStyle("80ms")}
-            className="mb-4 mt-4 flex flex-wrap items-center gap-3 text-[color:var(--nav-link)] sm:mb-6 sm:mt-6"
-          >
-            <span className="inline-flex h-11 w-11 items-center justify-center rounded-full bg-[color:var(--glass-bg)]/70 text-[color:var(--nav-link)] shadow-surface">
-              <EventNoteIcon className="text-[1.85rem]" />
-            </span>
-            <h1 className="text-[clamp(1.6rem,5vw,2.75rem)] font-bold tracking-tight text-[color:var(--page-text)]">
-              {t("events:pageTitle")}
-            </h1>
-          </div>
-
-          {/* Create button */}
-          {(user?.role === "admin" || user?.role === "teacher") && (
-            <div data-fade className="mb-5 flex justify-start" style={fadeDelayStyle("140ms")}>
-              <Button
-                size="lg"
-                onClick={() => setCreateOpen(true)}
-                disabled={imageUploading || loading}
-                className="px-6 text-[clamp(1rem,2.2vw,1.1rem)]"
-              >
-                {t("events:actions.openCreate")}
-              </Button>
+        <div className="w-screen min-h-screen bg-[color:var(--page-bg)] text-[color:var(--page-text)] py-8 sm:py-10">
+          <div className="px-2 md:px-4">
+            {/* Header */}
+            <div
+              data-fade
+              style={fadeDelayStyle("80ms")}
+              className="mb-8 flex flex-wrap items-center gap-4 sm:gap-5"
+            >
+              <div className="flex h-12 w-12 items-center justify-center rounded-full bg-[color:color-mix(in_srgb,var(--glass-bg)_70%,var(--nav-link)_30%)] text-[color:var(--nav-link)] shadow-[0_6px_20px_color-mix(in_srgb,var(--nav-link)_24%,transparent)] transition-transform duration-200 hover:scale-105 dark:bg-[color:color-mix(in_srgb,var(--glass-bg)_65%,var(--nav-link)_35%)] dark:shadow-[0_8px_24px_color-mix(in_srgb,var(--nav-link)_28%,transparent)] backdrop-blur-sm [-webkit-backdrop-filter:blur(12px)]">
+                <EventNoteIcon className="text-[2rem]" />
+              </div>
+              <h1 className="text-[clamp(1.6rem,5vw,2.75rem)] font-bold tracking-tight text-[color:var(--page-text)]">
+                {t("events:pageTitle")}
+              </h1>
             </div>
-          )}
 
-          {/* Tabs */}
-          <div
-            data-fade
-            style={fadeDelayStyle("200ms")}
-            className="relative mb-4 min-h-[45px] rounded-ue-xl border border-[color:var(--glass-border)] bg-[linear-gradient(135deg,rgba(0,118,255,0.12),rgba(0,118,255,0))] px-3 py-2 shadow-[0_18px_45px_rgba(15,23,42,0.18)] backdrop-blur-[16px] sm:px-4 sm:py-2.5 lg:max-w-4xl"
-            role="tablist"
-          >
-            <div className="flex flex-wrap items-center gap-2 sm:gap-4">
-              {tabs.map((tabItem) => (
-                <button
-                  key={tabItem.key}
-                  role="tab"
-                  id={`events-tab-${tabItem.key}`}
-                  aria-selected={tab === tabItem.key}
-                  aria-controls={`events-tabpanel-${tabItem.key}`}
-                  onClick={() => handleTabChange(tabItem.key)}
-                  className={cn(
-                    "relative px-4 py-2 text-base font-semibold transition-colors duration-200 rounded-ue-lg sm:px-6 sm:text-lg",
-                    tab === tabItem.key
-                      ? "text-[color:var(--nav-link)] font-bold"
-                      : "text-[color:var(--page-text)] opacity-80 hover:opacity-100"
-                  )}
+            {/* Create button */}
+            {(user?.role === "admin" || user?.role === "teacher") && (
+              <div data-fade style={fadeDelayStyle("140ms")} className="mb-6 flex justify-start">
+                <Button
+                  size="lg"
+                  onClick={() => setCreateOpen(true)}
+                  disabled={imageUploading || loading}
+                  className="px-6 text-[clamp(1rem,2.2vw,1.1rem)]"
                 >
-                  {tab === tabItem.key && (
-                    <span
-                      className="absolute bottom-0 left-0 right-0 h-0.5 bg-[color:var(--nav-link)] rounded-full"
-                      aria-hidden="true"
-                    />
-                  )}
-                  {t(`events:tabs.${tabItem.key}`)}
-                </button>
-              ))}
-            </div>
-          </div>
+                  {t("events:actions.openCreate")}
+                </Button>
+              </div>
+            )}
 
-          {/* Search and filters */}
-          <div
-            data-fade
-            style={fadeDelayStyle("240ms")}
-            className="mb-5 flex flex-wrap items-center gap-3 rounded-ue-xl border border-[color:var(--glass-border)] bg-[linear-gradient(135deg,rgba(14,116,144,0.12),rgba(14,116,144,0))] px-4 py-3 shadow-[0_18px_45px_rgba(15,23,42,0.18)] backdrop-blur-[14px] sm:px-5 sm:py-4 lg:max-w-4xl"
-          >
-            <div className="relative flex-1 min-w-[200px]">
-              <SearchIcon className="absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-[color:var(--secondary-text)] pointer-events-none" />
-              <input
-                type="text"
-                value={search}
-                onChange={(e) => setSearch(e.target.value)}
-                placeholder={t("events:filters.search")}
-                className={cn(inputClass, "pl-10 pr-10", "w-full")}
-              />
-              <div className="absolute right-2 top-1/2 flex -translate-y-1/2 items-center gap-1">
-                {search && (
+            {/* Tabs */}
+            <div
+              data-fade
+              style={fadeDelayStyle("200ms")}
+              className="relative mb-6 min-h-[45px] rounded-ue-xl border border-[color:color-mix(in_srgb,white_12%,var(--nav-link)_88%)] bg-[color:color-mix(in_srgb,var(--card-bg)_96%,white_4%)] px-3 py-2 shadow-[0_12px_32px_rgba(0,0,0,0.08),0_4px_12px_rgba(0,0,0,0.04)] backdrop-blur-[12px] sm:px-4 sm:py-2.5 lg:max-w-4xl"
+              role="tablist"
+            >
+              <div className="flex flex-wrap items-center gap-2 sm:gap-4">
+                {tabs.map((tabItem) => (
                   <button
-                    type="button"
-                    onClick={() => setSearch("")}
-                    className="rounded-full p-1.5 text-[color:var(--secondary-text)] transition-colors hover:text-[color:var(--nav-link)]"
-                    aria-label={t("events:aria.clearSearch")}
+                    key={tabItem.key}
+                    role="tab"
+                    id={`events-tab-${tabItem.key}`}
+                    aria-selected={tab === tabItem.key}
+                    aria-controls={`events-tabpanel-${tabItem.key}`}
+                    onClick={() => handleTabChange(tabItem.key)}
+                    className={cn(
+                      "relative rounded-ue-lg px-4 py-2 text-base font-semibold transition-colors duration-200 sm:px-6 sm:text-lg",
+                      tab === tabItem.key
+                        ? "text-[color:var(--nav-link)] font-bold"
+                        : "text-[color:var(--page-text)] opacity-80 hover:opacity-100"
+                    )}
                   >
-                    <ClearIcon className="h-4 w-4" />
-                  </button>
-                )}
-                <div className="relative">
-                  <button
-                    type="button"
-                    onClick={(e) => setFilterAnchor(e.currentTarget)}
-                    className="rounded-full p-1.5 text-[color:var(--secondary-text)] transition-colors hover:text-[color:var(--nav-link)]"
-                    aria-label={t("events:aria.openFilters")}
-                  >
-                    {filtersActive && (
+                    {tab === tabItem.key && (
                       <span
-                        className="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full bg-[color:var(--nav-link)]"
+                        className="absolute bottom-0 left-0 right-0 h-0.5 rounded-full bg-[color:var(--nav-link)]"
                         aria-hidden="true"
                       />
                     )}
-                    <FilterListIcon className="h-4 w-4" />
+                    {t(`events:tabs.${tabItem.key}`)}
                   </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Search and filters */}
+            <div
+              data-fade
+              style={fadeDelayStyle("240ms")}
+              className="mb-5 flex flex-wrap items-center gap-3 rounded-ue-xl border border-[color:var(--glass-border)] bg-[linear-gradient(135deg,rgba(14,116,144,0.12),rgba(14,116,144,0))] px-4 py-3 shadow-[0_18px_45px_rgba(15,23,42,0.18)] backdrop-blur-[14px] sm:px-5 sm:py-4 lg:max-w-4xl"
+            >
+              <div className="relative flex-1 min-w-[200px]">
+                <SearchIcon className="absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-[color:var(--secondary-text)] pointer-events-none" />
+                <input
+                  type="text"
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  placeholder={t("events:filters.search")}
+                  className={cn(inputClass, "pl-10 pr-10", "w-full")}
+                />
+                <div className="absolute right-2 top-1/2 flex -translate-y-1/2 items-center gap-1">
+                  {search && (
+                    <button
+                      type="button"
+                      onClick={() => setSearch("")}
+                      className="rounded-full p-1.5 text-[color:var(--secondary-text)] transition-colors hover:text-[color:var(--nav-link)]"
+                      aria-label={t("events:aria.clearSearch")}
+                    >
+                      <ClearIcon className="h-4 w-4" />
+                    </button>
+                  )}
+                  <div className="relative">
+                    <button
+                      type="button"
+                      onClick={(e) => setFilterAnchor(e.currentTarget)}
+                      className="rounded-full p-1.5 text-[color:var(--secondary-text)] transition-colors hover:text-[color:var(--nav-link)]"
+                      aria-label={t("events:aria.openFilters")}
+                    >
+                      {filtersActive && (
+                        <span
+                          className="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full bg-[color:var(--nav-link)]"
+                          aria-hidden="true"
+                        />
+                      )}
+                      <FilterListIcon className="h-4 w-4" />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
 
-          {/* Filter popover */}
-          {filtersOpen && filterAnchor && (
+            {/* Filter popover */}
+            {filtersOpen && filterAnchor && (
+              <div
+                ref={filterPopoverRef}
+                className="fixed z-50 mt-2 min-w-[260px] rounded-ue-lg border border-[color:var(--glass-border)] bg-[color:var(--card-bg)] p-4 shadow-surface-strong"
+                style={{
+                  top: filterAnchor.getBoundingClientRect().bottom + 8,
+                  left: Math.min(
+                    filterAnchor.getBoundingClientRect().left,
+                    window.innerWidth - 280
+                  ),
+                }}
+              >
+                <div className="space-y-4">
+                  <div>
+                    <label className="mb-2 block text-sm font-semibold text-[color:var(--secondary-text)]">
+                      {t("events:filters.type")}
+                    </label>
+                    <input
+                      type="text"
+                      value={type}
+                      onChange={(e) => setType(e.target.value)}
+                      className={inputClass}
+                    />
+                  </div>
+                  <div>
+                    <label className="mb-2 block text-sm font-semibold text-[color:var(--secondary-text)]">
+                      {t("events:filters.location")}
+                    </label>
+                    <input
+                      type="text"
+                      value={location}
+                      onChange={(e) => setLocation(e.target.value)}
+                      className={inputClass}
+                    />
+                  </div>
+                  <div className="flex justify-end gap-2">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => {
+                        setType("")
+                        setLocation("")
+                      }}
+                    >
+                      {t("common:buttons.reset")}
+                    </Button>
+                    <Button variant="solid" size="sm" onClick={() => setFilterAnchor(null)}>
+                      {t("common:buttons.done")}
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {/* Events grid */}
             <div
-              ref={filterPopoverRef}
-              className="fixed z-50 mt-2 min-w-[260px] rounded-ue-lg border border-[color:var(--glass-border)] bg-[color:var(--card-bg)] p-4 shadow-surface-strong"
-              style={{
-                top: filterAnchor.getBoundingClientRect().bottom + 8,
-                left: Math.min(filterAnchor.getBoundingClientRect().left, window.innerWidth - 280),
-              }}
+              data-fade
+              style={fadeDelayStyle("260ms")}
+              role="tabpanel"
+              id={`events-tabpanel-${tab}`}
+              aria-labelledby={`events-tab-${tab}`}
+              className={cn(
+                "flex flex-wrap gap-5 pb-6 transition-all duration-300 sm:gap-6 md:gap-8",
+                isMobile ? "flex-col" : ""
+              )}
+            >
+              {loading &&
+                Array.from({ length: skeletonCount }).map((_, i) => (
+                  <div key={`event-skel-${i}`} className="flex h-full">
+                    <div className="w-full max-w-[500px] space-y-3 rounded-ue-xl border border-[color:var(--glass-border)] bg-[color:var(--card-bg)] p-4 shadow-surface">
+                      <Skeleton height={isMobile ? 160 : 200} className="rounded-ue-lg" />
+                      <Skeleton height={isMobile ? 28 : 32} />
+                      <Skeleton height={20} width={isMobile ? "85%" : "80%"} />
+                      {!isMobile && <Skeleton height={20} width="60%" />}
+                    </div>
+                  </div>
+                ))}
+
+              {!loading &&
+                normalizedEvents.map((event) => (
+                  <div key={event.id} className="flex h-full">
+                    <EventCard {...event} onChange={handleRefresh} maxWidth="500px" />
+                  </div>
+                ))}
+
+              {!loading && normalizedEvents.length === 0 && (
+                <div className="mt-16 flex w-full justify-center">
+                  <div className="flex w-full max-w-[420px] flex-col items-center gap-5 rounded-ue-xl border border-[color:var(--glass-border)] bg-[color:color-mix(in_srgb,var(--card-bg)_96%,white_4%)] px-6 py-10 text-center text-[color:var(--secondary-text)] shadow-surface">
+                    <span className="flex h-16 w-16 items-center justify-center rounded-full bg-[color:var(--glass-bg)]/70 text-[color:var(--nav-link)] shadow-surface">
+                      <EventNoteIcon className="text-[2.2rem]" />
+                    </span>
+                    <p className="text-lg font-semibold text-[color:var(--page-text)] sm:text-xl">
+                      {t("events:states.empty")}
+                    </p>
+                  </div>
+                </div>
+              )}
+            </div>
+
+            {/* Load more */}
+            {hasMore && (
+              <div className="mb-8 flex justify-center">
+                <Button
+                  variant="outline"
+                  size="lg"
+                  onClick={loadMore}
+                  disabled={loadingMore}
+                  className="px-6"
+                >
+                  {loadingMore
+                    ? t("common:statuses.loading")
+                    : t("common:buttons.loadMore", { defaultValue: "Load more" })}
+                </Button>
+              </div>
+            )}
+
+            {/* Create dialog */}
+            <Dialog
+              open={createOpen}
+              onClose={closeCreate}
+              title={t("events:dialogs.create.title")}
+              size="lg"
+              fullScreenOnMobile
+              footer={
+                <>
+                  <Button variant="outline" onClick={closeCreate} className="w-full sm:w-auto">
+                    {t("common:buttons.cancel")}
+                  </Button>
+                  <Button
+                    onClick={handleCreateEvent}
+                    disabled={
+                      !normalizedTitle ||
+                      !eventData.starts_at ||
+                      !eventData.ends_at ||
+                      !normalizedLocation ||
+                      imageUploading ||
+                      dateError
+                    }
+                    className="w-full sm:w-auto"
+                  >
+                    {t("common:buttons.create")}
+                  </Button>
+                </>
+              }
+              footerClassName="flex-col-reverse gap-3 sm:flex-row"
             >
               <div className="space-y-4">
                 <div>
-                  <label className="mb-2 block text-sm font-semibold text-[color:var(--secondary-text)]">
-                    {t("events:filters.type")}
+                  <label className="mb-2 block text-sm font-semibold tracking-wide text-[color:color-mix(in_srgb,var(--secondary-text)_85%,white_15%)]">
+                    {language === "en"
+                      ? t("events:form.title_en", {
+                          defaultValue: `${t("events:form.title")} (English)`,
+                        })
+                      : t("events:form.title")}
                   </label>
                   <input
                     type="text"
-                    value={type}
-                    onChange={(e) => setType(e.target.value)}
+                    value={getLocalizedDraftValue("title")}
+                    onChange={(e) => updateLocalizedDraftValue("title", e.target.value)}
                     className={inputClass}
                   />
                 </div>
                 <div>
-                  <label className="mb-2 block text-sm font-semibold text-[color:var(--secondary-text)]">
-                    {t("events:filters.location")}
+                  <label className="mb-2 block text-sm font-semibold tracking-wide text-[color:color-mix(in_srgb,var(--secondary-text)_85%,white_15%)]">
+                    {language === "en"
+                      ? t("events:form.description_en", {
+                          defaultValue: `${t("events:form.description")} (English)`,
+                        })
+                      : t("events:form.description")}
+                  </label>
+                  <textarea
+                    value={getLocalizedDraftValue("description")}
+                    onChange={(e) => updateLocalizedDraftValue("description", e.target.value)}
+                    rows={3}
+                    className={cn(inputClass, "min-h-[120px] resize-y")}
+                  />
+                </div>
+                <div>
+                  <label className="mb-2 block text-sm font-semibold tracking-wide text-[color:color-mix(in_srgb,var(--secondary-text)_85%,white_15%)]">
+                    {language === "en"
+                      ? t("events:form.type_en", {
+                          defaultValue: `${t("events:form.type")} (English)`,
+                        })
+                      : t("events:form.type")}
                   </label>
                   <input
                     type="text"
-                    value={location}
-                    onChange={(e) => setLocation(e.target.value)}
+                    value={getLocalizedDraftValue("event_type")}
+                    onChange={(e) => updateLocalizedDraftValue("event_type", e.target.value)}
                     className={inputClass}
                   />
                 </div>
-                <div className="flex justify-end gap-2">
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => {
-                      setType("")
-                      setLocation("")
-                    }}
-                  >
-                    {t("common:buttons.reset")}
-                  </Button>
-                  <Button variant="solid" size="sm" onClick={() => setFilterAnchor(null)}>
-                    {t("common:buttons.done")}
-                  </Button>
-                </div>
-              </div>
-            </div>
-          )}
-
-          {/* Events grid */}
-          <div
-            data-fade
-            style={fadeDelayStyle("260ms")}
-            role="tabpanel"
-            id={`events-tabpanel-${tab}`}
-            aria-labelledby={`events-tab-${tab}`}
-            className={cn(
-              "flex flex-wrap gap-5 pb-6 transition-all duration-300 sm:gap-6 md:gap-8",
-              isMobile ? "flex-col" : ""
-            )}
-          >
-            {loading &&
-              Array.from({ length: skeletonCount }).map((_, i) => (
-                <div key={`event-skel-${i}`} className="flex h-full">
-                  <div className="w-full max-w-[500px] space-y-3 rounded-ue-xl border border-[color:var(--glass-border)] bg-[color:var(--card-bg)] p-4 shadow-surface">
-                    <Skeleton height={isMobile ? 160 : 200} className="rounded-ue-lg" />
-                    <Skeleton height={isMobile ? 28 : 32} />
-                    <Skeleton height={20} width={isMobile ? "85%" : "80%"} />
-                    {!isMobile && <Skeleton height={20} width="60%" />}
-                  </div>
-                </div>
-              ))}
-
-            {!loading &&
-              normalizedEvents.map((event) => (
-                <div key={event.id} className="flex h-full">
-                  <EventCard {...event} onChange={handleRefresh} maxWidth="500px" />
-                </div>
-              ))}
-
-            {!loading && normalizedEvents.length === 0 && (
-              <div className="mt-16 flex w-full justify-center">
-                <div className="flex w-full max-w-[420px] flex-col items-center gap-5 rounded-ue-xl border border-[color:var(--glass-border)] bg-[color:color-mix(in_srgb,var(--card-bg)_96%,white_4%)] px-6 py-10 text-center text-[color:var(--secondary-text)] shadow-surface">
-                  <span className="flex h-16 w-16 items-center justify-center rounded-full bg-[color:var(--glass-bg)]/70 text-[color:var(--nav-link)] shadow-surface">
-                    <EventNoteIcon className="text-[2.2rem]" />
-                  </span>
-                  <p className="text-lg font-semibold text-[color:var(--page-text)] sm:text-xl">
-                    {t("events:states.empty")}
-                  </p>
-                </div>
-              </div>
-            )}
-          </div>
-
-          {/* Load more */}
-          {hasMore && (
-            <div className="mb-8 flex justify-center">
-              <Button
-                variant="outline"
-                size="lg"
-                onClick={loadMore}
-                disabled={loadingMore}
-                className="px-6"
-              >
-                {loadingMore
-                  ? t("common:statuses.loading")
-                  : t("common:buttons.loadMore", { defaultValue: "Load more" })}
-              </Button>
-            </div>
-          )}
-
-          {/* Create dialog */}
-          <Dialog
-            open={createOpen}
-            onClose={closeCreate}
-            title={t("events:dialogs.create.title")}
-            size="lg"
-            fullScreenOnMobile
-            footer={
-              <>
-                <Button variant="outline" onClick={closeCreate} className="w-full sm:w-auto">
-                  {t("common:buttons.cancel")}
-                </Button>
-                <Button
-                  onClick={handleCreateEvent}
-                  disabled={
-                    !normalizedTitle ||
-                    !eventData.starts_at ||
-                    !eventData.ends_at ||
-                    !normalizedLocation ||
-                    imageUploading ||
-                    dateError
-                  }
-                  className="w-full sm:w-auto"
-                >
-                  {t("common:buttons.create")}
-                </Button>
-              </>
-            }
-            footerClassName="flex-col-reverse gap-3 sm:flex-row"
-          >
-            <div className="space-y-4">
-              <div>
-                <label className="mb-2 block text-sm font-semibold tracking-wide text-[color:color-mix(in_srgb,var(--secondary-text)_85%,white_15%)]">
-                  {language === "en"
-                    ? t("events:form.title_en", {
-                        defaultValue: `${t("events:form.title")} (English)`,
-                      })
-                    : t("events:form.title")}
-                </label>
-                <input
-                  type="text"
-                  value={getLocalizedDraftValue("title")}
-                  onChange={(e) => updateLocalizedDraftValue("title", e.target.value)}
-                  className={inputClass}
-                />
-              </div>
-              <div>
-                <label className="mb-2 block text-sm font-semibold tracking-wide text-[color:color-mix(in_srgb,var(--secondary-text)_85%,white_15%)]">
-                  {language === "en"
-                    ? t("events:form.description_en", {
-                        defaultValue: `${t("events:form.description")} (English)`,
-                      })
-                    : t("events:form.description")}
-                </label>
-                <textarea
-                  value={getLocalizedDraftValue("description")}
-                  onChange={(e) => updateLocalizedDraftValue("description", e.target.value)}
-                  rows={3}
-                  className={cn(inputClass, "min-h-[120px] resize-y")}
-                />
-              </div>
-              <div>
-                <label className="mb-2 block text-sm font-semibold tracking-wide text-[color:color-mix(in_srgb,var(--secondary-text)_85%,white_15%)]">
-                  {language === "en"
-                    ? t("events:form.type_en", {
-                        defaultValue: `${t("events:form.type")} (English)`,
-                      })
-                    : t("events:form.type")}
-                </label>
-                <input
-                  type="text"
-                  value={getLocalizedDraftValue("event_type")}
-                  onChange={(e) => updateLocalizedDraftValue("event_type", e.target.value)}
-                  className={inputClass}
-                />
-              </div>
-              <div>
-                <label className="mb-2 block text-sm font-semibold tracking-wide text-[color:color-mix(in_srgb,var(--secondary-text)_85%,white_15%)]">
-                  {language === "en"
-                    ? t("events:form.location_en", {
-                        defaultValue: `${t("events:form.location")} (English)`,
-                      })
-                    : t("events:form.location")}
-                </label>
-                <input
-                  type="text"
-                  value={getLocalizedDraftValue("location")}
-                  onChange={(e) => updateLocalizedDraftValue("location", e.target.value)}
-                  className={inputClass}
-                />
-              </div>
-              <div>
-                <label className="mb-2 block text-sm font-semibold tracking-wide text-[color:color-mix(in_srgb,var(--secondary-text)_85%,white_15%)]">
-                  {t("events:form.speaker")}
-                </label>
-                <input
-                  type="text"
-                  value={eventData.speaker}
-                  onChange={(e) => setEventData({ ...eventData, speaker: e.target.value })}
-                  className={inputClass}
-                />
-              </div>
-              <div>
-                <Button
-                  as="label"
-                  variant="outline"
-                  disabled={imageUploading}
-                  className="w-full sm:w-auto"
-                >
-                  {imageUploading
-                    ? t("common:statuses.uploading")
-                    : eventData.image_url
-                      ? t("events:form.imageSelected")
-                      : t("events:form.uploadImage")}
+                <div>
+                  <label className="mb-2 block text-sm font-semibold tracking-wide text-[color:color-mix(in_srgb,var(--secondary-text)_85%,white_15%)]">
+                    {language === "en"
+                      ? t("events:form.location_en", {
+                          defaultValue: `${t("events:form.location")} (English)`,
+                        })
+                      : t("events:form.location")}
+                  </label>
                   <input
-                    type="file"
-                    hidden
-                    accept="image/*"
-                    onChange={(e) => {
-                      const file = e.target.files?.[0]
-                      if (file) handleImageUpload(file)
-                    }}
+                    type="text"
+                    value={getLocalizedDraftValue("location")}
+                    onChange={(e) => updateLocalizedDraftValue("location", e.target.value)}
+                    className={inputClass}
                   />
-                </Button>
-                {(createPreview || eventData.image_url) && (
-                  <div className="mt-3">
-                    <SmartImage
-                      srcRaw={createPreview || eventData.image_url || ""}
-                      alt={t("events:alt.preview")}
-                      className="max-h-[140px] rounded-ue-lg border border-[color:var(--glass-border)] object-cover shadow-surface"
+                </div>
+                <div>
+                  <label className="mb-2 block text-sm font-semibold tracking-wide text-[color:color-mix(in_srgb,var(--secondary-text)_85%,white_15%)]">
+                    {t("events:form.speaker")}
+                  </label>
+                  <input
+                    type="text"
+                    value={eventData.speaker}
+                    onChange={(e) => setEventData({ ...eventData, speaker: e.target.value })}
+                    className={inputClass}
+                  />
+                </div>
+                <div>
+                  <Button
+                    as="label"
+                    variant="outline"
+                    disabled={imageUploading}
+                    className="w-full sm:w-auto"
+                  >
+                    {imageUploading
+                      ? t("common:statuses.uploading")
+                      : eventData.image_url
+                        ? t("events:form.imageSelected")
+                        : t("events:form.uploadImage")}
+                    <input
+                      type="file"
+                      hidden
+                      accept="image/*"
+                      onChange={(e) => {
+                        const file = e.target.files?.[0]
+                        if (file) handleImageUpload(file)
+                      }}
                     />
-                  </div>
-                )}
+                  </Button>
+                  {(createPreview || eventData.image_url) && (
+                    <div className="mt-3">
+                      <SmartImage
+                        srcRaw={createPreview || eventData.image_url || ""}
+                        alt={t("events:alt.preview")}
+                        className="max-h-[140px] rounded-ue-lg border border-[color:var(--glass-border)] object-cover shadow-surface"
+                      />
+                    </div>
+                  )}
+                </div>
+                <div>
+                  <label className="mb-2 block text-sm font-semibold tracking-wide text-[color:color-mix(in_srgb,var(--secondary-text)_85%,white_15%)]">
+                    {t("events:form.start")}
+                  </label>
+                  <input
+                    type="datetime-local"
+                    value={eventData.starts_at}
+                    onChange={(e) => setEventData({ ...eventData, starts_at: e.target.value })}
+                    className={inputClass}
+                  />
+                </div>
+                <div>
+                  <label className="mb-2 block text-sm font-semibold tracking-wide text-[color:color-mix(in_srgb,var(--secondary-text)_85%,white_15%)]">
+                    {t("events:form.end")}
+                  </label>
+                  <input
+                    type="datetime-local"
+                    value={eventData.ends_at}
+                    onChange={(e) => setEventData({ ...eventData, ends_at: e.target.value })}
+                    className={cn(inputClass, dateError && "border-red-500")}
+                  />
+                  {dateError && (
+                    <p className="mt-1 text-sm text-red-500">
+                      {t("events:form.errors.endsBeforeStarts")}
+                    </p>
+                  )}
+                </div>
               </div>
-              <div>
-                <label className="mb-2 block text-sm font-semibold tracking-wide text-[color:color-mix(in_srgb,var(--secondary-text)_85%,white_15%)]">
-                  {t("events:form.start")}
-                </label>
-                <input
-                  type="datetime-local"
-                  value={eventData.starts_at}
-                  onChange={(e) => setEventData({ ...eventData, starts_at: e.target.value })}
-                  className={inputClass}
-                />
-              </div>
-              <div>
-                <label className="mb-2 block text-sm font-semibold tracking-wide text-[color:color-mix(in_srgb,var(--secondary-text)_85%,white_15%)]">
-                  {t("events:form.end")}
-                </label>
-                <input
-                  type="datetime-local"
-                  value={eventData.ends_at}
-                  onChange={(e) => setEventData({ ...eventData, ends_at: e.target.value })}
-                  className={cn(inputClass, dateError && "border-red-500")}
-                />
-                {dateError && (
-                  <p className="mt-1 text-sm text-red-500">
-                    {t("events:form.errors.endsBeforeStarts")}
-                  </p>
-                )}
-              </div>
-            </div>
-          </Dialog>
+            </Dialog>
+          </div>
         </div>
       </PageFadeIn>
     </Layout>

--- a/root/frontend/src/pages/News.tsx
+++ b/root/frontend/src/pages/News.tsx
@@ -11,6 +11,7 @@ import {
   startTransition,
   useMemo,
   type ReactNode,
+  type CSSProperties,
 } from "react"
 import { createNews, uploadNewsImage } from "@/api/news"
 import ArticleIcon from "@mui/icons-material/Article"
@@ -26,6 +27,9 @@ import { useNewsFeed } from "@/hooks/useNewsFeed"
 const inputClass =
   "w-full rounded-ue-lg border border-white/12 bg-[color:color-mix(in_srgb,var(--card-bg)_94%,white_6%)] px-4 py-2.5 text-[0.98rem] text-[color:var(--page-text)] shadow-[inset_0_1px_0_rgba(15,23,42,0.08)] transition focus:border-[color:var(--nav-link)] focus:outline-none focus:shadow-focus placeholder:text-[color:var(--placeholder-fg)]"
 const textareaClass = `${inputClass} min-h-[148px] resize-y leading-relaxed`
+
+const fadeDelayStyle = (value: string): CSSProperties =>
+  ({ "--fade-delay": value }) as CSSProperties
 
 type NewsFormState = {
   title: string
@@ -186,195 +190,202 @@ const News = () => {
   return (
     <Layout>
       <PageFadeIn>
-        <div className="flex w-full flex-col px-4 pb-16 pt-6 sm:px-6 lg:px-8">
-          <div
-            data-fade
-            className="mb-4 mt-4 flex flex-wrap items-center gap-3 text-nav-link [--fade-delay:80ms] sm:mb-8 sm:mt-6"
-          >
-            <span className="inline-flex h-11 w-11 items-center justify-center rounded-full bg-[color:var(--glass-bg)]/70 text-[color:var(--nav-link)] shadow-surface">
-              <ArticleIcon className="text-[1.85rem]" />
-            </span>
-            <h1 className="text-[clamp(1.6rem,5vw,2.75rem)] font-bold tracking-tight text-[color:var(--page-text)]">
-              {t("news:pageTitle")}
-            </h1>
-          </div>
-
-          {user?.role === "admin" && (
-            <div data-fade className="mb-6 flex justify-start [--fade-delay:140ms]">
-              <Button
-                size="lg"
-                onClick={() => setAddOpen(true)}
-                disabled={adding}
-                className="px-6 text-[clamp(1rem,2.2vw,1.1rem)]"
-              >
-                {t("news:actions.add")}
-              </Button>
+        <div className="w-screen min-h-screen bg-[color:var(--page-bg)] text-[color:var(--page-text)] py-8 sm:py-10">
+          <div className="px-2 md:px-4">
+            <div
+              data-fade
+              style={fadeDelayStyle("80ms")}
+              className="mb-8 flex flex-wrap items-center gap-4 sm:gap-5"
+            >
+              <div className="flex h-12 w-12 items-center justify-center rounded-full bg-[color:color-mix(in_srgb,var(--glass-bg)_70%,var(--nav-link)_30%)] text-[color:var(--nav-link)] shadow-[0_6px_20px_color-mix(in_srgb,var(--nav-link)_24%,transparent)] transition-transform duration-200 hover:scale-105 dark:bg-[color:color-mix(in_srgb,var(--glass-bg)_65%,var(--nav-link)_35%)] dark:shadow-[0_8px_24px_color-mix(in_srgb,var(--nav-link)_28%,transparent)] backdrop-blur-sm [-webkit-backdrop-filter:blur(12px)]">
+                <ArticleIcon className="text-[2rem]" />
+              </div>
+              <h1 className="text-[clamp(1.6rem,5vw,2.75rem)] font-bold tracking-tight text-[color:var(--page-text)]">
+                {t("news:pageTitle")}
+              </h1>
             </div>
-          )}
 
-          <div data-fade className="flex flex-wrap gap-5 [--fade-delay:200ms] sm:gap-6">
-            {isInitialLoading
-              ? Array.from({ length: skeletonCount }).map((_, index) => (
-                  <div key={`news-skeleton-${index}`} className="flex h-full">
-                    <NewsCardSkeleton />
-                  </div>
-                ))
-              : Array.isArray(visibleList) &&
-                visibleList.map((news) => (
-                  <div key={news.id} className="flex h-full">
-                    <NewsCard
-                      {...news}
-                      image_url={news.image_url ?? undefined}
-                      onChange={() => {
-                        void refetchNews()
-                      }}
-                    />
-                  </div>
-                ))}
-
-            {showEmptyState && (
-              <div className="mt-16 flex w-full justify-start">
-                <div className="flex w-full max-w-[420px] flex-col items-center gap-5 rounded-ue-xl border border-white/12 bg-glass/60 px-6 py-10 text-center text-[color:var(--secondary-text)] shadow-surface">
-                  <span className="flex h-16 w-16 items-center justify-center rounded-full bg-[color:var(--glass-bg)]/70 text-[color:var(--nav-link)] shadow-surface">
-                    <ArticleIcon className="text-[2.2rem]" />
-                  </span>
-                  <p className="text-lg font-semibold text-[color:var(--page-text)] sm:text-xl">
-                    {t("news:states.empty")}
-                  </p>
-                  {user?.role === "admin" && (
-                    <Button size="lg" onClick={() => setAddOpen(true)} className="px-6">
-                      {t("news:actions.add")}
-                    </Button>
-                  )}
-                </div>
+            {user?.role === "admin" && (
+              <div data-fade style={fadeDelayStyle("140ms")} className="mb-6 flex justify-start">
+                <Button
+                  size="lg"
+                  onClick={() => setAddOpen(true)}
+                  disabled={adding}
+                  className="px-6 text-[clamp(1rem,2.2vw,1.1rem)]"
+                >
+                  {t("news:actions.add")}
+                </Button>
               </div>
             )}
-          </div>
 
-          <Dialog
-            open={addOpen}
-            onClose={handleCloseDialog}
-            title={t("news:dialogs.create.title")}
-            size="md"
-            fullScreenOnMobile
-            closeLabel={t("common:buttons.close")}
-            bodyClassName="space-y-4"
-            footerClassName="flex-col-reverse gap-3 sm:flex-row"
-            footer={
-              <>
-                <Button
-                  variant="outline"
-                  onClick={handleCloseDialog}
-                  disabled={adding}
-                  className="w-full sm:w-auto"
-                >
-                  {t("common:buttons.cancel")}
-                </Button>
-                <Button
-                  onClick={() => {
-                    void handleAddNews()
-                  }}
-                  disabled={!newsData.title.trim() || !newsData.content.trim() || adding}
-                  loading={adding}
-                  className="w-full sm:w-auto"
-                >
-                  {adding ? t("common:statuses.publishing") : t("news:actions.publish")}
-                </Button>
-              </>
-            }
-            initialFocus={() => titleInputRef.current ?? undefined}
-          >
-            <form
-              className="space-y-4"
-              onSubmit={(event) => {
-                event.preventDefault()
-                void handleAddNews()
-              }}
+            <div
+              data-fade
+              style={fadeDelayStyle("200ms")}
+              className="flex flex-wrap gap-5 sm:gap-6"
             >
-              <Field label={t("news:form.title") ?? ""} htmlFor="news-title" required>
-                <input
-                  id="news-title"
-                  ref={titleInputRef}
-                  type="text"
-                  value={newsData.title}
-                  onChange={(e) => setNewsData({ ...newsData, title: e.target.value })}
-                  maxLength={100}
-                  disabled={adding}
-                  className={inputClass}
-                />
-              </Field>
+              {isInitialLoading
+                ? Array.from({ length: skeletonCount }).map((_, index) => (
+                    <div key={`news-skeleton-${index}`} className="flex h-full">
+                      <NewsCardSkeleton />
+                    </div>
+                  ))
+                : Array.isArray(visibleList) &&
+                  visibleList.map((news) => (
+                    <div key={news.id} className="flex h-full">
+                      <NewsCard
+                        {...news}
+                        image_url={news.image_url ?? undefined}
+                        onChange={() => {
+                          void refetchNews()
+                        }}
+                      />
+                    </div>
+                  ))}
 
-              <Field label={t("news:form.content") ?? ""} htmlFor="news-content" required>
-                <textarea
-                  id="news-content"
-                  value={newsData.content}
-                  onChange={(e) => setNewsData({ ...newsData, content: e.target.value })}
-                  maxLength={3000}
-                  disabled={adding}
-                  className={textareaClass}
-                  rows={6}
-                />
-              </Field>
+              {showEmptyState && (
+                <div className="mt-16 flex w-full justify-start">
+                  <div className="flex w-full max-w-[420px] flex-col items-center gap-5 rounded-ue-xl border border-white/12 bg-glass/60 px-6 py-10 text-center text-[color:var(--secondary-text)] shadow-surface">
+                    <span className="flex h-16 w-16 items-center justify-center rounded-full bg-[color:var(--glass-bg)]/70 text-[color:var(--nav-link)] shadow-surface">
+                      <ArticleIcon className="text-[2.2rem]" />
+                    </span>
+                    <p className="text-lg font-semibold text-[color:var(--page-text)] sm:text-xl">
+                      {t("news:states.empty")}
+                    </p>
+                    {user?.role === "admin" && (
+                      <Button size="lg" onClick={() => setAddOpen(true)} className="px-6">
+                        {t("news:actions.add")}
+                      </Button>
+                    )}
+                  </div>
+                </div>
+              )}
+            </div>
 
-              <Field
-                label={t("news:form.title_en", { defaultValue: "Title (English)" }) ?? ""}
-                htmlFor="news-title-en"
+            <Dialog
+              open={addOpen}
+              onClose={handleCloseDialog}
+              title={t("news:dialogs.create.title")}
+              size="md"
+              fullScreenOnMobile
+              closeLabel={t("common:buttons.close")}
+              bodyClassName="space-y-4"
+              footerClassName="flex-col-reverse gap-3 sm:flex-row"
+              footer={
+                <>
+                  <Button
+                    variant="outline"
+                    onClick={handleCloseDialog}
+                    disabled={adding}
+                    className="w-full sm:w-auto"
+                  >
+                    {t("common:buttons.cancel")}
+                  </Button>
+                  <Button
+                    onClick={() => {
+                      void handleAddNews()
+                    }}
+                    disabled={!newsData.title.trim() || !newsData.content.trim() || adding}
+                    loading={adding}
+                    className="w-full sm:w-auto"
+                  >
+                    {adding ? t("common:statuses.publishing") : t("news:actions.publish")}
+                  </Button>
+                </>
+              }
+              initialFocus={() => titleInputRef.current ?? undefined}
+            >
+              <form
+                className="space-y-4"
+                onSubmit={(event) => {
+                  event.preventDefault()
+                  void handleAddNews()
+                }}
               >
-                <input
-                  id="news-title-en"
-                  type="text"
-                  value={newsData.title_en}
-                  onChange={(e) => setNewsData({ ...newsData, title_en: e.target.value })}
-                  maxLength={100}
-                  disabled={adding}
-                  className={inputClass}
-                />
-              </Field>
-
-              <Field
-                label={t("news:form.content_en", { defaultValue: "News text (English)" }) ?? ""}
-                htmlFor="news-content-en"
-              >
-                <textarea
-                  id="news-content-en"
-                  value={newsData.content_en}
-                  onChange={(e) => setNewsData({ ...newsData, content_en: e.target.value })}
-                  maxLength={3000}
-                  disabled={adding}
-                  className={textareaClass}
-                  rows={6}
-                />
-              </Field>
-
-              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                <Button
-                  as="label"
-                  variant="outline"
-                  size="sm"
-                  leadingIcon={<PhotoCamera className="text-[1.15rem]" />}
-                  className="w-full sm:w-auto"
-                  disabled={adding}
-                >
-                  {imageFile ? t("common:buttons.changePhoto") : t("common:buttons.uploadPhoto")}
+                <Field label={t("news:form.title") ?? ""} htmlFor="news-title" required>
                   <input
-                    type="file"
-                    accept="image/*"
-                    hidden
-                    ref={imageInputRef}
-                    onChange={handleImageChange}
+                    id="news-title"
+                    ref={titleInputRef}
+                    type="text"
+                    value={newsData.title}
+                    onChange={(e) => setNewsData({ ...newsData, title: e.target.value })}
+                    maxLength={100}
+                    disabled={adding}
+                    className={inputClass}
                   />
-                </Button>
+                </Field>
 
-                {imagePreview ? (
-                  <SmartImage
-                    srcRaw={imagePreview}
-                    alt={t("news:alt.newCover")}
-                    className="h-20 w-full max-w-[160px] rounded-ue-md border border-white/10 object-cover shadow-surface"
+                <Field label={t("news:form.content") ?? ""} htmlFor="news-content" required>
+                  <textarea
+                    id="news-content"
+                    value={newsData.content}
+                    onChange={(e) => setNewsData({ ...newsData, content: e.target.value })}
+                    maxLength={3000}
+                    disabled={adding}
+                    className={textareaClass}
+                    rows={6}
                   />
-                ) : null}
-              </div>
-            </form>
-          </Dialog>
+                </Field>
+
+                <Field
+                  label={t("news:form.title_en", { defaultValue: "Title (English)" }) ?? ""}
+                  htmlFor="news-title-en"
+                >
+                  <input
+                    id="news-title-en"
+                    type="text"
+                    value={newsData.title_en}
+                    onChange={(e) => setNewsData({ ...newsData, title_en: e.target.value })}
+                    maxLength={100}
+                    disabled={adding}
+                    className={inputClass}
+                  />
+                </Field>
+
+                <Field
+                  label={t("news:form.content_en", { defaultValue: "News text (English)" }) ?? ""}
+                  htmlFor="news-content-en"
+                >
+                  <textarea
+                    id="news-content-en"
+                    value={newsData.content_en}
+                    onChange={(e) => setNewsData({ ...newsData, content_en: e.target.value })}
+                    maxLength={3000}
+                    disabled={adding}
+                    className={textareaClass}
+                    rows={6}
+                  />
+                </Field>
+
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                  <Button
+                    as="label"
+                    variant="outline"
+                    size="sm"
+                    leadingIcon={<PhotoCamera className="text-[1.15rem]" />}
+                    className="w-full sm:w-auto"
+                    disabled={adding}
+                  >
+                    {imageFile ? t("common:buttons.changePhoto") : t("common:buttons.uploadPhoto")}
+                    <input
+                      type="file"
+                      accept="image/*"
+                      hidden
+                      ref={imageInputRef}
+                      onChange={handleImageChange}
+                    />
+                  </Button>
+
+                  {imagePreview ? (
+                    <SmartImage
+                      srcRaw={imagePreview}
+                      alt={t("news:alt.newCover")}
+                      className="h-20 w-full max-w-[160px] rounded-ue-md border border-white/10 object-cover shadow-surface"
+                    />
+                  ) : null}
+                </div>
+              </form>
+            </Dialog>
+          </div>
         </div>
       </PageFadeIn>
     </Layout>


### PR DESCRIPTION
## Summary
- wrap the news, events, and activity pages in the shared full-width schedule container to normalize spacing
- unify each page header with matching icon chips and typography so they mirror the schedule page presentation
- adjust action sections and content wrappers to respect the common layout styling across the three pages

## Testing
- npm --prefix root/frontend run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69114f6913f8832797cee145c0592957)