### PR TITLE
Align Activity page layout with other sections

### DIFF
--- a/root/frontend/src/pages/Activity.tsx
+++ b/root/frontend/src/pages/Activity.tsx
@@ -615,7 +615,7 @@ export default function Activity() {
             initial="hidden"
             animate="show"
             variants={headerVariants}
-            className="mx-auto max-w-6xl px-2 pb-16 sm:px-4"
+            className="px-2 pb-16 sm:px-4"
             style={
               reduce ? undefined : { willChange: "transform, opacity", transform: "translateZ(0)" }
             }


### PR DESCRIPTION
## Summary
- remove the max-width wrapper on the Activity page so its content aligns with other sections

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69115e8b94d88327998b4974465167ff)