### PR TITLE
Fix MFA settings validator when FieldValidationInfo missing

### DIFF
--- a/root/app/core/config.py
+++ b/root/app/core/config.py
@@ -11,6 +11,7 @@ from urllib.parse import urlparse
 from pydantic import (
     AliasChoices,
     Field,
+    FieldValidationInfo,
     ValidationError,
     ValidationInfo,
     field_validator,
@@ -543,8 +544,11 @@ class Settings(BaseSettings):
         "mfa_step_up_ttl_seconds",
     )
     @classmethod
-    def _validate_positive_mfa_values(cls, value: int, info):
-        return _validate_positive_int(value, label=info.field_name.upper())
+    def _validate_positive_mfa_values(
+        cls, value: int, info: FieldValidationInfo
+    ) -> int:
+        field_name = getattr(info, "field_name", None) or "mfa_value"
+        return _validate_positive_int(value, label=field_name.upper())
 
     @field_validator("password_reset_max_active_tokens")
     @classmethod


### PR DESCRIPTION
## Summary
- import `FieldValidationInfo` for settings validation
- ensure MFA-related positive value validator gracefully handles missing field metadata

## Testing
- pytest *(fails: environment lacks running asyncio event loop for async fixtures)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911d9af8e108327b0d0e0202376a162)