### PR TITLE
Fix user registration flow

### DIFF
--- a/root/app/auth/auth.py
+++ b/root/app/auth/auth.py
@@ -15,12 +15,12 @@ from pydantic import BaseModel, EmailStr
 from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app import crud
 from app.api.deps import get_current_user, require_fresh_mfa
 from app.auth import mfa
 from app.auth.security import (
     create_access_token,
     decode_token,
-    get_password_hash,
     verify_and_update_password,
 )
 from app.core.config import settings
@@ -1280,27 +1280,22 @@ async def register(
     db: AsyncSession = Depends(get_db),
 ):
     locale = resolve_locale(request=request)
-    email = user.email.strip().lower()
-    res = await db.execute(select(User).where(func.lower(User.email) == email))
-    if res.scalars().first():
-        message = translate("errors.users.email_in_use", locale=locale)
+    try:
+        new_user = await crud.create_user(db, user)
+    except ValueError as exc:
+        await db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+    except Exception as exc:  # pragma: no cover - defensive guard
+        await db.rollback()
+        message = translate("errors.users.create_failed", locale=locale)
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=message,
-        )
-    try:
-        hashed_password = get_password_hash(user.password, locale=locale)
-    except ValueError as exc:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
-    new_user = User(
-        email=email,
-        full_name=user.full_name,
-        hashed_password=hashed_password,
-        role="student",
-    )
-    db.add(new_user)
-    await db.commit()
-    await db.refresh(new_user)
+        ) from exc
+
     return {"status": "ok", "id": new_user.id}
 
 

--- a/root/frontend/src/pages/Register.tsx
+++ b/root/frontend/src/pages/Register.tsx
@@ -187,7 +187,7 @@ const Register = () => {
       }
 
       try {
-        await api.post("/users", {
+        await api.post("/auth/register", {
           full_name: fullName,
           email,
           password,

--- a/root/frontend/src/pages/__tests__/Register.test.tsx
+++ b/root/frontend/src/pages/__tests__/Register.test.tsx
@@ -25,7 +25,7 @@ const renderRegister = () =>
 describe("Register page", () => {
   it("surfaces API error messages", async () => {
     server.use(
-      http.post("*/users", () =>
+      http.post("*/auth/register", () =>
         HttpResponse.json({ detail: "Email already used" }, { status: 400 })
       )
     )
@@ -48,10 +48,10 @@ describe("Register page", () => {
   it("sends registration payload and navigates to login", async () => {
     const payloads: unknown[] = []
     server.use(
-      http.post("*/users", async ({ request }) => {
+      http.post("*/auth/register", async ({ request }) => {
         const body = await request.json()
         payloads.push(body)
-        return HttpResponse.json({ ok: true }, { status: 201 })
+        return HttpResponse.json({ status: "ok" })
       })
     )
 

--- a/root/frontend/src/tests/mocks/handlers.ts
+++ b/root/frontend/src/tests/mocks/handlers.ts
@@ -10,7 +10,7 @@ import type {
   TotpEnrollmentStartResponse,
 } from "@/types/Mfa"
 
-type NewUserPayload = {
+type RegisterPayload = {
   email?: string
   [key: string]: unknown
 }
@@ -560,12 +560,12 @@ export const handlers = [
     const removed = applyAdminQueueMutation(jobIds)
     return HttpResponse.json({ deleted: removed })
   }),
-  http.post("*/users", async ({ request }) => {
-    const body = (await request.json()) as NewUserPayload
+  http.post("*/auth/register", async ({ request }) => {
+    const body = (await request.json()) as RegisterPayload
     if (body.email === "taken@example.com") {
       return HttpResponse.json({ detail: "Email already used" }, { status: 400 })
     }
-    return HttpResponse.json({ id: 2, ...body }, { status: 201 })
+    return HttpResponse.json({ status: "ok", id: 2, ...body })
   }),
   http.post("*/auth/login", async ({ request }) => {
     const raw = await request.text()


### PR DESCRIPTION
## Summary
- reuse the shared user creation logic in the unauthenticated /auth/register endpoint
- update the registration page to submit to the public auth endpoint instead of the admin-only users API

## Testing
- pytest root/tests/test_auth_security.py::test_register_normalizes_email -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911e2efc9208327b6013f6a3279bbf8)