### PR TITLE
Align dashboard clock updates with minute boundary

### DIFF
--- a/root/frontend/src/pages/Dashboard.tsx
+++ b/root/frontend/src/pages/Dashboard.tsx
@@ -113,7 +113,7 @@ function useClock(locale: string) {
   const [time, setTime] = useState(getCurrentMinute)
   useEffect(() => {
     const tick = () => setTime(getCurrentMinute())
-    let intervalId: ReturnType<typeof window.setInterval> | null = null
+    let intervalId: number | null = null
     const now = new Date()
     const msUntilNextMinute = (60 - now.getSeconds()) * 1000 - now.getMilliseconds()
     const timeoutId = window.setTimeout(() => {

--- a/root/frontend/src/pages/Dashboard.tsx
+++ b/root/frontend/src/pages/Dashboard.tsx
@@ -103,21 +103,38 @@ function DateBullet({ date, locale }: { date?: string; locale: string }) {
   )
 }
 
+const getCurrentMinute = () => {
+  const d = new Date()
+  d.setSeconds(0, 0)
+  return d
+}
+
 function useClock(locale: string) {
-  const [time, setTime] = useState(new Date())
+  const [time, setTime] = useState(getCurrentMinute)
   useEffect(() => {
-    const id = setInterval(() => setTime(new Date()), 1000)
-    return () => clearInterval(id)
+    const tick = () => setTime(getCurrentMinute())
+    let intervalId: ReturnType<typeof window.setInterval> | null = null
+    const now = new Date()
+    const msUntilNextMinute = (60 - now.getSeconds()) * 1000 - now.getMilliseconds()
+    const timeoutId = window.setTimeout(() => {
+      tick()
+      intervalId = window.setInterval(tick, 60_000)
+    }, msUntilNextMinute)
+    return () => {
+      window.clearTimeout(timeoutId)
+      if (intervalId) {
+        window.clearInterval(intervalId)
+      }
+    }
   }, [])
   const hh = pad(time.getHours())
   const mm = pad(time.getMinutes())
-  const showColon = time.getSeconds() % 2 === 0
   const dateStr = time.toLocaleDateString(locale, {
     weekday: "long",
     day: "numeric",
     month: "long",
   })
-  return { hh, mm, showColon, dateStr, time }
+  return { hh, mm, dateStr, time }
 }
 
 function getGreetingKey(hour: number): "morning" | "afternoon" | "evening" | "night" {
@@ -174,7 +191,7 @@ export default function Dashboard() {
   const { language } = useLanguage()
   const locale = getLocaleForLanguage(language)
   const { t } = useTranslation(["dashboard", "common", "navigation"])
-  const { hh, mm, showColon, dateStr, time } = useClock(locale)
+  const { hh, mm, dateStr, time } = useClock(locale)
   const weekDaysDisplay = useMemo(() => {
     const result = t("dashboard:weekDays.display", { returnObjects: true }) as unknown
     if (Array.isArray(result) && result.length === 7) {
@@ -230,7 +247,7 @@ export default function Dashboard() {
       .sort((a, b) => fmtTime(a.start_time).localeCompare(fmtTime(b.start_time)))
   }, [schedule, parity, todayIndex, weekdayIndex])
 
-  const minutesNow = time.getHours() * 60 + time.getMinutes()
+  const minutesNow = useMemo(() => time.getHours() * 60 + time.getMinutes(), [time])
   const currentLesson = useMemo(() => {
     return (
       todayLessons.find((l) => {
@@ -558,13 +575,7 @@ export default function Dashboard() {
                     >
                       <span className="flex items-baseline gap-1 font-mono text-lg leading-none">
                         <span>{hh}</span>
-                        <span
-                          aria-hidden="true"
-                          className={cn(
-                            "transition-opacity duration-300 ease-out",
-                            showColon ? "opacity-100" : "opacity-0"
-                          )}
-                        >
+                        <span aria-hidden="true" className="inline-block animate-dash-colon-blink">
                           :
                         </span>
                         <span>{mm}</span>

--- a/root/frontend/src/styles/tailwind.css
+++ b/root/frontend/src/styles/tailwind.css
@@ -29,6 +29,30 @@
   }
 }
 
+@layer utilities {
+  @keyframes dash-colon-blink {
+    0%,
+    49.9% {
+      opacity: 1;
+    }
+
+    50%,
+    100% {
+      opacity: 0;
+    }
+  }
+
+  .animate-dash-colon-blink {
+    animation: dash-colon-blink 2s steps(2, start) infinite;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .animate-dash-colon-blink {
+      animation: none;
+    }
+  }
+}
+
 @layer components {
   /* Component tokens
      .card-glass   → Frosted surface using the glass palette + blur.


### PR DESCRIPTION
## Summary
- align the dashboard clock hook to tick on minute boundaries instead of every second
- memoize derived minute calculations so schedule progress updates when the minute changes
- replace the React-driven colon blink with a CSS animation utility class

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69120a6e16fc8327b06be689e1401e2d)