### PR TITLE
feat(frontend): refactor dashboard data fetching with queries

### DIFF
--- a/root/frontend/src/api/hooks/events.ts
+++ b/root/frontend/src/api/hooks/events.ts
@@ -3,6 +3,7 @@ import {
   useQuery,
   useQueryClient,
   type InfiniteData,
+  type QueryClient,
   type UseInfiniteQueryOptions,
   type UseInfiniteQueryResult,
   type UseQueryOptions,
@@ -130,6 +131,44 @@ const mergeEventPages = (pages: PaginatedResponse<Event>[] | undefined): Event[]
   return merged
 }
 
+const createEventsListQueryFn = (
+  queryClient: QueryClient,
+  normalized: NormalizedEventsListFilters,
+  queryKey: EventsListQueryKey
+) =>
+  async ({ pageParam, signal }: { pageParam?: string | null; signal?: AbortSignal }) => {
+    const etagKey = pageParam == null ? createEventsListEtagKey(normalized) : undefined
+    const params: Record<string, unknown> = {
+      limit: normalized.limit,
+      search: normalized.search,
+      type: normalized.type,
+      location: normalized.location,
+    }
+    if (normalized.is_active !== null) {
+      params.is_active = normalized.is_active
+    }
+    if (pageParam != null) {
+      params.cursor = pageParam
+    }
+
+    const requestConfig: TypedRequestOptions<"/events", "get"> = {
+      params,
+      signal,
+      validateStatus: (status) => status >= 200 && status < 400,
+      ...(etagKey ? { etagCacheKey: etagKey } : {}),
+    }
+
+    const response = await apiClient.get("/events", requestConfig)
+
+    if (response.status === 304) {
+      const cached =
+        queryClient.getQueryData<InfiniteData<PaginatedResponse<Event>, string | null>>(queryKey)
+      return ensurePaginatedResponse(cached?.pages?.[0], normalized.limit)
+    }
+
+    return ensurePaginatedResponse(response.data, normalized.limit)
+  }
+
 type UseEventsListQueryOptions = Omit<
   UseInfiniteQueryOptions<
     PaginatedResponse<Event>,
@@ -159,6 +198,11 @@ export const useEventsListQuery = (
   const queryKey: EventsListQueryKey = ["events", "list", normalized]
   const { enabled = true, ...rest } = options ?? {}
 
+  const queryFn = useMemo(
+    () => createEventsListQueryFn(queryClient, normalized, queryKey),
+    [queryClient, normalized, queryKey]
+  )
+
   const query = useInfiniteQuery<
     PaginatedResponse<Event>,
     Error,
@@ -170,38 +214,7 @@ export const useEventsListQuery = (
     enabled,
     initialPageParam: null,
     getNextPageParam: (lastPage) => lastPage?.next_cursor ?? null,
-    queryFn: async ({ pageParam, signal }) => {
-      const etagKey = pageParam == null ? createEventsListEtagKey(normalized) : undefined
-      const params: Record<string, unknown> = {
-        limit: normalized.limit,
-        search: normalized.search,
-        type: normalized.type,
-        location: normalized.location,
-      }
-      if (normalized.is_active !== null) {
-        params.is_active = normalized.is_active
-      }
-      if (pageParam != null) {
-        params.cursor = pageParam
-      }
-
-      const requestConfig: TypedRequestOptions<"/events", "get"> = {
-        params,
-        signal,
-        validateStatus: (status) => status >= 200 && status < 400,
-        ...(etagKey ? { etagCacheKey: etagKey } : {}),
-      }
-
-      const response = await apiClient.get("/events", requestConfig)
-
-      if (response.status === 304) {
-        const cached =
-          queryClient.getQueryData<InfiniteData<PaginatedResponse<Event>, string | null>>(queryKey)
-        return ensurePaginatedResponse(cached?.pages?.[0], normalized.limit)
-      }
-
-      return ensurePaginatedResponse(response.data, normalized.limit)
-    },
+    queryFn,
     ...rest,
   })
 
@@ -214,6 +227,22 @@ export const useEventsListQuery = (
     pagination,
     queryKey,
   }
+}
+
+export const prefetchEventsListQuery = (
+  queryClient: QueryClient,
+  filters: EventsListFilters
+) => {
+  const normalized = normalizeEventsListFilters(filters)
+  const queryKey: EventsListQueryKey = ["events", "list", normalized]
+  const queryFn = createEventsListQueryFn(queryClient, normalized, queryKey)
+
+  return queryClient.prefetchInfiniteQuery({
+    queryKey,
+    queryFn,
+    initialPageParam: null,
+    getNextPageParam: (lastPage) => lastPage?.next_cursor ?? null,
+  })
 }
 
 export type MyEventsQueryParams = {

--- a/root/frontend/src/api/hooks/events.ts
+++ b/root/frontend/src/api/hooks/events.ts
@@ -214,8 +214,7 @@ export const useEventsListQuery = (
     queryKey,
     enabled,
     initialPageParam: null as string | null,
-    getNextPageParam: (lastPage: PaginatedResponse<Event>) =>
-      lastPage?.next_cursor ?? null,
+    getNextPageParam: (lastPage: PaginatedResponse<Event>) => lastPage?.next_cursor ?? null,
     queryFn,
     ...rest,
   })
@@ -240,8 +239,7 @@ export const prefetchEventsListQuery = (queryClient: QueryClient, filters: Event
     queryKey,
     queryFn,
     initialPageParam: null as string | null,
-    getNextPageParam: (lastPage: PaginatedResponse<Event>) =>
-      lastPage?.next_cursor ?? null,
+    getNextPageParam: (lastPage: PaginatedResponse<Event>) => lastPage?.next_cursor ?? null,
   })
 }
 

--- a/root/frontend/src/api/hooks/events.ts
+++ b/root/frontend/src/api/hooks/events.ts
@@ -213,8 +213,9 @@ export const useEventsListQuery = (
   >({
     queryKey,
     enabled,
-    initialPageParam: null,
-    getNextPageParam: (lastPage) => lastPage?.next_cursor ?? null,
+    initialPageParam: null as string | null,
+    getNextPageParam: (lastPage: PaginatedResponse<Event>) =>
+      lastPage?.next_cursor ?? null,
     queryFn,
     ...rest,
   })
@@ -238,8 +239,9 @@ export const prefetchEventsListQuery = (queryClient: QueryClient, filters: Event
   return queryClient.prefetchInfiniteQuery({
     queryKey,
     queryFn,
-    initialPageParam: null,
-    getNextPageParam: (lastPage) => lastPage?.next_cursor ?? null,
+    initialPageParam: null as string | null,
+    getNextPageParam: (lastPage: PaginatedResponse<Event>) =>
+      lastPage?.next_cursor ?? null,
   })
 }
 

--- a/root/frontend/src/api/hooks/events.ts
+++ b/root/frontend/src/api/hooks/events.ts
@@ -131,11 +131,12 @@ const mergeEventPages = (pages: PaginatedResponse<Event>[] | undefined): Event[]
   return merged
 }
 
-const createEventsListQueryFn = (
-  queryClient: QueryClient,
-  normalized: NormalizedEventsListFilters,
-  queryKey: EventsListQueryKey
-) =>
+const createEventsListQueryFn =
+  (
+    queryClient: QueryClient,
+    normalized: NormalizedEventsListFilters,
+    queryKey: EventsListQueryKey
+  ) =>
   async ({ pageParam, signal }: { pageParam?: string | null; signal?: AbortSignal }) => {
     const etagKey = pageParam == null ? createEventsListEtagKey(normalized) : undefined
     const params: Record<string, unknown> = {
@@ -229,10 +230,7 @@ export const useEventsListQuery = (
   }
 }
 
-export const prefetchEventsListQuery = (
-  queryClient: QueryClient,
-  filters: EventsListFilters
-) => {
+export const prefetchEventsListQuery = (queryClient: QueryClient, filters: EventsListFilters) => {
   const normalized = normalizeEventsListFilters(filters)
   const queryKey: EventsListQueryKey = ["events", "list", normalized]
   const queryFn = createEventsListQueryFn(queryClient, normalized, queryKey)

--- a/root/frontend/src/app/__tests__/a11y.test.tsx
+++ b/root/frontend/src/app/__tests__/a11y.test.tsx
@@ -11,7 +11,7 @@ import { AuthContext } from "@/contexts/AuthContext"
 import { routerFutureFlags } from "@/App"
 import { checkA11y } from "@/tests/axeTest"
 import { createQueryClient } from "@/app/queryClient"
-import api from "@/api/client"
+import api, { apiClient } from "@/api/client"
 import type { User } from "@/types/User"
 import { LanguageProvider } from "@/contexts/LanguageContext"
 import { CssVarsProvider } from "@mui/material/styles"
@@ -188,6 +188,14 @@ describe("Accessibility checks", () => {
       }
       return { data: [], status: 200, headers: {} } as any
     })
+    const typedGetSpy = vi
+      .spyOn(apiClient, "get")
+      .mockImplementation(async (path: any) => {
+        if (path === "/news") {
+          return { data: [], status: 200, headers: {} } as any
+        }
+        return { data: [], status: 200, headers: {} } as any
+      })
 
     const { Wrapper } = createWrapper("/dashboard")
     const { container } = render(<Dashboard />, { wrapper: Wrapper })
@@ -196,6 +204,7 @@ describe("Accessibility checks", () => {
 
     await checkA11y(container)
     getSpy.mockRestore()
+    typedGetSpy.mockRestore()
   })
 
   it("Profile page has no axe violations", async () => {

--- a/root/frontend/src/app/__tests__/a11y.test.tsx
+++ b/root/frontend/src/app/__tests__/a11y.test.tsx
@@ -188,14 +188,12 @@ describe("Accessibility checks", () => {
       }
       return { data: [], status: 200, headers: {} } as any
     })
-    const typedGetSpy = vi
-      .spyOn(apiClient, "get")
-      .mockImplementation(async (path: any) => {
-        if (path === "/news") {
-          return { data: [], status: 200, headers: {} } as any
-        }
+    const typedGetSpy = vi.spyOn(apiClient, "get").mockImplementation(async (path: any) => {
+      if (path === "/news") {
         return { data: [], status: 200, headers: {} } as any
-      })
+      }
+      return { data: [], status: 200, headers: {} } as any
+    })
 
     const { Wrapper } = createWrapper("/dashboard")
     const { container } = render(<Dashboard />, { wrapper: Wrapper })

--- a/root/frontend/src/hooks/useDashboardEvents.ts
+++ b/root/frontend/src/hooks/useDashboardEvents.ts
@@ -1,0 +1,99 @@
+import { useMemo } from "react"
+import {
+  useQuery,
+  useQueryClient,
+  type QueryClient,
+  type QueryFunction,
+} from "@tanstack/react-query"
+
+import api from "@/api/client"
+import type { Event } from "@/types/Event"
+import type { PaginatedResponse } from "@/types/Pagination"
+
+type EventsSnapshot = {
+  items: Event[]
+}
+
+const DASHBOARD_EVENTS_ETAG_KEY = "dashboard:events"
+
+export const dashboardEventsQueryKey = ["dashboard", "events"] as const
+
+type DashboardEventsQueryKey = typeof dashboardEventsQueryKey
+
+const ensureEventList = (payload: PaginatedResponse<Event> | null | undefined): Event[] => {
+  if (!payload) {
+    return []
+  }
+  const items = Array.isArray(payload.items) ? payload.items : []
+  return items.filter(Boolean)
+}
+
+const sortEventsByStart = (items: Event[]): Event[] => {
+  return [...items]
+    .filter((event) => event?.starts_at)
+    .sort((a, b) => String(a.starts_at ?? "").localeCompare(String(b.starts_at ?? "")))
+    .slice(0, 30)
+}
+
+const createEventsQueryFn = (
+  queryClient: QueryClient
+): QueryFunction<EventsSnapshot, DashboardEventsQueryKey> => {
+  return async ({ signal }) => {
+    const previous = queryClient.getQueryData<EventsSnapshot>(dashboardEventsQueryKey)
+
+    try {
+      const response = await api.get<PaginatedResponse<Event>>("/events", {
+        params: { is_active: true, limit: 50 },
+        signal,
+        validateStatus: (status: number) => status >= 200 && status < 400,
+        etagCacheKey: DASHBOARD_EVENTS_ETAG_KEY,
+      })
+
+      if (response.status === 304 && previous) {
+        return previous
+      }
+
+      const normalized = sortEventsByStart(ensureEventList(response.data))
+      return { items: normalized }
+    } catch (error) {
+      if (signal?.aborted) {
+        throw error
+      }
+
+      const fallback = queryClient.getQueryData<EventsSnapshot>(dashboardEventsQueryKey)
+      if (fallback) {
+        return fallback
+      }
+
+      throw error
+    }
+  }
+}
+
+export const createDashboardEventsQueryOptions = (queryClient: QueryClient) => {
+  const queryFn = createEventsQueryFn(queryClient)
+
+  return {
+    queryKey: dashboardEventsQueryKey,
+    queryFn,
+    select: (snapshot: EventsSnapshot) => snapshot.items,
+    placeholderData: (previous: EventsSnapshot | undefined) => previous,
+    staleTime: 2 * 60_000,
+    gcTime: 30 * 60_000,
+  } as const
+}
+
+export const useDashboardEvents = () => {
+  const queryClient = useQueryClient()
+
+  const queryOptions = useMemo(
+    () => createDashboardEventsQueryOptions(queryClient),
+    [queryClient]
+  )
+
+  return useQuery(queryOptions)
+}
+
+export const prefetchDashboardEvents = (queryClient: QueryClient) =>
+  queryClient.prefetchQuery(createDashboardEventsQueryOptions(queryClient))
+

--- a/root/frontend/src/hooks/useDashboardEvents.ts
+++ b/root/frontend/src/hooks/useDashboardEvents.ts
@@ -86,14 +86,10 @@ export const createDashboardEventsQueryOptions = (queryClient: QueryClient) => {
 export const useDashboardEvents = () => {
   const queryClient = useQueryClient()
 
-  const queryOptions = useMemo(
-    () => createDashboardEventsQueryOptions(queryClient),
-    [queryClient]
-  )
+  const queryOptions = useMemo(() => createDashboardEventsQueryOptions(queryClient), [queryClient])
 
   return useQuery(queryOptions)
 }
 
 export const prefetchDashboardEvents = (queryClient: QueryClient) =>
   queryClient.prefetchQuery(createDashboardEventsQueryOptions(queryClient))
-

--- a/root/frontend/src/hooks/useDashboardNews.ts
+++ b/root/frontend/src/hooks/useDashboardNews.ts
@@ -7,6 +7,13 @@ import type { SupportedLanguage } from "@/contexts/LanguageContext"
 
 const DASHBOARD_NEWS_LIMIT = 4
 
+type MaybePinnedNewsItem = NewsItem & { pinned?: boolean | null }
+
+const getPinnedRank = (item: NewsItem) => {
+  const candidate = item as MaybePinnedNewsItem
+  return typeof candidate.pinned === "boolean" ? Number(candidate.pinned) : 0
+}
+
 const sortNewsItems = (items: readonly NewsItem[] | undefined) => {
   if (!items?.length) {
     return [] as NewsItem[]
@@ -14,7 +21,7 @@ const sortNewsItems = (items: readonly NewsItem[] | undefined) => {
 
   return [...items]
     .filter(Boolean)
-    .sort((a, b) => Number(b?.pinned === true) - Number(a?.pinned === true))
+    .sort((a, b) => getPinnedRank(b) - getPinnedRank(a))
     .slice(0, DASHBOARD_NEWS_LIMIT)
 }
 

--- a/root/frontend/src/hooks/useDashboardNews.ts
+++ b/root/frontend/src/hooks/useDashboardNews.ts
@@ -1,0 +1,43 @@
+import { useMemo } from "react"
+import type { QueryClient } from "@tanstack/react-query"
+
+import type { NewsItem } from "@/api/news"
+import { useNewsFeed, newsFeedQueryKey, createNewsFeedQueryOptions } from "@/hooks/useNewsFeed"
+import type { SupportedLanguage } from "@/contexts/LanguageContext"
+
+const DASHBOARD_NEWS_LIMIT = 4
+
+const sortNewsItems = (items: readonly NewsItem[] | undefined) => {
+  if (!items?.length) {
+    return [] as NewsItem[]
+  }
+
+  return [...items]
+    .filter(Boolean)
+    .sort(
+      (a, b) => Number(b?.pinned === true) - Number(a?.pinned === true)
+    )
+    .slice(0, DASHBOARD_NEWS_LIMIT)
+}
+
+export const useDashboardNews = (language: SupportedLanguage) => {
+  const query = useNewsFeed(language)
+
+  const sorted = useMemo(() => sortNewsItems(query.data), [query.data])
+
+  return {
+    ...query,
+    data: sorted,
+  }
+}
+
+export const prefetchDashboardNews = (
+  queryClient: QueryClient,
+  language: SupportedLanguage
+) => {
+  const options = createNewsFeedQueryOptions(queryClient, language)
+  return queryClient.prefetchQuery(options)
+}
+
+export const dashboardNewsQueryKey = newsFeedQueryKey
+

--- a/root/frontend/src/hooks/useDashboardNews.ts
+++ b/root/frontend/src/hooks/useDashboardNews.ts
@@ -14,9 +14,7 @@ const sortNewsItems = (items: readonly NewsItem[] | undefined) => {
 
   return [...items]
     .filter(Boolean)
-    .sort(
-      (a, b) => Number(b?.pinned === true) - Number(a?.pinned === true)
-    )
+    .sort((a, b) => Number(b?.pinned === true) - Number(a?.pinned === true))
     .slice(0, DASHBOARD_NEWS_LIMIT)
 }
 
@@ -31,13 +29,9 @@ export const useDashboardNews = (language: SupportedLanguage) => {
   }
 }
 
-export const prefetchDashboardNews = (
-  queryClient: QueryClient,
-  language: SupportedLanguage
-) => {
+export const prefetchDashboardNews = (queryClient: QueryClient, language: SupportedLanguage) => {
   const options = createNewsFeedQueryOptions(queryClient, language)
   return queryClient.prefetchQuery(options)
 }
 
 export const dashboardNewsQueryKey = newsFeedQueryKey
-

--- a/root/frontend/src/hooks/useDashboardSchedule.ts
+++ b/root/frontend/src/hooks/useDashboardSchedule.ts
@@ -1,9 +1,5 @@
 import { useMemo } from "react"
-import {
-  useQuery,
-  useQueryClient,
-  type QueryClient,
-} from "@tanstack/react-query"
+import { useQuery, useQueryClient, type QueryClient } from "@tanstack/react-query"
 
 import api from "@/api/client"
 import type { User } from "@/types/User"
@@ -93,6 +89,4 @@ export const prefetchDashboardSchedule = (
   queryClient: QueryClient,
   role: User["role"] | null | undefined,
   groupId: number | null | undefined
-) =>
-  queryClient.prefetchQuery(createScheduleQueryOptions(queryClient, role, groupId))
-
+) => queryClient.prefetchQuery(createScheduleQueryOptions(queryClient, role, groupId))

--- a/root/frontend/src/hooks/useDashboardSchedule.ts
+++ b/root/frontend/src/hooks/useDashboardSchedule.ts
@@ -1,0 +1,98 @@
+import { useMemo } from "react"
+import {
+  useQuery,
+  useQueryClient,
+  type QueryClient,
+} from "@tanstack/react-query"
+
+import api from "@/api/client"
+import type { User } from "@/types/User"
+
+export type DashboardLesson = {
+  id: number
+  subject: string
+  teacher: string
+  room: string
+  lesson_type: string
+  weekday: string
+  start_time: string
+  end_time: string
+  parity: "odd" | "even" | "both"
+}
+
+type ScheduleQueryKey = readonly [
+  "dashboard",
+  "schedule",
+  User["role"] | null | undefined,
+  number | null | undefined,
+]
+
+const createScheduleQueryKey = (
+  role: User["role"] | null | undefined,
+  groupId: number | null | undefined
+): ScheduleQueryKey => ["dashboard", "schedule", role, groupId]
+
+const ensureLessons = (payload: unknown): DashboardLesson[] => {
+  if (!Array.isArray(payload)) {
+    return []
+  }
+  return payload.filter(Boolean) as DashboardLesson[]
+}
+
+const createScheduleQueryOptions = (
+  queryClient: QueryClient,
+  role: User["role"] | null | undefined,
+  groupId: number | null | undefined
+) => ({
+  queryKey: createScheduleQueryKey(role, groupId),
+  queryFn: async ({ signal }: { signal?: AbortSignal }) => {
+    if (role !== "student" || !groupId) {
+      return [] as DashboardLesson[]
+    }
+
+    const previous = queryClient.getQueryData<DashboardLesson[]>(
+      createScheduleQueryKey(role, groupId)
+    )
+
+    try {
+      const response = await api.get<DashboardLesson[]>(`/schedule/${groupId}`, {
+        signal,
+      })
+      return ensureLessons(response.data)
+    } catch (error) {
+      if (signal?.aborted) {
+        throw error
+      }
+      if (previous) {
+        return previous
+      }
+      throw error
+    }
+  },
+  enabled: role === "student" && Boolean(groupId),
+  staleTime: 60_000,
+  gcTime: 10 * 60_000,
+  placeholderData: (previous: DashboardLesson[] | undefined) => previous ?? [],
+})
+
+export const useDashboardSchedule = (
+  role: User["role"] | null | undefined,
+  groupId: number | null | undefined
+) => {
+  const queryClient = useQueryClient()
+
+  const queryOptions = useMemo(
+    () => createScheduleQueryOptions(queryClient, role, groupId),
+    [queryClient, role, groupId]
+  )
+
+  return useQuery(queryOptions)
+}
+
+export const prefetchDashboardSchedule = (
+  queryClient: QueryClient,
+  role: User["role"] | null | undefined,
+  groupId: number | null | undefined
+) =>
+  queryClient.prefetchQuery(createScheduleQueryOptions(queryClient, role, groupId))
+

--- a/root/frontend/src/hooks/useDashboardStories.ts
+++ b/root/frontend/src/hooks/useDashboardStories.ts
@@ -1,0 +1,116 @@
+import { useMemo } from "react"
+import {
+  useQuery,
+  useQueryClient,
+  type QueryClient,
+  type QueryFunction,
+} from "@tanstack/react-query"
+
+import { fetchStories } from "@/api/stories"
+import type { StoryItem } from "@/types/Story"
+
+type StoriesSnapshot = {
+  items: StoryItem[]
+  etag: string | null
+}
+
+export const dashboardStoriesQueryKey = [
+  "dashboard",
+  "stories",
+] as const
+
+type DashboardStoriesQueryKey = typeof dashboardStoriesQueryKey
+
+const parseStoriesPayload = (payload: unknown): StoryItem[] => {
+  if (!Array.isArray(payload)) {
+    return []
+  }
+  return payload.filter(Boolean) as StoryItem[]
+}
+
+const extractEtag = (headers: unknown): string | null => {
+  if (!headers || typeof headers !== "object") {
+    return null
+  }
+
+  const lowercase = headers as Record<string, unknown>
+  const direct = lowercase?.etag
+  if (typeof direct === "string" && direct.trim()) {
+    return direct
+  }
+
+  const upper = lowercase?.ETag
+  if (typeof upper === "string" && upper.trim()) {
+    return upper
+  }
+
+  return null
+}
+
+const createStoriesQueryFn = (
+  queryClient: QueryClient
+): QueryFunction<StoriesSnapshot, DashboardStoriesQueryKey> => {
+  return async ({ signal }) => {
+    if (signal?.aborted) {
+      throw new DOMException("Aborted", "AbortError")
+    }
+
+    const previous = queryClient.getQueryData<StoriesSnapshot>(dashboardStoriesQueryKey)
+    const previousEtag = previous?.etag ?? null
+
+    try {
+      const response = await fetchStories(previousEtag)
+
+      const nextEtag = extractEtag(response.headers) ?? previousEtag
+
+      if (response.status === 304) {
+        if (previous) {
+          return previous
+        }
+        return { items: [], etag: nextEtag }
+      }
+
+      const items = parseStoriesPayload(response.data)
+      return { items, etag: nextEtag }
+    } catch (error) {
+      if (signal?.aborted) {
+        throw error
+      }
+
+      const fallback = queryClient.getQueryData<StoriesSnapshot>(dashboardStoriesQueryKey)
+      if (fallback) {
+        return fallback
+      }
+
+      throw error
+    }
+  }
+}
+
+export const createDashboardStoriesQueryOptions = (queryClient: QueryClient) => {
+  const queryFn = createStoriesQueryFn(queryClient)
+
+  return {
+    queryKey: dashboardStoriesQueryKey,
+    queryFn,
+    select: (snapshot: StoriesSnapshot) => snapshot.items,
+    placeholderData: (previous: StoriesSnapshot | undefined) => previous,
+    staleTime: 2 * 60_000,
+    gcTime: 30 * 60_000,
+  } as const
+}
+
+export const useDashboardStories = () => {
+  const queryClient = useQueryClient()
+
+  const queryOptions = useMemo(
+    () => createDashboardStoriesQueryOptions(queryClient),
+    [queryClient]
+  )
+
+  return useQuery(queryOptions)
+}
+
+export const prefetchDashboardStories = (queryClient: QueryClient) =>
+  queryClient.prefetchQuery(createDashboardStoriesQueryOptions(queryClient))
+

--- a/root/frontend/src/hooks/useDashboardStories.ts
+++ b/root/frontend/src/hooks/useDashboardStories.ts
@@ -14,10 +14,7 @@ type StoriesSnapshot = {
   etag: string | null
 }
 
-export const dashboardStoriesQueryKey = [
-  "dashboard",
-  "stories",
-] as const
+export const dashboardStoriesQueryKey = ["dashboard", "stories"] as const
 
 type DashboardStoriesQueryKey = typeof dashboardStoriesQueryKey
 
@@ -103,14 +100,10 @@ export const createDashboardStoriesQueryOptions = (queryClient: QueryClient) => 
 export const useDashboardStories = () => {
   const queryClient = useQueryClient()
 
-  const queryOptions = useMemo(
-    () => createDashboardStoriesQueryOptions(queryClient),
-    [queryClient]
-  )
+  const queryOptions = useMemo(() => createDashboardStoriesQueryOptions(queryClient), [queryClient])
 
   return useQuery(queryOptions)
 }
 
 export const prefetchDashboardStories = (queryClient: QueryClient) =>
   queryClient.prefetchQuery(createDashboardStoriesQueryOptions(queryClient))
-

--- a/root/frontend/src/hooks/useNewsFeed.ts
+++ b/root/frontend/src/hooks/useNewsFeed.ts
@@ -1,5 +1,11 @@
 import { useEffect, useMemo } from "react"
-import { useQuery, useQueryClient, type QueryKey } from "@tanstack/react-query"
+import {
+  useQuery,
+  useQueryClient,
+  type QueryClient,
+  type QueryKey,
+  type UseQueryOptions,
+} from "@tanstack/react-query"
 import { isAxiosError } from "axios"
 
 import { fetchNews, parseNewsList, type NewsItem } from "@/api/news"
@@ -160,10 +166,50 @@ const fetchNewsSnapshot = async (
   }
 }
 
+export const createNewsFeedQueryOptions = (
+  queryClient: QueryClient,
+  language: SupportedLanguage
+) => {
+  const queryKey = buildQueryKey(language)
+
+  const options: UseQueryOptions<
+    NewsFeedSnapshot,
+    Error,
+    NewsItem[],
+    NewsFeedQueryKey
+  > = {
+    queryKey,
+    queryFn: async ({ signal }) =>
+      fetchNewsSnapshot(
+        language,
+        signal,
+        () =>
+          queryClient.getQueryData<NewsFeedSnapshot>(queryKey) ?? readCacheSnapshot(language)
+      ),
+    select: (snapshot) => snapshot.items,
+    placeholderData: (previous) => previous,
+    staleTime: 2 * 60_000,
+    gcTime: 30 * 60_000,
+    networkMode: "offlineFirst",
+    retry: (failureCount, error) => {
+      if (isAxiosError(error) && error.response?.status && error.response.status < 500) {
+        return false
+      }
+      return failureCount < 2
+    },
+  }
+
+  return options
+}
+
 export const useNewsFeed = (language: SupportedLanguage) => {
   const queryClient = useQueryClient()
 
-  const queryKey = useMemo(() => buildQueryKey(language), [language])
+  const queryOptions = useMemo(
+    () => createNewsFeedQueryOptions(queryClient, language),
+    [queryClient, language]
+  )
+  const queryKey = queryOptions.queryKey
 
   useEffect(() => {
     clearLegacyStorageKeys()
@@ -184,26 +230,7 @@ export const useNewsFeed = (language: SupportedLanguage) => {
     }
   }, [language, queryClient, queryKey])
 
-  const query = useQuery<NewsFeedSnapshot, Error, NewsItem[], NewsFeedQueryKey>({
-    queryKey,
-    queryFn: async ({ signal }) =>
-      fetchNewsSnapshot(
-        language,
-        signal,
-        () => queryClient.getQueryData<NewsFeedSnapshot>(queryKey) ?? readCacheSnapshot(language)
-      ),
-    select: (snapshot) => snapshot.items,
-    placeholderData: (previous) => previous,
-    staleTime: 2 * 60_000,
-    gcTime: 30 * 60_000,
-    networkMode: "offlineFirst",
-    retry: (failureCount, error) => {
-      if (isAxiosError(error) && error.response?.status && error.response.status < 500) {
-        return false
-      }
-      return failureCount < 2
-    },
-  })
+  const query = useQuery(queryOptions)
 
   return query
 }

--- a/root/frontend/src/hooks/useNewsFeed.ts
+++ b/root/frontend/src/hooks/useNewsFeed.ts
@@ -172,19 +172,13 @@ export const createNewsFeedQueryOptions = (
 ) => {
   const queryKey = buildQueryKey(language)
 
-  const options: UseQueryOptions<
-    NewsFeedSnapshot,
-    Error,
-    NewsItem[],
-    NewsFeedQueryKey
-  > = {
+  const options: UseQueryOptions<NewsFeedSnapshot, Error, NewsItem[], NewsFeedQueryKey> = {
     queryKey,
     queryFn: async ({ signal }) =>
       fetchNewsSnapshot(
         language,
         signal,
-        () =>
-          queryClient.getQueryData<NewsFeedSnapshot>(queryKey) ?? readCacheSnapshot(language)
+        () => queryClient.getQueryData<NewsFeedSnapshot>(queryKey) ?? readCacheSnapshot(language)
       ),
     select: (snapshot) => snapshot.items,
     placeholderData: (previous) => previous,

--- a/root/frontend/src/pages/Dashboard.tsx
+++ b/root/frontend/src/pages/Dashboard.tsx
@@ -3,7 +3,6 @@ import {
   useMemo,
   useState,
   useCallback,
-  useRef,
   type KeyboardEvent,
   type CSSProperties,
 } from "react"
@@ -11,7 +10,6 @@ import Layout from "../components/Layout"
 import PageFadeIn from "../components/PageFadeIn"
 import DashboardStories from "@/components/DashboardStories"
 import { useAuth } from "../contexts/AuthContext"
-import axios from "../api/client"
 import { Link, useNavigate } from "react-router-dom"
 import { Badge, Button, Card, ProgressBar, Skeleton, Tooltip } from "@/components/ui"
 import AutoAwesomeRoundedIcon from "@mui/icons-material/AutoAwesomeRounded"
@@ -20,36 +18,17 @@ import { cn } from "@/utils/cn"
 import useMediaQuery from "@/hooks/useMediaQuery"
 import { useTranslation } from "react-i18next"
 import { getLocaleForLanguage, useLanguage } from "@/contexts/LanguageContext"
-import type { PaginatedResponse } from "@/types/Pagination"
+import { useQueryClient } from "@tanstack/react-query"
+import { useDashboardStories, prefetchDashboardStories } from "@/hooks/useDashboardStories"
+import { useDashboardNews, prefetchDashboardNews } from "@/hooks/useDashboardNews"
+import { useDashboardEvents, prefetchDashboardEvents } from "@/hooks/useDashboardEvents"
+import { useDashboardSchedule } from "@/hooks/useDashboardSchedule"
+import { EVENTS_PAGE_SIZE, prefetchEventsListQuery } from "@/api/hooks/events"
 import type { StoryItem } from "@/types/Story"
-import { fetchStories as fetchStoriesRequest } from "@/api/stories"
+import type { NewsItem } from "@/api/news"
+import type { Event } from "@/types/Event"
+import type { DashboardLesson } from "@/hooks/useDashboardSchedule"
 import WeatherWidget from "@/components/WeatherWidget"
-
-type NewsItem = {
-  id: number
-  title: string
-  content: string
-  created_at?: string
-  pinned?: boolean
-}
-type EventItem = {
-  id: number
-  title: string
-  description?: string
-  starts_at?: string
-  location?: string
-}
-type Lesson = {
-  id: number
-  subject: string
-  teacher: string
-  room: string
-  lesson_type: string
-  weekday: string
-  start_time: string
-  end_time: string
-  parity: "odd" | "even" | "both"
-}
 
 const pad = (n: number) => String(n).padStart(2, "0")
 const fmtTime = (s?: string) =>
@@ -165,24 +144,6 @@ const parseLocalDate = (s?: string) => {
   return new Date(Y || 1970, (M || 1) - 1, D || 1, h || 0, m || 0)
 }
 
-const CACHE_TTL = 120000
-function getCache<T>(key: string): T | null {
-  try {
-    const raw = localStorage.getItem(key)
-    if (!raw) return null
-    const { t, data } = JSON.parse(raw)
-    if (Date.now() - t > CACHE_TTL) return null
-    return data as T
-  } catch {
-    return null
-  }
-}
-function setCache<T>(key: string, data: T) {
-  try {
-    localStorage.setItem(key, JSON.stringify({ t: Date.now(), data }))
-  } catch {}
-}
-
 export default function Dashboard() {
   const { user } = useAuth()
   const isNarrow = useMediaQuery("(max-width:1100px)")
@@ -219,20 +180,26 @@ export default function Dashboard() {
   const greetingKey = useMemo(() => getGreetingKey(time.getHours()), [time])
   const greeting = t(`dashboard:greeting.${greetingKey}`)
 
-  const [loadingStories, setLoadingStories] = useState(true)
-  const [loadingNews, setLoadingNews] = useState(true)
-  const [loadingEvents, setLoadingEvents] = useState(true)
-  const [loadingSched, setLoadingSched] = useState(true)
+  const queryClient = useQueryClient()
 
-  const [stories, setStories] = useState<StoryItem[]>([])
-  const [news, setNews] = useState<NewsItem[]>([])
-  const [events, setEvents] = useState<EventItem[]>([])
-  const [schedule, setSchedule] = useState<Lesson[]>([])
+  const dashboardStoriesQuery = useDashboardStories()
+  const stories: StoryItem[] = dashboardStoriesQuery.data ?? []
+  const loadingStories = dashboardStoriesQuery.isLoading && stories.length === 0
+
+  const dashboardNewsQuery = useDashboardNews(language)
+  const news: NewsItem[] = dashboardNewsQuery.data ?? []
+  const loadingNews = dashboardNewsQuery.isLoading && news.length === 0
+
+  const dashboardEventsQuery = useDashboardEvents()
+  const events: Event[] = dashboardEventsQuery.data ?? []
+  const loadingEvents = dashboardEventsQuery.isLoading && events.length === 0
+
+  const shouldLoadSchedule = user?.role === "student" && Boolean(user?.group_id)
+  const dashboardScheduleQuery = useDashboardSchedule(user?.role ?? null, user?.group_id ?? null)
+  const schedule: DashboardLesson[] = dashboardScheduleQuery.data ?? []
+  const loadingSched = shouldLoadSchedule ? dashboardScheduleQuery.isLoading && schedule.length === 0 : false
 
   const [eventsScope, setEventsScope] = useState<"today" | "week">("today")
-  const storiesEtagRef = useRef<string | null>(null)
-  const eventsEtagRef = useRef<string | null>(null)
-  const storiesPrefetchedRef = useRef(false)
 
   const parity = useMemo(nowParity, [])
   const todayIndex = time.getDay()
@@ -299,126 +266,6 @@ export default function Dashboard() {
 
   const scopedEvents = eventsScope === "today" ? todayEvents : weekEvents
 
-  const fetchStories = useCallback(async () => {
-    try {
-      const previousTag = storiesEtagRef.current
-      const response = await fetchStoriesRequest(previousTag)
-      const responseTag = response.headers?.etag
-      storiesEtagRef.current = responseTag ?? null
-      if (response.status === 304) {
-        return
-      }
-      const arr = Array.isArray(response.data) ? response.data : []
-      setStories(arr)
-      setCache<StoryItem[]>("dash:stories", arr)
-    } catch {
-      const cached = getCache<StoryItem[]>("dash:stories")
-      if (cached) {
-        setStories(cached)
-      } else {
-        setStories([])
-      }
-      storiesEtagRef.current = null
-    } finally {
-      setLoadingStories(false)
-    }
-  }, [])
-
-  const fetchNews = useCallback(async () => {
-    try {
-      const r = await axios.get("/news")
-      const arr = Array.isArray(r.data) ? r.data : []
-      const sorted = [...arr].sort(
-        (a: any, b: any) => (b.pinned === true ? 1 : 0) - (a.pinned === true ? 1 : 0)
-      )
-      const sliced = sorted.slice(0, 4)
-      setNews(sliced)
-      setCache<NewsItem[]>("dash:news", sliced)
-    } catch {
-      const cached = getCache<NewsItem[]>("dash:news")
-      if (cached) {
-        setNews(cached)
-      } else {
-        setNews([])
-      }
-    } finally {
-      setLoadingNews(false)
-    }
-  }, [])
-
-  const fetchEvents = useCallback(async () => {
-    try {
-      const previousTag = eventsEtagRef.current
-      const r = await axios.get<PaginatedResponse<EventItem>>("/events", {
-        params: { is_active: true, limit: 50 },
-        headers: previousTag ? { "If-None-Match": previousTag } : undefined,
-        validateStatus: (status: number) => status >= 200 && status < 400,
-      })
-      const responseTag = r.headers?.etag
-      if (responseTag) {
-        eventsEtagRef.current = responseTag
-      } else {
-        eventsEtagRef.current = null
-      }
-      if (r.status === 304) {
-        return
-      }
-      const arr = Array.isArray(r.data?.items) ? r.data.items : []
-      const sorted = arr
-        .filter((e) => e.starts_at)
-        .sort((a, b) => String(a.starts_at).localeCompare(String(b.starts_at)))
-      setEvents(sorted.slice(0, 30))
-      setCache<EventItem[]>("dash:events", sorted.slice(0, 30))
-    } catch {
-      setEvents([])
-      eventsEtagRef.current = null
-    } finally {
-      setLoadingEvents(false)
-    }
-  }, [])
-
-  const fetchSchedule = useCallback(async () => {
-    if (!user) return
-    setLoadingSched(true)
-    try {
-      if (user.role === "student" && user.group_id) {
-        const r = await axios.get(`/schedule/${user.group_id}`)
-        setSchedule(Array.isArray(r.data) ? r.data : [])
-      } else {
-        setSchedule([])
-      }
-    } catch {
-      setSchedule([])
-    } finally {
-      setLoadingSched(false)
-    }
-  }, [user])
-
-  useEffect(() => {
-    const cachedStories = getCache<StoryItem[]>("dash:stories")
-    if (cachedStories) {
-      setStories(cachedStories)
-      setLoadingStories(false)
-    }
-    fetchStories()
-    const cachedN = getCache<NewsItem[]>("dash:news")
-    if (cachedN) {
-      setNews(cachedN)
-      setLoadingNews(false)
-    }
-    fetchNews()
-    const cachedE = getCache<EventItem[]>("dash:events")
-    if (cachedE) {
-      setEvents(cachedE)
-      setLoadingEvents(false)
-    }
-    fetchEvents()
-  }, [fetchStories, fetchNews, fetchEvents])
-
-  useEffect(() => {
-    fetchSchedule()
-  }, [fetchSchedule])
-
   const headerGradientClass = cn(
     "transition-[background] duration-700",
     isNarrow
@@ -476,33 +323,29 @@ export default function Dashboard() {
   const warmNewsPage = () => import("../pages/News").catch(() => {})
   const warmEventsPage = () => import("../pages/Events").catch(() => {})
   const warmSchedulePage = () => import("../pages/Schedule").catch(() => {})
-  const prefetchData = (type: "news" | "events" | "stories") => {
-    if (type === "news")
-      axios
-        .get("/news")
-        .then((r) => setCache("prefetch:news", r.data))
-        .catch(() => {})
-    if (type === "events")
-      axios
-        .get<PaginatedResponse<EventItem>>("/events", { params: { is_active: true, limit: 20 } })
-        .then((r) => setCache("prefetch:events", Array.isArray(r.data?.items) ? r.data.items : []))
-        .catch(() => {})
-    if (type === "stories")
-      axios
-        .get<StoryItem[]>("/stories")
-        .then((r) => setCache("prefetch:stories", Array.isArray(r.data) ? r.data : []))
-        .catch(() => {})
-  }
 
-  const triggerStoriesPrefetch = () => {
-    if (storiesPrefetchedRef.current) return
-    storiesPrefetchedRef.current = true
-    prefetchData("stories")
-  }
+  const prefetchStories = useCallback(() => {
+    void prefetchDashboardStories(queryClient)
+  }, [queryClient])
+
+  const prefetchNewsList = useCallback(() => {
+    warmNewsPage()
+    void prefetchDashboardNews(queryClient, language)
+  }, [language, queryClient])
+
+  const prefetchEventsList = useCallback(() => {
+    warmEventsPage()
+    void prefetchDashboardEvents(queryClient)
+    void prefetchEventsListQuery(queryClient, {
+      language,
+      is_active: true,
+      limit: EVENTS_PAGE_SIZE,
+    })
+  }, [language, queryClient])
 
   const handleStoryOpen = useCallback(() => {
-    triggerStoriesPrefetch()
-  }, [])
+    prefetchStories()
+  }, [prefetchStories])
 
   const prepareOnKey = (event: KeyboardEvent, callback: () => void) => {
     if (event.key === "Enter" || event.key === " " || event.key === "Spacebar") {
@@ -601,14 +444,14 @@ export default function Dashboard() {
               </div>
             </header>
 
-            <div data-fade="up" data-pop="true" style={fadeDelayStyle("100ms")}>
-              <DashboardStories
-                stories={stories}
-                loading={loadingStories}
-                onPrefetch={triggerStoriesPrefetch}
-                onStoryOpen={handleStoryOpen}
-              />
-            </div>
+            <div data-fade="up" data-pop="true" style={fadeDelayStyle("100ms")}> 
+              <DashboardStories 
+                stories={stories} 
+                loading={loadingStories} 
+                onPrefetch={prefetchStories} 
+                onStoryOpen={handleStoryOpen} 
+              /> 
+            </div> 
             <section className="mt-6 grid grid-cols-1 gap-4 md:mt-8 md:gap-6 lg:grid-cols-12">
               <Card
                 data-fade="left"
@@ -755,15 +598,9 @@ export default function Dashboard() {
                       variant="outline"
                       className="whitespace-nowrap px-5 transition-transform duration-300 hover:-translate-y-[2px]"
                       aria-label={t("dashboard:aria.viewAllNews")}
-                      onPointerDown={() => {
-                        warmNewsPage()
-                        prefetchData("news")
-                      }}
+                      onPointerDown={prefetchNewsList}
                       onKeyDown={(event) => {
-                        prepareOnKey(event, () => {
-                          warmNewsPage()
-                          prefetchData("news")
-                        })
+                        prepareOnKey(event, prefetchNewsList)
                       }}
                     >
                       {t("dashboard:viewAll")}
@@ -861,15 +698,9 @@ export default function Dashboard() {
                       variant="outline"
                       className="whitespace-nowrap px-5 transition-transform duration-300 hover:-translate-y-[2px]"
                       aria-label={t("dashboard:aria.viewAllEvents")}
-                      onPointerDown={() => {
-                        warmEventsPage()
-                        prefetchData("events")
-                      }}
+                      onPointerDown={prefetchEventsList}
                       onKeyDown={(event) => {
-                        prepareOnKey(event, () => {
-                          warmEventsPage()
-                          prefetchData("events")
-                        })
+                        prepareOnKey(event, prefetchEventsList)
                       }}
                     >
                       {t("dashboard:viewAll")}

--- a/root/frontend/src/pages/Dashboard.tsx
+++ b/root/frontend/src/pages/Dashboard.tsx
@@ -197,7 +197,9 @@ export default function Dashboard() {
   const shouldLoadSchedule = user?.role === "student" && Boolean(user?.group_id)
   const dashboardScheduleQuery = useDashboardSchedule(user?.role ?? null, user?.group_id ?? null)
   const schedule: DashboardLesson[] = dashboardScheduleQuery.data ?? []
-  const loadingSched = shouldLoadSchedule ? dashboardScheduleQuery.isLoading && schedule.length === 0 : false
+  const loadingSched = shouldLoadSchedule
+    ? dashboardScheduleQuery.isLoading && schedule.length === 0
+    : false
 
   const [eventsScope, setEventsScope] = useState<"today" | "week">("today")
 
@@ -444,14 +446,14 @@ export default function Dashboard() {
               </div>
             </header>
 
-            <div data-fade="up" data-pop="true" style={fadeDelayStyle("100ms")}> 
-              <DashboardStories 
-                stories={stories} 
-                loading={loadingStories} 
-                onPrefetch={prefetchStories} 
-                onStoryOpen={handleStoryOpen} 
-              /> 
-            </div> 
+            <div data-fade="up" data-pop="true" style={fadeDelayStyle("100ms")}>
+              <DashboardStories
+                stories={stories}
+                loading={loadingStories}
+                onPrefetch={prefetchStories}
+                onStoryOpen={handleStoryOpen}
+              />
+            </div>
             <section className="mt-6 grid grid-cols-1 gap-4 md:mt-8 md:gap-6 lg:grid-cols-12">
               <Card
                 data-fade="left"


### PR DESCRIPTION
## Summary
- add dedicated react-query hooks for dashboard stories, news, events, and schedules to reuse server caching
- refactor the dashboard page to consume the new hooks and prefetch related routes via the query client
- expose reusable events list prefetching utilities and adjust a11y tests for the new request flow

## Testing
- npm run lint
- npm run test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912200f87208327973519b782af9af5)