### PR TITLE
Ensure auth bootstrap requests bypass rate limit queue

### DIFF
--- a/root/frontend/src/contexts/AuthContext.tsx
+++ b/root/frontend/src/contexts/AuthContext.tsx
@@ -478,10 +478,9 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     }
     const promise = (async () => {
       try {
-        const response = await api.get<SessionSigningKeyResponse>(
-          "/auth/session/signing-key",
-          { skipRateLimitQueue: true }
-        )
+        const response = await api.get<SessionSigningKeyResponse>("/auth/session/signing-key", {
+          skipRateLimitQueue: true,
+        })
         const key = response.data.signing_key
         updateSessionSigningKey(key)
         return key

--- a/root/frontend/src/contexts/AuthContext.tsx
+++ b/root/frontend/src/contexts/AuthContext.tsx
@@ -416,7 +416,11 @@ export const fetchCurrentUser = async ({ signal }: FetchCurrentUserOptions = {})
     }
   }
   try {
-    const response = await api.get<User>("/users/me", { signal, headers })
+    const response = await api.get<User>("/users/me", {
+      signal,
+      headers,
+      skipRateLimitQueue: true,
+    })
     return response.data
   } catch (error) {
     if (
@@ -426,7 +430,10 @@ export const fetchCurrentUser = async ({ signal }: FetchCurrentUserOptions = {})
       !signal?.aborted
     ) {
       clearProfileCacheStorage()
-      const retry = await api.get<User>("/users/me", { signal })
+      const retry = await api.get<User>("/users/me", {
+        signal,
+        skipRateLimitQueue: true,
+      })
       return retry.data
     }
     throw error
@@ -471,7 +478,10 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     }
     const promise = (async () => {
       try {
-        const response = await api.get<SessionSigningKeyResponse>("/auth/session/signing-key")
+        const response = await api.get<SessionSigningKeyResponse>(
+          "/auth/session/signing-key",
+          { skipRateLimitQueue: true }
+        )
         const key = response.data.signing_key
         updateSessionSigningKey(key)
         return key

--- a/root/frontend/src/contexts/__tests__/AuthContext.requests.test.tsx
+++ b/root/frontend/src/contexts/__tests__/AuthContext.requests.test.tsx
@@ -1,0 +1,139 @@
+import { PropsWithChildren } from "react"
+import { renderHook, waitFor } from "@testing-library/react"
+import { QueryClientProvider } from "@tanstack/react-query"
+import { AxiosError } from "axios"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import api from "@/api/client"
+import { createQueryClient } from "@/app/queryClient"
+import {
+  AuthProvider,
+  PROFILE_CACHE_STORAGE_KEY,
+  fetchCurrentUser,
+  useAuth,
+} from "@/contexts/AuthContext"
+import { testUser } from "@/tests/mocks/handlers"
+
+describe("fetchCurrentUser request configuration", () => {
+  beforeEach(() => {
+    localStorage.clear()
+    sessionStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("passes skipRateLimitQueue when loading the current user", async () => {
+    const controller = new AbortController()
+    const getSpy = vi.spyOn(api, "get").mockResolvedValue({ data: testUser } as any)
+
+    await fetchCurrentUser({ signal: controller.signal })
+
+    expect(getSpy).toHaveBeenCalledWith(
+      "/users/me",
+      expect.objectContaining({ signal: controller.signal, skipRateLimitQueue: true })
+    )
+  })
+
+  it("includes the cached profile header while still skipping the rate limit queue", async () => {
+    const cachedEnvelope = JSON.stringify({ id: testUser.id })
+    localStorage.setItem(PROFILE_CACHE_STORAGE_KEY, cachedEnvelope)
+    const getSpy = vi.spyOn(api, "get").mockResolvedValue({ data: testUser } as any)
+
+    await fetchCurrentUser()
+
+    expect(getSpy).toHaveBeenCalledWith(
+      "/users/me",
+      expect.objectContaining({
+        headers: expect.objectContaining({ "X-Profile-Cache-Envelope": cachedEnvelope }),
+        skipRateLimitQueue: true,
+      })
+    )
+  })
+
+  it("continues to skip the rate limit queue when retrying without a cached header", async () => {
+    const cachedEnvelope = JSON.stringify({ id: testUser.id })
+    localStorage.setItem(PROFILE_CACHE_STORAGE_KEY, cachedEnvelope)
+    const axiosError = new AxiosError(
+      "Bad Request",
+      AxiosError.ERR_BAD_REQUEST,
+      undefined,
+      undefined,
+      {
+        status: 400,
+        statusText: "Bad Request",
+        headers: {},
+        config: {},
+        data: {},
+      }
+    )
+    const getSpy = vi
+      .spyOn(api, "get")
+      .mockRejectedValueOnce(axiosError)
+      .mockResolvedValueOnce({ data: testUser } as any)
+
+    await fetchCurrentUser()
+
+    expect(getSpy).toHaveBeenNthCalledWith(
+      1,
+      "/users/me",
+      expect.objectContaining({
+        headers: expect.objectContaining({ "X-Profile-Cache-Envelope": cachedEnvelope }),
+        skipRateLimitQueue: true,
+      })
+    )
+    expect(getSpy).toHaveBeenNthCalledWith(
+      2,
+      "/users/me",
+      expect.objectContaining({ skipRateLimitQueue: true })
+    )
+    expect(getSpy.mock.calls[1]?.[1]?.headers).toBeUndefined()
+  })
+})
+
+describe("ensureSessionSigningKey request configuration", () => {
+  beforeEach(() => {
+    localStorage.clear()
+    sessionStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  const setup = () => {
+    const queryClient = createQueryClient()
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>{children}</AuthProvider>
+      </QueryClientProvider>
+    )
+    return { queryClient, wrapper }
+  }
+
+  it("passes skipRateLimitQueue when requesting the session signing key", async () => {
+    const { queryClient, wrapper } = setup()
+    const getSpy = vi.spyOn(api, "get").mockImplementation((url, config) => {
+      if (url === "/users/me") {
+        return Promise.resolve({ data: testUser } as any)
+      }
+      if (url === "/auth/session/signing-key") {
+        return Promise.resolve({ data: { signing_key: "session-key" } })
+      }
+      throw new Error(`Unexpected url: ${url}`)
+    })
+
+    localStorage.setItem("token", "token-123")
+
+    renderHook(() => useAuth(), { wrapper })
+
+    await waitFor(() =>
+      expect(getSpy).toHaveBeenCalledWith(
+        "/auth/session/signing-key",
+        expect.objectContaining({ skipRateLimitQueue: true })
+      )
+    )
+
+    queryClient.clear()
+  })
+})

--- a/root/frontend/src/contexts/__tests__/AuthContext.requests.test.tsx
+++ b/root/frontend/src/contexts/__tests__/AuthContext.requests.test.tsx
@@ -1,7 +1,7 @@
 import { PropsWithChildren } from "react"
 import { renderHook, waitFor } from "@testing-library/react"
 import { QueryClientProvider } from "@tanstack/react-query"
-import { AxiosError } from "axios"
+import { AxiosError, AxiosHeaders } from "axios"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import api from "@/api/client"
 import { createQueryClient } from "@/app/queryClient"
@@ -63,7 +63,9 @@ describe("fetchCurrentUser request configuration", () => {
         status: 400,
         statusText: "Bad Request",
         headers: {},
-        config: {},
+        config: {
+          headers: new AxiosHeaders(),
+        },
         data: {},
       }
     )


### PR DESCRIPTION
## Summary
- ensure the bootstrap profile and session key requests skip the rate limit queue without dropping the cached profile header
- add unit tests covering the request configuration for `fetchCurrentUser` and the session signing key loader

## Testing
- npx vitest run src/contexts/__tests__/AuthContext.requests.test.tsx

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69126dbd51a08327bf0e6499e111d286)