### PR TITLE
Improve AuthContext loading behavior with cached profile

### DIFF
--- a/root/frontend/src/contexts/AuthContext.tsx
+++ b/root/frontend/src/contexts/AuthContext.tsx
@@ -456,10 +456,11 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const [userState, setUserState] = useState<UserState>(initializeCachedUser)
   const [pendingMfaState, setPendingMfaState] = useState<PendingMfaState | null>(null)
   const cachedUserRef = useRef<UserState>(userState)
+  const userStateRef = useRef<UserState>(userState)
   const sessionSigningKeyRef = useRef<string | null>(sessionSigningKey)
   const sessionSigningKeyPromiseRef = useRef<Promise<string | null> | null>(null)
   const pendingMfaRef = useRef<PendingMfaState | null>(pendingMfaState)
-  const [initializing, setInitializing] = useState<boolean>(true)
+  const [initializing, setInitializing] = useState<boolean>(() => userState == null)
   const [authOperation, setAuthOperation] = useState(false)
   const activeRequestRef = useRef<AbortController | null>(null)
 
@@ -528,6 +529,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         const next =
           typeof value === "function" ? (value as (prev: UserState) => UserState)(prev) : value
         const normalized: UserState = next ?? null
+        userStateRef.current = normalized
         if (persist) {
           persistUserToCache(normalized, sessionSigningKeyRef.current)
         }
@@ -654,7 +656,9 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     const controller = new AbortController()
     activeRequestRef.current?.abort()
     activeRequestRef.current = controller
-    setInitializing(true)
+    if (userStateRef.current == null) {
+      setInitializing(true)
+    }
     ;(async () => {
       try {
         const profile = await fetchCurrentUser({ signal: controller.signal })
@@ -697,7 +701,9 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     activeRequestRef.current = controller
 
     try {
-      setInitializing(true)
+      if (userStateRef.current == null) {
+        setInitializing(true)
+      }
       const profile = await fetchCurrentUser({ signal: controller.signal })
       try {
         await ensureSessionSigningKey()

--- a/root/frontend/src/contexts/__tests__/AuthContext.test.tsx
+++ b/root/frontend/src/contexts/__tests__/AuthContext.test.tsx
@@ -198,10 +198,6 @@ const primeCachedProfile = () => {
     id: testUser.id,
     full_name: testUser.full_name,
     avatar_url: testUser.avatar_url,
-    mfa_required: testUser.mfa_required,
-    mfa_default_method: testUser.mfa_default_method,
-    mfa_last_verified_at: testUser.mfa_last_verified_at,
-    mfa_recovery_codes_generated_at: testUser.mfa_recovery_codes_generated_at,
   }
 
   const payload = {

--- a/root/frontend/src/contexts/__tests__/AuthContext.test.tsx
+++ b/root/frontend/src/contexts/__tests__/AuthContext.test.tsx
@@ -178,13 +178,17 @@ const deriveCacheMetadata = () => {
   return { schemaVersion, sessionKeyStorageKey, versionKey }
 }
 
+const buildMockSigningKey = () =>
+  Array.from({ length: 32 }, (_, index) => ((index * 13 + 7) % 16).toString(16)).join("")
+
+const mockSigningKey = buildMockSigningKey()
+
 const primeCachedProfile = () => {
   const { schemaVersion, sessionKeyStorageKey, versionKey } = deriveCacheMetadata()
-  const signingKey = "cached-session-key"
   const originalGetItem = Storage.prototype.getItem
   vi.spyOn(Storage.prototype, "getItem").mockImplementation(function (this: Storage, key: string) {
     if (key === sessionKeyStorageKey) {
-      return signingKey
+      return mockSigningKey
     }
 
     return originalGetItem.call(this, key)
@@ -206,11 +210,7 @@ const primeCachedProfile = () => {
     data: snapshot,
   }
 
-  const signatureBytes = hmac(
-    sha256,
-    utf8ToBytes(signingKey),
-    utf8ToBytes(JSON.stringify(payload))
-  )
+  const signatureBytes = hmac(sha256, utf8ToBytes(mockSigningKey), utf8ToBytes(JSON.stringify(payload)))
   const signature = bytesToBase64(signatureBytes)
 
   const envelope = { ...payload, signature }
@@ -245,7 +245,7 @@ describe("AuthProvider loading state", () => {
         return Promise.resolve({ data: testUser })
       }
       if (url === "/auth/session/signing-key") {
-        return Promise.resolve({ data: { signing_key: "cached-session-key" } })
+        return Promise.resolve({ data: { signing_key: mockSigningKey } })
       }
       throw new Error(`Unexpected url: ${url}`)
     })
@@ -284,7 +284,7 @@ describe("AuthProvider loading state", () => {
       }
 
       if (url === "/auth/session/signing-key") {
-        return Promise.resolve({ data: { signing_key: "fresh-session-key" } })
+        return Promise.resolve({ data: { signing_key: mockSigningKey } })
       }
 
       throw new Error(`Unexpected url: ${url}`)

--- a/root/frontend/src/contexts/__tests__/AuthContext.test.tsx
+++ b/root/frontend/src/contexts/__tests__/AuthContext.test.tsx
@@ -142,7 +142,14 @@ const deriveCacheMetadata = () => {
 const primeCachedProfile = () => {
   const { schemaVersion, sessionKeyStorageKey, versionKey } = deriveCacheMetadata()
   const signingKey = "cached-session-key"
-  sessionStorage.setItem(sessionKeyStorageKey, signingKey)
+  const originalGetItem = Storage.prototype.getItem
+  vi.spyOn(Storage.prototype, "getItem").mockImplementation(function (this: Storage, key: string) {
+    if (key === sessionKeyStorageKey) {
+      return signingKey
+    }
+
+    return originalGetItem.call(this, key)
+  })
 
   const snapshot = {
     id: testUser.id,

--- a/root/frontend/src/contexts/__tests__/AuthContext.test.tsx
+++ b/root/frontend/src/contexts/__tests__/AuthContext.test.tsx
@@ -206,7 +206,11 @@ const primeCachedProfile = () => {
     data: snapshot,
   }
 
-  const signatureBytes = hmac(sha256, utf8ToBytes(mockSigningKey), utf8ToBytes(JSON.stringify(payload)))
+  const signatureBytes = hmac(
+    sha256,
+    utf8ToBytes(mockSigningKey),
+    utf8ToBytes(JSON.stringify(payload))
+  )
   const signature = bytesToBase64(signatureBytes)
 
   const envelope = { ...payload, signature }

--- a/root/frontend/src/contexts/__tests__/AuthContext.test.tsx
+++ b/root/frontend/src/contexts/__tests__/AuthContext.test.tsx
@@ -1,4 +1,5 @@
 import { PropsWithChildren } from "react"
+import { createHmac } from "node:crypto"
 import { renderHook, act, waitFor } from "@testing-library/react"
 import { QueryClientProvider } from "@tanstack/react-query"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
@@ -118,6 +119,148 @@ describe("AuthProvider caching", () => {
     await waitFor(() => expect(result.current.user).toBeNull())
     expect(localStorage.getItem(PROFILE_CACHE_STORAGE_KEY)).toBeNull()
     expect(queryClient.getQueryData(currentUserQueryKey)).toBeNull()
+
+    queryClient.clear()
+  })
+})
+
+const deriveCacheMetadata = () => {
+  const versionMatch = PROFILE_CACHE_STORAGE_KEY.match(/\.v(\d+)$/)
+  const schemaVersion = versionMatch ? Number.parseInt(versionMatch[1]!, 10) : 1
+  const baseKey = versionMatch
+    ? PROFILE_CACHE_STORAGE_KEY.replace(versionMatch[0]!, "")
+    : PROFILE_CACHE_STORAGE_KEY
+  const sessionKeyStorageKey = `${baseKey}.sessionKey`
+  const versionKey = `${baseKey}.version`
+  return { schemaVersion, sessionKeyStorageKey, versionKey }
+}
+
+const primeCachedProfile = () => {
+  const { schemaVersion, sessionKeyStorageKey, versionKey } = deriveCacheMetadata()
+  const signingKey = "cached-session-key"
+  sessionStorage.setItem(sessionKeyStorageKey, signingKey)
+
+  const snapshot = {
+    id: testUser.id,
+    full_name: testUser.full_name,
+    avatar_url: testUser.avatar_url,
+    mfa_required: testUser.mfa_required,
+    mfa_default_method: testUser.mfa_default_method,
+    mfa_last_verified_at: testUser.mfa_last_verified_at,
+    mfa_recovery_codes_generated_at: testUser.mfa_recovery_codes_generated_at,
+  }
+
+  const payload = {
+    version: schemaVersion,
+    expiresAt: Date.now() + 60_000,
+    data: snapshot,
+  }
+
+  const signature = createHmac("sha256", signingKey)
+    .update(JSON.stringify(payload))
+    .digest("base64")
+
+  const envelope = { ...payload, signature }
+  localStorage.setItem(PROFILE_CACHE_STORAGE_KEY, JSON.stringify(envelope))
+  localStorage.setItem(versionKey, String(schemaVersion))
+}
+
+describe("AuthProvider loading state", () => {
+  beforeEach(() => {
+    localStorage.clear()
+    sessionStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  const setup = () => {
+    const queryClient = createQueryClient()
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>{children}</AuthProvider>
+      </QueryClientProvider>
+    )
+    return { queryClient, wrapper }
+  }
+
+  it("keeps loading false when a cached profile is available", async () => {
+    primeCachedProfile()
+    const getSpy = vi.spyOn(api, "get").mockImplementation((url) => {
+      if (url === "/users/me") {
+        return Promise.resolve({ data: testUser })
+      }
+      if (url === "/auth/session/signing-key") {
+        return Promise.resolve({ data: { signing_key: "cached-session-key" } })
+      }
+      throw new Error(`Unexpected url: ${url}`)
+    })
+
+    const { queryClient, wrapper } = setup()
+    const { result } = renderHook(() => useAuth(), { wrapper })
+
+    expect(result.current.loading).toBe(false)
+    expect(result.current.user?.id).toBe(testUser.id)
+
+    await waitFor(() =>
+      expect(getSpy).toHaveBeenCalledWith(
+        "/users/me",
+        expect.objectContaining({ skipRateLimitQueue: true })
+      )
+    )
+
+    queryClient.clear()
+  })
+
+  it("toggles loading during refresh when no cached profile exists", async () => {
+    const { queryClient, wrapper } = setup()
+
+    let firstUserRequest = true
+    let resolveUserRequest: ((value: unknown) => void) | null = null
+    vi.spyOn(api, "get").mockImplementation((url) => {
+      if (url === "/users/me") {
+        if (firstUserRequest) {
+          firstUserRequest = false
+          return Promise.resolve({ data: testUser })
+        }
+
+        return new Promise((resolve) => {
+          resolveUserRequest = resolve
+        })
+      }
+
+      if (url === "/auth/session/signing-key") {
+        return Promise.resolve({ data: { signing_key: "fresh-session-key" } })
+      }
+
+      throw new Error(`Unexpected url: ${url}`)
+    })
+
+    const { result } = renderHook(() => useAuth(), { wrapper })
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    act(() => {
+      result.current.setUser(() => null)
+    })
+
+    await waitFor(() => expect(result.current.user).toBeNull())
+
+    let refreshPromise!: Promise<void>
+    await act(async () => {
+      refreshPromise = result.current.refresh()
+    })
+
+    await waitFor(() => expect(result.current.loading).toBe(true))
+
+    await act(async () => {
+      resolveUserRequest?.({ data: testUser })
+      resolveUserRequest = null
+      await refreshPromise
+    })
+
+    expect(result.current.loading).toBe(false)
 
     queryClient.clear()
   })

--- a/root/frontend/src/contexts/__tests__/AuthContext.test.tsx
+++ b/root/frontend/src/contexts/__tests__/AuthContext.test.tsx
@@ -1,5 +1,5 @@
 import { PropsWithChildren } from "react"
-import { createHmac } from "node:crypto"
+import { Buffer } from "node:buffer"
 import { renderHook, act, waitFor } from "@testing-library/react"
 import { QueryClientProvider } from "@tanstack/react-query"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
@@ -12,6 +12,10 @@ import {
 } from "@/contexts/AuthContext"
 import { testUser } from "@/tests/mocks/handlers"
 import api from "@/api/client"
+import { hmac } from "@noble/hashes/hmac"
+import { sha256 } from "@noble/hashes/sha256"
+
+const textEncoder = new TextEncoder()
 
 describe("AuthProvider caching", () => {
   beforeEach(() => {
@@ -156,9 +160,12 @@ const primeCachedProfile = () => {
     data: snapshot,
   }
 
-  const signature = createHmac("sha256", signingKey)
-    .update(JSON.stringify(payload))
-    .digest("base64")
+  const signatureBytes = hmac(
+    sha256,
+    textEncoder.encode(signingKey),
+    textEncoder.encode(JSON.stringify(payload))
+  )
+  const signature = Buffer.from(signatureBytes).toString("base64")
 
   const envelope = { ...payload, signature }
   localStorage.setItem(PROFILE_CACHE_STORAGE_KEY, JSON.stringify(envelope))

--- a/root/frontend/src/contexts/__tests__/AuthContext.test.tsx
+++ b/root/frontend/src/contexts/__tests__/AuthContext.test.tsx
@@ -1,5 +1,4 @@
 import { PropsWithChildren } from "react"
-import { Buffer } from "node:buffer"
 import { renderHook, act, waitFor } from "@testing-library/react"
 import { QueryClientProvider } from "@tanstack/react-query"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
@@ -14,8 +13,48 @@ import { testUser } from "@/tests/mocks/handlers"
 import api from "@/api/client"
 import { hmac } from "@noble/hashes/hmac"
 import { sha256 } from "@noble/hashes/sha256"
+import { utf8ToBytes } from "@noble/hashes/utils"
 
-const textEncoder = new TextEncoder()
+const bytesToBase64 = (bytes: Uint8Array): string => {
+  const maybeBuffer =
+    typeof globalThis !== "undefined" &&
+    typeof (globalThis as { Buffer?: unknown }).Buffer === "function"
+      ? (globalThis as { Buffer?: { from?: unknown } }).Buffer
+      : undefined
+
+  if (
+    maybeBuffer &&
+    typeof maybeBuffer === "function" &&
+    typeof (maybeBuffer as { from?: unknown }).from === "function"
+  ) {
+    return (
+      maybeBuffer as {
+        from: (
+          input: Uint8Array | string,
+          encoding?: string
+        ) => {
+          toString: (encoding: string) => string
+        }
+      }
+    )
+      .from(bytes)
+      .toString("base64")
+  }
+
+  let binary = ""
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte)
+  }
+
+  if (
+    typeof globalThis !== "undefined" &&
+    typeof (globalThis as { btoa?: (value: string) => string }).btoa === "function"
+  ) {
+    return (globalThis as { btoa: (value: string) => string }).btoa(binary)
+  }
+
+  throw new Error("Unable to encode payload in base64")
+}
 
 describe("AuthProvider caching", () => {
   beforeEach(() => {
@@ -169,10 +208,10 @@ const primeCachedProfile = () => {
 
   const signatureBytes = hmac(
     sha256,
-    textEncoder.encode(signingKey),
-    textEncoder.encode(JSON.stringify(payload))
+    utf8ToBytes(signingKey),
+    utf8ToBytes(JSON.stringify(payload))
   )
-  const signature = Buffer.from(signatureBytes).toString("base64")
+  const signature = bytesToBase64(signatureBytes)
 
   const envelope = { ...payload, signature }
   localStorage.setItem(PROFILE_CACHE_STORAGE_KEY, JSON.stringify(envelope))


### PR DESCRIPTION
## Summary
- derive the auth initializing state from cached profile availability and avoid toggling it during background revalidation
- ensure refresh requests only show the global loading indicator when no profile is present while keeping explicit auth flows unaffected
- add unit tests confirming cached profiles expose loading=false immediately and that refresh toggles loading when the profile is missing

## Testing
- npm --prefix root/frontend test -- AuthContext

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912816f9d2c832785185e411aa95bc9)