### PR TITLE
Return profile data with auth tokens

### DIFF
--- a/root/app/api/spotify.py
+++ b/root/app/api/spotify.py
@@ -183,13 +183,14 @@ async def _ensure_access_token(
 
 @router.get("/auth-url", response_model=SpotifyAuthURL)
 async def spotify_auth_url(user: User = Depends(get_current_user)):
-    state = await create_access_token(str(user.id), expires_delta=10)
+    state_result = await create_access_token(str(user.id), expires_delta=10)
+    state_token = state_result[0] if isinstance(state_result, tuple) else state_result
     params = {
         "client_id": settings.spotify_client_id,
         "response_type": "code",
         "redirect_uri": settings.spotify_redirect_uri,
         "scope": settings.spotify_scopes,
-        "state": state,
+        "state": state_token,
         "show_dialog": "false",
     }
     url = "https://accounts.spotify.com/authorize?" + urlencode(params)

--- a/root/app/auth/auth.py
+++ b/root/app/auth/auth.py
@@ -4,7 +4,7 @@ import math
 import secrets
 from collections.abc import Mapping, Sequence
 from datetime import UTC, datetime, timedelta
-from typing import Any, Literal
+from typing import Any, Literal, cast
 from uuid import uuid4
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
@@ -17,6 +17,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import crud
 from app.api.deps import get_current_user, require_fresh_mfa
+from app.api.users import _attach_pending_email
 from app.auth import mfa
 from app.auth.security import (
     create_access_token,
@@ -35,13 +36,15 @@ from app.models.models import (
     MfaWebAuthnCredential,
     User,
 )
+from app.models.user_loaders import ensure_mfa_relationships_loaded
 from app.schemas.schemas import (
     MfaRecoveryCodeOut,
     MfaTotpEnrollmentOut,
     MfaWebAuthnCredentialOut,
     SessionSigningKeyOut,
-    Token,
+    TokenWithProfile,
     UserCreate,
+    UserOut,
 )
 from app.utils.ratelimit import sensitive_route_limit
 
@@ -221,6 +224,30 @@ async def _mint_access_token(
     )
     await db.commit()
     return token
+
+
+async def _build_token_response(
+    db: AsyncSession,
+    user: User,
+    token: str,
+    session: ActiveSession | None,
+) -> TokenWithProfile:
+    refreshed_user = await ensure_mfa_relationships_loaded(db, user)
+    if refreshed_user is not None:
+        user = refreshed_user
+    enriched_user = await _attach_pending_email(db, user)
+    if enriched_user is not None:
+        user = enriched_user
+    session_payload: SessionSigningKeyOut | None = None
+    signing_key = getattr(session, "signing_key", None) if session else None
+    if isinstance(signing_key, str) and signing_key:
+        session_payload = SessionSigningKeyOut(signing_key=signing_key)
+    return TokenWithProfile(
+        access_token=token,
+        token_type="bearer",
+        user=UserOut.model_validate(user),
+        session=session_payload,
+    )
 
 
 async def _resolve_mfa_capabilities(db: AsyncSession, *, user: User) -> dict[str, bool]:
@@ -690,7 +717,7 @@ async def _perform_login(
 
     client_ip, user_agent = _extract_client_info(request)
     now = datetime.now(UTC)
-    token = await create_access_token(
+    token_result = await create_access_token(
         str(user.id),
         db=db,
         session_metadata={
@@ -703,6 +730,11 @@ async def _perform_login(
             "mfa_verified_at": now,
         },
     )
+    if isinstance(token_result, tuple):
+        token, session = token_result
+    else:
+        token = cast(str, token_result)
+        session = None
     _set_access_token_cookie(response, token)
     _audit_log(
         "auth.login.success",
@@ -710,12 +742,12 @@ async def _perform_login(
         user_id=user.id,
         reason="authenticated",
     )
-    return {"access_token": token, "token_type": "bearer"}
+    return await _build_token_response(db, user, token, session)
 
 
 @router.post(
     "/login",
-    response_model=Token,
+    response_model=TokenWithProfile,
     responses={status.HTTP_202_ACCEPTED: {"model": PendingMfaResponse}},
     dependencies=[Depends(sensitive_route_limit())],
 )
@@ -736,7 +768,7 @@ async def login(
 
 @router.post(
     "/login-json",
-    response_model=Token,
+    response_model=TokenWithProfile,
     responses={status.HTTP_202_ACCEPTED: {"model": PendingMfaResponse}},
     dependencies=[Depends(sensitive_route_limit())],
 )
@@ -1040,7 +1072,7 @@ async def regenerate_recovery_codes(
     }
 
 
-@router.post("/mfa/verify", response_model=Token)
+@router.post("/mfa/verify", response_model=TokenWithProfile)
 async def verify_mfa_challenge(
     payload: MfaVerifyIn,
     response: Response,
@@ -1211,7 +1243,7 @@ async def verify_mfa_challenge(
             reason="verified",
             extra={"session_id": session.id},
         )
-    return Token(access_token=token, token_type="bearer")
+    return await _build_token_response(db, user, token, session)
 
 
 @router.post(

--- a/root/app/auth/security.py
+++ b/root/app/auth/security.py
@@ -105,7 +105,7 @@ async def create_access_token(
     extra: dict | None = None,
     db: AsyncSession | None = None,
     session_metadata: dict | None = None,
-) -> str:
+) -> str | tuple[str, ActiveSession]:
     minutes = expires_delta or settings.access_token_expire_minutes
     now = datetime.now(UTC)
     expires_at = now + timedelta(minutes=minutes)
@@ -161,6 +161,8 @@ async def create_access_token(
                 session.mfa_verified_at = mfa_verified_at
         db.add(session)
         await db.commit()
+        await db.refresh(session)
+        return token, session
     return token
 
 

--- a/root/app/schemas/schemas.py
+++ b/root/app/schemas/schemas.py
@@ -474,6 +474,11 @@ class Token(BaseModel):
     token_type: str = "bearer"
 
 
+class TokenWithProfile(Token):
+    user: UserOut
+    session: "SessionSigningKeyOut | None" = None
+
+
 class SessionSigningKeyOut(BaseModel):
     signing_key: str
 

--- a/root/frontend/src/api/generated/schema.ts
+++ b/root/frontend/src/api/generated/schema.ts
@@ -2536,8 +2536,8 @@ export interface components {
       /** Is Active */
       is_active?: boolean | null
     }
-    /** Token */
-    Token: {
+    /** TokenWithProfile */
+    TokenWithProfile: {
       /** Access Token */
       access_token: string
       /**
@@ -2545,6 +2545,8 @@ export interface components {
        * @default bearer
        */
       token_type: string
+      user: components["schemas"]["UserOut"]
+      session?: components["schemas"]["SessionSigningKeyOut"] | null
     }
     /** TotpEnrollmentConfirmIn */
     TotpEnrollmentConfirmIn: {
@@ -2943,7 +2945,7 @@ export interface operations {
           [name: string]: unknown
         }
         content: {
-          "application/json": components["schemas"]["Token"]
+          "application/json": components["schemas"]["TokenWithProfile"]
         }
       }
       /** @description Accepted */
@@ -2985,7 +2987,7 @@ export interface operations {
           [name: string]: unknown
         }
         content: {
-          "application/json": components["schemas"]["Token"]
+          "application/json": components["schemas"]["TokenWithProfile"]
         }
       }
       /** @description Accepted */
@@ -3308,7 +3310,7 @@ export interface operations {
           [name: string]: unknown
         }
         content: {
-          "application/json": components["schemas"]["Token"]
+          "application/json": components["schemas"]["TokenWithProfile"]
         }
       }
       /** @description Validation Error */

--- a/root/frontend/src/contexts/AuthContext.tsx
+++ b/root/frontend/src/contexts/AuthContext.tsx
@@ -18,6 +18,7 @@ import { hmac } from "@noble/hashes/hmac"
 import { sha256 } from "@noble/hashes/sha256"
 import { hasPushConsent, softSyncPushSubscription, unsubscribePush } from "@/push/subscribe"
 import api, { API_UNAUTHORIZED_EVENT } from "../api/client"
+import type { components } from "@/api/generated/schema"
 import { SPOTIFY_REAUTH_EVENT } from "@/hooks/useNowPlaying"
 import type { PendingMfaResponse, MfaMethod, MfaVerifyPayload } from "@/types/Mfa"
 import type { User } from "@/types/User"
@@ -115,6 +116,8 @@ type CachedProfileEnvelope = {
 }
 
 type CacheSignaturePayload = Pick<CachedProfileEnvelope, "version" | "expiresAt" | "data">
+
+type SessionSigningKeyResponse = components["schemas"]["SessionSigningKeyOut"]
 
 type TokenWithProfileResponse = {
   access_token: string

--- a/root/frontend/src/contexts/AuthContext.tsx
+++ b/root/frontend/src/contexts/AuthContext.tsx
@@ -116,8 +116,35 @@ type CachedProfileEnvelope = {
 
 type CacheSignaturePayload = Pick<CachedProfileEnvelope, "version" | "expiresAt" | "data">
 
-type SessionSigningKeyResponse = {
-  signing_key: string
+type TokenWithProfileResponse = {
+  access_token: string
+  token_type: string
+  user?: User
+  session?: SessionSigningKeyResponse | null
+}
+
+const extractSigningKey = (
+  value: TokenWithProfileResponse | undefined | null
+): string | null => {
+  if (!value) return null
+  const key = value.session?.signing_key
+  return typeof key === "string" && key.length > 0 ? key : null
+}
+
+const isTokenWithProfileResponse = (
+  value: unknown
+): value is TokenWithProfileResponse & { user: User } => {
+  if (!value || typeof value !== "object") {
+    return false
+  }
+  const candidate = value as Record<string, unknown>
+  if (typeof candidate.access_token !== "string") {
+    return false
+  }
+  if (!candidate.user || typeof candidate.user !== "object") {
+    return false
+  }
+  return true
 }
 
 type ProfileBroadcastMessage =
@@ -759,15 +786,36 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const finalizeAuthenticatedSession = useCallback(
     async (
       controller: AbortController,
-      { skipPushSync = false }: { skipPushSync?: boolean } = {}
+      {
+        skipPushSync = false,
+        profile,
+        signingKey,
+      }: {
+        skipPushSync?: boolean
+        profile?: User | null
+        signingKey?: string | null
+      } = {}
     ) => {
-      const signingKeyPromise = ensureSessionSigningKey()
-      const profile = await fetchCurrentUser({ signal: controller.signal })
-      try {
-        await signingKeyPromise
-      } catch (error) {
-        if (!controller.signal.aborted && import.meta.env.DEV) {
-          console.warn("Failed to obtain session signing key", error)
+      let resolvedProfile: User | null = profile ?? null
+      let signingKeyPromise: Promise<string | null> | null = null
+
+      if (typeof signingKey === "string" && signingKey.length > 0) {
+        updateSessionSigningKey(signingKey)
+      } else {
+        signingKeyPromise = ensureSessionSigningKey()
+      }
+
+      if (!resolvedProfile) {
+        resolvedProfile = await fetchCurrentUser({ signal: controller.signal })
+      }
+
+      if (signingKeyPromise) {
+        try {
+          await signingKeyPromise
+        } catch (error) {
+          if (!controller.signal.aborted && import.meta.env.DEV) {
+            console.warn("Failed to obtain session signing key", error)
+          }
         }
       }
 
@@ -775,7 +823,9 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         return
       }
 
-      setUser(profile)
+      if (resolvedProfile) {
+        setUser(resolvedProfile)
+      }
 
       if (!skipPushSync && typeof window !== "undefined" && typeof Notification !== "undefined") {
         if (Notification.permission === "granted" && hasPushConsent()) {
@@ -789,7 +839,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         }
       }
     },
-    [ensureSessionSigningKey, setUser]
+    [ensureSessionSigningKey, setUser, updateSessionSigningKey]
   )
 
   const login = useCallback(
@@ -805,7 +855,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       try {
         setAuthOperation(true)
         setInitializing(true)
-        const response = await api.post<PendingMfaResponse | { access_token?: string }>(
+        const response = await api.post<PendingMfaResponse | TokenWithProfileResponse>(
           "/auth/login",
           payload,
           {
@@ -824,7 +874,15 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         }
 
         updatePendingMfa(null)
-        await finalizeAuthenticatedSession(controller)
+        if (isTokenWithProfileResponse(response.data)) {
+          const success = response.data
+          await finalizeAuthenticatedSession(controller, {
+            profile: success.user,
+            signingKey: extractSigningKey(success),
+          })
+        } else {
+          await finalizeAuthenticatedSession(controller)
+        }
         return null
       } catch (error) {
         if (!controller.signal.aborted) {
@@ -925,16 +983,29 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         }
 
         const skipPushSync = Boolean(pending.session_id)
-        await api.post("/auth/mfa/verify", requestPayload, { signal: controller.signal })
+        const response = await api.post<TokenWithProfileResponse | undefined>(
+          "/auth/mfa/verify",
+          requestPayload,
+          { signal: controller.signal }
+        )
 
         if (controller.signal.aborted) {
           return
         }
 
         updatePendingMfa(null)
-        await finalizeAuthenticatedSession(controller, {
-          skipPushSync,
-        })
+        if (isTokenWithProfileResponse(response.data)) {
+          const success = response.data
+          await finalizeAuthenticatedSession(controller, {
+            skipPushSync,
+            profile: success.user,
+            signingKey: extractSigningKey(success),
+          })
+        } else {
+          await finalizeAuthenticatedSession(controller, {
+            skipPushSync,
+          })
+        }
       } catch (error) {
         if (controller.signal.aborted) {
           return

--- a/root/frontend/src/contexts/AuthContext.tsx
+++ b/root/frontend/src/contexts/AuthContext.tsx
@@ -123,9 +123,7 @@ type TokenWithProfileResponse = {
   session?: SessionSigningKeyResponse | null
 }
 
-const extractSigningKey = (
-  value: TokenWithProfileResponse | undefined | null
-): string | null => {
+const extractSigningKey = (value: TokenWithProfileResponse | undefined | null): string | null => {
   if (!value) return null
   const key = value.session?.signing_key
   return typeof key === "string" && key.length > 0 ? key : null

--- a/root/tests/test_auth_mfa.py
+++ b/root/tests/test_auth_mfa.py
@@ -144,6 +144,11 @@ async def test_totp_enrollment_and_verification_flow(
     body = success.json()
     assert body["token_type"] == "bearer"
     assert body["access_token"]
+    assert body["user"]["id"] == user.id
+    session = body.get("session")
+    assert session is not None
+    assert isinstance(session.get("signing_key"), str)
+    assert session["signing_key"]
 
     result = await db_session.execute(
         select(models.MfaChallenge).where(

--- a/root/tests/test_auth_security.py
+++ b/root/tests/test_auth_security.py
@@ -184,6 +184,11 @@ async def test_login_migrates_legacy_hash(async_client, user_factory, db_session
     body = response.json()
     assert body["token_type"] == "bearer"
     assert body["access_token"]
+    assert body["user"]["id"] == user.id
+    session = body.get("session")
+    assert session is not None
+    assert isinstance(session.get("signing_key"), str)
+    assert session["signing_key"]
 
     await db_session.refresh(user)
     assert user.hashed_password.startswith("$argon2id$")
@@ -316,6 +321,11 @@ async def test_login_accepts_mixed_case_username(async_client, user_factory):
     body = response.json()
     assert body["token_type"] == "bearer"
     assert body["access_token"]
+    assert body["user"]["id"] == user.id
+    session = body.get("session")
+    assert session is not None
+    assert isinstance(session.get("signing_key"), str)
+    assert session["signing_key"]
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- extend access token creation to surface persisted session metadata and update callers
- return combined token, user profile, and signing key payloads for login and MFA endpoints
- adapt the frontend auth context and backend tests to consume the richer responses

## Testing
- pytest root/tests/test_auth_security.py root/tests/test_auth_mfa.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913a2f656048327a66808914328c227)