### PR TITLE
Prefetch dashboard data after auth session

### DIFF
--- a/root/frontend/src/contexts/AuthContext.tsx
+++ b/root/frontend/src/contexts/AuthContext.tsx
@@ -22,6 +22,7 @@ import type { components } from "@/api/generated/schema"
 import { SPOTIFY_REAUTH_EVENT } from "@/hooks/useNowPlaying"
 import type { PendingMfaResponse, MfaMethod, MfaVerifyPayload } from "@/types/Mfa"
 import type { User } from "@/types/User"
+import type { SupportedLanguage } from "@/contexts/LanguageContext"
 
 type UserState = User | null
 
@@ -477,7 +478,7 @@ const initializeCachedUser = (): UserState => {
 
 export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const queryClient = useQueryClient()
-  const { t } = useTranslation("auth")
+  const { t, i18n } = useTranslation("auth")
   const [sessionSigningKey, setSessionSigningKeyState] = useState<string | null>(() =>
     readStoredSessionSigningKey()
   )
@@ -826,6 +827,44 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 
       if (resolvedProfile) {
         setUser(resolvedProfile)
+
+        if (typeof window !== "undefined") {
+          const resolvedLanguage = (i18n.resolvedLanguage ?? i18n.language ?? "ru") as SupportedLanguage
+          const language: SupportedLanguage = resolvedLanguage === "en" ? "en" : "ru"
+
+          void (async () => {
+            try {
+              const [storiesModule, newsModule, eventsModule, eventsApiModule] = await Promise.all([
+                import("@/hooks/useDashboardStories"),
+                import("@/hooks/useDashboardNews"),
+                import("@/hooks/useDashboardEvents"),
+                import("@/api/hooks/events"),
+              ])
+
+              const promises: Promise<unknown>[] = [
+                storiesModule.prefetchDashboardStories(queryClient),
+                newsModule.prefetchDashboardNews(queryClient, language),
+                eventsModule.prefetchDashboardEvents(queryClient),
+              ]
+
+              if (resolvedProfile.role === "student" && resolvedProfile.group_id) {
+                promises.push(
+                  eventsApiModule.prefetchEventsListQuery(queryClient, {
+                    language,
+                    is_active: true,
+                    limit: eventsApiModule.EVENTS_PAGE_SIZE,
+                  })
+                )
+              }
+
+              await Promise.all(promises)
+            } catch (error) {
+              if (import.meta.env.DEV) {
+                console.warn("Failed to prefetch dashboard data", error)
+              }
+            }
+          })()
+        }
       }
 
       if (!skipPushSync && typeof window !== "undefined" && typeof Notification !== "undefined") {
@@ -840,7 +879,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         }
       }
     },
-    [ensureSessionSigningKey, setUser, updateSessionSigningKey]
+    [ensureSessionSigningKey, i18n, queryClient, setUser, updateSessionSigningKey]
   )
 
   const login = useCallback(

--- a/root/frontend/src/contexts/__tests__/AuthContext.test.tsx
+++ b/root/frontend/src/contexts/__tests__/AuthContext.test.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/contexts/AuthContext"
 import { testUser } from "@/tests/mocks/handlers"
 import api from "@/api/client"
+import i18n from "@/i18n/config"
 import { hmac } from "@noble/hashes/hmac"
 import { sha256 } from "@noble/hashes/sha256"
 import { utf8ToBytes } from "@noble/hashes/utils"
@@ -316,5 +317,151 @@ describe("AuthProvider loading state", () => {
     expect(result.current.loading).toBe(false)
 
     queryClient.clear()
+  })
+})
+
+describe("AuthProvider dashboard prefetch", () => {
+  beforeEach(() => {
+    localStorage.clear()
+    sessionStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  const setup = () => {
+    const queryClient = createQueryClient()
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>{children}</AuthProvider>
+      </QueryClientProvider>
+    )
+    return { queryClient, wrapper }
+  }
+
+  const resolveActiveLanguage = () => {
+    const resolved = i18n.resolvedLanguage ?? i18n.language ?? "ru"
+    return resolved === "en" ? "en" : "ru"
+  }
+
+  const preparePrefetchSpies = async () => {
+    const [storiesModule, newsModule, eventsModule, eventsApiModule] = await Promise.all([
+      import("@/hooks/useDashboardStories"),
+      import("@/hooks/useDashboardNews"),
+      import("@/hooks/useDashboardEvents"),
+      import("@/api/hooks/events"),
+    ])
+
+    const storiesSpy = vi
+      .spyOn(storiesModule, "prefetchDashboardStories")
+      .mockImplementation(async () => undefined)
+    const newsSpy = vi
+      .spyOn(newsModule, "prefetchDashboardNews")
+      .mockImplementation(async () => undefined)
+    const eventsSpy = vi
+      .spyOn(eventsModule, "prefetchDashboardEvents")
+      .mockImplementation(async () => undefined)
+    const eventsListSpy = vi
+      .spyOn(eventsApiModule, "prefetchEventsListQuery")
+      .mockImplementation(async () => undefined as any)
+
+    return {
+      storiesSpy,
+      newsSpy,
+      eventsSpy,
+      eventsListSpy,
+      eventsPageSize: eventsApiModule.EVENTS_PAGE_SIZE,
+    }
+  }
+
+  it("prefetches dashboard queries after login", async () => {
+    const postSpy = vi.spyOn(api, "post").mockResolvedValue({
+      status: 200,
+      data: {
+        access_token: "token",
+        token_type: "bearer",
+        user: { ...testUser, group_id: null },
+        session: { signing_key: "key" },
+      },
+    } as any)
+    vi.spyOn(api, "get").mockImplementation((url) => {
+      if (url === "/users/me") {
+        return Promise.resolve({ data: testUser })
+      }
+      if (url === "/auth/session/signing-key") {
+        return Promise.resolve({ data: { signing_key: "key" } })
+      }
+      throw new Error(`Unexpected url: ${url}`)
+    })
+
+    const { storiesSpy, newsSpy, eventsSpy, eventsListSpy } = await preparePrefetchSpies()
+    const language = resolveActiveLanguage()
+    const { wrapper } = setup()
+    const { result } = renderHook(() => useAuth(), { wrapper })
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    await act(async () => {
+      await result.current.login("user@example.com", "password")
+    })
+
+    await waitFor(() => {
+      expect(postSpy).toHaveBeenCalled()
+      expect(storiesSpy).toHaveBeenCalledTimes(1)
+      expect(newsSpy).toHaveBeenCalledTimes(1)
+      expect(eventsSpy).toHaveBeenCalledTimes(1)
+    })
+
+    expect(newsSpy).toHaveBeenCalledWith(expect.anything(), language)
+    expect(eventsListSpy).not.toHaveBeenCalled()
+  })
+
+  it("prefetches schedule data when the student has a group", async () => {
+    const loginUser = { ...testUser, group_id: 42 }
+    const postSpy = vi.spyOn(api, "post").mockResolvedValue({
+      status: 200,
+      data: {
+        access_token: "token",
+        token_type: "bearer",
+        user: loginUser,
+        session: { signing_key: "key" },
+      },
+    } as any)
+    vi.spyOn(api, "get").mockImplementation((url) => {
+      if (url === "/users/me") {
+        return Promise.resolve({ data: testUser })
+      }
+      if (url === "/auth/session/signing-key") {
+        return Promise.resolve({ data: { signing_key: "key" } })
+      }
+      throw new Error(`Unexpected url: ${url}`)
+    })
+
+    const { storiesSpy, newsSpy, eventsSpy, eventsListSpy, eventsPageSize } =
+      await preparePrefetchSpies()
+    const language = resolveActiveLanguage()
+    const { wrapper } = setup()
+    const { result } = renderHook(() => useAuth(), { wrapper })
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    await act(async () => {
+      await result.current.login("user@example.com", "password")
+    })
+
+    await waitFor(() => {
+      expect(postSpy).toHaveBeenCalled()
+      expect(storiesSpy).toHaveBeenCalledTimes(1)
+      expect(newsSpy).toHaveBeenCalledTimes(1)
+      expect(eventsSpy).toHaveBeenCalledTimes(1)
+      expect(eventsListSpy).toHaveBeenCalledTimes(1)
+    })
+
+    expect(eventsListSpy).toHaveBeenCalledWith(expect.anything(), {
+      language,
+      is_active: true,
+      limit: eventsPageSize,
+    })
   })
 })


### PR DESCRIPTION
## Summary
- lazily import dashboard data prefetchers after finalizing an authenticated session
- trigger dashboard query warmups for the active language and only fetch the schedule list for grouped students
- add AuthProvider regression tests to confirm dashboard prefetch helpers fire once login completes

## Testing
- npm run test -- src/contexts/__tests__/AuthContext.test.tsx

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914b417804c83278fb2f484600c55f3)