### PR TITLE
Add Redis service configuration to Docker stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,25 @@ This command builds the backend, frontend, and notifications worker images, star
 - Frontend UI: http://localhost:8080
 - Worker metrics: http://localhost:9101/metrics
 
+#### Opt in to Redis-backed features
+
+The Compose stack now includes a `redis` service that mirrors the cache and
+rate-limiting infrastructure used in production. To enable Redis locally you
+have two options:
+
+1. **Rely on the Compose defaults.** The `backend` and `notifications-worker`
+   containers already set `CACHE_ENABLED=true`,
+   `CACHE_REDIS_URL=redis://redis:6379/0`, and configure rate limiting to use
+   Redis (`RATE_LIMIT_STORAGE_BACKEND=redis`, `RATE_LIMIT_STORAGE_URI=redis://redis:6379/1`).
+   When you run `docker compose up` these overrides take effect automatically.
+2. **Apply the same settings when running services outside of Docker.** Copy
+   the commented examples in [`root/.env.example`](root/.env.example) into your
+   local `.env` file, then start the backend/worker after exporting the Redis
+   environment variables.
+
+With Redis enabled you can test cache hits, TTL expirations, and distributed
+rate limiting behavior exactly as it will run in production.
+
 ### 4. Run services manually (alternative)
 
 #### Backend (FastAPI)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,11 +13,18 @@ services:
       NOTIFICATIONS_SCHEDULER_INLINE_ENABLED: "false"
       ENABLE_METRICS_ENDPOINT: "true"
       METRICS_ALLOWLIST: 127.0.0.1,::1
+      CACHE_ENABLED: "true"
+      CACHE_REDIS_URL: redis://redis:6379/0
+      RATE_LIMIT_STORAGE_BACKEND: redis
+      RATE_LIMIT_STORAGE_URI: redis://redis:6379/1
+      RATE_LIMIT_HEADERS_ENABLED: "true"
     depends_on:
       migrations:
         condition: service_completed_successfully
       postgres:
         condition: service_healthy
+      redis:
+        condition: service_started
     ports:
       - "8000:8000"
     extra_hosts:
@@ -51,11 +58,17 @@ services:
       DATABASE_URL: postgresql+psycopg://postgres:postgres@postgres:5432/university
       NOTIFICATIONS_WORKER_METRICS_HOST: 0.0.0.0
       NOTIFICATIONS_WORKER_METRICS_PORT: "9101"
+      CACHE_ENABLED: "true"
+      CACHE_REDIS_URL: redis://redis:6379/0
+      RATE_LIMIT_STORAGE_BACKEND: redis
+      RATE_LIMIT_STORAGE_URI: redis://redis:6379/1
     depends_on:
       migrations:
         condition: service_completed_successfully
       postgres:
         condition: service_healthy
+      redis:
+        condition: service_started
     restart: unless-stopped
     ports:
       - "9101:9101"
@@ -75,6 +88,17 @@ services:
       retries: 5
     ports:
       - "5432:5432"
+
+  redis:
+    image: redis:7-alpine
+    command: ["redis-server", "--save", "", "--appendonly", "no"]
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    ports:
+      - "6379:6379"
 
   migrations:
     build:

--- a/root/.env.example
+++ b/root/.env.example
@@ -65,6 +65,11 @@ CACHE_ENABLED=false
 CACHE_REDIS_URL=redis://127.0.0.1:6379/0
 CACHE_DEFAULT_TTL_SECONDS=300
 
+# To mirror the Docker Compose defaults (Redis-backed cache), copy the
+# following overrides into your local `.env` file:
+# CACHE_ENABLED=true
+# CACHE_REDIS_URL=redis://redis:6379/0
+
 # ----- Rate limiting -----
 RATE_LIMIT_ENABLED=true
 RATE_LIMIT_DEFAULT=100/minute
@@ -72,6 +77,11 @@ RATE_LIMIT_SENSITIVE=5/minute
 RATE_LIMIT_STORAGE_BACKEND=memory
 RATE_LIMIT_STORAGE_URI=memory://
 RATE_LIMIT_HEADERS_ENABLED=true
+
+# Redis-backed rate limiting example (mirrors Compose):
+# RATE_LIMIT_STORAGE_BACKEND=redis
+# RATE_LIMIT_STORAGE_URI=redis://redis:6379/1
+# RATE_LIMIT_HEADERS_ENABLED=true
 
 # ----- Cleanup jobs -----
 SESSION_CLEANUP_INTERVAL_SECONDS=900


### PR DESCRIPTION
## Summary
- add a Redis service to docker-compose and enable cache/rate limit integrations for backend and worker containers
- include Redis-ready overrides in root/.env.example so local runs can mirror Compose defaults
- expand Docker instructions in the README to explain enabling Redis-backed features locally

## Testing
- not run (not applicable)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69153c8b5d7483279925ceaecf4558b0)