### PR TITLE
Add backend type checking with mypy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,27 @@ jobs:
           print("Runtime requirements look clean.")
           PY
 
+  backend-type-check:
+    name: Backend type check
+    runs-on: ubuntu-latest
+    needs: run-hooks
+    steps:
+      - uses: actions/checkout@v5
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: |
+            root/requirements.txt
+            root/requirements-dev.txt
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r root/requirements.txt -r root/requirements-dev.txt
+      - name: Run mypy
+        run: mypy
+
   backend-tests:
     name: Backend tests
     runs-on: ubuntu-latest

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,15 @@
+[mypy]
+python_version = 3.11
+mypy_path = root
+plugins = pydantic.mypy
+namespace_packages = True
+ignore_missing_imports = True
+allow_untyped_defs = True
+allow_untyped_globals = True
+warn_unused_ignores = True
+warn_redundant_casts = True
+warn_return_any = True
+warn_unreachable = True
+show_error_codes = True
+follow_imports = normal
+files = root/app/services/notification_templates.py, root/app/utils/images.py

--- a/root/app/services/notification_templates.py
+++ b/root/app/services/notification_templates.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from html import unescape
 from textwrap import shorten
-from typing import Any
+from typing import Any, Protocol
 
 from app.localization import SUPPORTED_LOCALES, translate
 
@@ -529,7 +529,14 @@ def _build_system(
     }
 
 
-_BUILDERS: dict[str, Any] = {
+class NotificationBuilder(Protocol):
+    def __call__(
+        self, context: ScenarioContext, *, locale: str | None = ...
+    ) -> dict[str, Any] | None:
+        """Build a notification payload for the given scenario."""
+
+
+_BUILDERS: dict[str, NotificationBuilder] = {
     "schedule.change": _build_schedule_change,
     "schedule.reminder": _build_schedule_reminder,
     "news.new": _build_news,

--- a/root/app/utils/images.py
+++ b/root/app/utils/images.py
@@ -3,17 +3,26 @@
 from __future__ import annotations
 
 from io import BytesIO
+from typing import cast
 
 from PIL import Image, ImageOps, UnidentifiedImageError
 
+try:  # Pillow >= 9.1 exposes the resampling enum in PIL.Image
+    from PIL.Image import Resampling
+except ImportError:  # pragma: no cover - Pillow < 9.1 compatibility
+    Resampling = int  # type: ignore[misc,assignment]
 
-def _resolve_resample_filter() -> int:
+
+def _resolve_resample_filter() -> Resampling:
     """Return the best available high-quality resampling filter."""
 
     resampling = getattr(Image, "Resampling", None)
     if resampling is not None:
-        return resampling.LANCZOS
-    return Image.LANCZOS  # pragma: no cover - compatibility fallback
+        return cast(Resampling, resampling.LANCZOS)
+    lanczos = getattr(Image, "LANCZOS", None)
+    if lanczos is None:
+        raise AttributeError("Pillow installation does not expose a LANCZOS filter")
+    return cast(Resampling, lanczos)
 
 
 def optimize_image(

--- a/root/requirements-dev.txt
+++ b/root/requirements-dev.txt
@@ -8,3 +8,4 @@ pre-commit>=3.8
 pyotp>=2.9
 webauthn>=1.11
 boto3>=1.34.0,<2.0.0
+mypy>=1.8


### PR DESCRIPTION
## Summary
- add mypy to the development requirements and configure it for the backend package layout
- improve typings for notification template builders and image utilities to satisfy the initial checks
- require the backend mypy run in CI so static analysis is enforced alongside existing checks

## Testing
- mypy

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915401771e4832784fe5d88ff809ea3)