### PR TITLE
Add cached fallback for WebAuthn metadata resolver

### DIFF
--- a/root/app/core/config.py
+++ b/root/app/core/config.py
@@ -296,6 +296,8 @@ class Settings(BaseSettings):
     mfa_webauthn_metadata_url: str = ""
     mfa_webauthn_metadata_json: str = ""
     mfa_webauthn_metadata_refresh_seconds: int = 86_400
+    mfa_webauthn_metadata_cache_file: str = ""
+    mfa_webauthn_metadata_cache_ttl_seconds: int = 604_800
     mfa_webauthn_metadata_enforcement: str = "log"
     mfa_step_up_ttl_seconds: int = 300
     security_csp: str = ""
@@ -529,13 +531,18 @@ class Settings(BaseSettings):
             )
         return normalized
 
-    @field_validator("mfa_webauthn_metadata_refresh_seconds")
+    @field_validator(
+        "mfa_webauthn_metadata_refresh_seconds",
+        "mfa_webauthn_metadata_cache_ttl_seconds",
+    )
     @classmethod
-    def _validate_webauthn_metadata_refresh(cls, value: int) -> int:
+    def _validate_webauthn_metadata_refresh(
+        cls, value: int, info: FieldValidationInfo
+    ) -> int:
         if value < 0:
-            raise ValueError(
-                "MFA_WEBAUTHN_METADATA_REFRESH_SECONDS must be zero or positive"
-            )
+            field_name = getattr(info, "field_name", "value")
+            label = str(field_name or "value").upper()
+            raise ValueError(f"{label} must be zero or positive")
         return value
 
     @field_validator(

--- a/root/app/services/webauthn_metadata.py
+++ b/root/app/services/webauthn_metadata.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 import time
 from collections.abc import Mapping
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 import httpx
@@ -97,13 +99,38 @@ class WebAuthnMetadataResolver:
         return (time.time() - self._fetched_at) >= ttl
 
     async def _reload(self) -> None:
+        used_cache = False
         try:
             raw = await self._load_source()
-        except Exception as exc:  # pragma: no cover - defensive
-            logger.warning("Failed to load WebAuthn metadata: %s", exc)
-            raise MetadataLoadError(str(exc)) from exc
+        except Exception as error:  # pragma: no cover - defensive
+            if isinstance(error, MetadataLoadError):
+                failure = error
+            else:
+                failure = MetadataLoadError(str(error))
+            cached = self._load_cached_payload()
+            if cached is not None:
+                logger.warning(
+                    "Failed to refresh WebAuthn metadata from source; using cached payload (%s)",
+                    failure,
+                    exc_info=True,
+                )
+                raw = cached
+                used_cache = True
+            else:
+                logger.error(
+                    "Failed to refresh WebAuthn metadata and no cached payload is available: %s",
+                    failure,
+                    exc_info=True,
+                )
+                if self._entries:
+                    self._fetched_at = time.time()
+                    return
+                if failure is error:
+                    raise
+                raise failure from error
         if raw is None:
             self.invalidate()
+            self._clear_cache()
             self._fetched_at = time.time()
             return
         entries = self._parse_entries(raw)
@@ -112,6 +139,8 @@ class WebAuthnMetadataResolver:
             aaguid: entry.attestation_root_certificates
             for aaguid, entry in entries.items()
         }
+        if not used_cache:
+            self._persist_cache(raw)
         self._fetched_at = time.time()
 
     async def _load_source(self) -> Mapping[str, Any] | None:
@@ -126,9 +155,19 @@ class WebAuthnMetadataResolver:
             return {"entries": []}
         timeout = httpx.Timeout(10.0, read=20.0)
         async with httpx.AsyncClient(timeout=timeout) as client:
-            response = await client.get(url)
-            response.raise_for_status()
-            return response.json()
+            try:
+                response = await client.get(url)
+                response.raise_for_status()
+            except httpx.HTTPError as exc:
+                raise MetadataLoadError(
+                    f"Failed to download WebAuthn metadata from {url}: {exc}"
+                ) from exc
+            try:
+                return response.json()
+            except ValueError as exc:
+                raise MetadataLoadError(
+                    f"Invalid WebAuthn metadata payload returned by {url}"
+                ) from exc
 
     def _parse_entries(self, raw: Mapping[str, Any]) -> dict[str, MetadataEntry]:
         entries_data = raw.get("entries")
@@ -188,6 +227,75 @@ class WebAuthnMetadataResolver:
             trust_score=trust_score,
             status_warning=status_warning,
         )
+
+    def _get_cache_path(self) -> Path | None:
+        cache_file = settings.mfa_webauthn_metadata_cache_file.strip()
+        if not cache_file:
+            return None
+        return Path(cache_file).expanduser()
+
+    def _persist_cache(self, payload: Mapping[str, Any]) -> None:
+        path = self._get_cache_path()
+        if path is None:
+            return
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            serialized = json.dumps(payload, ensure_ascii=False)
+            tmp_path = path.with_suffix(path.suffix + ".tmp")
+            with tmp_path.open("w", encoding="utf-8") as handle:
+                handle.write(serialized)
+            os.replace(tmp_path, path)
+        except Exception:  # pragma: no cover - defensive
+            logger.warning(
+                "Failed to persist WebAuthn metadata cache to %s", path, exc_info=True
+            )
+
+    def _clear_cache(self) -> None:
+        path = self._get_cache_path()
+        if path is None:
+            return
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            return
+        except Exception:  # pragma: no cover - defensive
+            logger.warning(
+                "Failed to remove WebAuthn metadata cache at %s", path, exc_info=True
+            )
+
+    def _load_cached_payload(self) -> Mapping[str, Any] | None:
+        path = self._get_cache_path()
+        if path is None:
+            return None
+        try:
+            stat = path.stat()
+        except FileNotFoundError:
+            return None
+        except OSError:  # pragma: no cover - defensive
+            logger.warning(
+                "Unable to stat WebAuthn metadata cache at %s", path, exc_info=True
+            )
+            return None
+        ttl = max(0, settings.mfa_webauthn_metadata_cache_ttl_seconds)
+        age = time.time() - stat.st_mtime
+        if ttl and age > ttl:
+            logger.warning(
+                "Cached WebAuthn metadata at %s is stale (age=%d seconds > ttl=%d)",
+                path,
+                int(age),
+                ttl,
+            )
+        try:
+            with path.open("r", encoding="utf-8") as handle:
+                return json.load(handle)
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.warning(
+                "Failed to load cached WebAuthn metadata from %s: %s",
+                path,
+                exc,
+                exc_info=True,
+            )
+            return None
 
     def _compute_trust_score(
         self, status_reports: list[Mapping[str, Any]]

--- a/root/tests/test_auth_mfa.py
+++ b/root/tests/test_auth_mfa.py
@@ -2,7 +2,9 @@ import base64
 import datetime as dt
 import json
 import logging
+from collections.abc import Mapping
 from types import SimpleNamespace
+from typing import Any
 
 import pyotp
 import pytest
@@ -24,7 +26,7 @@ from app.auth.security import get_password_hash
 from app.core.config import settings
 from app.management import reset_mfa
 from app.models import models
-from app.services.webauthn_metadata import metadata_resolver
+from app.services.webauthn_metadata import MetadataLoadError, metadata_resolver
 
 
 def _base64url(data: bytes) -> str:
@@ -880,5 +882,51 @@ async def test_webauthn_metadata_resolver_refresh(monkeypatch):
 
     await metadata_resolver.refresh(force=True)
     assert len(calls) == 3
+
+    metadata_resolver.invalidate()
+
+
+@pytest.mark.anyio
+async def test_webauthn_metadata_resolver_cached_fallback(monkeypatch, tmp_path):
+    metadata_resolver.invalidate()
+    cache_path = tmp_path / "metadata-cache.json"
+    monkeypatch.setattr(settings, "mfa_webauthn_metadata_cache_file", str(cache_path))
+    monkeypatch.setattr(settings, "mfa_webauthn_metadata_cache_ttl_seconds", 3600)
+    monkeypatch.setattr(settings, "mfa_webauthn_metadata_json", "")
+    monkeypatch.setattr(settings, "mfa_webauthn_metadata_url", "https://metadata.example")
+
+    payload = {
+        "entries": [
+            {
+                "aaguid": "00112233-4455-6677-8899-aabbccddeeff",
+                "metadataStatement": {
+                    "aaguid": "00112233-4455-6677-8899-aabbccddeeff",
+                    "description": "Sample Authenticator",
+                    "attestationRootCertificates": ["root-cert"],
+                    "authenticatorGetInfo": {"transports": ["usb"]},
+                },
+                "statusReports": [{"status": "FIDO_CERTIFIED"}],
+            }
+        ]
+    }
+
+    async def _load_ok() -> Mapping[str, Any]:
+        return payload
+
+    monkeypatch.setattr(metadata_resolver, "_load_source", _load_ok)
+    await metadata_resolver.refresh(force=True)
+    assert cache_path.is_file()
+
+    metadata_resolver.invalidate()
+
+    async def _load_fail() -> Mapping[str, Any]:
+        raise MetadataLoadError("network down")
+
+    monkeypatch.setattr(metadata_resolver, "_load_source", _load_fail)
+
+    entry = await metadata_resolver.get_entry("00112233-4455-6677-8899-aabbccddeeff")
+    assert entry is not None
+    assert entry.description == "Sample Authenticator"
+    assert "usb" in entry.allowed_transports
 
     metadata_resolver.invalidate()

--- a/root/tests/test_auth_mfa.py
+++ b/root/tests/test_auth_mfa.py
@@ -893,7 +893,9 @@ async def test_webauthn_metadata_resolver_cached_fallback(monkeypatch, tmp_path)
     monkeypatch.setattr(settings, "mfa_webauthn_metadata_cache_file", str(cache_path))
     monkeypatch.setattr(settings, "mfa_webauthn_metadata_cache_ttl_seconds", 3600)
     monkeypatch.setattr(settings, "mfa_webauthn_metadata_json", "")
-    monkeypatch.setattr(settings, "mfa_webauthn_metadata_url", "https://metadata.example")
+    monkeypatch.setattr(
+        settings, "mfa_webauthn_metadata_url", "https://metadata.example"
+    )
 
     payload = {
         "entries": [


### PR DESCRIPTION
## Summary
- add configuration options to persist WebAuthn metadata cache files and control cache TTL
- update the resolver to persist the last successful payload, reload cached data on fetch failures, and improve error logging
- extend MFA tests to cover the cached fallback path

## Testing
- pytest root/tests/test_auth_mfa.py::test_webauthn_metadata_resolver_refresh root/tests/test_auth_mfa.py::test_webauthn_metadata_resolver_cached_fallback

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915459307e48327aeff1d4eca3815ec)