### PR TITLE
Add manifest drift check to CI lint workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,10 +105,14 @@ jobs:
             git diff -- frontend/src/api/generated/schema.ts
             exit 1
           fi
-      - name: Run ESLint and Prettier
+      - name: Run ESLint, manifests check, and Prettier
         working-directory: root/frontend
         run: |
           npm run lint
+          if ! npm run manifests:check; then
+            echo "::error::Generated PWA manifests are not up to date. Run 'npm run generate:manifests' and commit the results."
+            exit 1
+          fi
           npm run format:check
 
   pip-audit:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -12,6 +12,9 @@
   introduce new localized screens.
 - Snapshot updates should reflect the finalized English strings; re-run Vitest
   with `--update` if assertions flag stale output.
+- Run `npm run manifests:check` from `root/frontend` to confirm generated PWA
+  manifests are clean before you push. If it reports drift, regenerate them with
+  `npm run generate:manifests` and include the updated files in your commit.
 
 ## Backend test coverage
 

--- a/root/app/services/webauthn_metadata.py
+++ b/root/app/services/webauthn_metadata.py
@@ -110,7 +110,10 @@ class WebAuthnMetadataResolver:
             cached = self._load_cached_payload()
             if cached is not None:
                 logger.warning(
-                    "Failed to refresh WebAuthn metadata from source; using cached payload (%s)",
+                    (
+                        "Failed to refresh WebAuthn metadata from source; "
+                        "using cached payload (%s)"
+                    ),
                     failure,
                     exc_info=True,
                 )
@@ -118,7 +121,10 @@ class WebAuthnMetadataResolver:
                 used_cache = True
             else:
                 logger.error(
-                    "Failed to refresh WebAuthn metadata and no cached payload is available: %s",
+                    (
+                        "Failed to refresh WebAuthn metadata and no cached "
+                        "payload is available: %s"
+                    ),
                     failure,
                     exc_info=True,
                 )


### PR DESCRIPTION
## Summary
- run the manifest drift check alongside the existing ESLint and Prettier CI step
- annotate manifest drift failures so contributors know to run the generator locally
- mention the manifest verification step in the frontend contributing guide

## Testing
- not run (not needed)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915473e88748327b933fe754e042f70)