### PR TITLE
Fix dark theme flash on reload

### DIFF
--- a/root/frontend/index.html
+++ b/root/frontend/index.html
@@ -37,7 +37,12 @@
           s = localStorage.getItem("theme");
         } catch (e) {}
         var m = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
-        var dark = s ? s === "dark" : m;
+        var dark = m;
+        if (s === "light") {
+          dark = false;
+        } else if (s === "dark") {
+          dark = true;
+        }
         var bg = dark ? "#0b0d11" : "#f4f8fd";
         var html = document.documentElement;
         html.style.backgroundColor = bg;


### PR DESCRIPTION
## Summary
- ensure the static shell honors the saved theme preference when it is set to follow the system scheme
- prevent the initial render from forcing the light background before React hydrates

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915919c74b48327bc5470f751d68e23)