### PR TITLE
Prevent white flash during initial theme load

### DIFF
--- a/root/frontend/index.html
+++ b/root/frontend/index.html
@@ -32,33 +32,46 @@
         document.documentElement.setAttribute("lang", lang);
         window.__UE_SELECTED_LANG__ = lang;
 
-        var s = null;
+        var storedTheme = null;
         try {
-          s = localStorage.getItem("theme");
+          storedTheme = localStorage.getItem("theme");
         } catch (e) {}
-        var m = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
-        var dark = m;
-        if (s === "light") {
+        var prefersDark = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
+        var dark = prefersDark;
+        if (storedTheme === "light") {
           dark = false;
-        } else if (s === "dark") {
+        } else if (storedTheme === "dark") {
           dark = true;
         }
-        var bg = dark ? "#0b0d11" : "#f4f8fd";
+        var bg = dark ? "#060b14" : "#e8f1fb";
         var html = document.documentElement;
         html.style.backgroundColor = bg;
-        if (dark) html.classList.add("dark");
-        document.addEventListener("DOMContentLoaded", function () {
+        html.style.colorScheme = dark ? "dark" : "light";
+        html.classList.toggle("dark", dark);
+        function applyThemeToBody() {
+          if (!document.body) return false;
           document.body.style.backgroundColor = bg;
           document.body.classList.toggle("dark", dark);
-          var r = document.getElementById("root");
-          if (r) r.style.backgroundColor = bg;
-        });
+          var root = document.getElementById("root");
+          if (root) root.style.backgroundColor = bg;
+          return true;
+        }
+        if (!applyThemeToBody()) {
+          document.addEventListener("readystatechange", function onReady() {
+            if (document.readyState !== "loading" && applyThemeToBody()) {
+              document.removeEventListener("readystatechange", onReady);
+            }
+          });
+          document.addEventListener("DOMContentLoaded", applyThemeToBody);
+        }
       })();
     </script>
     <style>
       html, body, #root { min-height: 100vh; min-height: 100svh; min-height: 100dvh; height: auto }
       body { margin: 0; background: inherit; overscroll-behavior-y: none }
       #root { background: inherit }
+      html.dark, html.dark body, html.dark #root { background-color: #060b14 !important; color: #dde6f7 }
+      html:not(.dark), html:not(.dark) body, html:not(.dark) #root { background-color: #e8f1fb; color: #101621 }
       * { scrollbar-width: none; -ms-overflow-style: none }
       *::-webkit-scrollbar { display: none; width: 0; height: 0 }
       html { scrollbar-gutter: stable }
@@ -66,8 +79,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta name="color-scheme" content="light dark" />
-    <meta name="theme-color" media="(prefers-color-scheme: light)" content="#f4f8fd" />
-    <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#0b0d11" />
+    <meta name="theme-color" media="(prefers-color-scheme: light)" content="#e8f1fb" />
+    <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#060b14" />
     <meta
       name="description"
       content="Всё необходимое — профиль, расписание, новости и события кампуса — в одном месте."


### PR DESCRIPTION
## Summary
- align the initial theme detection script with the stored theme colors
- apply the theme classes and colors to the document earlier in the lifecycle to avoid white flashes
- add inline fallbacks and updated theme-color metadata for consistent dark and light backgrounds

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69161073ae888327bf7a24bdf11155f6)