### PR TITLE
Prevent white flash on initial load

### DIFF
--- a/root/frontend/index.html
+++ b/root/frontend/index.html
@@ -67,9 +67,36 @@
       })();
     </script>
     <style>
-      html, body, #root { min-height: 100vh; min-height: 100svh; min-height: 100dvh; height: auto }
-      body { margin: 0; background: inherit; overscroll-behavior-y: none }
-      #root { background: inherit }
+      html {
+        background-color: #060b14;
+        color: #dde6f7;
+        color-scheme: dark;
+      }
+      @media (prefers-color-scheme: light) {
+        html {
+          background-color: #e8f1fb;
+          color: #101621;
+          color-scheme: light;
+        }
+      }
+      html,
+      body,
+      #root {
+        min-height: 100vh;
+        min-height: 100svh;
+        min-height: 100dvh;
+        height: auto;
+      }
+      body {
+        margin: 0;
+        background: inherit;
+        color: inherit;
+        overscroll-behavior-y: none;
+      }
+      #root {
+        background: inherit;
+        color: inherit;
+      }
       html.dark, html.dark body, html.dark #root { background-color: #060b14 !important; color: #dde6f7 }
       html:not(.dark), html:not(.dark) body, html:not(.dark) #root { background-color: #e8f1fb; color: #101621 }
       * { scrollbar-width: none; -ms-overflow-style: none }


### PR DESCRIPTION
## Summary
- pre-apply background and color-scheme styles on the HTML shell using prefers-color-scheme to avoid a white flash before scripts run

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691613d5c80c8327ab345066f2b0a6a8)