### PR TITLE
Fix initial theme flash by pre-seeding color scheme

### DIFF
--- a/root/frontend/index.html
+++ b/root/frontend/index.html
@@ -45,15 +45,24 @@
         }
         var bg = dark ? "#060b14" : "#e8f1fb";
         var html = document.documentElement;
+        var scheme = dark ? "dark" : "light";
         html.style.backgroundColor = bg;
-        html.style.colorScheme = dark ? "dark" : "light";
+        html.style.colorScheme = scheme;
         html.classList.toggle("dark", dark);
+        html.setAttribute("data-color-scheme", scheme);
+        html.setAttribute("data-mui-color-scheme", scheme);
         function applyThemeToBody() {
           if (!document.body) return false;
           document.body.style.backgroundColor = bg;
+          document.body.style.colorScheme = scheme;
           document.body.classList.toggle("dark", dark);
+          document.body.setAttribute("data-color-scheme", scheme);
+          document.body.setAttribute("data-mui-color-scheme", scheme);
           var root = document.getElementById("root");
-          if (root) root.style.backgroundColor = bg;
+          if (root) {
+            root.style.backgroundColor = bg;
+            root.style.colorScheme = scheme;
+          }
           return true;
         }
         if (!applyThemeToBody()) {


### PR DESCRIPTION
## Summary
- add pre-hydration theme detection that sets the color scheme attributes
- ensure the root container inherits the resolved background and color scheme to avoid white flashes

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69162128d168832780e2f078972bd57f)