### PR TITLE
Delete revoked sessions immediately

### DIFF
--- a/docs/DEPLOY.en.md
+++ b/docs/DEPLOY.en.md
@@ -196,6 +196,7 @@ server {
 
 - The API automatically removes stale records from `active_sessions` at startup and then every 15 minutes.
 - Adjust the frequency via `SESSION_CLEANUP_INTERVAL_SECONDS` (minimum 30 seconds). Setting the value to `0` disables the background scheduler; you can run the cleanup manually with `python -m app.services.session_cleanup` inside the container/virtual environment.
+- Session revocations (logout, `/auth/sessions/*`) now delete database rows immediately. Run the cleanup script once after upgrading to purge any previously revoked-but-not-deleted rows so that operator dashboards and the `/auth/sessions` UI stay in sync.
 
 ## MFA challenge cleanup
 

--- a/root/app/api/sessions.py
+++ b/root/app/api/sessions.py
@@ -143,8 +143,6 @@ async def revoke_other_sessions(
     ]
     if current_jti:
         where_parts.append(ActiveSession.jti != current_jti)
-    revoked = await delete_sessions_matching(
-        db=db, whereclause=and_(*where_parts)
-    )
+    revoked = await delete_sessions_matching(db=db, whereclause=and_(*where_parts))
     await db.commit()
     return schemas.SessionBulkRevokeOut(revoked=revoked)

--- a/root/app/api/sessions.py
+++ b/root/app/api/sessions.py
@@ -4,7 +4,7 @@ from datetime import UTC, datetime
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
-from sqlalchemy import select, update
+from sqlalchemy import and_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps import get_current_user, require_fresh_mfa
@@ -14,6 +14,7 @@ from app.localization import resolve_locale, translate
 from app.models.enums import UserRole
 from app.models.models import ActiveSession, User
 from app.schemas import schemas
+from app.services.session_cleanup import delete_sessions_matching
 
 router = APIRouter(prefix="/auth/sessions", tags=["auth"])
 
@@ -109,14 +110,15 @@ async def revoke_session(
     if session.user_id != current_user.id and current_user.role != UserRole.ADMIN.value:
         message = translate("errors.forbidden", locale=locale)
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=message)
-    if session.revoked_at is None:
-        session.revoked_at = datetime.now(UTC)
-        await db.commit()
-        await db.refresh(session)
+    revoked_at = session.revoked_at or datetime.now(UTC)
+    session.revoked_at = revoked_at
     current_jti = _extract_jti(request)
-    return schemas.ActiveSessionOut.model_validate(session).model_copy(
-        update={"is_current": session.jti == current_jti}
+    payload = schemas.ActiveSessionOut.model_validate(session).model_copy(
+        update={"is_current": session.jti == current_jti, "revoked_at": revoked_at}
     )
+    await delete_sessions_matching(db=db, whereclause=(ActiveSession.id == session.id))
+    await db.commit()
+    return payload
 
 
 @router.post("/revoke-others", response_model=schemas.SessionBulkRevokeOut)
@@ -134,17 +136,15 @@ async def revoke_other_sessions(
         requested_user_id=user_id,
         locale=locale,
     )
-    now = datetime.now(UTC)
     current_jti = _extract_jti(request)
-    stmt = (
-        update(ActiveSession)
-        .where(ActiveSession.user_id == target_user_id)
-        .where(ActiveSession.revoked_at.is_(None))
-        .values(revoked_at=now)
-    )
+    where_parts = [
+        ActiveSession.user_id == target_user_id,
+        ActiveSession.revoked_at.is_(None),
+    ]
     if current_jti:
-        stmt = stmt.where(ActiveSession.jti != current_jti)
-    result = await db.execute(stmt)
+        where_parts.append(ActiveSession.jti != current_jti)
+    revoked = await delete_sessions_matching(
+        db=db, whereclause=and_(*where_parts)
+    )
     await db.commit()
-    revoked = int(result.rowcount or 0)
     return schemas.SessionBulkRevokeOut(revoked=revoked)

--- a/root/app/api/users.py
+++ b/root/app/api/users.py
@@ -20,7 +20,7 @@ from fastapi import (
     status,
 )
 from pydantic import EmailStr, TypeAdapter
-from sqlalchemy import func, select, update
+from sqlalchemy import and_, func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import crud
@@ -38,6 +38,7 @@ from app.models.user_loaders import (
 )
 from app.schemas import schemas
 from app.services.notifications import create_notifications_for_users
+from app.services.session_cleanup import delete_sessions_matching
 from app.utils.email import RESET_TOKEN_EXPIRY_MINUTES, send_reset_email
 from app.utils.files import delete_static_file
 from app.utils.ratelimit import sensitive_route_limit
@@ -618,17 +619,13 @@ async def change_password(
         request.state, "active_session", None
     )
     current_session_id = active_session.id if active_session else None
-    now = datetime.now(UTC)
-    stmt = (
-        update(models.ActiveSession)
-        .where(models.ActiveSession.user_id == user.id)
-        .where(models.ActiveSession.revoked_at.is_(None))
-        .values(revoked_at=now)
-    )
+    conditions = [
+        models.ActiveSession.user_id == user.id,
+        models.ActiveSession.revoked_at.is_(None),
+    ]
     if current_session_id is not None:
-        stmt = stmt.where(models.ActiveSession.id != current_session_id)
-    result = await db.execute(stmt)
-    revoked = int(result.rowcount or 0)
+        conditions.append(models.ActiveSession.id != current_session_id)
+    revoked = await delete_sessions_matching(db=db, whereclause=and_(*conditions))
 
     await db.commit()
     await db.refresh(db_user)

--- a/root/app/auth/auth.py
+++ b/root/app/auth/auth.py
@@ -45,6 +45,7 @@ from app.schemas.schemas import (
     UserCreate,
     UserOut,
 )
+from app.services.session_cleanup import delete_sessions_matching
 from app.utils.ratelimit import sensitive_route_limit
 
 logger = logging.getLogger("app.auth")
@@ -1179,9 +1180,12 @@ async def logout(
     if jti:
         res = await db.execute(select(ActiveSession).where(ActiveSession.jti == jti))
         session = res.scalars().first()
-        if session and session.revoked_at is None:
-            session.revoked_at = datetime.now(UTC)
-            session.signing_key = secrets.token_urlsafe(32)
+        if session:
+            revoked_at = session.revoked_at or datetime.now(UTC)
+            session.revoked_at = revoked_at
+            await delete_sessions_matching(
+                db=db, whereclause=(ActiveSession.id == session.id)
+            )
             await db.commit()
             _audit_log(
                 "auth.logout.revoked",

--- a/root/app/services/session_cleanup.py
+++ b/root/app/services/session_cleanup.py
@@ -11,6 +11,7 @@ from datetime import UTC, datetime
 
 from sqlalchemy import delete, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql.elements import ClauseElement
 
 from app.core.database import async_session
 from app.core.observability import get_periodic_task_metrics
@@ -26,27 +27,16 @@ def _now() -> datetime:
     return datetime.now(UTC)
 
 
-async def cleanup_expired_sessions(
-    *, db: AsyncSession | None = None, now: datetime | None = None
+async def delete_sessions_matching(
+    *, db: AsyncSession, whereclause: ClauseElement[bool]
 ) -> int:
-    """Remove sessions where the expiry or revocation timestamp has passed."""
-
-    owns_session = db is None
-    if now is None:
-        now = _now()
-    if owns_session:
-        async with async_session() as session:
-            return await cleanup_expired_sessions(db=session, now=now)
-
-    expiry_condition = or_(
-        ActiveSession.expires_at <= now, ActiveSession.revoked_at <= now
-    )
+    """Delete sessions (and their MFA challenges) matching *whereclause*."""
 
     bind = db.get_bind()
     dialect = bind.dialect
 
     if dialect.name == "sqlite":
-        subquery = select(ActiveSession.id).where(expiry_condition)
+        subquery = select(ActiveSession.id).where(whereclause)
         challenge_delete_stmt = delete(MfaChallenge).where(
             MfaChallenge.session_id.in_(subquery)
         )
@@ -54,12 +44,12 @@ async def cleanup_expired_sessions(
         challenge_delete_stmt = (
             delete(MfaChallenge)
             .where(MfaChallenge.session_id == ActiveSession.id)
-            .where(expiry_condition)
+            .where(whereclause)
             .execution_options(synchronize_session=False)
         )
     await db.execute(challenge_delete_stmt)
 
-    delete_stmt = delete(ActiveSession).where(expiry_condition)
+    delete_stmt = delete(ActiveSession).where(whereclause)
     supports_returning = bool(getattr(dialect, "delete_returning", False))
     supports_rowcount_returning = bool(
         getattr(dialect, "supports_sane_rowcount_returning", False)
@@ -79,6 +69,26 @@ async def cleanup_expired_sessions(
     else:
         delete_result = await db.execute(delete_stmt)
         deleted = int(delete_result.rowcount or 0)
+    return deleted
+
+
+async def cleanup_expired_sessions(
+    *, db: AsyncSession | None = None, now: datetime | None = None
+) -> int:
+    """Remove sessions where the expiry or revocation timestamp has passed."""
+
+    owns_session = db is None
+    if now is None:
+        now = _now()
+    if owns_session:
+        async with async_session() as session:
+            return await cleanup_expired_sessions(db=session, now=now)
+
+    expiry_condition = or_(
+        ActiveSession.expires_at <= now, ActiveSession.revoked_at <= now
+    )
+
+    deleted = await delete_sessions_matching(db=db, whereclause=expiry_condition)
     await db.commit()
     if deleted:
         logger.info("Removed %s expired sessions", deleted)

--- a/root/tests/test_sessions_api.py
+++ b/root/tests/test_sessions_api.py
@@ -3,6 +3,7 @@ from datetime import UTC, datetime, timedelta
 import pytest
 from fastapi import status
 from httpx import AsyncClient
+from sqlalchemy import select
 
 from app.auth.security import get_password_hash
 from app.models.models import ActiveSession
@@ -137,7 +138,7 @@ async def test_non_admin_cannot_list_sessions_for_other_user(
 
 
 @pytest.mark.anyio
-async def test_revoke_session_marks_revoked(
+async def test_revoke_session_removes_from_listing(
     async_client: AsyncClient,
     user_factory,
     db_session,
@@ -157,6 +158,10 @@ async def test_revoke_session_marks_revoked(
 
     headers = await _login(async_client, email=user.email, password=password)
 
+    response = await async_client.get("/auth/sessions", headers=headers)
+    assert response.status_code == 200
+    assert len(response.json()) == 2
+
     response = await async_client.delete(
         f"/auth/sessions/{other_session.id}", headers=headers
     )
@@ -165,8 +170,16 @@ async def test_revoke_session_marks_revoked(
     assert body["revoked_at"] is not None
     assert body["is_current"] is False
 
-    await db_session.refresh(other_session)
-    assert other_session.revoked_at is not None
+    listing = await async_client.get("/auth/sessions", headers=headers)
+    assert listing.status_code == 200
+    sessions = listing.json()
+    assert len(sessions) == 1
+    assert all(entry["jti"] != "revocable" for entry in sessions)
+
+    deleted = await db_session.execute(
+        select(ActiveSession.id).where(ActiveSession.id == other_session.id)
+    )
+    assert deleted.scalars().first() is None
 
 
 @pytest.mark.anyio
@@ -195,6 +208,44 @@ async def test_admin_can_revoke_foreign_session(
     response = await async_client.delete(f"/auth/sessions/{doomed.id}", headers=headers)
     assert response.status_code == 200
     assert response.json()["revoked_at"] is not None
+
+    deleted = await db_session.execute(
+        select(ActiveSession.id).where(ActiveSession.id == doomed.id)
+    )
+    assert deleted.scalars().first() is None
+
+
+@pytest.mark.anyio
+async def test_logout_removes_session_immediately(
+    async_client: AsyncClient,
+    user_factory,
+    db_session,
+):
+    password = "Logout123!"
+    user = await user_factory(
+        email="logout@example.com", hashed_password=get_password_hash(password)
+    )
+
+    headers = await _login(async_client, email=user.email, password=password)
+
+    response = await async_client.get("/auth/sessions", headers=headers)
+    assert response.status_code == 200
+    assert len(response.json()) == 1
+
+    logout_response = await async_client.post("/auth/logout", headers=headers)
+    assert logout_response.status_code == 200
+
+    remaining = await db_session.execute(
+        select(ActiveSession.id).where(ActiveSession.user_id == user.id)
+    )
+    assert remaining.scalars().all() == []
+
+    new_headers = await _login(async_client, email=user.email, password=password)
+    refreshed = await async_client.get("/auth/sessions", headers=new_headers)
+    assert refreshed.status_code == 200
+    refreshed_sessions = refreshed.json()
+    assert len(refreshed_sessions) == 1
+    assert refreshed_sessions[0]["is_current"] is True
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- add a shared helper that deletes sessions and their MFA challenges, and reuse it from the cleanup task
- delete sessions immediately when logout/session management/password-change flows revoke them and update the docs accordingly
- extend the session API tests to cover the new behavior and ensure the listings drop revoked sessions

## Testing
- `pytest root/tests/test_sessions_api.py root/tests/test_session_cleanup.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919f23ba8248327bf866193a37c5bcd)