### PR TITLE
Improve MFA QR code contrast in dark mode

### DIFF
--- a/root/frontend/src/components/mfa/TotpQrDisplay.tsx
+++ b/root/frontend/src/components/mfa/TotpQrDisplay.tsx
@@ -38,8 +38,14 @@ export const TotpQrDisplay = ({ otpauthUrl, secret, label }: TotpQrDisplayProps)
       {label ? (
         <p className="text-sm text-page-text/70">{t("mfa.totp.accountLabel", { label })}</p>
       ) : null}
-      <div className="p-4 rounded-lg border border-glass-border bg-card">
-        <QRCodeSVG value={otpauthUrl} size={192} />
+      <div className="p-4 rounded-lg border border-glass-border bg-white shadow-sm dark:bg-white">
+        <QRCodeSVG
+          value={otpauthUrl}
+          size={192}
+          includeMargin
+          bgColor="#ffffff"
+          fgColor="#111827"
+        />
       </div>
       <div className="flex flex-row items-center gap-2 w-full max-w-[320px]">
         <div className="relative flex-1">


### PR DESCRIPTION
## Summary
- ensure the TOTP QR block always uses a neutral white background and subtle shadow so it stays readable when the rest of the UI is dark
- explicitly set the QR code colors and include an internal margin to maximize scan contrast for authenticator apps

## Testing
- npm run lint -- src/components/mfa/TotpQrDisplay.tsx

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a62cf230c83279531de23a3b441a0)