### PR TITLE
Require MFA challenge when TOTP is enrolled

### DIFF
--- a/root/app/auth/auth.py
+++ b/root/app/auth/auth.py
@@ -608,9 +608,7 @@ async def _perform_login(
 
     capabilities = await _resolve_mfa_capabilities(db, user=user)
     available_methods = [method for method, enabled in capabilities.items() if enabled]
-    require_mfa = bool(available_methods) and (
-        bool(settings.mfa_enabled) or bool(user.mfa_required)
-    )
+    require_mfa = bool(available_methods) or bool(user.mfa_required)
     if user.mfa_required and not available_methods:
         _audit_log(
             "auth.login.mfa_missing",


### PR DESCRIPTION
## Summary
- always trigger the MFA flow during login whenever a user has an active TOTP enrollment, even if global MFA toggles are off

## Testing
- `pytest tests/test_auth_mfa.py::test_totp_login_requires_mfa_even_when_toggle_disabled`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a70fb4eac83279d9ce32f2bc28fea)