### PR TITLE
Restore MFA challenges for legacy TOTP enrollments

### DIFF
--- a/root/app/auth/auth.py
+++ b/root/app/auth/auth.py
@@ -235,6 +235,16 @@ async def _resolve_mfa_capabilities(db: AsyncSession, *, user: User) -> dict[str
         .limit(1)
     )
     totp_available = bool((await db.execute(totp_stmt)).scalars().first())
+    if not totp_available and user.mfa_default_method == mfa.MFA_METHOD_TOTP:
+        legacy_stmt = (
+            select(MfaTotpEnrollment.id)
+            .where(MfaTotpEnrollment.user_id == user.id)
+            .where(MfaTotpEnrollment.is_active.is_(True))
+            .where(MfaTotpEnrollment.revoked_at.is_(None))
+            .where(MfaTotpEnrollment.confirmed_at.is_(None))
+            .limit(1)
+        )
+        totp_available = bool((await db.execute(legacy_stmt)).scalars().first())
     return {mfa.MFA_METHOD_TOTP: totp_available}
 
 
@@ -606,6 +616,9 @@ async def _perform_login(
     if new_hash:
         await db.refresh(user)
 
+    refreshed_user = await ensure_mfa_relationships_loaded(db, user)
+    if refreshed_user is not None:
+        user = refreshed_user
     capabilities = await _resolve_mfa_capabilities(db, user=user)
     available_methods = [method for method, enabled in capabilities.items() if enabled]
     require_mfa = bool(available_methods) or bool(user.mfa_required)

--- a/root/app/auth/mfa.py
+++ b/root/app/auth/mfa.py
@@ -553,6 +553,16 @@ async def verify_totp_for_user(
     )
     result = await db.execute(stmt)
     enrollments = list(result.scalars())
+    if not enrollments and user.mfa_default_method == MFA_METHOD_TOTP:
+        legacy_stmt = (
+            select(MfaTotpEnrollment)
+            .where(MfaTotpEnrollment.user_id == user.id)
+            .where(MfaTotpEnrollment.is_active.is_(True))
+            .where(MfaTotpEnrollment.revoked_at.is_(None))
+            .where(MfaTotpEnrollment.confirmed_at.is_(None))
+        )
+        legacy_result = await db.execute(legacy_stmt)
+        enrollments = list(legacy_result.scalars())
     if not enrollments:
         raise HTTPException(status.HTTP_400_BAD_REQUEST, "No active TOTP enrollment")
     loaded_challenge = challenge

--- a/root/tests/test_auth_mfa.py
+++ b/root/tests/test_auth_mfa.py
@@ -218,6 +218,7 @@ async def test_totp_login_handles_legacy_records_without_confirmed_at(
     )
     assert verify.status_code == status.HTTP_200_OK
 
+
 @pytest.mark.anyio
 async def test_totp_challenge_expiry_blocks_verification(
     async_client, user_factory, db_session

--- a/root/tests/test_auth_mfa.py
+++ b/root/tests/test_auth_mfa.py
@@ -176,6 +176,49 @@ async def test_totp_login_requires_mfa_even_when_toggle_disabled(
 
 
 @pytest.mark.anyio
+async def test_totp_login_handles_legacy_records_without_confirmed_at(
+    async_client, user_factory, db_session
+):
+    password = "TotpLegacy123!"
+    user = await user_factory(
+        email="mfa-legacy@example.com",
+        hashed_password=get_password_hash(password),
+    )
+
+    secret = await _enroll_totp(async_client, user, password, db_session)
+
+    result = await db_session.execute(
+        select(models.MfaTotpEnrollment)
+        .where(models.MfaTotpEnrollment.user_id == user.id)
+        .limit(1)
+    )
+    enrollment = result.scalars().first()
+    assert enrollment is not None
+    enrollment.confirmed_at = None
+    user.mfa_required = False
+    await db_session.commit()
+
+    pending_response = await async_client.post(
+        "/auth/login",
+        data={"username": user.email, "password": password},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert pending_response.status_code == status.HTTP_202_ACCEPTED
+    pending = pending_response.json()
+    totp_method = _get_method_entry(pending, mfa.MFA_METHOD_TOTP)
+
+    totp = pyotp.TOTP(secret)
+    verify = await async_client.post(
+        "/auth/mfa/verify",
+        json={
+            "method": mfa.MFA_METHOD_TOTP,
+            "challenge_token": totp_method["challenge_token"],
+            "code": totp.now(),
+        },
+    )
+    assert verify.status_code == status.HTTP_200_OK
+
+@pytest.mark.anyio
 async def test_totp_challenge_expiry_blocks_verification(
     async_client, user_factory, db_session
 ):


### PR DESCRIPTION
## Summary
- refresh a user's MFA relationships before computing login capabilities
- treat legacy authenticator enrollments that lack `confirmed_at` as valid when the account's default method is TOTP so logins still receive a challenge
- allow MFA verification to consume those legacy factors and add a regression test covering the flow

## Testing
- pytest tests/test_auth_mfa.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a75a241bc8327b5a50a9f54ec8b35)