### PR TITLE
Ensure pending TOTP enrollments stay inactive

### DIFF
--- a/root/alembic/versions/202509240001_mark_pending_totp_inactive.py
+++ b/root/alembic/versions/202509240001_mark_pending_totp_inactive.py
@@ -1,6 +1,7 @@
 from collections.abc import Sequence
 
 import sqlalchemy as sa
+
 from alembic import op
 
 revision: str = "202509240001"

--- a/root/alembic/versions/202509240001_mark_pending_totp_inactive.py
+++ b/root/alembic/versions/202509240001_mark_pending_totp_inactive.py
@@ -1,0 +1,65 @@
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "202509240001"
+down_revision: str | None = "202509230001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE_NAME = "mfa_totp_enrollments"
+
+
+def _table_exists(inspector) -> bool:
+    return _TABLE_NAME in inspector.get_table_names()
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if not _table_exists(inspector):
+        return
+
+    op.execute(
+        sa.text(
+            f"""
+            UPDATE {_TABLE_NAME}
+            SET is_active = FALSE
+            WHERE confirmed_at IS NULL AND is_active = TRUE
+            """
+        )
+    )
+
+    op.alter_column(
+        _TABLE_NAME,
+        "is_active",
+        existing_type=sa.Boolean(),
+        existing_nullable=False,
+        server_default=sa.false(),
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if not _table_exists(inspector):
+        return
+
+    op.alter_column(
+        _TABLE_NAME,
+        "is_active",
+        existing_type=sa.Boolean(),
+        existing_nullable=False,
+        server_default=sa.true(),
+    )
+
+    op.execute(
+        sa.text(
+            f"""
+            UPDATE {_TABLE_NAME}
+            SET is_active = TRUE
+            WHERE confirmed_at IS NULL AND is_active = FALSE
+            """
+        )
+    )

--- a/root/app/api/users.py
+++ b/root/app/api/users.py
@@ -830,6 +830,7 @@ async def get_user_mfa_methods(
         select(models.MfaTotpEnrollment)
         .where(models.MfaTotpEnrollment.user_id == user_id)
         .where(models.MfaTotpEnrollment.is_active.is_(True))
+        .where(models.MfaTotpEnrollment.confirmed_at.is_not(None))
         .order_by(models.MfaTotpEnrollment.created_at)
     )
     recovery_rows = await db.execute(

--- a/root/app/auth/auth.py
+++ b/root/app/auth/auth.py
@@ -806,6 +806,7 @@ async def list_totp_enrollments(
     stmt = (
         select(MfaTotpEnrollment)
         .where(MfaTotpEnrollment.user_id == user.id)
+        .where(MfaTotpEnrollment.confirmed_at.is_not(None))
         .order_by(MfaTotpEnrollment.created_at.desc())
     )
     result = await db.execute(stmt)

--- a/root/app/auth/mfa.py
+++ b/root/app/auth/mfa.py
@@ -468,7 +468,7 @@ async def start_totp_enrollment(
         user_id=user.id,
         secret=secret,
         label=label or user.email,
-        is_active=True,
+        is_active=False,
     )
     db.add(enrollment)
     await db.flush()

--- a/root/app/models/models.py
+++ b/root/app/models/models.py
@@ -253,7 +253,7 @@ class MfaTotpEnrollment(Base):
     )
     secret = Column(EncryptedString(), nullable=False)
     label = Column(String(255))
-    is_active = Column(Boolean, nullable=False, default=True, index=True)
+    is_active = Column(Boolean, nullable=False, default=False, index=True)
     confirmed_at = Column(DateTime(timezone=True), nullable=True, index=True)
     revoked_at = Column(DateTime(timezone=True), nullable=True, index=True)
     created_at = Column(

--- a/root/tests/test_auth_mfa.py
+++ b/root/tests/test_auth_mfa.py
@@ -63,6 +63,46 @@ async def _enroll_totp(async_client, user, password: str, db_session) -> str:
     return secret
 
 
+@pytest.mark.anyio
+async def test_totp_enrollment_pending_state(async_client, user_factory, db_session):
+    password = "PendingTotp123!"
+    user = await user_factory(
+        email="mfa-pending@example.com",
+        hashed_password=get_password_hash(password),
+    )
+
+    token = await _login_for_token(async_client, user.email, password)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    start_response = await async_client.post("/auth/mfa/totp/start", headers=headers)
+    assert start_response.status_code == status.HTTP_200_OK, start_response.text
+    start_payload = start_response.json()
+    assert start_payload["enrollment"]["is_active"] is False
+    assert start_payload["enrollment"]["confirmed_at"] is None
+
+    list_response = await async_client.get("/auth/mfa/totp", headers=headers)
+    assert list_response.status_code == status.HTTP_200_OK
+    assert list_response.json() == []
+
+    totp = pyotp.TOTP(start_payload["secret"])
+    confirm_response = await async_client.post(
+        "/auth/mfa/totp/confirm",
+        headers=headers,
+        json={
+            "enrollment_id": start_payload["enrollment"]["id"],
+            "code": totp.now(),
+        },
+    )
+    assert confirm_response.status_code == status.HTTP_200_OK, confirm_response.text
+
+    list_after_confirm = await async_client.get("/auth/mfa/totp", headers=headers)
+    assert list_after_confirm.status_code == status.HTTP_200_OK
+    rows = list_after_confirm.json()
+    assert len(rows) == 1
+    assert rows[0]["is_active"] is True
+    assert rows[0]["confirmed_at"] is not None
+
+
 def _find_audit_event(caplog, logger_name: str, event: str) -> dict:
     for record in caplog.records:
         if record.name != logger_name:


### PR DESCRIPTION
## Summary
- mark new TOTP enrollments as inactive until the verification code is confirmed and only list confirmed enrollments through the auth and admin APIs
- add a migration to flip existing unconfirmed enrollments to inactive and change the default going forward
- extend MFA tests to cover the pending state so clients can distinguish pending vs confirmed enrollments

## Testing
- pytest root/tests/test_auth_mfa.py::test_totp_enrollment_pending_state


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a7fb6aebc8327b24d0325cce5e44d)