### PR TITLE
Improve TOTP enrollment handling

### DIFF
--- a/root/app/auth/auth.py
+++ b/root/app/auth/auth.py
@@ -78,6 +78,7 @@ class PendingMfaResponse(BaseModel):
 
 class TotpEnrollmentStartIn(BaseModel):
     label: str | None = None
+    reuse_existing: bool | None = False
 
 
 class TotpEnrollmentStartOut(BaseModel):
@@ -741,10 +742,12 @@ async def start_totp_enrollment_endpoint(
     db: AsyncSession = Depends(get_db),
 ):
     label = payload.label if payload else None
+    reuse_existing = bool(payload.reuse_existing) if payload else False
     enrollment, secret, otpauth_url = await mfa.start_totp_enrollment(
         db,
         user=user,
         label=label,
+        reuse_existing=reuse_existing,
     )
     await db.commit()
     await db.refresh(enrollment)

--- a/root/app/auth/mfa.py
+++ b/root/app/auth/mfa.py
@@ -14,7 +14,7 @@ from typing import Any
 
 import pyotp
 from fastapi import HTTPException, status
-from sqlalchemy import delete, or_, select
+from sqlalchemy import delete, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
@@ -36,6 +36,14 @@ _RECOVERY_CODE_COUNT = 10
 _TOTP_SECRET_LENGTH = 32
 _TOTP_VALID_WINDOW = settings.mfa_totp_initial_skew_windows
 _TOTP_DIGITS = 6
+_MAX_ACTIVE_TOTP_ENROLLMENTS = 5
+
+TOTP_ENROLLMENT_PENDING_ERROR = (
+    "A TOTP enrollment is already pending. Confirm or reuse it before starting a new one."
+)
+TOTP_ENROLLMENT_LIMIT_ERROR = (
+    "You have reached the maximum number of active TOTP enrollments."
+)
 
 CHALLENGE_TYPE_TOTP_ENROLL = "totp-enroll"
 CHALLENGE_TYPE_TOTP_VERIFY = "totp-verify"
@@ -462,7 +470,39 @@ async def start_totp_enrollment(
     *,
     user: User,
     label: str | None = None,
+    reuse_existing: bool = False,
 ) -> tuple[MfaTotpEnrollment, str, str]:
+    pending_stmt = (
+        select(MfaTotpEnrollment)
+        .where(MfaTotpEnrollment.user_id == user.id)
+        .where(MfaTotpEnrollment.confirmed_at.is_(None))
+        .where(MfaTotpEnrollment.revoked_at.is_(None))
+        .order_by(MfaTotpEnrollment.created_at.desc())
+    )
+    result = await db.execute(pending_stmt)
+    pending = result.scalars().first()
+    if pending:
+        if not reuse_existing:
+            raise HTTPException(
+                status.HTTP_400_BAD_REQUEST, TOTP_ENROLLMENT_PENDING_ERROR
+            )
+        if label and label != pending.label:
+            pending.label = label
+            await db.flush()
+        account_name = label or pending.label or user.email
+        otpauth_url = build_totp_uri(pending.secret, account_name=account_name)
+        return pending, pending.secret, otpauth_url
+
+    count_stmt = (
+        select(func.count())
+        .select_from(MfaTotpEnrollment)
+        .where(MfaTotpEnrollment.user_id == user.id)
+        .where(MfaTotpEnrollment.revoked_at.is_(None))
+    )
+    active_count = await db.scalar(count_stmt)
+    if active_count and active_count >= _MAX_ACTIVE_TOTP_ENROLLMENTS:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, TOTP_ENROLLMENT_LIMIT_ERROR)
+
     secret = create_totp_secret()
     enrollment = MfaTotpEnrollment(
         user_id=user.id,

--- a/root/app/auth/mfa.py
+++ b/root/app/auth/mfa.py
@@ -38,9 +38,7 @@ _TOTP_VALID_WINDOW = settings.mfa_totp_initial_skew_windows
 _TOTP_DIGITS = 6
 _MAX_ACTIVE_TOTP_ENROLLMENTS = 5
 
-TOTP_ENROLLMENT_PENDING_ERROR = (
-    "A TOTP enrollment is already pending. Confirm or reuse it before starting a new one."
-)
+TOTP_ENROLLMENT_PENDING_ERROR = "A TOTP enrollment is already pending. Confirm or reuse it before starting a new one."
 TOTP_ENROLLMENT_LIMIT_ERROR = (
     "You have reached the maximum number of active TOTP enrollments."
 )

--- a/root/frontend/src/api/generated/schema.ts
+++ b/root/frontend/src/api/generated/schema.ts
@@ -2466,6 +2466,8 @@ export interface components {
     TotpEnrollmentStartIn: {
       /** Label */
       label?: string | null
+      /** Reuse Existing */
+      reuse_existing?: boolean | null
     }
     /** TotpEnrollmentStartOut */
     TotpEnrollmentStartOut: {

--- a/root/frontend/src/pages/Settings.tsx
+++ b/root/frontend/src/pages/Settings.tsx
@@ -1839,14 +1839,19 @@ export default function Settings() {
       const { data } = await startTotpEnrollment()
       setTotpDraft(data)
     } catch (error) {
+      const message = resolveDetailMessage(
+        error,
+        t("settings:security.snackbar.totpStartFailed")
+      )
+      setTotpError(message)
       setSnack({
-        text: resolveDetailMessage(error, t("settings:security.snackbar.totpStartFailed")),
+        text: message,
         sev: "error",
       })
     } finally {
       setTotpBusy(false)
     }
-  }, [resolveDetailMessage, setSnack, t, totpBusy])
+  }, [resolveDetailMessage, setSnack, setTotpError, t, totpBusy])
 
   const handleConfirmTotp = useCallback(
     async (code: string) => {
@@ -2743,6 +2748,11 @@ export default function Settings() {
                                 {t("settings:security.totp.empty")}
                               </SectionSubtitle>
                             )}
+                            {totpError ? (
+                              <Alert severity="error" variant="outlined">
+                                {totpError}
+                              </Alert>
+                            ) : null}
                             <Button
                               variant="contained"
                               onClick={() => void handleStartTotp()}

--- a/root/tests/test_auth_mfa.py
+++ b/root/tests/test_auth_mfa.py
@@ -103,6 +103,52 @@ async def test_totp_enrollment_pending_state(async_client, user_factory, db_sess
     assert rows[0]["confirmed_at"] is not None
 
 
+@pytest.mark.anyio
+async def test_totp_start_requires_reuse(async_client, user_factory):
+    password = "TotpReuseRequired123!"
+    user = await user_factory(
+        email="mfa-totp-reuse-required@example.com",
+        hashed_password=get_password_hash(password),
+    )
+
+    token = await _login_for_token(async_client, user.email, password)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    first_start = await async_client.post("/auth/mfa/totp/start", headers=headers)
+    assert first_start.status_code == status.HTTP_200_OK, first_start.text
+
+    second_start = await async_client.post("/auth/mfa/totp/start", headers=headers)
+    assert second_start.status_code == status.HTTP_400_BAD_REQUEST
+    assert second_start.json()["detail"] == mfa.TOTP_ENROLLMENT_PENDING_ERROR
+
+
+@pytest.mark.anyio
+async def test_totp_start_reuse_returns_same_secret(async_client, user_factory):
+    password = "TotpReuseSameSecret123!"
+    user = await user_factory(
+        email="mfa-totp-reuse@example.com",
+        hashed_password=get_password_hash(password),
+    )
+
+    token = await _login_for_token(async_client, user.email, password)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    first_start = await async_client.post("/auth/mfa/totp/start", headers=headers)
+    assert first_start.status_code == status.HTTP_200_OK, first_start.text
+    first_payload = first_start.json()
+
+    reuse_response = await async_client.post(
+        "/auth/mfa/totp/start",
+        headers=headers,
+        json={"reuse_existing": True},
+    )
+    assert reuse_response.status_code == status.HTTP_200_OK, reuse_response.text
+    reuse_payload = reuse_response.json()
+
+    assert reuse_payload["secret"] == first_payload["secret"]
+    assert reuse_payload["enrollment"]["id"] == first_payload["enrollment"]["id"]
+
+
 def _find_audit_event(caplog, logger_name: str, event: str) -> dict:
     for record in caplog.records:
         if record.name != logger_name:


### PR DESCRIPTION
## Summary
- prevent duplicate or excessive TOTP enrollments by reusing pending records when requested and limiting active factors
- expose the new reuse option through the API schema and surface the backend validation error inside the settings UI
- add regression tests that cover the duplicate-start failure and the reuse-success flow

## Testing
- pytest root/tests/test_auth_mfa.py -k "totp_start" -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b36aaa4308327b0d970d20e900423)