### PR TITLE
Require MFA step-up before enrolling additional authenticators

### DIFF
--- a/docs/manual-mfa-checklist.md
+++ b/docs/manual-mfa-checklist.md
@@ -8,6 +8,14 @@ Use this checklist to validate the end-to-end TOTP-only multi-factor authenticat
 3. Click **Set up authenticator app** and scan the QR code with an authenticator app.
 4. Enter the generated 6-digit code and confirm setup.
 5. Verify that the enrollment list now shows the authenticator with a timestamp and that the warning banner disappears.
+6. (New) Sign out and back in so the session reflects the new factor; verify that the default method is displayed as TOTP in the UI.
+
+## 1b. Adding an additional authenticator
+1. Sign back in with an account that already has a confirmed TOTP device.
+2. Navigate to **Settings → Security & MFA** and click **Set up authenticator app** again.
+3. Confirm that a **Step up verification** dialog appears instead of the QR code.
+4. Complete the step-up challenge using the existing authenticator.
+5. Verify that the QR code is displayed only after the challenge succeeds and that cancelling the dialog keeps the user on the security page without creating a new enrollment.
 
 ## 2. Login verification
 1. Sign out of the account.

--- a/root/app/api/deps.py
+++ b/root/app/api/deps.py
@@ -6,6 +6,7 @@ from fastapi.security import OAuth2PasswordBearer
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.auth import mfa
 from app.auth.security import decode_token
 from app.core.config import settings
 from app.core.database import get_db
@@ -74,10 +75,7 @@ async def get_current_user(
     return user
 
 
-def require_fresh_mfa(
-    request: Request,
-    _: Annotated[User, Depends(get_current_user)],
-) -> None:
+def _enforce_fresh_mfa(request: Request) -> None:
     session: ActiveSession | None = getattr(request.state, "active_session", None)
     locale = resolve_locale(request=request)
     if session is None:
@@ -112,3 +110,19 @@ def require_fresh_mfa(
                 "session_id": session.id,
             },
         )
+
+
+def require_fresh_mfa(
+    request: Request,
+    _: Annotated[User, Depends(get_current_user)],
+) -> None:
+    _enforce_fresh_mfa(request)
+
+
+def require_fresh_mfa_for_enrollment(
+    request: Request,
+    user: Annotated[User, Depends(get_current_user)],
+) -> None:
+    if not mfa.user_has_confirmed_interactive_factor(user):
+        return
+    _enforce_fresh_mfa(request)

--- a/root/app/auth/auth.py
+++ b/root/app/auth/auth.py
@@ -16,7 +16,11 @@ from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import crud
-from app.api.deps import get_current_user, require_fresh_mfa
+from app.api.deps import (
+    get_current_user,
+    require_fresh_mfa,
+    require_fresh_mfa_for_enrollment,
+)
 from app.api.users import _attach_pending_email
 from app.auth import mfa
 from app.auth.security import (
@@ -734,7 +738,11 @@ async def login_json(
     )
 
 
-@router.post("/mfa/totp/start", response_model=TotpEnrollmentStartOut)
+@router.post(
+    "/mfa/totp/start",
+    response_model=TotpEnrollmentStartOut,
+    dependencies=[Depends(require_fresh_mfa_for_enrollment)],
+)
 async def start_totp_enrollment_endpoint(
     request: Request,
     payload: TotpEnrollmentStartIn | None = None,
@@ -765,7 +773,11 @@ async def start_totp_enrollment_endpoint(
     )
 
 
-@router.post("/mfa/totp/confirm", response_model=MfaTotpEnrollmentOut)
+@router.post(
+    "/mfa/totp/confirm",
+    response_model=MfaTotpEnrollmentOut,
+    dependencies=[Depends(require_fresh_mfa_for_enrollment)],
+)
 async def confirm_totp_enrollment(
     payload: TotpEnrollmentConfirmIn,
     request: Request,

--- a/root/app/auth/mfa.py
+++ b/root/app/auth/mfa.py
@@ -80,6 +80,20 @@ def _utcnow() -> datetime:
     return datetime.now(UTC)
 
 
+def user_has_confirmed_interactive_factor(user: User) -> bool:
+    """Return True if the user has at least one confirmed interactive factor."""
+
+    if user.mfa_default_method:
+        return True
+    enrollments = getattr(user, "totp_enrollments", None)
+    if not enrollments:
+        return False
+    for enrollment in enrollments:
+        if enrollment.revoked_at is None and enrollment.confirmed_at is not None:
+            return True
+    return False
+
+
 def _base64url_encode(data: bytes) -> str:
     encoded = base64.urlsafe_b64encode(data).decode("utf-8")
     return encoded.rstrip("=")

--- a/root/frontend/src/pages/Settings.tsx
+++ b/root/frontend/src/pages/Settings.tsx
@@ -1847,24 +1847,44 @@ export default function Settings() {
     ]
   )
 
-  const handleStartTotp = useCallback(async () => {
-    if (totpBusy) return
-    setTotpBusy(true)
-    setTotpError(null)
-    try {
-      const { data } = await startTotpEnrollment()
-      setTotpDraft(data)
-    } catch (error) {
-      const message = resolveDetailMessage(error, t("settings:security.snackbar.totpStartFailed"))
-      setTotpError(message)
-      setSnack({
-        text: message,
-        sev: "error",
-      })
-    } finally {
-      setTotpBusy(false)
-    }
-  }, [resolveDetailMessage, setSnack, setTotpError, t, totpBusy])
+  const handleStartTotp = useCallback(
+    async (options?: { skipStepUp?: boolean }) => {
+      if (totpBusy) return
+      setTotpBusy(true)
+      setTotpError(null)
+      try {
+        const { data } = await startTotpEnrollment()
+        setTotpDraft(data)
+      } catch (error) {
+        if (!options?.skipStepUp && isStepUpError(error)) {
+          openStepUpFor(async () => {
+            await handleStartTotp({ skipStepUp: true })
+          })
+          return
+        }
+        const message = resolveDetailMessage(
+          error,
+          t("settings:security.snackbar.totpStartFailed"),
+        )
+        setTotpError(message)
+        setSnack({
+          text: message,
+          sev: "error",
+        })
+      } finally {
+        setTotpBusy(false)
+      }
+    },
+    [
+      isStepUpError,
+      openStepUpFor,
+      resolveDetailMessage,
+      setSnack,
+      setTotpError,
+      t,
+      totpBusy,
+    ],
+  )
 
   const handleConfirmTotp = useCallback(
     async (code: string) => {

--- a/root/tests/test_auth_mfa.py
+++ b/root/tests/test_auth_mfa.py
@@ -312,6 +312,7 @@ async def test_totp_confirm_requires_step_up_when_session_stale(
     detail = confirm_second.json().get("detail", {})
     assert detail.get("error") == "mfa_step_up_required"
 
+
 def _find_audit_event(caplog, logger_name: str, event: str) -> dict:
     for record in caplog.records:
         if record.name != logger_name:

--- a/root/tests/test_auth_mfa.py
+++ b/root/tests/test_auth_mfa.py
@@ -213,6 +213,105 @@ async def test_pending_totp_enrollment_cancel_rejected_for_confirmed(
     assert cancel_response.json()["detail"] == "Enrollment is not pending"
 
 
+@pytest.mark.anyio
+async def test_totp_start_requires_step_up_for_existing_factor(
+    async_client, user_factory, db_session
+):
+    password = "TotpStepUpStart123!"
+    user = await user_factory(
+        email="mfa-stepup-start@example.com",
+        hashed_password=get_password_hash(password),
+    )
+
+    token = await _login_for_token(async_client, user.email, password)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    start_response = await async_client.post("/auth/mfa/totp/start", headers=headers)
+    assert start_response.status_code == status.HTTP_200_OK, start_response.text
+    start_payload = start_response.json()
+    totp = pyotp.TOTP(start_payload["secret"])
+    confirm_response = await async_client.post(
+        "/auth/mfa/totp/confirm",
+        headers=headers,
+        json={
+            "enrollment_id": start_payload["enrollment"]["id"],
+            "code": totp.now(),
+        },
+    )
+    assert confirm_response.status_code == status.HTTP_200_OK, confirm_response.text
+    await db_session.refresh(user)
+    assert user.mfa_default_method == mfa.MFA_METHOD_TOTP
+
+    result = await db_session.execute(
+        select(models.ActiveSession)
+        .where(models.ActiveSession.user_id == user.id)
+        .order_by(models.ActiveSession.id.desc())
+    )
+    session = result.scalars().first()
+    assert session is not None
+    session.mfa_verified_at = None
+    await db_session.commit()
+
+    second_start = await async_client.post("/auth/mfa/totp/start", headers=headers)
+    assert second_start.status_code == status.HTTP_428_PRECONDITION_REQUIRED
+    detail = second_start.json().get("detail", {})
+    assert detail.get("error") == "mfa_step_up_required"
+
+
+@pytest.mark.anyio
+async def test_totp_confirm_requires_step_up_when_session_stale(
+    async_client, user_factory, db_session
+):
+    password = "TotpStepUpConfirm123!"
+    user = await user_factory(
+        email="mfa-stepup-confirm@example.com",
+        hashed_password=get_password_hash(password),
+    )
+
+    token = await _login_for_token(async_client, user.email, password)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    start_response = await async_client.post("/auth/mfa/totp/start", headers=headers)
+    assert start_response.status_code == status.HTTP_200_OK, start_response.text
+    start_payload = start_response.json()
+    totp = pyotp.TOTP(start_payload["secret"])
+    confirm_response = await async_client.post(
+        "/auth/mfa/totp/confirm",
+        headers=headers,
+        json={
+            "enrollment_id": start_payload["enrollment"]["id"],
+            "code": totp.now(),
+        },
+    )
+    assert confirm_response.status_code == status.HTTP_200_OK, confirm_response.text
+
+    second_start = await async_client.post("/auth/mfa/totp/start", headers=headers)
+    assert second_start.status_code == status.HTTP_200_OK, second_start.text
+    second_payload = second_start.json()
+
+    result = await db_session.execute(
+        select(models.ActiveSession)
+        .where(models.ActiveSession.user_id == user.id)
+        .order_by(models.ActiveSession.id.desc())
+    )
+    session = result.scalars().first()
+    assert session is not None
+    session.mfa_verified_at = None
+    await db_session.commit()
+
+    pending_totp = pyotp.TOTP(second_payload["secret"])
+    confirm_second = await async_client.post(
+        "/auth/mfa/totp/confirm",
+        headers=headers,
+        json={
+            "enrollment_id": second_payload["enrollment"]["id"],
+            "code": pending_totp.now(),
+        },
+    )
+    assert confirm_second.status_code == status.HTTP_428_PRECONDITION_REQUIRED
+    detail = confirm_second.json().get("detail", {})
+    assert detail.get("error") == "mfa_step_up_required"
+
 def _find_audit_event(caplog, logger_name: str, event: str) -> dict:
     for record in caplog.records:
         if record.name != logger_name:


### PR DESCRIPTION
## Summary
- add a conditional dependency that reuses `require_fresh_mfa` for TOTP enrollment routes and expose a helper in the MFA service to detect whether a user already has an interactive factor
- update the settings page to surface the step-up dialog when `/auth/mfa/totp/start` responds with HTTP 428 and document the new manual test case
- extend the API tests to cover the 428 responses when an existing MFA user attempts to start or confirm another enrollment without a fresh verification

## Testing
- pytest root/tests/test_auth_mfa.py -k "step_up_for_existing_factor or step_up_when_session_stale"


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b562db11083279a623ae2310d745d)