### PR TITLE
Fix missing QR code for pending TOTP enrollments

### DIFF
--- a/root/frontend/src/pages/Settings.tsx
+++ b/root/frontend/src/pages/Settings.tsx
@@ -1866,10 +1866,7 @@ export default function Settings() {
           })
           return
         }
-        const message = resolveDetailMessage(
-          error,
-          t("settings:security.snackbar.totpStartFailed"),
-        )
+        const message = resolveDetailMessage(error, t("settings:security.snackbar.totpStartFailed"))
         setTotpError(message)
         setSnack({
           text: message,
@@ -1879,15 +1876,7 @@ export default function Settings() {
         setTotpBusy(false)
       }
     },
-    [
-      isStepUpError,
-      openStepUpFor,
-      resolveDetailMessage,
-      setSnack,
-      setTotpError,
-      t,
-      totpBusy,
-    ],
+    [isStepUpError, openStepUpFor, resolveDetailMessage, setSnack, setTotpError, t, totpBusy]
   )
 
   useEffect(() => {

--- a/root/frontend/src/pages/Settings.tsx
+++ b/root/frontend/src/pages/Settings.tsx
@@ -28,7 +28,11 @@ import OtpEntry from "@/components/mfa/OtpEntry"
 import StepUpDialog from "@/components/mfa/StepUpDialog"
 import type { User } from "@/types/User"
 import type { ActiveSession } from "@/types/Session"
-import type { MfaTotpEnrollment, TotpEnrollmentStartResponse } from "@/types/Mfa"
+import type {
+  MfaTotpEnrollment,
+  TotpEnrollmentStartPayload,
+  TotpEnrollmentStartResponse,
+} from "@/types/Mfa"
 import { useTranslation } from "react-i18next"
 import dayjs from "dayjs"
 import { Settings as SettingsIcon, Moon, Sun, Monitor } from "lucide-react"
@@ -1848,17 +1852,17 @@ export default function Settings() {
   )
 
   const handleStartTotp = useCallback(
-    async (options?: { skipStepUp?: boolean }) => {
+    async (options?: { skipStepUp?: boolean; payload?: TotpEnrollmentStartPayload }) => {
       if (totpBusy) return
       setTotpBusy(true)
       setTotpError(null)
       try {
-        const { data } = await startTotpEnrollment()
+        const { data } = await startTotpEnrollment(options?.payload)
         setTotpDraft(data)
       } catch (error) {
         if (!options?.skipStepUp && isStepUpError(error)) {
           openStepUpFor(async () => {
-            await handleStartTotp({ skipStepUp: true })
+            await handleStartTotp({ skipStepUp: true, payload: options?.payload })
           })
           return
         }
@@ -1885,6 +1889,13 @@ export default function Settings() {
       totpBusy,
     ],
   )
+
+  useEffect(() => {
+    if (!pendingTotpEnrollment || totpDraft) {
+      return
+    }
+    void handleStartTotp({ payload: { reuse_existing: true } })
+  }, [handleStartTotp, pendingTotpEnrollment, totpDraft])
 
   const handleConfirmTotp = useCallback(
     async (code: string) => {


### PR DESCRIPTION
## Summary
- allow the TOTP enrollment flow to request the existing secret again when there is a pending enrollment
- update the enrollment starter to accept payloads so the reuse flag survives step-up reauthentication

## Testing
- npm run test -- src/pages/__tests__/Settings.totp.test.tsx


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b5f48fb3483278ab985abf2293e90)