### PR TITLE
Restyle auth pages with Tailwind

### DIFF
--- a/root/frontend/src/pages/Login.tsx
+++ b/root/frontend/src/pages/Login.tsx
@@ -2,11 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { Link, useNavigate } from "react-router-dom"
 import { useTranslation } from "react-i18next"
 import { ShieldCheck, Sparkles, BookOpen, Eye, EyeOff, Zap } from "lucide-react"
-import {
-  ChallengeLockedError,
-  type PendingMfaState,
-  useAuth,
-} from "@/contexts/AuthContext"
+import { ChallengeLockedError, type PendingMfaState, useAuth } from "@/contexts/AuthContext"
 import OtpEntry from "@/components/mfa/OtpEntry"
 
 type ChallengeMethod = PendingMfaState["methods"][number]
@@ -337,7 +333,9 @@ const Login = () => {
               </div>
               <div className="space-y-3">
                 <h1 className="text-3xl font-extrabold leading-tight sm:text-4xl">
-                  {t("auth:mfa.verifySubtitle", { email: activeEmail || t("auth:mfa.unknownEmail") })}
+                  {t("auth:mfa.verifySubtitle", {
+                    email: activeEmail || t("auth:mfa.unknownEmail"),
+                  })}
                 </h1>
                 <p className="text-base text-[color:color-mix(in_srgb,var(--page-text)_82%,var(--secondary-text)_18%)]">
                   {t("auth:mfa.otpHint")}
@@ -389,7 +387,9 @@ const Login = () => {
             {t("auth:login.heroBadge", { defaultValue: "University Ecosystem" })}
           </p>
           <h1 className="mt-4 text-4xl font-extrabold leading-tight text-[color:var(--page-text)] sm:text-5xl">
-            {t("auth:login.heroHeading", { defaultValue: "Добро пожаловать в кампус нового поколения" })}
+            {t("auth:login.heroHeading", {
+              defaultValue: "Добро пожаловать в кампус нового поколения",
+            })}
           </h1>
           <p className="mt-4 text-lg leading-relaxed text-[color:color-mix(in_srgb,var(--page-text)_82%,var(--secondary-text)_18%)]">
             {t("auth:login.heroDescription", {
@@ -428,7 +428,12 @@ const Login = () => {
         </div>
 
         <div className="w-full max-w-xl rounded-[2.4rem] border border-[color:color-mix(in_srgb,var(--glass-border)_80%,transparent)] bg-[color:color-mix(in_srgb,var(--card-bg)_98%,rgba(255,255,255,0.12)_2%)] p-6 shadow-[0_30px_70px_rgba(15,23,42,0.3)] backdrop-blur-2xl sm:p-10">
-          <form noValidate autoComplete="on" onSubmit={handleSubmit} className="flex flex-col gap-6">
+          <form
+            noValidate
+            autoComplete="on"
+            onSubmit={handleSubmit}
+            className="flex flex-col gap-6"
+          >
             <div className="space-y-2 text-center">
               <h2 className="text-3xl font-extrabold">{t("auth:login.title")}</h2>
               <p className="text-sm text-[color:color-mix(in_srgb,var(--page-text)_78%,var(--secondary-text)_22%)]">
@@ -439,7 +444,10 @@ const Login = () => {
             </div>
 
             <div className="space-y-2">
-              <label htmlFor="username" className="text-sm font-semibold text-[color:var(--page-text)]">
+              <label
+                htmlFor="username"
+                className="text-sm font-semibold text-[color:var(--page-text)]"
+              >
                 {t("auth:fields.email")}
               </label>
               <input
@@ -487,7 +495,11 @@ const Login = () => {
                   title={t("auth:actions.holdReveal") ?? undefined}
                   aria-label={t("auth:actions.showPassword") ?? undefined}
                 >
-                  {showPassword ? <EyeOff className="h-4 w-4" aria-hidden="true" /> : <Eye className="h-4 w-4" aria-hidden="true" />}
+                  {showPassword ? (
+                    <EyeOff className="h-4 w-4" aria-hidden="true" />
+                  ) : (
+                    <Eye className="h-4 w-4" aria-hidden="true" />
+                  )}
                   {t("auth:actions.showPassword")}
                 </button>
               </div>
@@ -512,7 +524,10 @@ const Login = () => {
               </div>
             </div>
 
-            <div className="min-h-[1.5rem] text-center text-sm font-semibold text-red-400" aria-live="assertive">
+            <div
+              className="min-h-[1.5rem] text-center text-sm font-semibold text-red-400"
+              aria-live="assertive"
+            >
               {submitError}
             </div>
 

--- a/root/frontend/src/pages/Login.tsx
+++ b/root/frontend/src/pages/Login.tsx
@@ -1,36 +1,28 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
-import { useNavigate, Link } from "react-router-dom"
-import { ChallengeLockedError, type PendingMfaState, useAuth } from "@/contexts/AuthContext"
-import {
-  Box,
-  Paper,
-  Typography,
-  TextField,
-  Button,
-  Stack,
-  InputAdornment,
-  IconButton,
-  useMediaQuery,
-  CircularProgress,
-  Checkbox,
-  FormControlLabel,
-  Chip,
-  Tooltip,
-  Alert,
-} from "@mui/material"
-import Visibility from "@mui/icons-material/Visibility"
-import VisibilityOff from "@mui/icons-material/VisibilityOff"
+import { Link, useNavigate } from "react-router-dom"
 import { useTranslation } from "react-i18next"
+import { ShieldCheck, Sparkles, BookOpen, Eye, EyeOff, Zap } from "lucide-react"
+import {
+  ChallengeLockedError,
+  type PendingMfaState,
+  useAuth,
+} from "@/contexts/AuthContext"
 import OtpEntry from "@/components/mfa/OtpEntry"
 
+type ChallengeMethod = PendingMfaState["methods"][number]
+type ChallengeWithAttempts = ChallengeMethod &
+  Partial<{ attempt_limit: number | null; remaining_attempts: number | null }>
+
 function levenshtein(a: string, b: string) {
-  const m = a.length,
-    n = b.length
+  const m = a.length
+  const n = b.length
   if (!m) return n
   if (!n) return m
+
   const dp = Array.from({ length: m + 1 }, () => new Array(n + 1).fill(0))
   for (let i = 0; i <= m; i++) dp[i][0] = i
   for (let j = 0; j <= n; j++) dp[0][j] = j
+
   for (let i = 1; i <= m; i++) {
     for (let j = 1; j <= n; j++) {
       const cost = a[i - 1] === b[j - 1] ? 0 : 1
@@ -57,18 +49,22 @@ const COMMON_EMAIL_DOMAINS = [
   "rambler.ru",
   "proton.me",
 ]
+
 const emailRe = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
 function suggestEmailDomain(email: string) {
   const at = email.indexOf("@")
   if (at < 0) return null
+
   const local = email.slice(0, at).trim()
   const dom = email
     .slice(at + 1)
     .trim()
     .toLowerCase()
+
   if (!local || !dom) return null
   if (COMMON_EMAIL_DOMAINS.includes(dom)) return null
+
   let best: { d: string; dist: number } | null = null
   for (const cand of COMMON_EMAIL_DOMAINS) {
     const dist = levenshtein(dom, cand)
@@ -77,12 +73,32 @@ function suggestEmailDomain(email: string) {
   return best ? `${local}@${best.d}` : null
 }
 
-type ChallengeMethod = PendingMfaState["methods"][number]
-type ChallengeWithAttempts = ChallengeMethod &
-  Partial<{ attempt_limit: number | null; remaining_attempts: number | null }>
+const inputBaseClass =
+  "w-full rounded-[1.2rem] border border-[color:color-mix(in_srgb,white_12%,var(--nav-link)_88%)] " +
+  "bg-[color:color-mix(in_srgb,var(--card-bg)_96%,rgba(255,255,255,0.94)_4%)] px-4 py-3 text-base font-medium " +
+  "text-[color:var(--page-text)] shadow-[0_10px_30px_rgba(15,23,42,0.08)] focus:border-[color:var(--nav-link)] " +
+  "focus:outline-none focus:shadow-[0_0_0_3px_color-mix(in_srgb,var(--nav-link)_20%,transparent)] " +
+  "placeholder:text-[color:color-mix(in_srgb,var(--placeholder-fg)_75%,transparent)] " +
+  "dark:border-[color:color-mix(in_srgb,white_8%,var(--nav-link)_92%)] " +
+  "dark:bg-[color:color-mix(in_srgb,var(--card-bg)_92%,rgba(10,18,32,0.94)_8%)]"
+
+const badgeClass =
+  "inline-flex items-center gap-2 rounded-full border border-[color:color-mix(in_srgb,var(--glass-border)_80%,transparent)] " +
+  "bg-[color:color-mix(in_srgb,var(--card-bg)_92%,rgba(255,255,255,0.12)_8%)] px-4 py-2 text-sm font-semibold " +
+  "text-[color:color-mix(in_srgb,var(--page-text)_90%,var(--nav-link)_10%)] shadow-[0_6px_20px_rgba(15,23,42,0.12)]"
+
+const Spinner = () => (
+  <span
+    className="inline-flex h-5 w-5 animate-spin rounded-full border-2 border-current/60 border-t-transparent"
+    aria-hidden="true"
+  />
+)
 
 const Login = () => {
   const { t } = useTranslation(["auth"])
+  const navigate = useNavigate()
+  const { login, pendingMfa, submitMfaChallenge } = useAuth()
+
   const savedEmail = useRef<string>(localStorage.getItem("auth:lastEmail") || "")
   const [remember, setRemember] = useState<boolean>(
     () => localStorage.getItem("auth:remember") === "1"
@@ -91,10 +107,6 @@ const Login = () => {
   const [showPassword, setShowPassword] = useState(false)
   const [emailSuggestion, setEmailSuggestion] = useState<string | null>(null)
   const [emailMirror, setEmailMirror] = useState(savedEmail.current)
-
-  const navigate = useNavigate()
-  const { login, pendingMfa, submitMfaChallenge } = useAuth()
-  const isMobile = useMediaQuery("(max-width:600px)")
 
   const emailRef = useRef<HTMLInputElement | null>(null)
   const passwordRef = useRef<HTMLInputElement | null>(null)
@@ -163,7 +175,7 @@ const Login = () => {
       clearTimeout(t1)
       clearTimeout(t2)
     }
-  }, [])
+  }, [emailMirror])
 
   const applySuggestion = () => {
     if (emailSuggestion && emailRef.current) {
@@ -178,6 +190,7 @@ const Login = () => {
     const s = suggestEmailDomain(val)
     setEmailSuggestion(s && s !== val ? s : null)
   }
+
   const [submitting, setSubmitting] = useState(false)
   const [submitError, setSubmitError] = useState<string | null>(null)
 
@@ -270,245 +283,286 @@ const Login = () => {
   const activeEmail = pendingEmail || currentEmail || savedEmail.current || ""
   const generalMfaError = mfaErrorSource === "general" ? mfaError : null
 
+  const heroHighlights = [
+    {
+      icon: ShieldCheck,
+      title: t("auth:login.highlightSecurity", {
+        defaultValue: "Многоуровневая защита",
+      }),
+      description: t("auth:login.highlightSecurityDescription", {
+        defaultValue: "MFA и интеллектуальные подсказки для безошибочного входа.",
+      }),
+    },
+    {
+      icon: Sparkles,
+      title: t("auth:login.highlightExperience", {
+        defaultValue: "Премиальный опыт",
+      }),
+      description: t("auth:login.highlightExperienceDescription", {
+        defaultValue: "Продуманный интерфейс, вдохновляющий с первого экрана.",
+      }),
+    },
+    {
+      icon: BookOpen,
+      title: t("auth:login.highlightContent", {
+        defaultValue: "Весь кампус под рукой",
+      }),
+      description: t("auth:login.highlightContentDescription", {
+        defaultValue: "События, профиль и обучение — всё доступно после входа.",
+      }),
+    },
+  ]
+
+  const statPills = [
+    {
+      value: t("auth:login.statStudents", { defaultValue: "120k+" }),
+      label: t("auth:login.statStudentsLabel", { defaultValue: "студентов доверяют" }),
+    },
+    {
+      value: t("auth:login.statSatisfaction", { defaultValue: "98%" }),
+      label: t("auth:login.statSatisfactionLabel", { defaultValue: "удовлетворённость" }),
+    },
+  ]
+
   if (loginChallenge) {
     return (
-      <Box
-        sx={{
-          minHeight: "100dvh",
-          bgcolor: "var(--page-bg)",
-          color: "var(--page-text)",
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          px: 1,
-        }}
-      >
-        <Paper
-          elevation={7}
-          sx={{
-            width: "100%",
-            maxWidth: 440,
-            p: { xs: 2, sm: 4 },
-            borderRadius: { xs: 3, sm: 5 },
-            boxShadow: 8,
-            bgcolor: "var(--card-bg)",
-            transition: "background 0.22s, box-shadow 0.22s",
-          }}
-        >
-          <Stack spacing={2.5}>
-            <Typography variant={isMobile ? "h5" : "h4"} fontWeight={700} align="center">
-              {t("auth:mfa.verifyTitle")}
-            </Typography>
-            <Typography
-              variant="body2"
-              align="center"
-              sx={{ color: "color-mix(in srgb, var(--page-text) 72%, transparent)" }}
-            >
-              {t("auth:mfa.verifySubtitle", { email: activeEmail || t("auth:mfa.unknownEmail") })}
-            </Typography>
-            {generalMfaError ? (
-              <Alert severity="error" variant="outlined">
-                {generalMfaError}
-              </Alert>
-            ) : null}
-            {otpChallenge ? (
-              <OtpEntry
-                loading={mfaBusy}
-                error={mfaErrorSource === "totp" ? mfaError : null}
-                helperText={otpHelperText ?? t("auth:mfa.otpHint")}
-                onSubmit={handleOtpVerify}
-              />
-            ) : null}
-            {!otpChallenge ? (
-              <Alert severity="warning" variant="outlined">
-                {t("auth:mfa.noMethods")}
-              </Alert>
-            ) : null}
-            <Button
-              variant="text"
-              color="inherit"
-              onClick={() => window.location.reload()}
-              sx={{ mt: 1 }}
-            >
-              {t("auth:mfa.startOver")}
-            </Button>
-          </Stack>
-        </Paper>
-      </Box>
+      <div className="relative min-h-screen w-full bg-[color:var(--page-bg)] text-[color:var(--page-text)]">
+        <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,var(--nav-link)/0.28,transparent_58%)]" />
+        <div className="relative z-10 flex min-h-screen items-center justify-center px-4 py-12 sm:px-6 lg:px-8">
+          <div className="w-full max-w-2xl rounded-[2rem] border border-[color:color-mix(in_srgb,var(--glass-border)_80%,transparent)] bg-[color:color-mix(in_srgb,var(--card-bg)_95%,rgba(255,255,255,0.08)_5%)] p-8 shadow-[0_35px_80px_rgba(15,23,42,0.35)] backdrop-blur-2xl">
+            <div className="flex flex-col items-center gap-6 text-center">
+              <div className="inline-flex items-center gap-2 rounded-full border border-[color:color-mix(in_srgb,var(--glass-border)_80%,transparent)] bg-[color:color-mix(in_srgb,var(--card-bg)_92%,rgba(255,255,255,0.14)_8%)] px-4 py-1 text-sm font-semibold tracking-wide text-[color:color-mix(in_srgb,var(--page-text)_90%,var(--nav-link)_10%)]">
+                <ShieldCheck className="h-4 w-4" aria-hidden="true" />
+                {t("auth:mfa.verifyTitle")}
+              </div>
+              <div className="space-y-3">
+                <h1 className="text-3xl font-extrabold leading-tight sm:text-4xl">
+                  {t("auth:mfa.verifySubtitle", { email: activeEmail || t("auth:mfa.unknownEmail") })}
+                </h1>
+                <p className="text-base text-[color:color-mix(in_srgb,var(--page-text)_82%,var(--secondary-text)_18%)]">
+                  {t("auth:mfa.otpHint")}
+                </p>
+              </div>
+
+              {generalMfaError ? (
+                <div className="w-full rounded-2xl border border-red-400/50 bg-red-400/10 px-4 py-3 text-sm font-semibold text-red-200 dark:text-red-100">
+                  {generalMfaError}
+                </div>
+              ) : null}
+
+              {otpChallenge ? (
+                <div className="w-full">
+                  <OtpEntry
+                    loading={mfaBusy}
+                    error={mfaErrorSource === "totp" ? mfaError : null}
+                    helperText={otpHelperText ?? t("auth:mfa.otpHint")}
+                    onSubmit={handleOtpVerify}
+                  />
+                </div>
+              ) : (
+                <div className="w-full rounded-2xl border border-amber-400/40 bg-amber-400/10 px-4 py-3 text-sm font-semibold text-amber-200">
+                  {t("auth:mfa.noMethods")}
+                </div>
+              )}
+
+              <button
+                type="button"
+                onClick={() => window.location.reload()}
+                className="inline-flex items-center gap-2 rounded-full border border-[color:color-mix(in_srgb,var(--nav-link)_50%,transparent)] px-5 py-2 text-sm font-semibold text-[color:var(--nav-link)] transition hover:bg-[color:color-mix(in_srgb,var(--nav-link)_12%,transparent)]"
+              >
+                <Zap className="h-4 w-4" aria-hidden="true" />
+                {t("auth:mfa.startOver")}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
     )
   }
 
   return (
-    <Box
-      sx={{
-        minHeight: "100dvh",
-        bgcolor: "var(--page-bg)",
-        color: "var(--page-text)",
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        px: 1,
-      }}
-    >
-      <Paper
-        elevation={7}
-        sx={{
-          width: "100%",
-          maxWidth: 400,
-          p: { xs: 2, sm: 4 },
-          borderRadius: { xs: 3, sm: 5 },
-          boxShadow: 8,
-          bgcolor: "var(--card-bg)",
-          transition: "background 0.22s, box-shadow 0.22s",
-        }}
-      >
-        <form noValidate autoComplete="on" onSubmit={handleSubmit}>
-          <Typography variant={isMobile ? "h5" : "h4"} fontWeight={700} align="center" mb={3}>
-            {t("auth:login.title")}
-          </Typography>
-          <Stack spacing={2}>
-            <TextField
-              label={t("auth:fields.email")}
-              name="username"
-              type="email"
-              fullWidth
-              variant="outlined"
-              defaultValue={savedEmail.current}
-              inputRef={emailRef}
-              onChange={(e) => setEmailMirror(e.target.value)}
-              onBlur={handleEmailBlur}
-              autoComplete="username"
-              autoFocus
-              disabled={submitting}
-              error={!emailValid}
-              helperText={!emailValid ? t("auth:messages.invalidFormat") : " "}
-              inputProps={{
-                inputMode: "email",
-                autoCapitalize: "none",
-                autoCorrect: "off",
-                spellCheck: "false",
-              }}
-              required
-            />
-            {emailSuggestion && (
-              <Box sx={{ mt: -1.5 }}>
-                <Chip
-                  size="small"
-                  variant="outlined"
-                  color="primary"
-                  label={t("auth:messages.emailSuggestion", { suggestion: emailSuggestion })}
+    <div className="relative min-h-screen w-full overflow-hidden bg-[color:var(--page-bg)] text-[color:var(--page-text)]">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,var(--nav-link)/0.24,transparent_58%),radial-gradient(circle_at_bottom,var(--glass-highlight)/0.18,transparent_65%)]" />
+      <div className="relative z-10 mx-auto flex min-h-screen w-full max-w-6xl flex-col items-center justify-center gap-10 px-4 py-12 sm:px-6 lg:px-8 lg:flex-row">
+        <div className="w-full rounded-[2.4rem] border border-[color:color-mix(in_srgb,var(--glass-border)_80%,transparent)] bg-[color:color-mix(in_srgb,var(--card-bg)_94%,rgba(255,255,255,0.1)_6%)] p-8 shadow-[0_30px_90px_rgba(15,23,42,0.28)] backdrop-blur-3xl lg:p-12">
+          <p className="text-sm font-semibold uppercase tracking-[0.3em] text-[color:color-mix(in_srgb,var(--page-text)_70%,var(--nav-link)_30%)]">
+            {t("auth:login.heroBadge", { defaultValue: "University Ecosystem" })}
+          </p>
+          <h1 className="mt-4 text-4xl font-extrabold leading-tight text-[color:var(--page-text)] sm:text-5xl">
+            {t("auth:login.heroHeading", { defaultValue: "Добро пожаловать в кампус нового поколения" })}
+          </h1>
+          <p className="mt-4 text-lg leading-relaxed text-[color:color-mix(in_srgb,var(--page-text)_82%,var(--secondary-text)_18%)]">
+            {t("auth:login.heroDescription", {
+              defaultValue:
+                "Войдите, чтобы управлять расписанием, следить за событиями и общаться с наставниками в единой цифровой среде.",
+            })}
+          </p>
+
+          <div className="mt-8 grid gap-4 sm:grid-cols-2">
+            {heroHighlights.map(({ icon: Icon, title, description }) => (
+              <div
+                key={title}
+                className="group relative overflow-hidden rounded-3xl border border-[color:color-mix(in_srgb,var(--glass-border)_85%,transparent)] bg-[color:color-mix(in_srgb,var(--card-bg)_96%,rgba(255,255,255,0.08)_4%)] px-5 py-6 shadow-[0_20px_50px_rgba(15,23,42,0.18)] transition-transform duration-300 hover:-translate-y-1"
+              >
+                <div className="flex items-center gap-3">
+                  <span className="flex size-12 items-center justify-center rounded-2xl bg-[color:color-mix(in_srgb,var(--nav-link)_15%,transparent)] text-[color:var(--nav-link)]">
+                    <Icon className="h-5 w-5" aria-hidden="true" />
+                  </span>
+                  <p className="text-base font-semibold">{title}</p>
+                </div>
+                <p className="mt-4 text-sm text-[color:color-mix(in_srgb,var(--page-text)_78%,var(--secondary-text)_22%)]">
+                  {description}
+                </p>
+              </div>
+            ))}
+          </div>
+
+          <div className="mt-10 flex flex-wrap gap-4">
+            {statPills.map((pill) => (
+              <div key={pill.label} className={badgeClass}>
+                <span className="text-2xl font-extrabold">{pill.value}</span>
+                <span className="text-xs uppercase tracking-[0.2em] opacity-80">{pill.label}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="w-full max-w-xl rounded-[2.4rem] border border-[color:color-mix(in_srgb,var(--glass-border)_80%,transparent)] bg-[color:color-mix(in_srgb,var(--card-bg)_98%,rgba(255,255,255,0.12)_2%)] p-6 shadow-[0_30px_70px_rgba(15,23,42,0.3)] backdrop-blur-2xl sm:p-10">
+          <form noValidate autoComplete="on" onSubmit={handleSubmit} className="flex flex-col gap-6">
+            <div className="space-y-2 text-center">
+              <h2 className="text-3xl font-extrabold">{t("auth:login.title")}</h2>
+              <p className="text-sm text-[color:color-mix(in_srgb,var(--page-text)_78%,var(--secondary-text)_22%)]">
+                {t("auth:login.subtitle", {
+                  defaultValue: "Войдите, чтобы продолжить путешествие по университету",
+                })}
+              </p>
+            </div>
+
+            <div className="space-y-2">
+              <label htmlFor="username" className="text-sm font-semibold text-[color:var(--page-text)]">
+                {t("auth:fields.email")}
+              </label>
+              <input
+                id="username"
+                name="username"
+                type="email"
+                className={`${inputBaseClass} ${!emailValid ? "border-red-400 focus:border-red-400" : ""}`}
+                defaultValue={savedEmail.current}
+                ref={emailRef}
+                onChange={(e) => setEmailMirror(e.target.value)}
+                onBlur={handleEmailBlur}
+                autoComplete="username"
+                autoFocus
+                disabled={submitting}
+                inputMode="email"
+                required
+              />
+              <p className="text-xs text-[color:color-mix(in_srgb,var(--page-text)_70%,var(--secondary-text)_30%)]">
+                {!emailValid ? t("auth:messages.invalidFormat") : " "}
+              </p>
+              {emailSuggestion ? (
+                <button
+                  type="button"
                   onClick={applySuggestion}
-                />
-              </Box>
-            )}
-            <TextField
-              label={t("auth:fields.password")}
-              name="password"
-              type={showPassword ? "text" : "password"}
-              fullWidth
-              variant="outlined"
-              inputRef={passwordRef}
-              onKeyUp={(e) => setCaps((e as any).getModifierState?.("CapsLock"))}
-              onKeyDown={(e) => setCaps((e as any).getModifierState?.("CapsLock"))}
-              autoComplete="current-password"
-              disabled={submitting}
-              InputProps={{
-                endAdornment: (
-                  <InputAdornment position="end">
-                    <Tooltip title={t("auth:actions.holdReveal")}>
-                      <IconButton
-                        aria-label={t("auth:actions.showPassword")}
-                        onMouseDown={() => setShowPassword(true)}
-                        onMouseUp={() => setShowPassword(false)}
-                        onMouseLeave={() => setShowPassword(false)}
-                        onClick={() => setShowPassword((v) => !v)}
-                        edge="end"
-                        tabIndex={-1}
-                        sx={{ color: "var(--page-text)" }}
-                      >
-                        {showPassword ? <VisibilityOff /> : <Visibility />}
-                      </IconButton>
-                    </Tooltip>
-                  </InputAdornment>
-                ),
-              }}
-              required
-            />
-            <Box sx={{ minHeight: 20, textAlign: "left" }}>
-              {caps && (
-                <Typography color="warning.main" fontSize={13}>
-                  {t("auth:messages.capsLock")}
-                </Typography>
-              )}
-            </Box>
-            <Box
-              sx={{
-                minHeight: 22,
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-              }}
-              aria-live="assertive"
-            >
-              {submitError && (
-                <Typography color="error" fontSize={15}>
-                  {submitError}
-                </Typography>
-              )}
-            </Box>
-            <FormControlLabel
-              control={
-                <Checkbox
-                  checked={remember}
-                  onChange={(e) => setRemember(e.target.checked)}
+                  className="inline-flex items-center gap-2 rounded-full border border-[color:color-mix(in_srgb,var(--nav-link)_60%,transparent)] px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-[color:var(--nav-link)] transition hover:bg-[color:color-mix(in_srgb,var(--nav-link)_12%,transparent)]"
+                >
+                  <Sparkles className="h-4 w-4" aria-hidden="true" />
+                  {t("auth:messages.emailSuggestion", { suggestion: emailSuggestion })}
+                </button>
+              ) : null}
+            </div>
+
+            <div className="space-y-2">
+              <div className="flex items-center justify-between">
+                <label htmlFor="password" className="text-sm font-semibold">
+                  {t("auth:fields.password")}
+                </label>
+                <button
+                  type="button"
+                  onMouseDown={() => setShowPassword(true)}
+                  onMouseUp={() => setShowPassword(false)}
+                  onMouseLeave={() => setShowPassword(false)}
+                  onClick={() => setShowPassword((v) => !v)}
+                  className="inline-flex items-center gap-2 rounded-full border border-transparent px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-[color:var(--nav-link)] transition hover:border-[color:color-mix(in_srgb,var(--nav-link)_50%,transparent)]"
+                  title={t("auth:actions.holdReveal") ?? undefined}
+                  aria-label={t("auth:actions.showPassword") ?? undefined}
+                >
+                  {showPassword ? <EyeOff className="h-4 w-4" aria-hidden="true" /> : <Eye className="h-4 w-4" aria-hidden="true" />}
+                  {t("auth:actions.showPassword")}
+                </button>
+              </div>
+              <div className="relative">
+                <input
+                  id="password"
+                  name="password"
+                  type={showPassword ? "text" : "password"}
+                  className={inputBaseClass}
+                  ref={passwordRef}
+                  onKeyUp={(e) => setCaps((e as any).getModifierState?.("CapsLock"))}
+                  onKeyDown={(e) => setCaps((e as any).getModifierState?.("CapsLock"))}
+                  autoComplete="current-password"
                   disabled={submitting}
+                  required
                 />
-              }
-              label={t("auth:actions.rememberEmail")}
-              sx={{ mt: -0.5 }}
-            />
-            <Button
+                {caps ? (
+                  <span className="absolute inset-y-0 right-4 flex items-center text-xs font-semibold text-amber-400">
+                    {t("auth:messages.capsLock")}
+                  </span>
+                ) : null}
+              </div>
+            </div>
+
+            <div className="min-h-[1.5rem] text-center text-sm font-semibold text-red-400" aria-live="assertive">
+              {submitError}
+            </div>
+
+            <label className="flex items-center gap-3 text-sm font-medium text-[color:color-mix(in_srgb,var(--page-text)_90%,var(--secondary-text)_10%)]">
+              <input
+                type="checkbox"
+                className="size-5 rounded-lg border-[color:color-mix(in_srgb,var(--nav-link)_50%,transparent)] bg-transparent accent-[color:var(--nav-link)]"
+                checked={remember}
+                onChange={(e) => setRemember(e.target.checked)}
+                disabled={submitting}
+              />
+              {t("auth:actions.rememberEmail")}
+            </label>
+
+            <button
               type="submit"
-              variant="contained"
-              size="large"
-              fullWidth
+              className="inline-flex w-full items-center justify-center gap-2 rounded-[1.6rem] bg-[radial-gradient(circle_at_top,var(--nav-link),var(--nav-link-hover))] px-6 py-4 text-lg font-extrabold text-white shadow-[0_20px_45px_rgba(36,99,235,0.35)] transition hover:translate-y-[-2px] hover:shadow-[0_30px_60px_rgba(36,99,235,0.45)] disabled:opacity-60"
               disabled={submitting}
-              sx={{
-                mt: 1,
-                fontWeight: 600,
-                borderRadius: 2,
-                fontSize: 17,
-                py: 1.2,
-                bgcolor: "var(--nav-link)",
-                color: "#fff",
-                touchAction: "manipulation",
-                "&:hover": { bgcolor: "var(--nav-link-hover)" },
-              }}
             >
               {submitting ? (
-                <CircularProgress size={26} color="inherit" />
+                <>
+                  <Spinner />
+                  {t("auth:login.processing", { defaultValue: "Входим..." })}
+                </>
               ) : (
                 t("auth:actions.signIn")
               )}
-            </Button>
-          </Stack>
-          <Box mt={1.5} textAlign="center" fontSize={15}>
-            <Link
-              to="/forgot-password"
-              style={{ color: "var(--nav-link)", textDecoration: "underline" }}
-            >
-              {t("auth:login.forgot")}
-            </Link>
-          </Box>
-          <Box mt={2} textAlign="center" fontSize={15}>
-            {t("auth:login.noAccount")}{" "}
-            <Link to="/register" style={{ color: "var(--nav-link)", textDecoration: "underline" }}>
-              {t("auth:login.ctaRegister")}
-            </Link>
-          </Box>
-        </form>
-      </Paper>
-    </Box>
+            </button>
+
+            <div className="space-y-2 text-center text-sm">
+              <Link
+                to="/forgot-password"
+                className="font-semibold text-[color:var(--nav-link)] underline-offset-4 transition hover:underline"
+              >
+                {t("auth:login.forgot")}
+              </Link>
+              <div>
+                {t("auth:login.noAccount")}{" "}
+                <Link
+                  to="/register"
+                  className="font-semibold text-[color:var(--nav-link)] underline-offset-4 transition hover:underline"
+                >
+                  {t("auth:login.ctaRegister")}
+                </Link>
+              </div>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
   )
 }
 

--- a/root/frontend/src/pages/Register.tsx
+++ b/root/frontend/src/pages/Register.tsx
@@ -1,45 +1,8 @@
 import { useActionState, useEffect, useMemo, useRef, useState } from "react"
-import { useNavigate, Link } from "react-router-dom"
-import api from "../api/client"
-import {
-  Box,
-  Paper,
-  Typography,
-  TextField,
-  Button,
-  Stack,
-  Select,
-  MenuItem,
-  InputLabel,
-  FormControl,
-  useMediaQuery,
-  CircularProgress,
-  InputAdornment,
-  IconButton,
-  LinearProgress,
-  Chip,
-  Tooltip,
-} from "@mui/material"
-import Visibility from "@mui/icons-material/Visibility"
-import VisibilityOff from "@mui/icons-material/VisibilityOff"
+import { Link, useNavigate } from "react-router-dom"
 import { useTranslation } from "react-i18next"
-
-function levenshtein(a: string, b: string) {
-  const m = a.length,
-    n = b.length
-  if (!m) return n
-  if (!n) return m
-  const dp = Array.from({ length: m + 1 }, () => new Array(n + 1).fill(0))
-  for (let i = 0; i <= m; i++) dp[i][0] = i
-  for (let j = 0; j <= n; j++) dp[0][j] = j
-  for (let i = 1; i <= m; i++) {
-    for (let j = 1; j <= n; j++) {
-      const cost = a[i - 1] === b[j - 1] ? 0 : 1
-      dp[i][j] = Math.min(dp[i - 1][j] + 1, dp[i][j - 1] + 1, dp[i - 1][j - 1] + cost)
-    }
-  }
-  return dp[m][n]
-}
+import { Eye, EyeOff, Sparkles, UsersRound, ShieldCheck, Crown } from "lucide-react"
+import api from "../api/client"
 
 const COMMON_EMAIL_DOMAINS = [
   "gmail.com",
@@ -59,16 +22,46 @@ const COMMON_EMAIL_DOMAINS = [
   "proton.me",
 ]
 
+const emailRe = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+type RegisterState = {
+  status: "idle" | "success" | "error"
+  error?: string
+  field?: "full_name" | "email" | "password" | "confirm" | "invite_code"
+}
+
+function levenshtein(a: string, b: string) {
+  const m = a.length
+  const n = b.length
+  if (!m) return n
+  if (!n) return m
+
+  const dp = Array.from({ length: m + 1 }, () => new Array(n + 1).fill(0))
+  for (let i = 0; i <= m; i++) dp[i][0] = i
+  for (let j = 0; j <= n; j++) dp[0][j] = j
+
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1
+      dp[i][j] = Math.min(dp[i - 1][j] + 1, dp[i][j - 1] + 1, dp[i - 1][j - 1] + cost)
+    }
+  }
+  return dp[m][n]
+}
+
 function suggestEmailDomain(email: string) {
   const at = email.indexOf("@")
   if (at < 0) return null
+
   const local = email.slice(0, at).trim()
   const dom = email
     .slice(at + 1)
     .trim()
     .toLowerCase()
+
   if (!local || !dom) return null
   if (COMMON_EMAIL_DOMAINS.includes(dom)) return null
+
   let best: { d: string; dist: number } | null = null
   for (const cand of COMMON_EMAIL_DOMAINS) {
     const dist = levenshtein(dom, cand)
@@ -77,13 +70,24 @@ function suggestEmailDomain(email: string) {
   return best ? `${local}@${best.d}` : null
 }
 
-const emailRe = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+const inputBaseClass =
+  "w-full rounded-[1.2rem] border border-[color:color-mix(in_srgb,white_12%,var(--nav-link)_88%)] " +
+  "bg-[color:color-mix(in_srgb,var(--card-bg)_96%,rgba(255,255,255,0.94)_4%)] px-4 py-3 text-base font-medium " +
+  "text-[color:var(--page-text)] shadow-[0_10px_30px_rgba(15,23,42,0.08)] focus:border-[color:var(--nav-link)] " +
+  "focus:outline-none focus:shadow-[0_0_0_3px_color-mix(in_srgb,var(--nav-link)_20%,transparent)] " +
+  "placeholder:text-[color:color-mix(in_srgb,var(--placeholder-fg)_75%,transparent)] " +
+  "dark:border-[color:color-mix(in_srgb,white_8%,var(--nav-link)_92%)] " +
+  "dark:bg-[color:color-mix(in_srgb,var(--card-bg)_92%,rgba(10,18,32,0.94)_8%)]"
 
-type RegisterState = {
-  status: "idle" | "success" | "error"
-  error?: string
-  field?: "full_name" | "email" | "password" | "confirm" | "invite_code"
-}
+const chipClass =
+  "inline-flex items-center gap-2 rounded-full border border-[color:color-mix(in_srgb,white_18%,var(--nav-link)_82%)] px-4 py-1.5 text-xs font-semibold uppercase tracking-[0.2em]"
+
+const Spinner = () => (
+  <span
+    className="inline-flex h-5 w-5 animate-spin rounded-full border-2 border-current/60 border-t-transparent"
+    aria-hidden="true"
+  />
+)
 
 const Register = () => {
   const { t } = useTranslation(["auth"])
@@ -103,12 +107,12 @@ const Register = () => {
   const [strength, setStrength] = useState<number | null>(null)
   const [emailSuggestion, setEmailSuggestion] = useState<string | null>(null)
 
-  const isMobile = useMediaQuery("(max-width:600px)")
   const fullNameRef = useRef<HTMLInputElement | null>(null)
   const emailRef = useRef<HTMLInputElement | null>(null)
   const inviteRef = useRef<HTMLInputElement | null>(null)
   const passwordRef = useRef<HTMLInputElement | null>(null)
   const confirmRef = useRef<HTMLInputElement | null>(null)
+
   const needsInvite = form.role === "teacher" || form.role === "admin"
   const minLenOk = form.password.length >= 8
   const matchOk = form.confirm.length > 0 && form.password === form.confirm
@@ -120,7 +124,7 @@ const Register = () => {
     matchOk &&
     (!needsInvite || form.invite_code.trim().length > 0)
 
-  const handleChange = (e: any) => {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
     setForm((f) => ({ ...f, [e.target.name]: e.target.value }))
   }
 
@@ -129,15 +133,15 @@ const Register = () => {
     setEmailSuggestion(s && s !== form.email ? s : null)
   }
 
-  const handlePass = async (v: string) => {
-    setForm((f) => ({ ...f, password: v }))
-    if (!v) {
+  const handlePass = async (value: string) => {
+    setForm((f) => ({ ...f, password: value }))
+    if (!value) {
       setStrength(null)
       return
     }
     try {
       const { default: zxcvbn } = await import("zxcvbn")
-      const score = zxcvbn(v).score
+      const score = zxcvbn(value).score
       setStrength(score)
     } catch {
       setStrength(null)
@@ -212,7 +216,7 @@ const Register = () => {
 
   const registerStatus = registerState.status
   const registerErrorField = registerState.field
-  const registerErrorMessage = registerStatus === "error" ? (registerState.error ?? "") : ""
+  const registerErrorMessage = registerStatus === "error" ? registerState.error ?? "" : ""
 
   useEffect(() => {
     if (!registerPending && registerStatus === "error" && registerErrorField) {
@@ -224,266 +228,326 @@ const Register = () => {
     }
   }, [registerPending, registerStatus, registerErrorField])
 
+  const passwordStrengthPercent = useMemo(() => {
+    if (strength === null) return null
+    return [10, 30, 55, 75, 100][strength]
+  }, [strength])
+
+  const passwordStrengthLabel = useMemo(() => {
+    if (strength === null) return null
+    return [
+      t("auth:register.passwordStrength.veryWeak", { defaultValue: "Очень слабый" }),
+      t("auth:register.passwordStrength.weak", { defaultValue: "Слабый" }),
+      t("auth:register.passwordStrength.medium", { defaultValue: "Средний" }),
+      t("auth:register.passwordStrength.good", { defaultValue: "Хороший" }),
+      t("auth:register.passwordStrength.excellent", { defaultValue: "Отличный" }),
+    ][strength]
+  }, [strength, t])
+
+  const heroPerks = [
+    {
+      icon: UsersRound,
+      title: t("auth:register.perkCommunity", { defaultValue: "Глобальное сообщество" }),
+      description: t("auth:register.perkCommunityDesc", {
+        defaultValue: "Наставники, кураторы и студенты объединены в одну экосистему.",
+      }),
+    },
+    {
+      icon: ShieldCheck,
+      title: t("auth:register.perkSecure", { defaultValue: "Безопасные роли" }),
+      description: t("auth:register.perkSecureDesc", {
+        defaultValue: "Гибкая выдача прав, приглашения и прозрачные процессы.",
+      }),
+    },
+    {
+      icon: Sparkles,
+      title: t("auth:register.perkExperience", { defaultValue: "Мировой уровень" }),
+      description: t("auth:register.perkExperienceDesc", {
+        defaultValue: "Вдохновляющий дизайн, созданный, чтобы мотивировать учиться.",
+      }),
+    },
+  ]
+
+  const inviteHint = needsInvite
+    ? t("auth:register.inviteRequired", { defaultValue: "Пригласительный код обязателен" })
+    : t("auth:register.inviteOptional", { defaultValue: "Приглашение необязательно" })
+
   return (
-    <Box
-      sx={{
-        minHeight: "100vh",
-        bgcolor: "var(--page-bg)",
-        color: "var(--page-text)",
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        flexDirection: "column",
-        px: 1,
-        width: "100vw",
-        overflow: "visible",
-      }}
-    >
-      <Paper
-        elevation={7}
-        sx={{
-          width: "100%",
-          minWidth: 0,
-          maxWidth: 460,
-          p: { xs: 2, sm: 4 },
-          borderRadius: { xs: 3, sm: 5 },
-          boxShadow: 8,
-          bgcolor: "var(--card-bg)",
-          mx: "auto",
-        }}
-      >
-        <form action={registerAction} autoComplete="off">
-          <Typography variant={isMobile ? "h5" : "h4"} fontWeight={700} align="center" mb={3}>
+    <div className="relative min-h-screen w-full overflow-hidden bg-[color:var(--page-bg)] text-[color:var(--page-text)]">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,var(--nav-link)/0.22,transparent_60%),radial-gradient(circle_at_bottom,var(--glass-tint-1)/0.18,transparent_65%)]" />
+      <div className="relative z-10 mx-auto flex min-h-screen w-full max-w-6xl flex-col items-center justify-center gap-10 px-4 py-12 sm:px-6 lg:px-8 lg:flex-row">
+        <div className="w-full rounded-[2.8rem] border border-[color:color-mix(in_srgb,var(--glass-border)_80%,transparent)] bg-[color:color-mix(in_srgb,var(--card-bg)_94%,rgba(255,255,255,0.12)_6%)] p-8 shadow-[0_35px_100px_rgba(15,23,42,0.3)] backdrop-blur-3xl lg:p-12">
+          <div className="flex items-center gap-3 text-sm font-semibold uppercase tracking-[0.35em] text-[color:color-mix(in_srgb,var(--page-text)_70%,var(--nav-link)_30%)]">
+            <Crown className="h-5 w-5" aria-hidden="true" />
+            {t("auth:register.heroBadge", { defaultValue: "Добро пожаловать" })}
+          </div>
+          <h1 className="mt-6 text-4xl font-extrabold leading-tight text-[color:var(--page-text)] sm:text-5xl">
             {t("auth:register.title")}
-          </Typography>
-          <Stack spacing={2}>
-            <TextField
-              name="full_name"
-              label={t("auth:fields.name")}
-              value={form.full_name}
-              onChange={handleChange}
-              fullWidth
-              variant="outlined"
-              autoComplete="name"
-              autoFocus
-              inputRef={fullNameRef}
-              disabled={registerPending}
-              inputProps={{ autoCapitalize: "words", spellCheck: "false" }}
-            />
-            <TextField
-              name="email"
-              label={t("auth:fields.email")}
-              type="email"
-              value={form.email}
-              onChange={handleChange}
-              onBlur={handleEmailBlur}
-              fullWidth
-              variant="outlined"
-              autoComplete="email"
-              error={!emailValid}
-              helperText={!emailValid ? t("auth:messages.invalidFormat") : " "}
-              inputRef={emailRef}
-              disabled={registerPending}
-              inputProps={{
-                inputMode: "email",
-                autoCapitalize: "none",
-                autoCorrect: "off",
-                spellCheck: "false",
-              }}
-            />
-            {emailSuggestion && (
-              <Box sx={{ mt: -1.5 }}>
-                <Chip
-                  size="small"
-                  variant="outlined"
-                  color="primary"
-                  label={t("auth:messages.emailSuggestion", { suggestion: emailSuggestion })}
+          </h1>
+          <p className="mt-4 text-lg leading-relaxed text-[color:color-mix(in_srgb,var(--page-text)_82%,var(--secondary-text)_18%)]">
+            {t("auth:register.heroDescription", {
+              defaultValue:
+                "Создайте аккаунт, чтобы управлять своей академической траекторией, посещать события и мгновенно взаимодействовать с кампусом.",
+            })}
+          </p>
+          <div className="mt-8 grid gap-5 sm:grid-cols-2">
+            {heroPerks.map(({ icon: Icon, title, description }) => (
+              <div
+                key={title}
+                className="rounded-[1.8rem] border border-[color:color-mix(in_srgb,var(--glass-border)_85%,transparent)] bg-[color:color-mix(in_srgb,var(--card-bg)_96%,rgba(255,255,255,0.08)_4%)] px-5 py-6 shadow-[0_25px_55px_rgba(15,23,42,0.18)]"
+              >
+                <div className="flex items-center gap-3">
+                  <div className="flex size-12 items-center justify-center rounded-2xl bg-[color:color-mix(in_srgb,var(--nav-link)_18%,transparent)] text-[color:var(--nav-link)]">
+                    <Icon className="h-5 w-5" aria-hidden="true" />
+                  </div>
+                  <p className="text-base font-semibold">{title}</p>
+                </div>
+                <p className="mt-4 text-sm text-[color:color-mix(in_srgb,var(--page-text)_78%,var(--secondary-text)_22%)]">
+                  {description}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="w-full max-w-2xl rounded-[2.4rem] border border-[color:color-mix(in_srgb,var(--glass-border)_80%,transparent)] bg-[color:color-mix(in_srgb,var(--card-bg)_98%,rgba(255,255,255,0.12)_2%)] p-6 shadow-[0_35px_80px_rgba(15,23,42,0.3)] backdrop-blur-2xl sm:p-10">
+          <form action={registerAction} autoComplete="off" className="flex flex-col gap-6">
+            <div className="grid gap-5 sm:grid-cols-2">
+              <div className="space-y-2">
+                <label htmlFor="full_name" className="text-sm font-semibold">
+                  {t("auth:fields.name")}
+                </label>
+                <input
+                  id="full_name"
+                  name="full_name"
+                  value={form.full_name}
+                  onChange={handleChange}
+                  className={inputBaseClass}
+                  autoComplete="name"
+                  ref={fullNameRef}
+                  disabled={registerPending}
+                  placeholder={t("auth:register.namePlaceholder", { defaultValue: "Имя и фамилия" }) ?? undefined}
+                />
+              </div>
+              <div className="space-y-2">
+                <label htmlFor="role" className="text-sm font-semibold">
+                  {t("auth:fields.role")}
+                </label>
+                <div className="relative">
+                  <select
+                    id="role"
+                    name="role"
+                    value={form.role}
+                    onChange={handleChange}
+                    className={`${inputBaseClass} appearance-none pr-12`}
+                    disabled={registerPending}
+                  >
+                    <option value="student">{t("auth:register.role.student")}</option>
+                    <option value="teacher">{t("auth:register.role.teacher")}</option>
+                    <option value="admin">{t("auth:register.role.admin")}</option>
+                  </select>
+                  <Sparkles className="pointer-events-none absolute right-4 top-1/2 h-4 w-4 -translate-y-1/2 text-[color:var(--nav-link)]" aria-hidden="true" />
+                </div>
+                <p className="text-xs text-[color:color-mix(in_srgb,var(--page-text)_70%,var(--secondary-text)_30%)]">{inviteHint}</p>
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <label htmlFor="email" className="text-sm font-semibold">
+                {t("auth:fields.email")}
+              </label>
+              <input
+                id="email"
+                name="email"
+                type="email"
+                value={form.email}
+                onChange={handleChange}
+                onBlur={handleEmailBlur}
+                className={`${inputBaseClass} ${!emailValid ? "border-red-400 focus:border-red-400" : ""}`}
+                autoComplete="email"
+                ref={emailRef}
+                disabled={registerPending}
+                placeholder="name@university.edu"
+              />
+              <p className="text-xs text-[color:color-mix(in_srgb,var(--page-text)_70%,var(--secondary-text)_30%)]">
+                {!emailValid ? t("auth:messages.invalidFormat") : " "}
+              </p>
+              {emailSuggestion ? (
+                <button
+                  type="button"
                   onClick={() => {
                     setForm((f) => ({ ...f, email: emailSuggestion }))
                     setEmailSuggestion(null)
                   }}
+                  className="inline-flex items-center gap-2 rounded-full border border-[color:color-mix(in_srgb,var(--nav-link)_60%,transparent)] px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-[color:var(--nav-link)] transition hover:bg-[color:color-mix(in_srgb,var(--nav-link)_12%,transparent)]"
+                >
+                  <Sparkles className="h-4 w-4" aria-hidden="true" />
+                  {t("auth:messages.emailSuggestion", { suggestion: emailSuggestion })}
+                </button>
+              ) : null}
+            </div>
+
+            {needsInvite ? (
+              <div className="space-y-2">
+                <label htmlFor="invite_code" className="text-sm font-semibold">
+                  {t("auth:fields.inviteCode")}
+                </label>
+                <input
+                  id="invite_code"
+                  name="invite_code"
+                  value={form.invite_code}
+                  onChange={handleChange}
+                  className={inputBaseClass}
+                  autoComplete="one-time-code"
+                  ref={inviteRef}
+                  disabled={registerPending}
+                  placeholder="ABCD-1234"
                 />
-              </Box>
-            )}
-            <FormControl fullWidth>
-              <InputLabel id="role-label">{t("auth:fields.role")}</InputLabel>
-              <Select
-                labelId="role-label"
-                name="role"
-                label={t("auth:fields.role")}
-                value={form.role}
-                onChange={handleChange}
-                variant="outlined"
-                disabled={registerPending}
-                MenuProps={{
-                  PaperProps: { sx: { maxHeight: 220, borderRadius: 2 } },
-                  anchorOrigin: { vertical: "bottom", horizontal: "left" },
-                  transformOrigin: { vertical: "top", horizontal: "left" },
-                  sx: { zIndex: 3000 },
-                }}
-              >
-                <MenuItem value="student">{t("auth:register.role.student")}</MenuItem>
-                <MenuItem value="teacher">{t("auth:register.role.teacher")}</MenuItem>
-                <MenuItem value="admin">{t("auth:register.role.admin")}</MenuItem>
-              </Select>
-            </FormControl>
-            {(form.role === "teacher" || form.role === "admin") && (
-              <TextField
-                name="invite_code"
-                label={t("auth:fields.inviteCode")}
-                value={form.invite_code}
-                onChange={handleChange}
-                fullWidth
-                variant="outlined"
-                autoComplete="one-time-code"
-                inputRef={inviteRef}
-                disabled={registerPending}
-                inputProps={{ autoCapitalize: "characters", spellCheck: "false" }}
-              />
-            )}
-            <TextField
-              name="password"
-              label={t("auth:fields.password")}
-              type={showPass ? "text" : "password"}
-              value={form.password}
-              onChange={(e) => handlePass(e.target.value)}
-              onKeyUp={(e) => setCapsPass((e as any).getModifierState?.("CapsLock"))}
-              onKeyDown={(e) => setCapsPass((e as any).getModifierState?.("CapsLock"))}
-              fullWidth
-              variant="outlined"
-              autoComplete="new-password"
-              inputRef={passwordRef}
-              disabled={registerPending}
-              helperText={t("auth:register.passwordHint")}
-              FormHelperTextProps={{ sx: { mt: 0.5 } }}
-              InputProps={{
-                endAdornment: (
-                  <InputAdornment position="end">
-                    <Tooltip title={t("auth:actions.holdReveal")}>
-                      <IconButton
-                        aria-label={t("auth:actions.showPassword")}
-                        onMouseDown={() => setShowPass(true)}
-                        onMouseUp={() => setShowPass(false)}
-                        onMouseLeave={() => setShowPass(false)}
-                        onClick={() => setShowPass((v) => !v)}
-                        edge="end"
-                        tabIndex={-1}
-                      >
-                        {showPass ? <VisibilityOff /> : <Visibility />}
-                      </IconButton>
-                    </Tooltip>
-                  </InputAdornment>
-                ),
-              }}
-            />
-            {strength !== null && (
-              <LinearProgress
-                variant="determinate"
-                value={[10, 30, 55, 75, 100][strength]}
-                sx={{ mt: -0.5, height: 8, borderRadius: 1 }}
-                aria-label={t("auth:register.passwordStrength")}
-              />
-            )}
-            <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap", mt: 0.5 }}>
-              <Chip
-                size="small"
-                label={t("auth:register.passwordChip.minLength")}
-                color={minLenOk ? "success" : "default"}
-                variant={minLenOk ? "filled" : "outlined"}
-              />
-              <Chip
-                size="small"
-                label={t("auth:register.passwordChip.match")}
-                color={matchOk ? "success" : "default"}
-                variant={matchOk ? "filled" : "outlined"}
-              />
-            </Box>
-            <Box sx={{ minHeight: 20, textAlign: "left" }}>
-              {capsPass && (
-                <Typography color="warning.main" fontSize={13}>
-                  {t("auth:messages.capsLock")}
-                </Typography>
-              )}
-            </Box>
-            <TextField
-              name="confirm"
-              label={t("auth:fields.confirmPassword")}
-              type={showConfirm ? "text" : "password"}
-              value={form.confirm}
-              onChange={handleChange}
-              onKeyUp={(e) => setCapsConfirm((e as any).getModifierState?.("CapsLock"))}
-              onKeyDown={(e) => setCapsConfirm((e as any).getModifierState?.("CapsLock"))}
-              fullWidth
-              variant="outlined"
-              autoComplete="new-password"
-              inputRef={confirmRef}
-              disabled={registerPending}
-              InputProps={{
-                endAdornment: (
-                  <InputAdornment position="end">
-                    <Tooltip title={t("auth:actions.holdReveal")}>
-                      <IconButton
-                        aria-label={t("auth:actions.showPassword")}
-                        onMouseDown={() => setShowConfirm(true)}
-                        onMouseUp={() => setShowConfirm(false)}
-                        onMouseLeave={() => setShowConfirm(false)}
-                        onClick={() => setShowConfirm((v) => !v)}
-                        edge="end"
-                        tabIndex={-1}
-                      >
-                        {showConfirm ? <VisibilityOff /> : <Visibility />}
-                      </IconButton>
-                    </Tooltip>
-                  </InputAdornment>
-                ),
-              }}
-            />
-            <Box sx={{ minHeight: 20 }}>
-              {capsConfirm && (
-                <Typography color="warning.main" fontSize={13}>
-                  {t("auth:messages.capsLock")}
-                </Typography>
-              )}
-            </Box>
-            <Box
-              sx={{
-                minHeight: 22,
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-              }}
-              aria-live="assertive"
-            >
-              {registerErrorMessage && (
-                <Typography color="error" fontSize={15}>
-                  {registerErrorMessage}
-                </Typography>
-              )}
-            </Box>
-            <Button
+              </div>
+            ) : null}
+
+            <div className="space-y-2">
+              <label htmlFor="password" className="text-sm font-semibold">
+                {t("auth:fields.password")}
+              </label>
+              <div className="relative">
+                <input
+                  id="password"
+                  name="password"
+                  type={showPass ? "text" : "password"}
+                  value={form.password}
+                  onChange={(e) => handlePass(e.target.value)}
+                  onKeyUp={(e) => setCapsPass((e as any).getModifierState?.("CapsLock"))}
+                  onKeyDown={(e) => setCapsPass((e as any).getModifierState?.("CapsLock"))}
+                  className={inputBaseClass}
+                  autoComplete="new-password"
+                  ref={passwordRef}
+                  disabled={registerPending}
+                />
+                <button
+                  type="button"
+                  onMouseDown={() => setShowPass(true)}
+                  onMouseUp={() => setShowPass(false)}
+                  onMouseLeave={() => setShowPass(false)}
+                  onClick={() => setShowPass((v) => !v)}
+                  className="absolute inset-y-0 right-4 flex items-center text-[color:var(--nav-link)]"
+                  aria-label={t("auth:actions.showPassword") ?? undefined}
+                  title={t("auth:actions.holdReveal") ?? undefined}
+                >
+                  {showPass ? <EyeOff className="h-5 w-5" aria-hidden="true" /> : <Eye className="h-5 w-5" aria-hidden="true" />}
+                </button>
+              </div>
+              <p className="text-xs text-[color:color-mix(in_srgb,var(--page-text)_70%,var(--secondary-text)_30%)]">
+                {t("auth:register.passwordHint")}
+              </p>
+              {passwordStrengthPercent !== null ? (
+                <div className="space-y-1">
+                  <div className="h-3 w-full rounded-full bg-[color:color-mix(in_srgb,var(--progress-track)_70%,transparent)]">
+                    <div
+                      className="h-full rounded-full bg-[color:var(--nav-link)] transition-all duration-300"
+                      style={{ width: `${passwordStrengthPercent}%` }}
+                    />
+                  </div>
+                  {passwordStrengthLabel ? (
+                    <p className="text-xs font-semibold text-[color:color-mix(in_srgb,var(--page-text)_78%,var(--secondary-text)_22%)]">
+                      {passwordStrengthLabel}
+                    </p>
+                  ) : null}
+                </div>
+              ) : null}
+              <div className="flex flex-wrap gap-2">
+                <span
+                  className={`${chipClass} ${
+                    minLenOk
+                      ? "border-[color:color-mix(in_srgb,var(--nav-link)_80%,white_20%)] text-[color:var(--nav-link)]"
+                      : "text-[color:color-mix(in_srgb,var(--page-text)_70%,var(--secondary-text)_30%)]"
+                  }`}
+                >
+                  {t("auth:register.passwordChip.minLength")}
+                </span>
+                <span
+                  className={`${chipClass} ${
+                    matchOk
+                      ? "border-[color:color-mix(in_srgb,var(--nav-link)_80%,white_20%)] text-[color:var(--nav-link)]"
+                      : "text-[color:color-mix(in_srgb,var(--page-text)_70%,var(--secondary-text)_30%)]"
+                  }`}
+                >
+                  {t("auth:register.passwordChip.match")}
+                </span>
+              </div>
+              {capsPass ? (
+                <p className="text-xs font-semibold text-amber-400">{t("auth:messages.capsLock")}</p>
+              ) : null}
+            </div>
+
+            <div className="space-y-2">
+              <label htmlFor="confirm" className="text-sm font-semibold">
+                {t("auth:fields.confirmPassword")}
+              </label>
+              <div className="relative">
+                <input
+                  id="confirm"
+                  name="confirm"
+                  type={showConfirm ? "text" : "password"}
+                  value={form.confirm}
+                  onChange={handleChange}
+                  onKeyUp={(e) => setCapsConfirm((e as any).getModifierState?.("CapsLock"))}
+                  onKeyDown={(e) => setCapsConfirm((e as any).getModifierState?.("CapsLock"))}
+                  className={inputBaseClass}
+                  autoComplete="new-password"
+                  ref={confirmRef}
+                  disabled={registerPending}
+                />
+                <button
+                  type="button"
+                  onMouseDown={() => setShowConfirm(true)}
+                  onMouseUp={() => setShowConfirm(false)}
+                  onMouseLeave={() => setShowConfirm(false)}
+                  onClick={() => setShowConfirm((v) => !v)}
+                  className="absolute inset-y-0 right-4 flex items-center text-[color:var(--nav-link)]"
+                  aria-label={t("auth:actions.showPassword") ?? undefined}
+                  title={t("auth:actions.holdReveal") ?? undefined}
+                >
+                  {showConfirm ? <EyeOff className="h-5 w-5" aria-hidden="true" /> : <Eye className="h-5 w-5" aria-hidden="true" />}
+                </button>
+              </div>
+              {capsConfirm ? (
+                <p className="text-xs font-semibold text-amber-400">{t("auth:messages.capsLock")}</p>
+              ) : null}
+            </div>
+
+            <div className="min-h-[1.5rem] text-center text-sm font-semibold text-red-400" aria-live="assertive">
+              {registerErrorMessage}
+            </div>
+
+            <button
               type="submit"
-              variant="contained"
-              size="large"
-              fullWidth
-              sx={{ mt: 1, fontWeight: 600, borderRadius: 2, fontSize: 17, py: 1.2 }}
+              className="inline-flex w-full items-center justify-center gap-2 rounded-[1.6rem] bg-[radial-gradient(circle_at_top,var(--nav-link),var(--nav-link-hover))] px-6 py-4 text-lg font-extrabold text-white shadow-[0_25px_50px_rgba(36,99,235,0.35)] transition hover:-translate-y-0.5 hover:shadow-[0_35px_70px_rgba(36,99,235,0.45)] disabled:opacity-60"
               disabled={registerPending || !isValid}
             >
               {registerPending ? (
-                <CircularProgress size={26} color="inherit" />
+                <>
+                  <Spinner />
+                  {t("auth:register.processing", { defaultValue: "Регистрируем..." })}
+                </>
               ) : (
                 t("auth:actions.signUp")
               )}
-            </Button>
-          </Stack>
-          <Box mt={4} textAlign="center" fontSize={15}>
-            {t("auth:register.haveAccount")}{" "}
-            <Link to="/login" style={{ color: "var(--nav-link)", textDecoration: "underline" }}>
-              {t("auth:register.ctaLogin")}
-            </Link>
-          </Box>
-        </form>
-      </Paper>
-    </Box>
+            </button>
+
+            <div className="text-center text-sm">
+              {t("auth:register.haveAccount")}{" "}
+              <Link
+                to="/login"
+                className="font-semibold text-[color:var(--nav-link)] underline-offset-4 transition hover:underline"
+              >
+                {t("auth:register.ctaLogin")}
+              </Link>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
   )
 }
 

--- a/root/frontend/src/pages/Register.tsx
+++ b/root/frontend/src/pages/Register.tsx
@@ -216,7 +216,7 @@ const Register = () => {
 
   const registerStatus = registerState.status
   const registerErrorField = registerState.field
-  const registerErrorMessage = registerStatus === "error" ? registerState.error ?? "" : ""
+  const registerErrorMessage = registerStatus === "error" ? (registerState.error ?? "") : ""
 
   useEffect(() => {
     if (!registerPending && registerStatus === "error" && registerErrorField) {
@@ -326,7 +326,10 @@ const Register = () => {
                   autoComplete="name"
                   ref={fullNameRef}
                   disabled={registerPending}
-                  placeholder={t("auth:register.namePlaceholder", { defaultValue: "Имя и фамилия" }) ?? undefined}
+                  placeholder={
+                    t("auth:register.namePlaceholder", { defaultValue: "Имя и фамилия" }) ??
+                    undefined
+                  }
                 />
               </div>
               <div className="space-y-2">
@@ -346,9 +349,14 @@ const Register = () => {
                     <option value="teacher">{t("auth:register.role.teacher")}</option>
                     <option value="admin">{t("auth:register.role.admin")}</option>
                   </select>
-                  <Sparkles className="pointer-events-none absolute right-4 top-1/2 h-4 w-4 -translate-y-1/2 text-[color:var(--nav-link)]" aria-hidden="true" />
+                  <Sparkles
+                    className="pointer-events-none absolute right-4 top-1/2 h-4 w-4 -translate-y-1/2 text-[color:var(--nav-link)]"
+                    aria-hidden="true"
+                  />
                 </div>
-                <p className="text-xs text-[color:color-mix(in_srgb,var(--page-text)_70%,var(--secondary-text)_30%)]">{inviteHint}</p>
+                <p className="text-xs text-[color:color-mix(in_srgb,var(--page-text)_70%,var(--secondary-text)_30%)]">
+                  {inviteHint}
+                </p>
               </div>
             </div>
 
@@ -434,7 +442,11 @@ const Register = () => {
                   aria-label={t("auth:actions.showPassword") ?? undefined}
                   title={t("auth:actions.holdReveal") ?? undefined}
                 >
-                  {showPass ? <EyeOff className="h-5 w-5" aria-hidden="true" /> : <Eye className="h-5 w-5" aria-hidden="true" />}
+                  {showPass ? (
+                    <EyeOff className="h-5 w-5" aria-hidden="true" />
+                  ) : (
+                    <Eye className="h-5 w-5" aria-hidden="true" />
+                  )}
                 </button>
               </div>
               <p className="text-xs text-[color:color-mix(in_srgb,var(--page-text)_70%,var(--secondary-text)_30%)]">
@@ -476,7 +488,9 @@ const Register = () => {
                 </span>
               </div>
               {capsPass ? (
-                <p className="text-xs font-semibold text-amber-400">{t("auth:messages.capsLock")}</p>
+                <p className="text-xs font-semibold text-amber-400">
+                  {t("auth:messages.capsLock")}
+                </p>
               ) : null}
             </div>
 
@@ -508,15 +522,24 @@ const Register = () => {
                   aria-label={t("auth:actions.showPassword") ?? undefined}
                   title={t("auth:actions.holdReveal") ?? undefined}
                 >
-                  {showConfirm ? <EyeOff className="h-5 w-5" aria-hidden="true" /> : <Eye className="h-5 w-5" aria-hidden="true" />}
+                  {showConfirm ? (
+                    <EyeOff className="h-5 w-5" aria-hidden="true" />
+                  ) : (
+                    <Eye className="h-5 w-5" aria-hidden="true" />
+                  )}
                 </button>
               </div>
               {capsConfirm ? (
-                <p className="text-xs font-semibold text-amber-400">{t("auth:messages.capsLock")}</p>
+                <p className="text-xs font-semibold text-amber-400">
+                  {t("auth:messages.capsLock")}
+                </p>
               ) : null}
             </div>
 
-            <div className="min-h-[1.5rem] text-center text-sm font-semibold text-red-400" aria-live="assertive">
+            <div
+              className="min-h-[1.5rem] text-center text-sm font-semibold text-red-400"
+              aria-live="assertive"
+            >
               {registerErrorMessage}
             </div>
 


### PR DESCRIPTION
## Summary
- rewrite the login and registration screens using Tailwind-based layouts that match the site aesthetic and add hero storytelling blocks
- keep all validation flows (MFA, email suggestions, caps lock hints, password helpers) while modernizing every control, gradient, and dark/light handling

## Testing
- npx eslint --max-warnings=0 src/pages/Login.tsx src/pages/Register.tsx

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b77d6c5c083278d430a496e8566fd)