### PR TITLE
Remove duplicated MFA hint

### DIFF
--- a/root/frontend/src/pages/Login.tsx
+++ b/root/frontend/src/pages/Login.tsx
@@ -337,9 +337,6 @@ const Login = () => {
                     email: activeEmail || t("auth:mfa.unknownEmail"),
                   })}
                 </h1>
-                <p className="text-base text-[color:color-mix(in_srgb,var(--page-text)_82%,var(--secondary-text)_18%)]">
-                  {t("auth:mfa.otpHint")}
-                </p>
               </div>
 
               {generalMfaError ? (
@@ -353,7 +350,7 @@ const Login = () => {
                   <OtpEntry
                     loading={mfaBusy}
                     error={mfaErrorSource === "totp" ? mfaError : null}
-                    helperText={otpHelperText ?? t("auth:mfa.otpHint")}
+                    helperText={otpHelperText ?? null}
                     onSubmit={handleOtpVerify}
                   />
                 </div>


### PR DESCRIPTION
## Summary
- remove the extra hint paragraph from the MFA challenge card so instructions are not repeated twice
- only surface helper text inside the OTP input when there is dynamic information to show

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b80837fe883279b0ad38f8cc120f7)