### PR TITLE
Localize session and notification guard errors

### DIFF
--- a/root/app/api/notifications.py
+++ b/root/app/api/notifications.py
@@ -55,9 +55,15 @@ _MISSING_COLUMN_MARKERS = (
 )
 
 
-async def _require_admin_user(user: User = Depends(get_current_user)) -> User:
+async def _require_admin_user(
+    request: Request, user: User = Depends(get_current_user)
+) -> User:
+    locale = resolve_locale(request=request, user=user)
     if user.role != "admin":
-        raise HTTPException(status_code=403, detail="Not enough permissions")
+        raise HTTPException(
+            status_code=403,
+            detail=translate("errors.notifications.admin_required", locale=locale),
+        )
     return user
 
 

--- a/root/app/api/users.py
+++ b/root/app/api/users.py
@@ -60,11 +60,12 @@ def _enforce_profile_cache_integrity(request: Request) -> None:
     if not raw_envelope:
         return
 
+    locale = resolve_locale(request=request)
     session = getattr(request.state, "active_session", None)
     if session is None or not getattr(session, "signing_key", None):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Active session is missing profile signing key",
+            detail=translate("errors.sessions.signing_key_missing", locale=locale),
         )
 
     try:
@@ -72,20 +73,22 @@ def _enforce_profile_cache_integrity(request: Request) -> None:
     except json.JSONDecodeError as exc:  # pragma: no cover - invalid client input
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Invalid profile cache envelope",
+            detail=translate("errors.profile_cache.invalid_envelope", locale=locale),
         ) from exc
 
     if not isinstance(candidate, dict):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Invalid profile cache envelope",
+            detail=translate("errors.profile_cache.invalid_envelope", locale=locale),
         )
 
     signature = candidate.get("signature")
     if not isinstance(signature, str) or not signature:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Invalid profile cache envelope signature",
+            detail=translate(
+                "errors.profile_cache.invalid_signature", locale=locale
+            ),
         )
 
     payload = {
@@ -101,7 +104,7 @@ def _enforce_profile_cache_integrity(request: Request) -> None:
     ):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Invalid profile cache envelope",
+            detail=translate("errors.profile_cache.invalid_envelope", locale=locale),
         )
 
     payload_json = json.dumps(payload, separators=(",", ":"))
@@ -115,7 +118,9 @@ def _enforce_profile_cache_integrity(request: Request) -> None:
     if not hmac.compare_digest(signature, expected_signature):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Invalid profile cache envelope signature",
+            detail=translate(
+                "errors.profile_cache.invalid_signature", locale=locale
+            ),
         )
 
 

--- a/root/app/api/users.py
+++ b/root/app/api/users.py
@@ -86,9 +86,7 @@ def _enforce_profile_cache_integrity(request: Request) -> None:
     if not isinstance(signature, str) or not signature:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=translate(
-                "errors.profile_cache.invalid_signature", locale=locale
-            ),
+            detail=translate("errors.profile_cache.invalid_signature", locale=locale),
         )
 
     payload = {
@@ -118,9 +116,7 @@ def _enforce_profile_cache_integrity(request: Request) -> None:
     if not hmac.compare_digest(signature, expected_signature):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=translate(
-                "errors.profile_cache.invalid_signature", locale=locale
-            ),
+            detail=translate("errors.profile_cache.invalid_signature", locale=locale),
         )
 
 

--- a/root/app/auth/auth.py
+++ b/root/app/auth/auth.py
@@ -1116,7 +1116,10 @@ async def get_session_signing_key(
     if session is None or not getattr(session, "signing_key", None):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Active session missing signing key",
+            detail=translate(
+                "errors.sessions.signing_key_missing",
+                locale=resolve_locale(request=request),
+            ),
         )
     return SessionSigningKeyOut(signing_key=session.signing_key)
 

--- a/root/app/localization.py
+++ b/root/app/localization.py
@@ -265,6 +265,10 @@ _TRANSLATIONS: Mapping[str, Mapping[str, str]] = {
         "ru": "Уведомление не найдено",
         "en": "Notification not found",
     },
+    "errors.notifications.admin_required": {
+        "ru": "Доступно только администраторам",
+        "en": "Administrator privileges are required",
+    },
     "errors.push.not_configured": {
         "ru": "Web push не настроен",
         "en": "Web push is not configured",
@@ -384,6 +388,18 @@ _TRANSLATIONS: Mapping[str, Mapping[str, str]] = {
     "errors.sessions.not_found": {
         "ru": "Сессия не найдена",
         "en": "Session not found",
+    },
+    "errors.sessions.signing_key_missing": {
+        "ru": "Активная сессия не содержит ключ подписи",
+        "en": "The active session is missing a signing key",
+    },
+    "errors.profile_cache.invalid_envelope": {
+        "ru": "Некорректный конверт кэша профиля",
+        "en": "Invalid profile cache envelope",
+    },
+    "errors.profile_cache.invalid_signature": {
+        "ru": "Некорректная подпись конверта профиля",
+        "en": "Invalid profile cache envelope signature",
     },
     "notifications.push.test.title_default": {
         "ru": "Тестовое веб-push уведомление",

--- a/root/tests/test_auth_cookie_flow.py
+++ b/root/tests/test_auth_cookie_flow.py
@@ -29,6 +29,39 @@ async def _login(async_client, email: str, password: str):
     )
 
 
+@pytest.mark.parametrize("locale", ["en", "ru"])
+async def test_session_signing_key_missing_localized(
+    async_client, user_factory, db_session, locale: str
+):
+    password = "SessionKeyLocale123!"
+    user = await _create_active_user(user_factory, password)
+
+    response = await _login(async_client, user.email, password)
+    assert response.status_code == 200
+    token = response.json()["access_token"]
+
+    session = (
+        await db_session.execute(
+            select(ActiveSession)
+            .where(ActiveSession.user_id == user.id)
+            .order_by(ActiveSession.id.desc())
+        )
+    ).scalars().first()
+    assert session is not None
+    session.signing_key = ""
+    await db_session.commit()
+
+    signing_key_response = await async_client.get(
+        f"/auth/session/signing-key?lang={locale}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert signing_key_response.status_code == 400
+    assert signing_key_response.json()["detail"] == translate(
+        "errors.sessions.signing_key_missing", locale=locale
+    )
+
+
 @pytest.fixture
 def configure_cookie_security(monkeypatch):
     def _configure(value):

--- a/root/tests/test_auth_cookie_flow.py
+++ b/root/tests/test_auth_cookie_flow.py
@@ -41,12 +41,16 @@ async def test_session_signing_key_missing_localized(
     token = response.json()["access_token"]
 
     session = (
-        await db_session.execute(
-            select(ActiveSession)
-            .where(ActiveSession.user_id == user.id)
-            .order_by(ActiveSession.id.desc())
+        (
+            await db_session.execute(
+                select(ActiveSession)
+                .where(ActiveSession.user_id == user.id)
+                .order_by(ActiveSession.id.desc())
+            )
         )
-    ).scalars().first()
+        .scalars()
+        .first()
+    )
     assert session is not None
     session.signing_key = ""
     await db_session.commit()

--- a/root/tests/test_notifications_api.py
+++ b/root/tests/test_notifications_api.py
@@ -7,8 +7,8 @@ from sqlalchemy import select, text, update
 from app.api.notifications import _serialize_notification
 from app.auth.security import get_password_hash
 from app.core.database import async_session
-from app.models.models import Notification, NotificationQueueJob
 from app.localization import translate
+from app.models.models import Notification, NotificationQueueJob
 from app.services.notifications import create_notifications_for_users
 
 

--- a/root/tests/test_notifications_api.py
+++ b/root/tests/test_notifications_api.py
@@ -8,6 +8,7 @@ from app.api.notifications import _serialize_notification
 from app.auth.security import get_password_hash
 from app.core.database import async_session
 from app.models.models import Notification, NotificationQueueJob
+from app.localization import translate
 from app.services.notifications import create_notifications_for_users
 
 
@@ -351,6 +352,27 @@ async def test_admin_dead_letter_requires_admin(
     )
 
     assert response.status_code == 403
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("locale", ["en", "ru"])
+async def test_admin_dead_letter_guard_localized(
+    async_client: AsyncClient, user_factory, locale: str
+):
+    password = "LocalizedAdminGuard123!"
+    hashed = get_password_hash(password)
+    user = await user_factory(hashed_password=hashed, is_active=True, role="student")
+
+    headers = await _login(async_client, user.email, password)
+    response = await async_client.get(
+        f"/notifications/admin/dead-letter?lang={locale}",
+        headers=headers,
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == translate(
+        "errors.notifications.admin_required", locale=locale
+    )
 
 
 @pytest.mark.anyio

--- a/root/tests/test_users_profile_cache.py
+++ b/root/tests/test_users_profile_cache.py
@@ -1,0 +1,114 @@
+import json
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+
+from app.auth.security import get_password_hash
+from app.localization import translate
+from app.models.models import ActiveSession
+
+PROFILE_CACHE_HEADER = "X-Profile-Cache-Envelope"
+
+
+async def _login(async_client: AsyncClient, email: str, password: str) -> str:
+    response = await async_client.post(
+        "/auth/login",
+        data={"username": email, "password": password},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert response.status_code == 200
+    return response.json()["access_token"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("locale", ["en", "ru"])
+async def test_profile_cache_missing_signing_key_localized(
+    async_client: AsyncClient, user_factory, db_session, locale: str
+):
+    password = "ProfileLocale123!"
+    hashed = get_password_hash(password)
+    user = await user_factory(hashed_password=hashed, is_active=True)
+
+    token = await _login(async_client, user.email, password)
+    session = (
+        await db_session.execute(
+            select(ActiveSession)
+            .where(ActiveSession.user_id == user.id)
+            .order_by(ActiveSession.id.desc())
+        )
+    ).scalars().first()
+    assert session is not None
+    session.signing_key = ""
+    await db_session.commit()
+
+    response = await async_client.get(
+        f"/users/me?lang={locale}",
+        headers={
+            "Authorization": f"Bearer {token}",
+            PROFILE_CACHE_HEADER: json.dumps(
+                {"version": 1, "expiresAt": 0, "data": {}, "signature": "stub"}
+            ),
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == translate(
+        "errors.sessions.signing_key_missing", locale=locale
+    )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("locale", ["en", "ru"])
+async def test_profile_cache_invalid_envelope_localized(
+    async_client: AsyncClient, user_factory, locale: str
+):
+    password = "ProfileInvalidEnvelope123!"
+    hashed = get_password_hash(password)
+    user = await user_factory(hashed_password=hashed, is_active=True)
+
+    token = await _login(async_client, user.email, password)
+    response = await async_client.get(
+        f"/users/me?lang={locale}",
+        headers={
+            "Authorization": f"Bearer {token}",
+            PROFILE_CACHE_HEADER: "not-json",
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == translate(
+        "errors.profile_cache.invalid_envelope", locale=locale
+    )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("locale", ["en", "ru"])
+async def test_profile_cache_invalid_signature_localized(
+    async_client: AsyncClient, user_factory, locale: str
+):
+    password = "ProfileInvalidSignature123!"
+    hashed = get_password_hash(password)
+    user = await user_factory(hashed_password=hashed, is_active=True)
+
+    token = await _login(async_client, user.email, password)
+    envelope = json.dumps(
+        {
+            "version": 1,
+            "expiresAt": 0,
+            "data": {},
+            "signature": "",
+        }
+    )
+    response = await async_client.get(
+        f"/users/me?lang={locale}",
+        headers={
+            "Authorization": f"Bearer {token}",
+            PROFILE_CACHE_HEADER: envelope,
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == translate(
+        "errors.profile_cache.invalid_signature", locale=locale
+    )

--- a/root/tests/test_users_profile_cache.py
+++ b/root/tests/test_users_profile_cache.py
@@ -32,12 +32,16 @@ async def test_profile_cache_missing_signing_key_localized(
 
     token = await _login(async_client, user.email, password)
     session = (
-        await db_session.execute(
-            select(ActiveSession)
-            .where(ActiveSession.user_id == user.id)
-            .order_by(ActiveSession.id.desc())
+        (
+            await db_session.execute(
+                select(ActiveSession)
+                .where(ActiveSession.user_id == user.id)
+                .order_by(ActiveSession.id.desc())
+            )
         )
-    ).scalars().first()
+        .scalars()
+        .first()
+    )
     assert session is not None
     session.signing_key = ""
     await db_session.commit()


### PR DESCRIPTION
## Summary
- localize the notifications admin guard and add translations for profile cache enforcement along with the session signing key endpoint
- ensure profile cache validation and the session signing key route resolve the caller locale and emit translated error details
- cover the new behavior with tests for notifications, profile cache envelopes, and the session signing key flow in both English and Russian

## Testing
- pytest root/tests/test_notifications_api.py -k admin_dead_letter_guard_localized
- pytest root/tests/test_users_profile_cache.py
- pytest root/tests/test_auth_cookie_flow.py -k signing_key_missing_localized

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bd84931ac832788b7b509997be9e3)