### PR TITLE
feat: isolate media caching by session

### DIFF
--- a/root/frontend/src/sw.ts
+++ b/root/frontend/src/sw.ts
@@ -151,13 +151,22 @@ const cacheMediaResponse = async (request: Request, response: Response, event?: 
   if (!cacheName) {
     return
   }
-  const cache = await caches.open(cacheName)
-  await cache.put(request, response)
+
+  try {
+    const cache = await caches.open(cacheName)
+    await cache.put(request, response)
+  } catch (error) {
+    logWarning("SW: failed to cache media response", error)
+    return
+  }
+
   const expiration = getMediaCacheExpiration(cacheName)
   const maintenance = Promise.all([
     expiration.updateTimestamp(request.url),
     expiration.expireEntries(),
-  ])
+  ]).catch((error) => {
+    logWarning("SW: failed to update media cache expiration", error)
+  })
   if (event) {
     try {
       event.waitUntil(maintenance)

--- a/root/frontend/src/sw.ts
+++ b/root/frontend/src/sw.ts
@@ -141,22 +141,23 @@ const hasSignedUrlFlag = (response: Response) => {
 const shouldTreatAsPublicMedia = (response: Response) =>
   hasPublicCacheControl(response) || hasSignedUrlFlag(response)
 
-const cacheMediaResponse = async (
-  request: Request,
-  response: Response,
-  event?: FetchEvent
-) => {
+const cacheMediaResponse = async (request: Request, response: Response, event?: FetchEvent) => {
   if (!response.ok || request.method !== "GET") {
     return
   }
-  const cacheName = shouldTreatAsPublicMedia(response) ? MEDIA_PUBLIC_CACHE : getMediaSessionCacheName()
+  const cacheName = shouldTreatAsPublicMedia(response)
+    ? MEDIA_PUBLIC_CACHE
+    : getMediaSessionCacheName()
   if (!cacheName) {
     return
   }
   const cache = await caches.open(cacheName)
   await cache.put(request, response)
   const expiration = getMediaCacheExpiration(cacheName)
-  const maintenance = Promise.all([expiration.updateTimestamp(request.url), expiration.expireEntries()])
+  const maintenance = Promise.all([
+    expiration.updateTimestamp(request.url),
+    expiration.expireEntries(),
+  ])
   if (event) {
     try {
       event.waitUntil(maintenance)

--- a/root/frontend/src/sw.ts
+++ b/root/frontend/src/sw.ts
@@ -6,9 +6,10 @@ import {
   createHandlerBoundToURL,
 } from "workbox-precaching"
 import { clientsClaim } from "workbox-core"
+import type { RouteHandlerCallbackOptions } from "workbox-core"
 import { registerRoute, NavigationRoute } from "workbox-routing"
 import { StaleWhileRevalidate, CacheFirst, NetworkFirst } from "workbox-strategies"
-import { ExpirationPlugin } from "workbox-expiration"
+import { CacheExpiration, ExpirationPlugin } from "workbox-expiration"
 import {
   NotificationData,
   buildNotificationDetails,
@@ -22,6 +23,9 @@ declare const self: ServiceWorkerGlobalScope & typeof globalThis
 const OFFLINE_URL = "/offline.html"
 const API_CACHE = "api-cache"
 const API_CACHE_SESSION_PREFIX = `${API_CACHE}:`
+const MEDIA_PUBLIC_CACHE = "media-public"
+const MEDIA_PRIVATE_CACHE_PREFIX = "media-private:"
+const MEDIA_CACHE_LIMITS = { maxEntries: 200, maxAgeSeconds: 24 * 60 * 60 }
 const IMG_CACHE = "img-cache"
 const BACKEND_STATIC_CACHE = "backend-static"
 const CLICK_DB_NAME = "notification-interactions"
@@ -33,13 +37,14 @@ const REPORT_SYNC_TAG = "notification-click:report"
 const PROCESS_QUEUE_MESSAGE = SERVICE_WORKER_MESSAGE_TYPES.PROCESS_NOTIFICATION_CLICK_QUEUE
 
 const apiStrategies = new Map<string, StaleWhileRevalidate>()
-let apiSessionCacheHash: string | null = null
+const mediaCacheExpirations = new Map<string, CacheExpiration>()
+let sessionCacheHash: string | null = null
 
 const API_CACHE_PLUGIN = new ExpirationPlugin({ maxEntries: 100, maxAgeSeconds: 60 * 60 })
 
 const getApiCacheName = () =>
-  apiSessionCacheHash && apiSessionCacheHash.length > 0
-    ? `${API_CACHE_SESSION_PREFIX}${apiSessionCacheHash}`
+  sessionCacheHash && sessionCacheHash.length > 0
+    ? `${API_CACHE_SESSION_PREFIX}${sessionCacheHash}`
     : API_CACHE
 
 const getApiStrategy = () => {
@@ -57,22 +62,130 @@ const getApiStrategy = () => {
   return strategy
 }
 
-const purgeApiCaches = async () => {
+const purgeSessionCaches = async () => {
   const cacheKeys = await caches.keys()
   const deletions = cacheKeys
-    .filter((key) => key === API_CACHE || key.startsWith(API_CACHE_SESSION_PREFIX))
-    .map((key) => caches.delete(key))
+    .filter(
+      (key) =>
+        key === API_CACHE ||
+        key.startsWith(API_CACHE_SESSION_PREFIX) ||
+        key.startsWith(MEDIA_PRIVATE_CACHE_PREFIX)
+    )
+    .map(async (key) => {
+      const tracker = mediaCacheExpirations.get(key)
+      if (tracker) {
+        mediaCacheExpirations.delete(key)
+        try {
+          await tracker.delete()
+        } catch {
+          /* ignore */
+        }
+      }
+      await caches.delete(key)
+    })
   apiStrategies.clear()
   await Promise.all(deletions)
 }
 
-const setApiSessionCache = (hash: unknown) => {
+const setSessionCacheKey = (hash: unknown) => {
   if (typeof hash === "string" && hash.length > 0) {
-    apiSessionCacheHash = hash
+    sessionCacheHash = hash
   } else {
-    apiSessionCacheHash = null
+    sessionCacheHash = null
   }
   apiStrategies.clear()
+}
+
+const getMediaSessionCacheName = () =>
+  sessionCacheHash && sessionCacheHash.length > 0
+    ? `${MEDIA_PRIVATE_CACHE_PREFIX}${sessionCacheHash}`
+    : null
+
+const getMediaCacheExpiration = (cacheName: string) => {
+  let expiration = mediaCacheExpirations.get(cacheName)
+  if (!expiration) {
+    expiration = new CacheExpiration(cacheName, MEDIA_CACHE_LIMITS)
+    mediaCacheExpirations.set(cacheName, expiration)
+  }
+  return expiration
+}
+
+const matchMediaCaches = async (request: Request) => {
+  const cacheNames: (string | null)[] = [getMediaSessionCacheName(), MEDIA_PUBLIC_CACHE]
+  for (const cacheName of cacheNames) {
+    if (!cacheName) continue
+    const cache = await caches.open(cacheName)
+    const match = await cache.match(request)
+    if (match) {
+      return match
+    }
+  }
+  return null
+}
+
+const hasPublicCacheControl = (response: Response) => {
+  const cacheControl = response.headers.get("Cache-Control")
+  return cacheControl ? /\bpublic\b/i.test(cacheControl) : false
+}
+
+const hasSignedUrlFlag = (response: Response) => {
+  const signedHeaders = ["x-media-signed-url", "x-signed-url", "x-media-signed"]
+  return signedHeaders.some((header) => {
+    const value = response.headers.get(header)
+    if (!value) return false
+    const normalized = value.trim().toLowerCase()
+    return normalized !== "0" && normalized !== "false"
+  })
+}
+
+const shouldTreatAsPublicMedia = (response: Response) =>
+  hasPublicCacheControl(response) || hasSignedUrlFlag(response)
+
+const cacheMediaResponse = async (
+  request: Request,
+  response: Response,
+  event?: FetchEvent
+) => {
+  if (!response.ok || request.method !== "GET") {
+    return
+  }
+  const cacheName = shouldTreatAsPublicMedia(response) ? MEDIA_PUBLIC_CACHE : getMediaSessionCacheName()
+  if (!cacheName) {
+    return
+  }
+  const cache = await caches.open(cacheName)
+  await cache.put(request, response)
+  const expiration = getMediaCacheExpiration(cacheName)
+  const maintenance = Promise.all([expiration.updateTimestamp(request.url), expiration.expireEntries()])
+  if (event) {
+    try {
+      event.waitUntil(maintenance)
+    } catch {
+      void maintenance
+    }
+  } else {
+    void maintenance
+  }
+}
+
+const mediaRouteHandler = async ({ event }: RouteHandlerCallbackOptions) => {
+  const fetchEvent = event as FetchEvent
+  const request = fetchEvent.request
+  if (request.method !== "GET") {
+    return fetch(request)
+  }
+  try {
+    const response = await fetch(request)
+    const clone = response.clone()
+    void cacheMediaResponse(request, clone, fetchEvent)
+    return response
+  } catch (error) {
+    const cached = await matchMediaCaches(request)
+    if (cached) {
+      return cached
+    }
+    throw error
+  }
 }
 
 type PendingNavigation = {
@@ -448,6 +561,7 @@ type ServiceWorkerTestingApi = {
   processPendingNavigations: typeof processPendingNavigations
   processPendingReports: typeof processPendingReports
   processAllQueues: typeof processAllQueues
+  handleMediaRequest: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
 }
 
 declare global {
@@ -465,6 +579,14 @@ if (import.meta.env.MODE === "test") {
     processPendingNavigations,
     processPendingReports,
     processAllQueues,
+    handleMediaRequest: (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = new Request(input, init)
+      const event = Object.assign(Object.create(null), {
+        request,
+        waitUntil: (promise: Promise<unknown>) => promise,
+      }) as FetchEvent
+      return mediaRouteHandler({ event, request, url: new URL(request.url) })
+    },
   }
 }
 
@@ -486,9 +608,9 @@ self.addEventListener("message", (event) => {
   } else if (type === PROCESS_QUEUE_MESSAGE) {
     event.waitUntil(processAllQueues())
   } else if (type === SERVICE_WORKER_MESSAGE_TYPES.CLEAR_API_CACHE) {
-    event.waitUntil(purgeApiCaches())
+    event.waitUntil(purgeSessionCaches())
   } else if (type === SERVICE_WORKER_MESSAGE_TYPES.SET_API_SESSION_CACHE_KEY) {
-    setApiSessionCache(message.sessionHash)
+    setSessionCacheKey(message.sessionHash)
   }
 })
 
@@ -535,12 +657,14 @@ registerRoute(
 )
 
 registerRoute(
-  ({ url }) => url.pathname.startsWith("/static/") || url.pathname.startsWith("/media/"),
+  ({ url }) => url.pathname.startsWith("/static/"),
   new NetworkFirst({
     cacheName: BACKEND_STATIC_CACHE,
     plugins: [new ExpirationPlugin({ maxEntries: 200, maxAgeSeconds: 24 * 60 * 60 })],
   })
 )
+
+registerRoute(({ url }) => url.pathname.startsWith("/media/"), mediaRouteHandler, "GET")
 
 registerRoute(
   ({ request }) => request.destination === "image",

--- a/root/frontend/src/tests/sw.test.ts
+++ b/root/frontend/src/tests/sw.test.ts
@@ -1,6 +1,8 @@
 import "fake-indexeddb/auto"
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
+import { http, HttpResponse } from "msw"
 import { SERVICE_WORKER_MESSAGE_TYPES } from "@/constants/serviceWorkerMessages"
+import { server } from "@/tests/mocks/server"
 
 vi.mock("workbox-precaching", () => ({
   cleanupOutdatedCaches: vi.fn(),
@@ -23,9 +25,17 @@ vi.mock("workbox-strategies", () => ({
   NetworkFirst: vi.fn(() => ({})),
 }))
 
-vi.mock("workbox-expiration", () => ({
-  ExpirationPlugin: vi.fn(() => ({})),
-}))
+vi.mock("workbox-expiration", () => {
+  const CacheExpiration = vi.fn(() => ({
+    updateTimestamp: vi.fn(async () => {}),
+    expireEntries: vi.fn(async () => {}),
+    delete: vi.fn(async () => {}),
+  }))
+  return {
+    ExpirationPlugin: vi.fn(() => ({})),
+    CacheExpiration,
+  }
+})
 
 const CLICK_DB_NAME = "notification-interactions"
 
@@ -121,6 +131,7 @@ type ServiceWorkerTestingApi = {
   processPendingNavigations: () => Promise<void>
   processPendingReports: () => Promise<void>
   processAllQueues: () => Promise<void>
+  handleMediaRequest: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
 }
 
 const deleteDatabase = async () => {
@@ -239,6 +250,16 @@ const getListener = (type: string) => {
     throw new Error(`Expected listener for ${type}`)
   }
   return registered[registered.length - 1]
+}
+
+const dispatchSwMessage = async (data: Record<string, unknown>) => {
+  const listener = getListener("message")
+  const waitUntil = vi.fn((promise: Promise<unknown>) => promise)
+  listener({ data, waitUntil } as unknown as ExtendableMessageEvent)
+  const pending = waitUntil.mock.calls[0]?.[0]
+  if (pending instanceof Promise) {
+    await pending
+  }
 }
 
 describe("service worker offline queues", () => {
@@ -363,5 +384,61 @@ describe("service worker api cache controls", () => {
     }
 
     expect(cacheStorage.__store.has(cacheName)).toBe(false)
+  })
+})
+
+describe("service worker media cache controls", () => {
+  test("clears session-specific media caches when requested", async () => {
+    const scope = self as unknown as TestServiceWorkerScope
+    const cacheName = "media-private:session-alpha"
+    const cache = await scope.caches.open(cacheName)
+    await cache.put("https://example.com/media/private.png", new Response("alpha"))
+
+    await dispatchSwMessage({ type: SERVICE_WORKER_MESSAGE_TYPES.CLEAR_API_CACHE })
+
+    expect(scope.caches.__store.has(cacheName)).toBe(false)
+  })
+
+  test("private media responses are not reused across sessions", async () => {
+    const sw = await loadServiceWorker()
+    const scope = self as unknown as TestServiceWorkerScope
+    const mediaUrl = "https://example.com/media/private.png"
+    let requestCount = 0
+
+    server.use(
+      http.get(mediaUrl, () => {
+        requestCount += 1
+        return HttpResponse.text(`private-response-${requestCount}`, {
+          headers: { "Cache-Control": "private" },
+        })
+      })
+    )
+
+    await dispatchSwMessage({
+      type: SERVICE_WORKER_MESSAGE_TYPES.SET_API_SESSION_CACHE_KEY,
+      sessionHash: "alpha",
+    })
+
+    const first = await sw.handleMediaRequest(mediaUrl)
+    await expect(first.text()).resolves.toBe("private-response-1")
+    expect(scope.caches.__store.has("media-private:alpha")).toBe(true)
+
+    await dispatchSwMessage({ type: SERVICE_WORKER_MESSAGE_TYPES.CLEAR_API_CACHE })
+    expect(scope.caches.__store.has("media-private:alpha")).toBe(false)
+
+    await dispatchSwMessage({
+      type: SERVICE_WORKER_MESSAGE_TYPES.SET_API_SESSION_CACHE_KEY,
+      sessionHash: "beta",
+    })
+
+    server.use(
+      http.get(mediaUrl, () => {
+        return HttpResponse.error()
+      })
+    )
+
+    await expect(sw.handleMediaRequest(mediaUrl)).rejects.toThrow()
+    const betaCache = await scope.caches.open("media-private:beta")
+    await expect(betaCache.match(mediaUrl)).resolves.toBeUndefined()
   })
 })

--- a/root/frontend/src/tests/sw.test.ts
+++ b/root/frontend/src/tests/sw.test.ts
@@ -441,4 +441,63 @@ describe("service worker media cache controls", () => {
     const betaCache = await scope.caches.open("media-private:beta")
     await expect(betaCache.match(mediaUrl)).resolves.toBeUndefined()
   })
+
+  test("public media responses fall back to the shared cache when offline", async () => {
+    const sw = await loadServiceWorker()
+    const scope = self as unknown as TestServiceWorkerScope
+    const mediaUrl = "https://example.com/media/banner.png"
+    let requestCount = 0
+
+    server.use(
+      http.get(mediaUrl, () => {
+        requestCount += 1
+        if (requestCount === 1) {
+          return HttpResponse.text("public-response", {
+            headers: { "Cache-Control": "public, max-age=60" },
+          })
+        }
+        return HttpResponse.error()
+      })
+    )
+
+    const first = await sw.handleMediaRequest(mediaUrl)
+    await expect(first.text()).resolves.toBe("public-response")
+    expect(scope.caches.__store.has("media-public")).toBe(true)
+
+    const second = await sw.handleMediaRequest(mediaUrl)
+    await expect(second.text()).resolves.toBe("public-response")
+  })
+
+  test("signed media responses are cached publicly even during authenticated sessions", async () => {
+    const sw = await loadServiceWorker()
+    const scope = self as unknown as TestServiceWorkerScope
+    const mediaUrl = "https://example.com/media/signed.png"
+
+    await dispatchSwMessage({
+      type: SERVICE_WORKER_MESSAGE_TYPES.SET_API_SESSION_CACHE_KEY,
+      sessionHash: "gamma",
+    })
+
+    server.use(
+      http.get(mediaUrl, () =>
+        HttpResponse.text("signed-media", {
+          headers: { "x-media-signed-url": "true" },
+        })
+      )
+    )
+
+    const first = await sw.handleMediaRequest(mediaUrl)
+    await expect(first.text()).resolves.toBe("signed-media")
+    expect(scope.caches.__store.has("media-public")).toBe(true)
+    expect(scope.caches.__store.has("media-private:gamma")).toBe(false)
+
+    server.use(
+      http.get(mediaUrl, () => {
+        return HttpResponse.error()
+      })
+    )
+
+    const second = await sw.handleMediaRequest(mediaUrl)
+    await expect(second.text()).resolves.toBe("signed-media")
+  })
 })


### PR DESCRIPTION
## Summary
- split the static and media Workbox routes so media requests go through a custom handler
- add session-aware media caching with public/shared buckets and delete private caches on logout messages
- extend the service worker test suite with MSW-based media cache regression coverage

## Testing
- npm run test -- src/tests/sw.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cac77723c83279067201020993140)