### PR TITLE
Reset ETag cache on auth transitions

### DIFF
--- a/root/frontend/src/api/hooks/__tests__/events.etag.test.tsx
+++ b/root/frontend/src/api/hooks/__tests__/events.etag.test.tsx
@@ -1,0 +1,79 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { HttpResponse, http } from "msw"
+import type { PropsWithChildren } from "react"
+import { describe, expect, it } from "vitest"
+
+import { resetEtagCache } from "@/api/client"
+import { useEventsListQuery } from "@/api/hooks/events"
+import type { Event } from "@/types/Event"
+import { testEvents } from "@/tests/mocks/handlers"
+import { server } from "@/tests/mocks/server"
+
+const SHARED_EVENTS_ETAG = '"events-list-shared"'
+
+const cloneEvents = (source: Event[], label: string, offset: number): Event[] =>
+  source.map((event, index) => ({
+    ...event,
+    id: event.id + offset + index,
+    title: `${label} list ${index + 1}`,
+    title_en: `${label} list ${index + 1}`,
+    description: `${label} description ${index + 1}`,
+    description_en: `${label} description ${index + 1}`,
+  }))
+
+describe("useEventsListQuery", () => {
+  it("forces a revalidation after resetEtagCache for the next user session", async () => {
+    const baseEvents = testEvents.slice(0, 4)
+    const firstUserEvents = cloneEvents(baseEvents, "First", 0)
+    const secondUserEvents = cloneEvents(baseEvents, "Second", 200)
+    let activeSnapshot = firstUserEvents
+
+    server.use(
+      http.get("*/events", ({ request }) => {
+        if (request.headers.get("if-none-match") === SHARED_EVENTS_ETAG) {
+          return new HttpResponse(null, {
+            status: 304,
+            headers: { ETag: SHARED_EVENTS_ETAG },
+          })
+        }
+
+        return HttpResponse.json(
+          {
+            items: activeSnapshot,
+            total: activeSnapshot.length,
+            limit: 12,
+            cursor: null,
+            next_cursor: null,
+            has_more: false,
+          },
+          { headers: { ETag: SHARED_EVENTS_ETAG } }
+        )
+      })
+    )
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+
+    const { result } = renderHook(
+      () => useEventsListQuery({ language: "ru", is_active: true }),
+      { wrapper }
+    )
+
+    await waitFor(() => expect(result.current.events).toEqual(firstUserEvents))
+
+    activeSnapshot = secondUserEvents
+    resetEtagCache()
+
+    await act(async () => {
+      await result.current.refetch()
+    })
+
+    await waitFor(() => expect(result.current.events).toEqual(secondUserEvents))
+  })
+})

--- a/root/frontend/src/api/hooks/__tests__/events.etag.test.tsx
+++ b/root/frontend/src/api/hooks/__tests__/events.etag.test.tsx
@@ -60,10 +60,9 @@ describe("useEventsListQuery", () => {
       <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
     )
 
-    const { result } = renderHook(
-      () => useEventsListQuery({ language: "ru", is_active: true }),
-      { wrapper }
-    )
+    const { result } = renderHook(() => useEventsListQuery({ language: "ru", is_active: true }), {
+      wrapper,
+    })
 
     await waitFor(() => expect(result.current.events).toEqual(firstUserEvents))
 

--- a/root/frontend/src/app/__tests__/a11y.test.tsx
+++ b/root/frontend/src/app/__tests__/a11y.test.tsx
@@ -110,6 +110,7 @@ const createWrapper = (route = "/dashboard") => {
     pendingMfa: null,
     submitMfaChallenge: vi.fn().mockResolvedValue(undefined),
     requireMfa: vi.fn().mockResolvedValue(null),
+    resetEtagCache: vi.fn(),
   }
 
   const Wrapper = ({ children }: PropsWithChildren) => (

--- a/root/frontend/src/contexts/AuthContext.tsx
+++ b/root/frontend/src/contexts/AuthContext.tsx
@@ -17,7 +17,7 @@ import type { TFunction } from "i18next"
 import { hmac } from "@noble/hashes/hmac"
 import { sha256 } from "@noble/hashes/sha256"
 import { hasPushConsent, softSyncPushSubscription, unsubscribePush } from "@/push/subscribe"
-import api, { API_UNAUTHORIZED_EVENT } from "../api/client"
+import api, { API_UNAUTHORIZED_EVENT, resetEtagCache } from "../api/client"
 import type { components } from "@/api/generated/schema"
 import { SPOTIFY_REAUTH_EVENT } from "@/hooks/useNowPlaying"
 import type { PendingMfaResponse, MfaVerifyPayload } from "@/types/Mfa"
@@ -50,6 +50,7 @@ type AuthContextType = {
   pendingMfa: PendingMfaState | null
   submitMfaChallenge: (payload: SubmitMfaChallengePayload) => Promise<void>
   requireMfa: () => Promise<PendingMfaState | null>
+  resetEtagCache: () => void
 }
 
 export class ChallengeLockedError extends Error {
@@ -80,6 +81,7 @@ export const AuthContext = createContext<AuthContextType>({
   pendingMfa: null,
   submitMfaChallenge: async () => {},
   requireMfa: async () => null,
+  resetEtagCache,
 })
 
 export const useAuth = () => useContext(AuthContext)
@@ -695,6 +697,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 
   const handleUnauthorized = useCallback(
     ({ broadcast = true, persist = true }: HandleUnauthorizedOptions = {}) => {
+      resetEtagCache()
       sessionSigningKeyPromiseRef.current = null
       updateSessionSigningKey(null)
       clearProfile({ persist })
@@ -888,6 +891,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         signingKey?: string | null
       } = {}
     ) => {
+      resetEtagCache()
       let resolvedProfile: User | null = profile ?? null
       let signingKeyPromise: Promise<string | null> | null = null
 
@@ -1235,6 +1239,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       } catch (error) {
         console.error("Failed to unsubscribe push subscription on logout", error)
       } finally {
+        resetEtagCache()
         handleUnauthorized()
         setAuthOperation(false)
       }
@@ -1258,6 +1263,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       pendingMfa,
       submitMfaChallenge,
       requireMfa,
+      resetEtagCache,
     }),
     [
       isAuth,
@@ -1270,6 +1276,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       pendingMfa,
       submitMfaChallenge,
       requireMfa,
+      resetEtagCache,
     ]
   )
 

--- a/root/frontend/src/hooks/__tests__/useDashboardEvents.etag.test.tsx
+++ b/root/frontend/src/hooks/__tests__/useDashboardEvents.etag.test.tsx
@@ -1,0 +1,76 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { HttpResponse, http } from "msw"
+import type { PropsWithChildren } from "react"
+import { describe, expect, it } from "vitest"
+
+import { resetEtagCache } from "@/api/client"
+import { dashboardEventsQueryKey, useDashboardEvents } from "@/hooks/useDashboardEvents"
+import type { Event } from "@/types/Event"
+import { testEvents } from "@/tests/mocks/handlers"
+import { server } from "@/tests/mocks/server"
+
+const SHARED_DASHBOARD_ETAG = '"dashboard-events-shared"'
+
+const cloneEvents = (source: Event[], label: string, offset: number): Event[] =>
+  source.map((event, index) => ({
+    ...event,
+    id: event.id + offset + index,
+    title: `${label} event ${index + 1}`,
+    title_en: `${label} event ${index + 1}`,
+    description: `${label} description ${index + 1}`,
+    description_en: `${label} description ${index + 1}`,
+  }))
+
+describe("useDashboardEvents", () => {
+  it("fetches fresh events after resetEtagCache when a new user signs in", async () => {
+    const baseEvents = testEvents.slice(0, 3)
+    const firstUserEvents = cloneEvents(baseEvents, "First user", 0)
+    const secondUserEvents = cloneEvents(baseEvents, "Second user", 100)
+    let activeSnapshot = firstUserEvents
+
+    server.use(
+      http.get("*/events", ({ request }) => {
+        if (request.headers.get("if-none-match") === SHARED_DASHBOARD_ETAG) {
+          return new HttpResponse(null, {
+            status: 304,
+            headers: { ETag: SHARED_DASHBOARD_ETAG },
+          })
+        }
+
+        return HttpResponse.json(
+          {
+            items: activeSnapshot,
+            total: activeSnapshot.length,
+            limit: 50,
+            cursor: null,
+            next_cursor: null,
+            has_more: false,
+          },
+          { headers: { ETag: SHARED_DASHBOARD_ETAG } }
+        )
+      })
+    )
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+
+    const { result } = renderHook(() => useDashboardEvents(), { wrapper })
+
+    await waitFor(() => expect(result.current.data).toEqual(firstUserEvents))
+
+    activeSnapshot = secondUserEvents
+    resetEtagCache()
+
+    await act(async () => {
+      await queryClient.invalidateQueries({ queryKey: dashboardEventsQueryKey })
+    })
+
+    await waitFor(() => expect(result.current.data).toEqual(secondUserEvents))
+  })
+})

--- a/root/frontend/src/pages/__tests__/Settings.media.test.tsx
+++ b/root/frontend/src/pages/__tests__/Settings.media.test.tsx
@@ -96,6 +96,7 @@ const renderSettings = () => {
                 pendingMfa: null,
                 submitMfaChallenge: vi.fn().mockResolvedValue(undefined),
                 requireMfa: vi.fn().mockResolvedValue(null),
+                resetEtagCache: vi.fn(),
               }}
             >
               <Settings />

--- a/root/frontend/src/pages/__tests__/Settings.radio.test.tsx
+++ b/root/frontend/src/pages/__tests__/Settings.radio.test.tsx
@@ -95,6 +95,7 @@ const renderSettings = () => {
                 pendingMfa: null,
                 submitMfaChallenge: vi.fn().mockResolvedValue(undefined),
                 requireMfa: vi.fn().mockResolvedValue(null),
+                resetEtagCache: vi.fn(),
               }}
             >
               <Settings />

--- a/root/frontend/src/pages/__tests__/Settings.sessions.test.tsx
+++ b/root/frontend/src/pages/__tests__/Settings.sessions.test.tsx
@@ -90,6 +90,7 @@ const renderSettings = () => {
                 pendingMfa: null,
                 submitMfaChallenge: vi.fn().mockResolvedValue(undefined),
                 requireMfa: vi.fn().mockResolvedValue(null),
+                resetEtagCache: vi.fn(),
               }}
             >
               <Settings />

--- a/root/frontend/src/pages/__tests__/Settings.totp.test.tsx
+++ b/root/frontend/src/pages/__tests__/Settings.totp.test.tsx
@@ -78,6 +78,7 @@ const renderSettings = (options?: RenderSettingsOptions) => {
           pendingMfa: null,
           submitMfaChallenge: vi.fn(),
           requireMfa: vi.fn(),
+          resetEtagCache: vi.fn(),
         }}
       >
         {children}

--- a/root/frontend/src/tests/pages/AdminNotifications.test.tsx
+++ b/root/frontend/src/tests/pages/AdminNotifications.test.tsx
@@ -59,6 +59,7 @@ const authValue = {
   pendingMfa: null,
   submitMfaChallenge: vi.fn().mockResolvedValue(undefined),
   requireMfa: vi.fn().mockResolvedValue(null),
+  resetEtagCache: vi.fn(),
 }
 
 type RenderResult = { queryClient: QueryClient }

--- a/root/frontend/src/tests/pages/EventsCache.test.tsx
+++ b/root/frontend/src/tests/pages/EventsCache.test.tsx
@@ -87,6 +87,7 @@ const authValue: AuthContextValue = {
   pendingMfa: null,
   submitMfaChallenge: vi.fn().mockResolvedValue(undefined),
   requireMfa: vi.fn().mockResolvedValue(null),
+  resetEtagCache: vi.fn(),
 }
 
 describe("Events caching", () => {

--- a/root/frontend/src/tests/pages/EventsPagination.test.tsx
+++ b/root/frontend/src/tests/pages/EventsPagination.test.tsx
@@ -94,6 +94,7 @@ const authValue: AuthContextValue = {
   pendingMfa: null,
   submitMfaChallenge: vi.fn().mockResolvedValue(undefined),
   requireMfa: vi.fn().mockResolvedValue(null),
+  resetEtagCache: vi.fn(),
 }
 
 describe("Events pagination UI", () => {

--- a/root/frontend/src/tests/pages/News/NewsFeed.test.tsx
+++ b/root/frontend/src/tests/pages/News/NewsFeed.test.tsx
@@ -141,6 +141,7 @@ const renderNewsPage = async (queryClient?: QueryClient) => {
     pendingMfa: null,
     submitMfaChallenge: vi.fn().mockResolvedValue(undefined),
     requireMfa: vi.fn().mockResolvedValue(null),
+    resetEtagCache: vi.fn(),
   }
 
   const client =


### PR DESCRIPTION
## Summary
- expose the API client's `resetEtagCache` through the auth context and invoke it when sessions start, end, or expire so new logins do not reuse stale ETags
- update every test helper that provides an `AuthContext` value to satisfy the new contract
- add unit tests for `useDashboardEvents` and `useEventsListQuery` that ensure a cache reset forces a fresh fetch for the next user

## Testing
- `cd root/frontend && npm run test -- src/hooks/__tests__/useDashboardEvents.etag.test.tsx src/api/hooks/__tests__/events.etag.test.tsx`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cecd96d7083279f54ca0ea6077103)