### PR TITLE
Ensure unique skip links and add accessibility test

### DIFF
--- a/root/frontend/src/pages/Dashboard.tsx
+++ b/root/frontend/src/pages/Dashboard.tsx
@@ -357,11 +357,8 @@ export default function Dashboard() {
 
   return (
     <Layout>
-      <a href="#main" className="skip-link">
-        {t("common:skipToMain")}
-      </a>
       <PageFadeIn>
-        <section id="main" className={heroSectionClass}>
+        <section className={heroSectionClass}>
           <div aria-hidden="true" className="pointer-events-none absolute inset-0">
             {heroBackdropLayers.map((layer, index) => (
               <div key={index} className={layer} />

--- a/root/frontend/src/pages/Profile.tsx
+++ b/root/frontend/src/pages/Profile.tsx
@@ -10,6 +10,7 @@ import spotifyLogo from "../assets/spotify_icon.png"
 import { AVATAR_PLACEHOLDER_URL } from "@/constants/placeholders"
 const DEFAULT_AVATAR = AVATAR_PLACEHOLDER_URL
 import PageFadeIn from "../components/PageFadeIn"
+import Layout from "../components/Layout"
 import {
   CircularProgress,
   Snackbar,
@@ -659,7 +660,7 @@ export default function Profile() {
   const snackMessage = snack?.key ? t(`profile:snackbar.${snack.key}`) : snack?.message || ""
 
   return (
-    <>
+    <Layout>
       {/* Seamless tiled background */}
       <div className="profile-background" aria-hidden>
         <div
@@ -674,8 +675,7 @@ export default function Profile() {
           animate={{ opacity: 1, y: 0 }}
           transition={isTest ? { duration: 0 } : { type: "spring", stiffness: 460, damping: 34 }}
         >
-          <main
-            id="main"
+          <section
             className="profile-page relative min-h-screen flex flex-col py-12 sm:py-16 md:py-20 lg:py-24 px-3 sm:px-4 md:px-6 lg:px-8"
             data-testid="profile-root"
             aria-label={t("profile:aria.page")}
@@ -1241,7 +1241,7 @@ export default function Profile() {
                 </div>
               </motion.div>
             </div>
-          </main>
+          </section>
         </motion.div>
       </PageFadeIn>
 
@@ -1348,6 +1348,6 @@ export default function Profile() {
           {snackMessage}
         </Alert>
       </Snackbar>
-    </>
+    </Layout>
   )
 }

--- a/root/frontend/src/tests/accessibility/skipLink.test.tsx
+++ b/root/frontend/src/tests/accessibility/skipLink.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest"
-import type { ReactElement } from "react"
+import type { ContextType, ReactElement } from "react"
 import { MemoryRouter } from "react-router-dom"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 
@@ -38,6 +38,8 @@ vi.mock("@/components/WeatherWidget", () => ({
   default: () => <div data-testid="stub-weather-widget" />,
 }))
 
+type AuthContextValue = ContextType<typeof AuthContext>
+
 const baseUser: User = {
   id: 1,
   email: "student@example.com",
@@ -74,7 +76,7 @@ const baseUser: User = {
   mfa_challenges: [],
 }
 
-const baseAuthValue = {
+const baseAuthValue: AuthContextValue = {
   isAuth: true,
   login: vi.fn(),
   logout: vi.fn(),
@@ -88,7 +90,7 @@ const baseAuthValue = {
   resetEtagCache: vi.fn(),
 }
 
-const unauthenticatedAuthValue = {
+const unauthenticatedAuthValue: AuthContextValue = {
   ...baseAuthValue,
   isAuth: false,
   user: null,

--- a/root/frontend/src/tests/accessibility/skipLink.test.tsx
+++ b/root/frontend/src/tests/accessibility/skipLink.test.tsx
@@ -1,0 +1,164 @@
+import { describe, expect, it, vi } from "vitest"
+import type { ReactElement } from "react"
+import { MemoryRouter } from "react-router-dom"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+
+import { renderWithA11y } from "../axeTest"
+import { AuthContext } from "@/contexts/AuthContext"
+import { LanguageProvider } from "@/contexts/LanguageContext"
+import type { User } from "@/types/User"
+import Dashboard from "@/pages/Dashboard"
+import Profile from "@/pages/Profile"
+import Login from "@/pages/Login"
+
+vi.mock("@/hooks/useDashboardStories", () => ({
+  useDashboardStories: () => ({ data: [], isLoading: false }),
+  prefetchDashboardStories: vi.fn(),
+}))
+
+vi.mock("@/hooks/useDashboardNews", () => ({
+  useDashboardNews: () => ({ data: [], isLoading: false }),
+  prefetchDashboardNews: vi.fn(),
+}))
+
+vi.mock("@/hooks/useDashboardEvents", () => ({
+  useDashboardEvents: () => ({ data: [], isLoading: false }),
+  prefetchDashboardEvents: vi.fn(),
+}))
+
+vi.mock("@/hooks/useDashboardSchedule", () => ({
+  useDashboardSchedule: () => ({ data: [], isLoading: false }),
+}))
+
+vi.mock("@/components/DashboardStories", () => ({
+  default: () => <div data-testid="stub-dashboard-stories" />,
+}))
+
+vi.mock("@/components/WeatherWidget", () => ({
+  default: () => <div data-testid="stub-weather-widget" />,
+}))
+
+const baseUser: User = {
+  id: 1,
+  email: "student@example.com",
+  full_name: "Test User",
+  role: "student",
+  group_id: 101,
+  avatar_url: null,
+  cover_url: null,
+  about: null,
+  record_book_number: null,
+  status: null,
+  institute: null,
+  course: null,
+  education_level: null,
+  track: null,
+  program: null,
+  telegram: null,
+  achievements: null,
+  department: null,
+  position: null,
+  spotify_connected: false,
+  spotify_display_name: null,
+  spotify_is_connected: null,
+  dnd_enabled: false,
+  dnd_start: null,
+  dnd_end: null,
+  is_active: true,
+  mfa_required: false,
+  mfa_default_method: null,
+  mfa_last_verified_at: null,
+  mfa_recovery_codes_generated_at: null,
+  totp_enrollments: [],
+  recovery_codes: [],
+  mfa_challenges: [],
+}
+
+const baseAuthValue = {
+  isAuth: true,
+  login: vi.fn(),
+  logout: vi.fn(),
+  user: baseUser,
+  loading: false,
+  setUser: vi.fn(),
+  refresh: vi.fn(),
+  pendingMfa: null,
+  submitMfaChallenge: vi.fn(),
+  requireMfa: vi.fn(),
+  resetEtagCache: vi.fn(),
+}
+
+const unauthenticatedAuthValue = {
+  ...baseAuthValue,
+  isAuth: false,
+  user: null,
+}
+
+type RouteTestCase = {
+  name: string
+  element: ReactElement
+  initialEntries: string[]
+  authValue: typeof baseAuthValue
+}
+
+const routes: RouteTestCase[] = [
+  {
+    name: "dashboard",
+    element: <Dashboard />,
+    initialEntries: ["/dashboard"],
+    authValue: baseAuthValue,
+  },
+  {
+    name: "profile",
+    element: <Profile />,
+    initialEntries: ["/profile"],
+    authValue: baseAuthValue,
+  },
+  {
+    name: "login",
+    element: <Login />,
+    initialEntries: ["/login"],
+    authValue: unauthenticatedAuthValue,
+  },
+]
+
+const GlobalSkipLink = () => (
+  <a href="#main" className="skip-link">
+    Skip to content
+  </a>
+)
+
+async function renderRoute({ element, authValue, initialEntries }: RouteTestCase) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  })
+
+  const result = await renderWithA11y(
+    <MemoryRouter initialEntries={initialEntries}>
+      <AuthContext.Provider value={authValue}>
+        <LanguageProvider>
+          <QueryClientProvider client={queryClient}>
+            <>
+              <GlobalSkipLink />
+              {element}
+            </>
+          </QueryClientProvider>
+        </LanguageProvider>
+      </AuthContext.Provider>
+    </MemoryRouter>
+  )
+
+  queryClient.clear()
+  return result
+}
+
+describe("global skip link", () => {
+  it.each(routes)("renders a single skip link on $name", async (route) => {
+    const { container } = await renderRoute(route)
+    expect(container.querySelectorAll("a.skip-link")).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
## Summary
- remove the dashboard-specific skip link so the global shortcut always targets the Layout container
- wrap the profile page with Layout so there is a single `id="main"` landmark
- add an axe-powered Vitest that renders key routes and asserts exactly one `.skip-link` per view

## Testing
- npm run test -- skipLink

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cf4b96058832795fd950c9037e14e)