### PR TITLE
Add cache headers to schedule API responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,15 @@ have two options:
 With Redis enabled you can test cache hits, TTL expirations, and distributed
 rate limiting behavior exactly as it will run in production.
 
+#### Schedule API caching & conditional GETs
+
+The schedule endpoint (`GET /schedule/{group_id}`) emits entity tags when the
+cache backend is enabled. Each response sets `Cache-Control: private,
+max-age=300` and an `Expires` header 5 minutes in the future so API consumers
+can reuse data between polls. Send the previously observed `ETag` value via
+`If-None-Match` to receive a `304 Not Modified` response with the same cache
+headers whenever the schedule has not changed.
+
 ### 4. Run services manually (alternative)
 
 #### Backend (FastAPI)

--- a/root/app/api/schedule.py
+++ b/root/app/api/schedule.py
@@ -1,4 +1,6 @@
 from collections.abc import Callable, Mapping, Sequence
+from datetime import datetime, timedelta, timezone
+from email.utils import format_datetime
 from functools import lru_cache
 from typing import Any
 
@@ -30,11 +32,23 @@ def _get_vary_helper() -> Callable[[Response, str], None]:
     return _ensure_vary_header
 
 
+_SCHEDULE_CACHE_TTL_SECONDS = 300
+_SCHEDULE_CACHE_CONTROL = f"private, max-age={_SCHEDULE_CACHE_TTL_SECONDS}"
+
+
 router = APIRouter(prefix="/schedule", tags=["schedule"])
 
 
 def _schedule_cache_key(group_id: int) -> str:
     return f"schedule:group:{group_id}"
+
+
+def _set_schedule_cache_headers(response: Response) -> None:
+    response.headers["Cache-Control"] = _SCHEDULE_CACHE_CONTROL
+    expires_at = datetime.now(timezone.utc) + timedelta(
+        seconds=_SCHEDULE_CACHE_TTL_SECONDS
+    )
+    response.headers["Expires"] = format_datetime(expires_at, usegmt=True)
 
 
 def _localize_schedule_payload(
@@ -80,6 +94,7 @@ async def get_schedule(
     locale = resolve_locale(request=request)
     _get_vary_helper()(response, "Accept-Language")
     response.headers["Content-Language"] = locale
+    _set_schedule_cache_headers(response)
     cache = get_cache()
     cache_key = _schedule_cache_key(group_id)
     if cache.enabled:
@@ -90,6 +105,7 @@ async def get_schedule(
                 cached_response = Response(status_code=status.HTTP_304_NOT_MODIFIED)
                 cached_response.headers["ETag"] = etag_header
                 _get_vary_helper()(cached_response, "Accept-Language")
+                _set_schedule_cache_headers(cached_response)
                 return cached_response
             response.headers["ETag"] = etag_header
             return _localize_schedule_payload(cached.payload, locale=locale)
@@ -100,7 +116,9 @@ async def get_schedule(
     localized_payload = _localize_schedule_payload(payload, locale=locale)
 
     if cache.enabled:
-        entry = await cache.set(cache_key, payload)
+        entry = await cache.set(
+            cache_key, payload, ttl=_SCHEDULE_CACHE_TTL_SECONDS
+        )
         response.headers["ETag"] = format_etag(entry.etag)
     return localized_payload
 

--- a/root/app/api/schedule.py
+++ b/root/app/api/schedule.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable, Mapping, Sequence
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from email.utils import format_datetime
 from functools import lru_cache
 from typing import Any
@@ -45,9 +45,7 @@ def _schedule_cache_key(group_id: int) -> str:
 
 def _set_schedule_cache_headers(response: Response) -> None:
     response.headers["Cache-Control"] = _SCHEDULE_CACHE_CONTROL
-    expires_at = datetime.now(timezone.utc) + timedelta(
-        seconds=_SCHEDULE_CACHE_TTL_SECONDS
-    )
+    expires_at = datetime.now(UTC) + timedelta(seconds=_SCHEDULE_CACHE_TTL_SECONDS)
     response.headers["Expires"] = format_datetime(expires_at, usegmt=True)
 
 
@@ -116,9 +114,7 @@ async def get_schedule(
     localized_payload = _localize_schedule_payload(payload, locale=locale)
 
     if cache.enabled:
-        entry = await cache.set(
-            cache_key, payload, ttl=_SCHEDULE_CACHE_TTL_SECONDS
-        )
+        entry = await cache.set(cache_key, payload, ttl=_SCHEDULE_CACHE_TTL_SECONDS)
         response.headers["ETag"] = format_etag(entry.etag)
     return localized_payload
 

--- a/root/tests/test_schedule_ics.py
+++ b/root/tests/test_schedule_ics.py
@@ -2,6 +2,7 @@ from datetime import UTC, datetime
 
 import pytest
 
+from app.api.schedule import _SCHEDULE_CACHE_CONTROL
 from app.localization import translate, translate_lesson_type
 from app.models import models
 from app.services.ical import generate_schedule_ics
@@ -188,6 +189,8 @@ async def test_schedule_endpoint_preserves_existing_vary_values(
     }
     fresh_response = await async_client.get(f"/schedule/{group.id}", headers=headers)
     assert fresh_response.status_code == 200
+    assert fresh_response.headers.get("Cache-Control") == _SCHEDULE_CACHE_CONTROL
+    assert fresh_response.headers.get("Expires")
     fresh_vary_values = {
         value.strip()
         for value in fresh_response.headers.get("Vary", "").split(",")
@@ -203,6 +206,8 @@ async def test_schedule_endpoint_preserves_existing_vary_values(
         headers={**headers, "If-None-Match": etag},
     )
     assert cached_response.status_code == 304
+    assert cached_response.headers.get("Cache-Control") == _SCHEDULE_CACHE_CONTROL
+    assert cached_response.headers.get("Expires")
     cached_vary_values = {
         value.strip()
         for value in cached_response.headers.get("Vary", "").split(",")


### PR DESCRIPTION
## Summary
- add Cache-Control/Expires headers (5 minute TTL) to fresh and cached schedule responses and ensure cache entries reuse the same TTL
- document the schedule API caching behavior in the README so integrators know how to use ETags and conditional requests
- extend the schedule endpoint test to assert the new headers for cache hits and misses

## Testing
- pytest tests/test_schedule_ics.py::test_schedule_endpoint_preserves_existing_vary_values


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d00f5767883279b6cc0aaf7a6ff1d)