### PR TITLE
Normalize stats cache invalidation periods

### DIFF
--- a/root/app/services/stats_cache.py
+++ b/root/app/services/stats_cache.py
@@ -11,6 +11,11 @@ _STATS_KNOWN_KINDS = ("attendance", "grades", "participation")
 _DEFAULT_PERIOD_KEYS = ("30d", "90d", "180d")
 
 
+def _normalize_period_key(period_key: str | None) -> str:
+    normalized = (period_key or "").strip().lower()
+    return normalized or "default"
+
+
 def _ensure_cache(cache: BaseCache | None) -> BaseCache:
     return cache or get_cache()
 
@@ -26,7 +31,7 @@ def resolve_period_key(period_key: str | None, period_days: int | None) -> str:
 
 def _make_cache_key(kind: str, user_id: int, period_key: str) -> str:
     normalized_kind = kind.strip().lower()
-    normalized_period = period_key.strip().lower() or "default"
+    normalized_period = _normalize_period_key(period_key)
     return f"{_STATS_CACHE_PREFIX}:{normalized_kind}:{int(user_id)}:{normalized_period}"
 
 
@@ -88,12 +93,12 @@ async def invalidate_user_stats_cache(
     )
     if not selected_kinds:
         return
-    chosen_periods = tuple(
-        {
-            (period or "").strip().lower() or "default"
-            for period in (period_keys or _DEFAULT_PERIOD_KEYS)
-        }
-    )
+    normalized_periods = {
+        _normalize_period_key(period)
+        for period in (period_keys if period_keys else _DEFAULT_PERIOD_KEYS)
+    }
+    normalized_periods.add("default")
+    chosen_periods = tuple(normalized_periods)
     keys: list[str] = []
     for user_id in unique_users:
         for kind in selected_kinds:

--- a/root/tests/test_stats_api.py
+++ b/root/tests/test_stats_api.py
@@ -430,18 +430,24 @@ async def test_stats_cache_invalidation_includes_default_and_custom_periods(fake
         payload={"value": "custom"},
     )
 
-    assert await stats_cache.get_cached_stats(
-        cache=fake_cache,
-        kind=kind,
-        user_id=user_id,
-        period_key="default",
-    ) is not None
-    assert await stats_cache.get_cached_stats(
-        cache=fake_cache,
-        kind=kind,
-        user_id=user_id,
-        period_key="7d",
-    ) is not None
+    assert (
+        await stats_cache.get_cached_stats(
+            cache=fake_cache,
+            kind=kind,
+            user_id=user_id,
+            period_key="default",
+        )
+        is not None
+    )
+    assert (
+        await stats_cache.get_cached_stats(
+            cache=fake_cache,
+            kind=kind,
+            user_id=user_id,
+            period_key="7d",
+        )
+        is not None
+    )
 
     await stats_cache.invalidate_user_stats_cache(
         cache=fake_cache,
@@ -450,15 +456,21 @@ async def test_stats_cache_invalidation_includes_default_and_custom_periods(fake
         period_keys=("7D",),
     )
 
-    assert await stats_cache.get_cached_stats(
-        cache=fake_cache,
-        kind=kind,
-        user_id=user_id,
-        period_key="default",
-    ) is None
-    assert await stats_cache.get_cached_stats(
-        cache=fake_cache,
-        kind=kind,
-        user_id=user_id,
-        period_key="7d",
-    ) is None
+    assert (
+        await stats_cache.get_cached_stats(
+            cache=fake_cache,
+            kind=kind,
+            user_id=user_id,
+            period_key="default",
+        )
+        is None
+    )
+    assert (
+        await stats_cache.get_cached_stats(
+            cache=fake_cache,
+            kind=kind,
+            user_id=user_id,
+            period_key="7d",
+        )
+        is None
+    )

--- a/root/tests/test_stats_api.py
+++ b/root/tests/test_stats_api.py
@@ -408,3 +408,57 @@ async def test_registering_for_event_invalidates_stats_cache(
     flattened = [key for call in invalidated for key in call]
     assert any(key.startswith("stats:attendance") for key in flattened)
     assert any(key.startswith("stats:participation") for key in flattened)
+
+
+@pytest.mark.anyio
+async def test_stats_cache_invalidation_includes_default_and_custom_periods(fake_cache):
+    user_id = 77
+    kind = "attendance"
+
+    await stats_cache.set_cached_stats(
+        cache=fake_cache,
+        kind=kind,
+        user_id=user_id,
+        period_key="default",
+        payload={"value": "default"},
+    )
+    await stats_cache.set_cached_stats(
+        cache=fake_cache,
+        kind=kind,
+        user_id=user_id,
+        period_key="7d",
+        payload={"value": "custom"},
+    )
+
+    assert await stats_cache.get_cached_stats(
+        cache=fake_cache,
+        kind=kind,
+        user_id=user_id,
+        period_key="default",
+    ) is not None
+    assert await stats_cache.get_cached_stats(
+        cache=fake_cache,
+        kind=kind,
+        user_id=user_id,
+        period_key="7d",
+    ) is not None
+
+    await stats_cache.invalidate_user_stats_cache(
+        cache=fake_cache,
+        user_ids=user_id,
+        kinds=(kind,),
+        period_keys=("7D",),
+    )
+
+    assert await stats_cache.get_cached_stats(
+        cache=fake_cache,
+        kind=kind,
+        user_id=user_id,
+        period_key="default",
+    ) is None
+    assert await stats_cache.get_cached_stats(
+        cache=fake_cache,
+        kind=kind,
+        user_id=user_id,
+        period_key="7d",
+    ) is None


### PR DESCRIPTION
## Summary
- normalize stats cache period keys so invalidation always includes the default bucket in addition to caller-specified periods
- add a regression test covering invalidation of both default and custom (e.g., 7d) cache entries

## Testing
- pytest root/tests/test_stats_api.py -k stats_cache_invalidation_includes_default_and_custom_periods


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d07972c548327bd613371d2a702e2)