### PR TITLE
Trim failed enqueue history on retry

### DIFF
--- a/root/app/services/notification_queue.py
+++ b/root/app/services/notification_queue.py
@@ -162,11 +162,7 @@ async def record_enqueue_failure(
     )
     async with _failed_enqueue_lock:
         _failed_enqueue_records.append(record)
-        while len(_failed_enqueue_records) > _FAILED_ENQUEUE_HISTORY_LIMIT:
-            dropped = _failed_enqueue_records.popleft()
-            logger.debug(
-                "Discarding oldest failed enqueue record", extra={"job": dropped.job}
-            )
+        _trim_failed_enqueue_history("record_enqueue_failure")
 
 
 async def get_failed_enqueue_records() -> list[FailedEnqueueRecord]:
@@ -221,8 +217,21 @@ async def retry_failed_enqueues(limit: int | None = None) -> int:
         async with _failed_enqueue_lock:
             for record in failures:
                 _failed_enqueue_records.append(record)
+            _trim_failed_enqueue_history("retry_failed_enqueues")
 
     return successes
+
+
+def _trim_failed_enqueue_history(context: str) -> None:
+    """Ensure failed enqueue history does not exceed its configured limit."""
+
+    while len(_failed_enqueue_records) > _FAILED_ENQUEUE_HISTORY_LIMIT:
+        dropped = _failed_enqueue_records.popleft()
+        logger.warning(
+            "Failed enqueue history exceeded limit during %s; dropped oldest record",
+            context,
+            extra={"dropped_job": dropped.job, "dropped_source": dropped.source},
+        )
 
 
 async def _ensure_worker() -> None:

--- a/root/tests/test_notification_queue_worker.py
+++ b/root/tests/test_notification_queue_worker.py
@@ -232,6 +232,43 @@ async def test_notification_queue_records_drops_when_saturated(
 
 
 @pytest.mark.anyio
+async def test_retry_failed_enqueues_respects_history_limit(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    async def _always_fail(job: notification_queue.NotificationJob) -> None:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(notification_queue, "_enqueue_job", _always_fail)
+
+    async with notification_queue._failed_enqueue_lock:
+        notification_queue._failed_enqueue_records.clear()
+        for record_id in range(
+            notification_queue._FAILED_ENQUEUE_HISTORY_LIMIT + 10
+        ):
+            notification_queue._failed_enqueue_records.append(
+                notification_queue.FailedEnqueueRecord(
+                    job=notification_queue.NotificationJob(
+                        kind="event", record_id=record_id, locale=None
+                    ),
+                    error=None,
+                    source="test",
+                    occurred_at=datetime.now(UTC),
+                )
+            )
+
+    try:
+        await notification_queue.retry_failed_enqueues()
+        async with notification_queue._failed_enqueue_lock:
+            assert (
+                len(notification_queue._failed_enqueue_records)
+                == notification_queue._FAILED_ENQUEUE_HISTORY_LIMIT
+            )
+    finally:
+        async with notification_queue._failed_enqueue_lock:
+            notification_queue._failed_enqueue_records.clear()
+
+
+@pytest.mark.anyio
 async def test_notification_queue_records_processing_latency(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/root/tests/test_notification_queue_worker.py
+++ b/root/tests/test_notification_queue_worker.py
@@ -242,9 +242,7 @@ async def test_retry_failed_enqueues_respects_history_limit(
 
     async with notification_queue._failed_enqueue_lock:
         notification_queue._failed_enqueue_records.clear()
-        for record_id in range(
-            notification_queue._FAILED_ENQUEUE_HISTORY_LIMIT + 10
-        ):
+        for record_id in range(notification_queue._FAILED_ENQUEUE_HISTORY_LIMIT + 10):
             notification_queue._failed_enqueue_records.append(
                 notification_queue.FailedEnqueueRecord(
                     job=notification_queue.NotificationJob(


### PR DESCRIPTION
## Summary
- ensure failed enqueue records are trimmed consistently and emit warnings when history needs to be truncated
- add regression coverage for retry_failed_enqueues to ensure the deque never exceeds the configured cap

## Testing
- pytest root/tests/test_notification_queue_worker.py -k history_limit

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691deeac7db8832783549211db8d0945)