### PR TITLE
Handle News creation errors

### DIFF
--- a/root/frontend/src/pages/News.tsx
+++ b/root/frontend/src/pages/News.tsx
@@ -13,6 +13,8 @@ import {
   type ReactNode,
   type CSSProperties,
 } from "react"
+import { Alert } from "@mui/material"
+import { isAxiosError } from "axios"
 import { createNews, uploadNewsImage } from "@/api/news"
 import ArticleIcon from "@mui/icons-material/Article"
 import PhotoCamera from "@mui/icons-material/PhotoCamera"
@@ -78,6 +80,7 @@ const News = () => {
   const [addOpen, setAddOpen] = useState(false)
   const [newsData, setNewsData] = useState(initialNews)
   const [adding, setAdding] = useState(false)
+  const [addError, setAddError] = useState<string | null>(null)
   const [imageFile, setImageFile] = useState<File | null>(null)
   const [imagePreview, setImagePreview] = useState<string | null>(null)
   const imageInputRef = useRef<HTMLInputElement | null>(null)
@@ -138,9 +141,36 @@ const News = () => {
     [imagePreview]
   )
 
+  const resolveCreateError = useCallback(
+    (error: unknown) => {
+      const fallback =
+        t("news:notifications.savedError", { defaultValue: "Failed to save the news" }) ??
+        "Failed to save the news"
+
+      if (isAxiosError(error)) {
+        const data = error.response?.data
+        if (typeof data === "string" && data.trim()) return data
+        if (data && typeof data === "object") {
+          const detail = (data as { detail?: unknown }).detail
+          if (typeof detail === "string" && detail.trim()) return detail
+          const message = (data as { message?: unknown }).message
+          if (typeof message === "string" && message.trim()) return message
+        }
+      }
+
+      if (error instanceof Error && error.message?.trim()) {
+        return error.message
+      }
+
+      return fallback
+    },
+    [t]
+  )
+
   const handleAddNews = useCallback(async () => {
     if (adding) return
     setAdding(true)
+    setAddError(null)
     try {
       let image_url = ""
       if (imageFile) {
@@ -166,14 +196,17 @@ const News = () => {
       }
       void refetchNews()
       if (imageInputRef.current) imageInputRef.current.value = ""
+    } catch (error) {
+      setAddError(resolveCreateError(error))
     } finally {
       setAdding(false)
     }
-  }, [adding, imageFile, imagePreview, newsData, refetchNews])
+  }, [adding, imageFile, imagePreview, newsData, refetchNews, resolveCreateError])
 
   const handleCloseDialog = useCallback(() => {
     setAddOpen(false)
     setNewsData(initialNews)
+    setAddError(null)
     setImageFile(null)
     if (imagePreview) {
       URL.revokeObjectURL(imagePreview)
@@ -301,6 +334,12 @@ const News = () => {
                   void handleAddNews()
                 }}
               >
+                {addError ? (
+                  <Alert severity="error" variant="outlined">
+                    {addError}
+                  </Alert>
+                ) : null}
+
                 <Field label={t("news:form.title") ?? ""} htmlFor="news-title" required>
                   <input
                     id="news-title"

--- a/root/frontend/src/pages/__tests__/News.create.test.tsx
+++ b/root/frontend/src/pages/__tests__/News.create.test.tsx
@@ -1,0 +1,119 @@
+import type { ReactNode } from "react"
+import userEvent from "@testing-library/user-event"
+import { render, screen, within } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("@/api/news", () => ({
+  createNews: vi.fn(),
+  uploadNewsImage: vi.fn(),
+}))
+
+vi.mock("@/components/Dialog", () => {
+  const MockDialog = ({
+    open,
+    children,
+    footer,
+    title,
+  }: {
+    open: boolean
+    children: ReactNode
+    footer?: ReactNode
+    title?: ReactNode
+  }) => {
+    if (!open) return null
+    return (
+      <div role="dialog">
+        {title ? <h2>{title}</h2> : null}
+        <div>{children}</div>
+        {footer}
+      </div>
+    )
+  }
+
+  MockDialog.displayName = "MockDialog"
+
+  return {
+    __esModule: true,
+    default: MockDialog,
+  }
+})
+
+vi.mock("@/hooks/useNewsFeed", () => ({
+  useNewsFeed: () => ({
+    data: [],
+    isPending: false,
+    isFetching: false,
+    refetch: vi.fn(),
+  }),
+}))
+
+vi.mock("../../contexts/AuthContext", () => ({
+  useAuth: () => ({
+    user: { id: 1, role: "admin" },
+  }),
+}))
+
+vi.mock("../../contexts/LanguageContext", () => ({
+  useLanguage: () => ({
+    language: "en" as const,
+    setLanguage: vi.fn(),
+    available: ["en", "ru"] as const,
+  }),
+}))
+
+import News from "../News"
+import { createNews } from "@/api/news"
+
+const createNewsMock = vi.mocked(createNews)
+
+const renderNews = () => {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  })
+
+  return render(
+    <QueryClientProvider client={client}>
+      <News />
+    </QueryClientProvider>
+  )
+}
+
+describe("News creation dialog", () => {
+  beforeEach(() => {
+    createNewsMock.mockReset()
+  })
+
+  it("keeps the dialog open and surfaces errors when creation fails", async () => {
+    const user = userEvent.setup()
+    const errorMessage = "Title already exists"
+
+    createNewsMock.mockRejectedValueOnce({
+      isAxiosError: true,
+      response: { data: { detail: errorMessage } },
+    })
+
+    renderNews()
+
+    const addButtons = screen.getAllByRole("button", { name: /\+ add news/i })
+    await user.click(addButtons[0]!)
+
+    const dialog = await screen.findByRole("dialog")
+
+    const titleInput = await within(dialog).findByLabelText(/^Title(?! \()/)
+    const contentInput = await within(dialog).findByLabelText(/^News text(?! \()/)
+
+    await user.type(titleInput, "Test headline")
+    await user.type(contentInput, "Test content body")
+
+    await user.click(screen.getByRole("button", { name: /publish/i }))
+
+    const alert = await screen.findByRole("alert")
+    expect(alert).toHaveTextContent(errorMessage)
+    expect(titleInput).toHaveValue("Test headline")
+    expect(contentInput).toHaveValue("Test content body")
+    expect(screen.getByRole("dialog")).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- wrap the News creation flow in error handling that surfaces backend failures inside the dialog while keeping the admin's input intact
- add a regression test that mocks a failed createNews request and asserts that the error alert remains visible

## Testing
- npm run test -- src/pages/__tests__/News.create.test.tsx

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691df1b2cc3c8327a44f909fc9f27339)