### PR TITLE
Remove frontend build artifacts from version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ bower_components
 .lock-wscript
 build/Release
 node_modules/
+root/node_modules/
+root/frontend/node_modules/
+root/frontend/dev-dist/
 jspm_packages/
 web_modules/
 *.tsbuildinfo

--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ npm run dev -- --host
 ```
 The dev server exposes the UI at http://localhost:5173 and proxies API calls to the backend origin configured via `VITE_BACKEND_ORIGIN`.
 
+> Frontend dependencies and build outputs are intentionally excluded from the repository. Run `npm install` to restore `node_modules` and `npm run build` (or `npm run dev`) to regenerate any `dev-dist` artifacts locally.
+
 #### Notifications worker
 ```bash
 cd root

--- a/root/frontend/dev-dist/registerSW.js
+++ b/root/frontend/dev-dist/registerSW.js
@@ -1,1 +1,0 @@
-if('serviceWorker' in navigator) navigator.serviceWorker.register('/dev-sw.js?dev-sw', { scope: '/', type: 'module' })


### PR DESCRIPTION
## Summary
- remove the tracked dev-dist build output and exclude frontend node_modules/dev-dist directories from version control
- document that frontend dependencies and build artifacts should be recreated locally via npm install/build steps

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e14ac9e688327bcbfbea386d4b00b)