### PR TITLE
Prevent node_modules from being archived

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,3 +10,7 @@
 *.zip binary
 *.tar.gz binary
 *.woff* binary
+
+# Exclude dependency installs from archives and prevent accidental tracking
+root/node_modules/ export-ignore
+root/frontend/node_modules/ export-ignore


### PR DESCRIPTION
## Summary
- remove ignored node_modules directories from the repository workspace
- add export-ignore entries so node_modules folders are omitted from archives and not reintroduced

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e2780dc988327af45bc0fcdc52ebb)