### PR TITLE
Add messenger translations to i18n resources

### DIFF
--- a/root/frontend/src/i18n/config.ts
+++ b/root/frontend/src/i18n/config.ts
@@ -29,6 +29,8 @@ import adminEn from "./locales/en/admin.json" assert { type: "json" }
 import adminRu from "./locales/ru/admin.json" assert { type: "json" }
 import storiesEn from "./locales/en/stories.json" assert { type: "json" }
 import storiesRu from "./locales/ru/stories.json" assert { type: "json" }
+import messengerEn from "./locales/en/messenger.json" assert { type: "json" }
+import messengerRu from "./locales/ru/messenger.json" assert { type: "json" }
 
 export const defaultNS = "common"
 
@@ -48,6 +50,7 @@ export const resources = {
     notifications: notificationsEn,
     admin: adminEn,
     stories: storiesEn,
+    messenger: messengerEn,
   },
   ru: {
     common: commonRu,
@@ -64,6 +67,7 @@ export const resources = {
     notifications: notificationsRu,
     admin: adminRu,
     stories: storiesRu,
+    messenger: messengerRu,
   },
 } as const
 


### PR DESCRIPTION
## Summary
- register the messenger locale files in the i18n configuration so messenger texts follow the selected language

## Testing
- npm run i18n:check

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69234616816083279f3bfaf22ccd04be)