### PR TITLE
Fix audit log routing and email cleanup tests

### DIFF
--- a/root/app/services/audit_service.py
+++ b/root/app/services/audit_service.py
@@ -11,6 +11,15 @@ class AuditService:
     def __init__(self):
         self.logger = logger
 
+    def _select_logger(self, event: str) -> logging.Logger:
+        """Route audit events to component-specific loggers."""
+
+        if event.startswith("auth."):
+            return logging.getLogger("app.auth")
+        if event.startswith(("password.", "users.")):
+            return logging.getLogger("app.users.audit")
+        return self.logger
+
     def log(
         self,
         event: str,
@@ -26,4 +35,5 @@ class AuditService:
             "path": request.url.path,
             **kwargs,
         }
-        self.logger.log(level, json.dumps(payload), extra=payload)
+        logger = self._select_logger(event)
+        logger.log(level, json.dumps(payload), extra=payload)

--- a/root/tests/test_email_change_cleanup.py
+++ b/root/tests/test_email_change_cleanup.py
@@ -14,7 +14,9 @@ from app.services.email_change_cleanup import (
 from app.utils.email import RESET_TOKEN_EXPIRY_MINUTES
 
 
-@pytest.mark.asyncio
+pytestmark = pytest.mark.anyio("asyncio")
+
+
 async def test_cleanup_stale_email_change_tokens_respects_retention(db_session):
     now = dt.datetime.now(dt.UTC)
 
@@ -75,7 +77,7 @@ async def test_cleanup_stale_email_change_tokens_respects_retention(db_session):
     assert recent_record.used is False
 
 
-@pytest.mark.asyncio
+
 async def test_cleanup_stale_email_change_tokens_default_retention(db_session):
     now = dt.datetime.now(dt.UTC)
 
@@ -102,7 +104,7 @@ async def test_cleanup_stale_email_change_tokens_default_retention(db_session):
     assert list(remaining) == []
 
 
-@pytest.mark.asyncio
+
 async def test_start_email_change_cleanup_scheduler(monkeypatch):
     calls: list[int] = []
     event = asyncio.Event()

--- a/root/tests/test_email_change_cleanup.py
+++ b/root/tests/test_email_change_cleanup.py
@@ -13,7 +13,6 @@ from app.services.email_change_cleanup import (
 )
 from app.utils.email import RESET_TOKEN_EXPIRY_MINUTES
 
-
 pytestmark = pytest.mark.anyio("asyncio")
 
 
@@ -77,7 +76,6 @@ async def test_cleanup_stale_email_change_tokens_respects_retention(db_session):
     assert recent_record.used is False
 
 
-
 async def test_cleanup_stale_email_change_tokens_default_retention(db_session):
     now = dt.datetime.now(dt.UTC)
 
@@ -102,7 +100,6 @@ async def test_cleanup_stale_email_change_tokens_default_retention(db_session):
     db_session.expire_all()
     remaining = await db_session.execute(select(EmailChangeToken.token_hash))
     assert list(remaining) == []
-
 
 
 async def test_start_email_change_cleanup_scheduler(monkeypatch):


### PR DESCRIPTION
## Summary
- route audit events to component-specific loggers so authentication and user flows emit the expected audit records
- mark email change cleanup tests with anyio to ensure async fixtures are provided correctly

## Testing
- pytest root/tests/test_audit_logs.py::test_login_success_logs_audit --maxfail=1


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928709937c883278792334bd8e08441)