### PR TITLE
Sanitize external links and contact actions

### DIFF
--- a/root/frontend/src/components/LivePushToasts.tsx
+++ b/root/frontend/src/components/LivePushToasts.tsx
@@ -54,7 +54,7 @@ const buildToastId = (toast: ToastPayload) => {
 const toActiveToast = (toast: ToastPayload): ActiveToast | null => {
   const hasContent = Boolean(toast.title?.trim() || toast.body?.trim())
   if (!hasContent) return null
-  const safeUrl = toast.url ? sanitizeHttpUrl(toast.url) ?? undefined : undefined
+  const safeUrl = toast.url ? (sanitizeHttpUrl(toast.url) ?? undefined) : undefined
   return { ...toast, id: buildToastId(toast), url: safeUrl }
 }
 

--- a/root/frontend/src/components/LivePushToasts.tsx
+++ b/root/frontend/src/components/LivePushToasts.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState, type SyntheticEvent } from "react"
 import { Alert, Button, Snackbar, Stack, Typography } from "@mui/material"
 import type { SnackbarCloseReason } from "@mui/material/Snackbar"
 import { useTranslation } from "react-i18next"
+import { sanitizeHttpUrl } from "@/utils/sanitize"
 
 type SnackbarSeverity = "success" | "info" | "warning" | "error"
 
@@ -53,16 +54,17 @@ const buildToastId = (toast: ToastPayload) => {
 const toActiveToast = (toast: ToastPayload): ActiveToast | null => {
   const hasContent = Boolean(toast.title?.trim() || toast.body?.trim())
   if (!hasContent) return null
-  return { ...toast, id: buildToastId(toast) }
+  const safeUrl = toast.url ? sanitizeHttpUrl(toast.url) ?? undefined : undefined
+  return { ...toast, id: buildToastId(toast), url: safeUrl }
 }
 
 let memoryBuffer: ActiveToast[] = []
 
 const sanitizeBuffer = (buffer: unknown): ActiveToast[] => {
   if (!Array.isArray(buffer)) return []
-  return buffer.filter((item): item is ActiveToast => {
-    return Boolean(item && typeof item === "object" && typeof (item as ActiveToast).id === "string")
-  })
+  return buffer
+    .map((item) => (item && typeof item === "object" ? toActiveToast(item as ToastPayload) : null))
+    .filter((item): item is ActiveToast => Boolean(item))
 }
 
 const readBuffer = (): ActiveToast[] => {
@@ -113,10 +115,7 @@ export default function LivePushToasts() {
   const [open, setOpen] = useState(false)
 
   const enqueue = useCallback((toast: ToastPayload | ActiveToast) => {
-    const normalized =
-      typeof (toast as ActiveToast).id === "string" && (toast as ActiveToast).id.trim()
-        ? (toast as ActiveToast)
-        : toActiveToast(toast as ToastPayload)
+    const normalized = toActiveToast(toast as ToastPayload)
     if (!normalized) return
     setQueue((prev) => [...prev, normalized])
   }, [])
@@ -184,8 +183,10 @@ export default function LivePushToasts() {
 
   const handleAction = useCallback(() => {
     if (!current?.url) return
+    const safeUrl = sanitizeHttpUrl(current.url)
+    if (!safeUrl) return
     try {
-      const resolved = new URL(current.url, window.location.href)
+      const resolved = new URL(safeUrl, window.location.href)
       const sameOrigin = resolved.origin === window.location.origin
       window.open(
         resolved.href,
@@ -194,7 +195,7 @@ export default function LivePushToasts() {
       )
     } catch (error) {
       console.error("Failed to open toast link", error)
-      window.open(current.url, "_blank", "noopener,noreferrer")
+      window.open(safeUrl, "_blank", "noopener,noreferrer")
     }
     setOpen(false)
     setCurrent(null)

--- a/root/frontend/src/pages/Profile.tsx
+++ b/root/frontend/src/pages/Profile.tsx
@@ -32,6 +32,7 @@ import ContentCopyIcon from "@mui/icons-material/ContentCopy"
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore"
 import QrCodeIcon from "@mui/icons-material/QrCode"
 import OpenInNewIcon from "@mui/icons-material/OpenInNew"
+import { sanitizeEmailAddress, sanitizeTelegramUrl } from "@/utils/sanitize"
 
 const isTest = typeof import.meta !== "undefined" && import.meta.env.MODE === "test"
 
@@ -479,6 +480,7 @@ export default function Profile() {
   }, [])
 
   const copy = async (text: string, evt?: { clientX: number; clientY: number }) => {
+    if (!text) return
     try {
       await navigator.clipboard?.writeText(text)
     } finally {
@@ -497,21 +499,28 @@ export default function Profile() {
   }
 
   const handleEmailCopy = () => {
-    copy(user!.email)
+    const email = sanitizeEmailAddress(user?.email)
+    if (!email) return
+    copy(email)
     setEmailMenuAnchor(null)
   }
 
   const handleEmailOpen = () => {
-    window.location.href = `mailto:${user!.email}`
+    const email = sanitizeEmailAddress(user?.email)
+    if (!email) return
+    window.location.href = `mailto:${encodeURIComponent(email)}`
     setEmailMenuAnchor(null)
   }
 
   const handleTelegramCopy = () => {
-    copy(user!.telegram!)
+    const telegram = sanitizeTelegramUrl(user?.telegram)
+    if (!telegram) return
+    copy(telegram)
     setTelegramMenuAnchor(null)
   }
 
   const handleTelegramOpen = () => {
+    if (!telegramHref) return
     window.open(telegramHref, "_blank", "noopener,noreferrer")
     setTelegramMenuAnchor(null)
   }
@@ -567,14 +576,7 @@ export default function Profile() {
   const openQrModal = useCallback(() => setQrOpen(true), [])
   const closeQrModal = useCallback(() => setQrOpen(false), [])
 
-  const telegramHref = useMemo(() => {
-    const t = user?.telegram || ""
-    if (!t) return ""
-    let v = String(t).trim()
-    if (v.startsWith("http")) return v
-    if (v.startsWith("@")) v = v.slice(1)
-    return `https://t.me/${v}`
-  }, [user?.telegram])
+  const telegramHref = useMemo(() => sanitizeTelegramUrl(user?.telegram), [user?.telegram])
 
   const achievementsList = useMemo(
     () =>

--- a/root/frontend/src/utils/sanitize.ts
+++ b/root/frontend/src/utils/sanitize.ts
@@ -50,3 +50,50 @@ export const sanitizeNewsHtml = (dirty: string | null | undefined): string | Tru
 export const sanitizeNewsText = (dirty: string | null | undefined): string => {
   return DOMPurify.sanitize(dirty ?? "", TEXT_CONFIG) as string
 }
+
+const DEFAULT_BASE = "http://localhost"
+const TELEGRAM_HOSTS = new Set(["t.me", "telegram.me"])
+
+export const sanitizeHttpUrl = (raw: string | null | undefined): string | null => {
+  if (!raw) return null
+  try {
+    const base = typeof window !== "undefined" && typeof window.location?.href === "string"
+      ? window.location.href
+      : DEFAULT_BASE
+    const parsed = new URL(raw, base)
+    const protocol = parsed.protocol.toLowerCase()
+    if (protocol !== "http:" && protocol !== "https:") return null
+    if (parsed.username || parsed.password) return null
+    return parsed.toString()
+  } catch {
+    return null
+  }
+}
+
+export const sanitizeEmailAddress = (raw: string | null | undefined): string => {
+  if (!raw) return ""
+  const email = String(raw).trim()
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email) ? email : ""
+}
+
+export const sanitizeTelegramUrl = (raw: string | null | undefined): string => {
+  if (!raw) return ""
+  const trimmed = String(raw).trim()
+  if (!trimmed) return ""
+
+  if (trimmed.startsWith("http")) {
+    const safe = sanitizeHttpUrl(trimmed)
+    if (!safe) return ""
+    try {
+      const parsed = new URL(safe)
+      if (!TELEGRAM_HOSTS.has(parsed.hostname.toLowerCase())) return ""
+      return parsed.toString()
+    } catch {
+      return ""
+    }
+  }
+
+  const withoutPrefix = trimmed.replace(/^@+/, "")
+  if (!withoutPrefix) return ""
+  return `https://t.me/${encodeURIComponent(withoutPrefix)}`
+}

--- a/root/frontend/src/utils/sanitize.ts
+++ b/root/frontend/src/utils/sanitize.ts
@@ -57,9 +57,10 @@ const TELEGRAM_HOSTS = new Set(["t.me", "telegram.me"])
 export const sanitizeHttpUrl = (raw: string | null | undefined): string | null => {
   if (!raw) return null
   try {
-    const base = typeof window !== "undefined" && typeof window.location?.href === "string"
-      ? window.location.href
-      : DEFAULT_BASE
+    const base =
+      typeof window !== "undefined" && typeof window.location?.href === "string"
+        ? window.location.href
+        : DEFAULT_BASE
     const parsed = new URL(raw, base)
     const protocol = parsed.protocol.toLowerCase()
     if (protocol !== "http:" && protocol !== "https:") return null


### PR DESCRIPTION
## Summary
- add shared sanitizers for HTTP URLs, email addresses, and Telegram handles
- sanitize live push toast links before opening and when restoring buffered toasts
- sanitize user contact actions in the profile page to avoid unsafe mailto or Telegram URLs

## Testing
- npm run lint -- --max-warnings=0

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c80dc8edc8327b80078cb3f00c973)