### PR TITLE
Add healthchecks for backend and notifications worker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,11 +24,17 @@ services:
       postgres:
         condition: service_healthy
       redis:
-        condition: service_started
+        condition: service_healthy
     ports:
       - "8000:8000"
     extra_hosts:
       - "host.docker.internal:host-gateway"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:8000/healthz >/dev/null || exit 1"]
+      interval: 10s
+      timeout: 5s
+      start_period: 60s
+      retries: 5
 
   frontend:
     build:
@@ -68,10 +74,16 @@ services:
       postgres:
         condition: service_healthy
       redis:
-        condition: service_started
+        condition: service_healthy
     restart: unless-stopped
     ports:
       - "9101:9101"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:9101/healthz >/dev/null || exit 1"]
+      interval: 30s
+      timeout: 5s
+      start_period: 30s
+      retries: 3
 
   postgres:
     image: postgres:16-alpine


### PR DESCRIPTION
## Summary
- add curl-based healthchecks for backend and notifications worker services in docker-compose
- tighten dependency conditions to wait for redis health before starting backend and worker
- expose worker monitoring endpoint for health validation via docker healthcheck

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69326f28e8a48327b17e096c5cd42a0d)