### PR TITLE
Add coverage for auth, file scanning, and rate limit edge cases

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -4,7 +4,7 @@ python_files = test_*.py *_test.py
 python_classes = Test* *Tests
 python_functions = test_*
 addopts = -q -ra
-cov_fail_under = 72
+cov_fail_under = 88
 asyncio_mode = auto
 filterwarnings =
     ignore:Accessing argon2\.__version__ is deprecated:DeprecationWarning:passlib.handlers.argon2

--- a/root/tests/test_auth_mfa.py
+++ b/root/tests/test_auth_mfa.py
@@ -786,3 +786,70 @@ async def test_reset_mfa_command_noop_logs_reason(user_factory, caplog, monkeypa
     audit_event = _find_audit_event(caplog, "app.users.audit", "users.mfa.reset")
     assert audit_event["user_id"] == str(user.id)
     assert audit_event["reason"] == "admin_reset_noop"
+
+
+@pytest.mark.anyio
+async def test_mfa_verification_rejects_revoked_session(
+    async_client, user_factory, db_session
+):
+    password = "RevokedSession123!"
+    user = await user_factory(
+        email="mfa-revoked@example.com", hashed_password=get_password_hash(password)
+    )
+
+    enrollment = models.MfaTotpEnrollment(
+        user_id=user.id,
+        secret="JBSWY3DPEHPK3PXP",
+        is_active=True,
+        confirmed_at=dt.datetime.now(dt.timezone.utc),
+    )
+    session = models.ActiveSession(
+        user_id=user.id,
+        jti="revoked-token",
+        expires_at=dt.datetime.now(dt.timezone.utc) + dt.timedelta(hours=1),
+        revoked_at=dt.datetime.now(dt.timezone.utc),
+    )
+    db_session.add_all([enrollment, session])
+    await db_session.flush()
+
+    challenge = await mfa.issue_challenge(
+        db_session,
+        user_id=user.id,
+        session_id=session.id,
+        challenge_type=mfa.CHALLENGE_TYPE_TOTP_VERIFY,
+    )
+    await db_session.commit()
+
+    response = await async_client.post(
+        "/auth/mfa/verify",
+        json={
+            "challenge_token": challenge.token,
+            "method": mfa.MFA_METHOD_TOTP,
+            "code": "000000",
+        },
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json()["detail"] == "Associated session has been revoked"
+
+
+@pytest.mark.anyio
+async def test_totp_reenrollment_after_reset(async_client, user_factory, db_session):
+    password = "ReenrollMfa123!"
+    user = await user_factory(
+        email="mfa-reenroll@example.com", hashed_password=get_password_hash(password)
+    )
+
+    await _enroll_totp(async_client, user, password, db_session)
+    await mfa.reset_user_mfa(db_session, user=user)
+    await db_session.commit()
+    await db_session.refresh(user)
+
+    assert user.mfa_default_method is None
+    assert user.mfa_required is False
+
+    await _enroll_totp(async_client, user, password, db_session)
+    await db_session.refresh(user)
+
+    assert user.mfa_default_method == mfa.MFA_METHOD_TOTP
+    assert user.mfa_required is True

--- a/root/tests/test_auth_mfa.py
+++ b/root/tests/test_auth_mfa.py
@@ -801,13 +801,13 @@ async def test_mfa_verification_rejects_revoked_session(
         user_id=user.id,
         secret="JBSWY3DPEHPK3PXP",
         is_active=True,
-        confirmed_at=dt.datetime.now(dt.timezone.utc),
+        confirmed_at=dt.datetime.now(dt.UTC),
     )
     session = models.ActiveSession(
         user_id=user.id,
         jti="revoked-token",
-        expires_at=dt.datetime.now(dt.timezone.utc) + dt.timedelta(hours=1),
-        revoked_at=dt.datetime.now(dt.timezone.utc),
+        expires_at=dt.datetime.now(dt.UTC) + dt.timedelta(hours=1),
+        revoked_at=dt.datetime.now(dt.UTC),
     )
     db_session.add_all([enrollment, session])
     await db_session.flush()

--- a/root/tests/test_file_utils.py
+++ b/root/tests/test_file_utils.py
@@ -263,7 +263,9 @@ async def test_scan_for_malware_rejects_unknown_backend(monkeypatch):
         await files.scan_for_malware(b"payload", locale="en")
 
     assert excinfo.value.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
-    assert excinfo.value.detail == translate("errors.files.scanner_unavailable", locale="en")
+    assert excinfo.value.detail == translate(
+        "errors.files.scanner_unavailable", locale="en"
+    )
 
 
 @pytest.mark.asyncio

--- a/root/tests/test_file_utils.py
+++ b/root/tests/test_file_utils.py
@@ -3,12 +3,13 @@ import io
 import re
 
 import pytest
-from fastapi import HTTPException, UploadFile
+from fastapi import HTTPException, UploadFile, status
 from PIL import Image
 from starlette.datastructures import Headers
 
 from app.core.config import settings
 from app.localization import translate
+from app.services import file_scanner
 from app.services.storage import StaticFSStorage
 from app.utils import files
 
@@ -251,3 +252,34 @@ async def test_save_attachment_falls_back_to_declared_type(monkeypatch):
     assert relative_path.endswith(".txt")
     assert kwargs["content_type"] == "text/plain"
     assert data == payload
+
+
+@pytest.mark.asyncio
+async def test_scan_for_malware_rejects_unknown_backend(monkeypatch):
+    monkeypatch.setattr(settings, "event_file_scanner_enabled", True)
+    monkeypatch.setattr(settings, "event_file_scanner_backend", "unknown")
+
+    with pytest.raises(HTTPException) as excinfo:
+        await files.scan_for_malware(b"payload", locale="en")
+
+    assert excinfo.value.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+    assert excinfo.value.detail == translate("errors.files.scanner_unavailable", locale="en")
+
+
+@pytest.mark.asyncio
+async def test_scan_for_malware_handles_scanner_unavailable(monkeypatch):
+    monkeypatch.setattr(settings, "event_file_scanner_enabled", True)
+    monkeypatch.setattr(settings, "event_file_scanner_backend", "clamd")
+
+    async def fail_scan(*args, **kwargs):  # type: ignore[no-untyped-def]
+        raise file_scanner.FileScannerUnavailableError("offline")
+
+    monkeypatch.setattr(file_scanner, "_scan_bytes_with_clamd", fail_scan)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await files.scan_for_malware(b"payload", locale="fr")
+
+    assert excinfo.value.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+    assert excinfo.value.detail == translate(
+        "errors.files.scanner_unavailable", locale="fr"
+    )

--- a/root/tests/test_rate_limit.py
+++ b/root/tests/test_rate_limit.py
@@ -3,10 +3,12 @@ import pytest
 from fastapi import Depends, FastAPI, Response, status
 
 from app.auth.security import get_password_hash
+from app.core import rate_limit
 from app.core.config import settings
 from app.core.rate_limit import RateLimitMiddleware
 from app.localization import translate
 from app.utils import ratelimit as ratelimit_module
+from redis.exceptions import RedisError
 
 
 @pytest.mark.anyio
@@ -356,3 +358,55 @@ async def test_sensitive_dependency_redis_backend_forwarded_header(
     assert second.status_code == status.HTTP_200_OK
     assert third.status_code == status.HTTP_429_TOO_MANY_REQUESTS
     assert third.headers.get("Retry-After") is not None
+
+
+@pytest.mark.anyio
+async def test_enforce_rate_limit_falls_back_on_redis_error(monkeypatch):
+    monkeypatch.setattr(rate_limit, "_memory_buckets", {})
+
+    async def failing_redis(*args, **kwargs):  # type: ignore[no-untyped-def]
+        raise RedisError("unknown command EVAL")
+
+    monkeypatch.setattr(rate_limit, "_redis_rate_limit", failing_redis)
+
+    await rate_limit.enforce_rate_limit(
+        identifier="demo", namespace="ns", limit=1, window_seconds=60, redis_url="redis://test"
+    )
+
+    with pytest.raises(rate_limit.RateLimitExceeded):
+        await rate_limit.enforce_rate_limit(
+            identifier="demo",
+            namespace="ns",
+            limit=1,
+            window_seconds=60,
+            redis_url="redis://test",
+        )
+
+
+@pytest.mark.anyio
+async def test_rate_limit_middleware_allows_when_redis_fails(monkeypatch):
+    app = FastAPI()
+
+    app.add_middleware(
+        RateLimitMiddleware,
+        storage_backend="redis",
+        redis_url="redis://test",  # not actually used
+        limit=1,
+        window_seconds=60,
+    )
+
+    @app.get("/ping")
+    async def _ping():  # pragma: no cover - simple response
+        return {"ok": True}
+
+    async def fail_check(self, identifier):  # type: ignore[no-untyped-def]
+        raise RedisError("boom")
+
+    monkeypatch.setattr(RateLimitMiddleware, "_check_limit", fail_check)
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.get("/ping")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert "X-RateLimit-Limit" not in response.headers

--- a/root/tests/test_rate_limit.py
+++ b/root/tests/test_rate_limit.py
@@ -1,6 +1,7 @@
 import httpx
 import pytest
 from fastapi import Depends, FastAPI, Response, status
+from redis.exceptions import RedisError
 
 from app.auth.security import get_password_hash
 from app.core import rate_limit
@@ -8,7 +9,6 @@ from app.core.config import settings
 from app.core.rate_limit import RateLimitMiddleware
 from app.localization import translate
 from app.utils import ratelimit as ratelimit_module
-from redis.exceptions import RedisError
 
 
 @pytest.mark.anyio
@@ -370,7 +370,11 @@ async def test_enforce_rate_limit_falls_back_on_redis_error(monkeypatch):
     monkeypatch.setattr(rate_limit, "_redis_rate_limit", failing_redis)
 
     await rate_limit.enforce_rate_limit(
-        identifier="demo", namespace="ns", limit=1, window_seconds=60, redis_url="redis://test"
+        identifier="demo",
+        namespace="ns",
+        limit=1,
+        window_seconds=60,
+        redis_url="redis://test",
     )
 
     with pytest.raises(rate_limit.RateLimitExceeded):
@@ -405,7 +409,9 @@ async def test_rate_limit_middleware_allows_when_redis_fails(monkeypatch):
     monkeypatch.setattr(RateLimitMiddleware, "_check_limit", fail_check)
 
     transport = httpx.ASGITransport(app=app)
-    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://testserver"
+    ) as client:
         response = await client.get("/ping")
 
     assert response.status_code == status.HTTP_200_OK


### PR DESCRIPTION
## Summary
- raise the pytest coverage gate to 88%
- add MFA session revocation and re-enrollment tests to cover authentication edge cases
- extend malware scanner and rate limit tests for fallback and backend error handling paths

## Testing
- pytest root/tests/test_auth_mfa.py::test_mfa_verification_rejects_revoked_session \
       root/tests/test_auth_mfa.py::test_totp_reenrollment_after_reset \
       root/tests/test_file_utils.py::test_scan_for_malware_rejects_unknown_backend \
       root/tests/test_file_utils.py::test_scan_for_malware_handles_scanner_unavailable \
       root/tests/test_rate_limit.py::test_enforce_rate_limit_falls_back_on_redis_error \
       root/tests/test_rate_limit.py::test_rate_limit_middleware_allows_when_redis_fails \
       --cov=root/app --cov-report=term-missing

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693631de2b688327826f7b61727a5396)