### PR TITLE
Use env vars for Compose database credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ cp root/.env.example root/.env
 
 Important backend values include `DATABASE_URL`, `SECRET_KEY`, `FRONTEND_ORIGIN(S)`, and the VAPID/Spotify credentials. Redis-related toggles (`CACHE_ENABLED`, `CACHE_REDIS_URL`, `RATE_LIMIT_STORAGE_BACKEND`, `RATE_LIMIT_STORAGE_URI`) default to in-memory behavior unless you enable Redis. For quick SQLite development you may set `AUTO_CREATE_SCHEMA=1`, but production deployments should run Alembic migrations instead.
 
+Docker Compose reads the `POSTGRES_USER`, `POSTGRES_PASSWORD`, and `POSTGRES_DB` values from `root/.env`. The defaults are set to non-default development credentials (`university` / `devpassword`) but **must be changed for any shared or remote host** along with the generated `DATABASE_URL` connection string.
+
 Frontend builds read `VITE_*` variables at build time (for example `VITE_BACKEND_ORIGIN`, `VITE_MAP_CONSTRUCTOR_ID`, `VITE_APP_RELEASE`, `VITE_SENTRY_DSN`).
 
 ### 2. Run database migrations
@@ -77,6 +79,8 @@ The stack builds the backend, frontend, and notifications worker images, starts 
 - Backend metrics: http://localhost:8000/metrics (enable via `ENABLE_METRICS_ENDPOINT` and credentials)
 - Frontend UI: http://localhost:8080
 - Worker metrics: http://localhost:9101/metrics
+
+PostgreSQL (`127.0.0.1:5432`) and Redis (`127.0.0.1:6379`) bindings are scoped to localhost to avoid accidental exposure on public hosts. Adjust the bindings only when you explicitly need external access.
 
 Redis-backed cache and rate limiting are enabled by default in Compose via `CACHE_ENABLED=true`, `CACHE_REDIS_URL=redis://redis:6379/0`, `RATE_LIMIT_STORAGE_BACKEND=redis`, and `RATE_LIMIT_STORAGE_URI=redis://redis:6379/1`.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     env_file:
       - root/.env
     environment:
-      DATABASE_URL: postgresql+psycopg://postgres:postgres@postgres:5432/university
+      DATABASE_URL: ${DATABASE_URL:-postgresql+psycopg://${POSTGRES_USER:-university}:${POSTGRES_PASSWORD:-university}@postgres:5432/${POSTGRES_DB:-university}}
       FRONTEND_ORIGIN: http://localhost:8080
       FRONTEND_ORIGINS: http://localhost:8080
       NOTIFICATIONS_SCHEDULER_INLINE_ENABLED: "false"
@@ -61,7 +61,7 @@ services:
     env_file:
       - root/.env
     environment:
-      DATABASE_URL: postgresql+psycopg://postgres:postgres@postgres:5432/university
+      DATABASE_URL: ${DATABASE_URL:-postgresql+psycopg://${POSTGRES_USER:-university}:${POSTGRES_PASSWORD:-university}@postgres:5432/${POSTGRES_DB:-university}}
       NOTIFICATIONS_WORKER_METRICS_HOST: 0.0.0.0
       NOTIFICATIONS_WORKER_METRICS_PORT: "9101"
       CACHE_ENABLED: "true"
@@ -88,18 +88,18 @@ services:
   postgres:
     image: postgres:16-alpine
     environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
-      POSTGRES_DB: university
+      POSTGRES_USER: ${POSTGRES_USER:-university}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-university}
+      POSTGRES_DB: ${POSTGRES_DB:-university}
     volumes:
       - postgres-data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-university}"]
       interval: 5s
       timeout: 5s
       retries: 5
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
 
   redis:
     image: redis:7-alpine
@@ -110,7 +110,7 @@ services:
       timeout: 5s
       retries: 5
     ports:
-      - "6379:6379"
+      - "127.0.0.1:6379:6379"
 
   migrations:
     build:
@@ -121,7 +121,7 @@ services:
     env_file:
       - root/.env
     environment:
-      DATABASE_URL: postgresql+psycopg://postgres:postgres@postgres:5432/university
+      DATABASE_URL: ${DATABASE_URL:-postgresql+psycopg://${POSTGRES_USER:-university}:${POSTGRES_PASSWORD:-university}@postgres:5432/${POSTGRES_DB:-university}}
     depends_on:
       postgres:
         condition: service_healthy

--- a/root/.env
+++ b/root/.env
@@ -1,5 +1,9 @@
 # ----- Core backend settings (copy to .env before running locally) -----
-DATABASE_URL=postgresql+asyncpg://postgres:1@127.0.0.1:5432/university
+# Non-default Docker Compose credentials; change these for any shared or remote deployment.
+POSTGRES_USER=university
+POSTGRES_PASSWORD=devpassword
+POSTGRES_DB=university
+DATABASE_URL=postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@127.0.0.1:5432/${POSTGRES_DB}
 SECRET_KEY=Qj7p4R2zYx8N1a5Hk9V3u0Mw6Tg4Lr8Cz2Jv5Qw7Xn1Dk6Fh0Sg3Vb9Pp4Rz8Lm2
 ALGORITHM=HS256
 ACCESS_TOKEN_EXPIRE_MINUTES=30

--- a/root/.env.example
+++ b/root/.env.example
@@ -1,5 +1,9 @@
 # ----- Core backend settings (copy to .env before running locally) -----
-DATABASE_URL=postgresql+asyncpg://postgres:1@127.0.0.1:5432/university
+# Non-default Docker Compose credentials; change these for any shared or remote deployment.
+POSTGRES_USER=university
+POSTGRES_PASSWORD=devpassword
+POSTGRES_DB=university
+DATABASE_URL=postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@127.0.0.1:5432/${POSTGRES_DB}
 SECRET_KEY=Qj7p4R2zYx8N1a5Hk9V3u0Mw6Tg4Lr8Cz2Jv5Qw7Xn1Dk6Fh0Sg3Vb9Pp4Rz8Lm2
 ALGORITHM=HS256
 ACCESS_TOKEN_EXPIRE_MINUTES=30


### PR DESCRIPTION
## Summary
- source Compose database connection settings from environment variables with localhost-only Postgres/Redis bindings
- document non-default default Postgres credentials in the environment templates and README with guidance to rotate for shared/remote hosts
- align environment defaults to support the templated credentials and generated connection string

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693747ee266c832796eb89e1e576e89b)