### PR TITLE
Handle profile cache fetch failures

### DIFF
--- a/root/frontend/src/hooks/auth/useProfileSync.ts
+++ b/root/frontend/src/hooks/auth/useProfileSync.ts
@@ -264,12 +264,7 @@ export const fetchCurrentUser = async ({ signal }: FetchCurrentUserOptions = {})
     })
     return response.data
   } catch (error) {
-    if (
-      cachedEnvelope &&
-      isAxiosError(error) &&
-      !signal?.aborted &&
-      error.response
-    ) {
+    if (cachedEnvelope && isAxiosError(error) && !signal?.aborted && error.response) {
       // If the cached envelope causes the request to fail (even with a 500),
       // drop it and retry once without the header to recover gracefully.
       clearProfileCacheStorage()

--- a/root/frontend/src/hooks/auth/useProfileSync.ts
+++ b/root/frontend/src/hooks/auth/useProfileSync.ts
@@ -267,9 +267,11 @@ export const fetchCurrentUser = async ({ signal }: FetchCurrentUserOptions = {})
     if (
       cachedEnvelope &&
       isAxiosError(error) &&
-      error.response?.status === 400 &&
-      !signal?.aborted
+      !signal?.aborted &&
+      error.response
     ) {
+      // If the cached envelope causes the request to fail (even with a 500),
+      // drop it and retry once without the header to recover gracefully.
       clearProfileCacheStorage()
       const retry = await api.get<User>("/users/me", {
         signal,


### PR DESCRIPTION
## Summary
- retry the current user request without the cached profile header when it fails to improve resiliency

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69376c973fbc8327a20d2160ceccc101)