### PR TITLE
Fix admin event/news interactions

### DIFF
--- a/root/frontend/src/components/EventCard.tsx
+++ b/root/frontend/src/components/EventCard.tsx
@@ -195,8 +195,17 @@ const EventCardComponent: FC<EventCardProps> = ({
         setMenuAnchor(null)
       }
     }
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setMenuAnchor(null)
+      }
+    }
     document.addEventListener("mousedown", handleClickOutside)
-    return () => document.removeEventListener("mousedown", handleClickOutside)
+    document.addEventListener("keydown", handleEscape)
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside)
+      document.removeEventListener("keydown", handleEscape)
+    }
   }, [menuAnchor])
 
   const getLocalizedEditValue = (field: "title" | "description" | "event_type" | "location") => {
@@ -510,12 +519,12 @@ const EventCardComponent: FC<EventCardProps> = ({
   return (
     <div
       className={cn(
-        "event-card relative min-h-[320px] rounded-[1.1rem] sm:rounded-[1.2rem] border border-[color:var(--glass-border)] bg-[color:var(--card-bg)] text-[color:var(--page-text)] p-4 sm:p-6 shadow-surface overflow-hidden transition-all duration-300",
+        "event-card relative min-h-[320px] rounded-[1.1rem] sm:rounded-[1.2rem] border border-[color:var(--glass-border)] bg-[color:var(--card-bg)] text-[color:var(--page-text)] p-4 sm:p-6 shadow-surface overflow-visible transition-all duration-300",
         editOpen ? "cursor-default" : "cursor-pointer",
         qrOpen && "pointer-events-none grayscale-[0.12] opacity-90",
         !editOpen &&
           !qrOpen &&
-          "hover:-translate-y-0.5 hover:scale-[1.02] hover:shadow-surface-strong active:scale-[0.997]",
+          "hover:shadow-surface-strong",
         "focus-visible:outline-2 focus-visible:outline-[color:var(--nav-link)] focus-visible:outline-offset-2"
       )}
       style={{ maxWidth: maxWidth ?? "500px", width: "100%" }}
@@ -549,11 +558,7 @@ const EventCardComponent: FC<EventCardProps> = ({
           {menuAnchor && (
             <div
               ref={menuRef}
-              className="fixed z-50 mt-2 min-w-[160px] rounded-ue-lg border border-[color:var(--glass-border)] bg-[color:var(--card-bg)] shadow-surface-strong"
-              style={{
-                top: menuAnchor.getBoundingClientRect().bottom + 8,
-                left: Math.min(menuAnchor.getBoundingClientRect().left, window.innerWidth - 180),
-              }}
+              className="absolute right-0 top-12 z-50 min-w-[160px] rounded-ue-lg border border-[color:var(--glass-border)] bg-[color:var(--card-bg)] shadow-surface-strong"
             >
               <div className="py-1">
                 <button

--- a/root/frontend/src/pages/News.tsx
+++ b/root/frontend/src/pages/News.tsx
@@ -24,7 +24,8 @@ import Dialog from "@/components/Dialog"
 import { useAuth } from "../contexts/AuthContext"
 import { useLanguage } from "../contexts/LanguageContext"
 import { useTranslation } from "react-i18next"
-import { useNewsFeed } from "@/hooks/useNewsFeed"
+import { newsFeedQueryKey, useNewsFeed } from "@/hooks/useNewsFeed"
+import { useQueryClient } from "@tanstack/react-query"
 
 const inputClass =
   "w-full rounded-ue-lg border border-white/12 bg-[color:color-mix(in_srgb,var(--card-bg)_94%,white_6%)] px-4 py-2.5 text-[0.98rem] text-[color:var(--page-text)] shadow-[inset_0_1px_0_rgba(15,23,42,0.08)] transition focus:border-[color:var(--nav-link)] focus:outline-none focus:shadow-focus placeholder:text-[color:var(--placeholder-fg)]"
@@ -73,6 +74,7 @@ const News = () => {
   const { user } = useAuth()
   const { t } = useTranslation(["news", "common"])
   const { language } = useLanguage()
+  const queryClient = useQueryClient()
   const { data: newsDataList, refetch: refetchNews, isPending, isFetching } = useNewsFeed(language)
   const newsList = newsDataList ?? []
   const deferredList = useDeferredValue(newsList)
@@ -195,13 +197,23 @@ const News = () => {
         setImagePreview(null)
       }
       void refetchNews()
+      void queryClient.invalidateQueries({ queryKey: newsFeedQueryKey(language) })
       if (imageInputRef.current) imageInputRef.current.value = ""
     } catch (error) {
       setAddError(resolveCreateError(error))
     } finally {
       setAdding(false)
     }
-  }, [adding, imageFile, imagePreview, newsData, refetchNews, resolveCreateError])
+  }, [
+    adding,
+    imageFile,
+    imagePreview,
+    language,
+    newsData,
+    queryClient,
+    refetchNews,
+    resolveCreateError,
+  ])
 
   const handleCloseDialog = useCallback(() => {
     setAddOpen(false)


### PR DESCRIPTION
## Summary
- refresh the news feed cache after creating a news item so new posts appear immediately
- keep event admin action menus anchored to their cards and prevent hover jitter
- close event action menus consistently via escape and outside clicks

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a3b341b848327911643a8b851725c)