### PR TITLE
Fix news feed cache invalidation after mutations

### DIFF
--- a/root/frontend/src/hooks/useNewsFeed.ts
+++ b/root/frontend/src/hooks/useNewsFeed.ts
@@ -94,6 +94,19 @@ const persistCacheSnapshot = async (language: SupportedLanguage, snapshot: NewsF
   }
 }
 
+const deleteCacheSnapshot = async (language: SupportedLanguage) => {
+  if (typeof window === "undefined" || !("caches" in window) || !window.caches) {
+    return
+  }
+
+  try {
+    const cache = await window.caches.open(NEWS_CACHE_NAME)
+    await cache.delete(buildCacheRequest(language), { ignoreMethod: true })
+  } catch (error) {
+    console.warn("useNewsFeed: failed to delete cached snapshot", error)
+  }
+}
+
 let legacyKeysCleared = false
 
 const clearLegacyStorageKeys = () => {
@@ -233,3 +246,12 @@ export type UseNewsFeedResult = ReturnType<typeof useNewsFeed>
 export type NewsFeedQueryKey = ReturnType<typeof buildQueryKey>
 
 export const newsFeedQueryKey = buildQueryKey
+
+export const invalidateNewsFeed = async (
+  queryClient: QueryClient,
+  language: SupportedLanguage
+) => {
+  const queryKey = buildQueryKey(language)
+  await queryClient.removeQueries({ queryKey })
+  await deleteCacheSnapshot(language)
+}

--- a/root/frontend/src/hooks/useNewsFeed.ts
+++ b/root/frontend/src/hooks/useNewsFeed.ts
@@ -247,11 +247,8 @@ export type NewsFeedQueryKey = ReturnType<typeof buildQueryKey>
 
 export const newsFeedQueryKey = buildQueryKey
 
-export const invalidateNewsFeed = async (
-  queryClient: QueryClient,
-  language: SupportedLanguage
-) => {
+export const invalidateNewsFeed = async (queryClient: QueryClient, language: SupportedLanguage) => {
   const queryKey = buildQueryKey(language)
-  await queryClient.removeQueries({ queryKey })
   await deleteCacheSnapshot(language)
+  await queryClient.invalidateQueries({ queryKey, refetchType: "all" })
 }

--- a/root/frontend/src/pages/News.tsx
+++ b/root/frontend/src/pages/News.tsx
@@ -24,7 +24,7 @@ import Dialog from "@/components/Dialog"
 import { useAuth } from "../contexts/AuthContext"
 import { useLanguage } from "../contexts/LanguageContext"
 import { useTranslation } from "react-i18next"
-import { newsFeedQueryKey, useNewsFeed } from "@/hooks/useNewsFeed"
+import { invalidateNewsFeed, useNewsFeed } from "@/hooks/useNewsFeed"
 import { useQueryClient } from "@tanstack/react-query"
 
 const inputClass =
@@ -91,6 +91,11 @@ const News = () => {
   const isInitialLoading = isPending && newsList.length === 0
   const showEmptyState = !isInitialLoading && !isFetching && newsList.length === 0
   const skeletonCount = Math.max(visibleCount || 0, 6)
+
+  const refreshNews = useCallback(async () => {
+    await invalidateNewsFeed(queryClient, language)
+    await refetchNews()
+  }, [language, queryClient, refetchNews])
 
   useEffect(() => {
     return () => {
@@ -196,8 +201,7 @@ const News = () => {
         URL.revokeObjectURL(imagePreview)
         setImagePreview(null)
       }
-      void refetchNews()
-      void queryClient.invalidateQueries({ queryKey: newsFeedQueryKey(language) })
+      void refreshNews()
       if (imageInputRef.current) imageInputRef.current.value = ""
     } catch (error) {
       setAddError(resolveCreateError(error))
@@ -210,8 +214,7 @@ const News = () => {
     imagePreview,
     language,
     newsData,
-    queryClient,
-    refetchNews,
+    refreshNews,
     resolveCreateError,
   ])
 
@@ -281,7 +284,7 @@ const News = () => {
                         {...news}
                         image_url={news.image_url ?? undefined}
                         onChange={() => {
-                          void refetchNews()
+                          void refreshNews()
                         }}
                       />
                     </div>

--- a/root/frontend/src/pages/News.tsx
+++ b/root/frontend/src/pages/News.tsx
@@ -208,15 +208,7 @@ const News = () => {
     } finally {
       setAdding(false)
     }
-  }, [
-    adding,
-    imageFile,
-    imagePreview,
-    language,
-    newsData,
-    refreshNews,
-    resolveCreateError,
-  ])
+  }, [adding, imageFile, imagePreview, language, newsData, refreshNews, resolveCreateError])
 
   const handleCloseDialog = useCallback(() => {
     setAddOpen(false)

--- a/root/frontend/src/pages/NewsDetail.tsx
+++ b/root/frontend/src/pages/NewsDetail.tsx
@@ -22,6 +22,7 @@ import { Button } from "@/components/ui"
 import Dialog from "@/components/Dialog"
 import { useAuth } from "@/contexts/AuthContext"
 import { useLanguage } from "@/contexts/LanguageContext"
+import { invalidateNewsFeed } from "@/hooks/useNewsFeed"
 import { useTranslation } from "react-i18next"
 import { cn } from "@/utils/cn"
 
@@ -247,7 +248,7 @@ export default function NewsDetail() {
       }
       const { data } = await updateNews(query.data.id, payload)
       queryClient.setQueryData(["news", id, language], data)
-      await queryClient.invalidateQueries({ queryKey: ["news"] })
+      await invalidateNewsFeed(queryClient, language)
       setSnack(t("news:notifications.updated"))
       closeEdit()
     } catch (error) {
@@ -265,7 +266,7 @@ export default function NewsDetail() {
       await deleteNews(query.data.id)
       setSnack(t("news:notifications.deleted"))
       queryClient.removeQueries({ queryKey: ["news", id] })
-      await queryClient.invalidateQueries({ queryKey: ["news"] })
+      await invalidateNewsFeed(queryClient, language)
       if (window.history.length > 1) navigate(-1)
       else navigate("/news")
     } catch (error) {


### PR DESCRIPTION
## Summary
- add a helper to clear cached news feed responses and query data
- refresh the news list after creating, updating, or deleting items using the new helper

## Testing
- npm test -- src/pages/__tests__/News.create.test.tsx


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693add6515bc8327b3807f3a6fc07fa8)