### PR TITLE
Disable client-side caching for news API responses

### DIFF
--- a/root/app/api/news.py
+++ b/root/app/api/news.py
@@ -40,9 +40,10 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/news", tags=["news"])
 
-# Disable client-side caching so new items appear immediately while still
-# allowing ETag-based revalidation handled by the backend cache layer.
-_NEWS_CACHE_CONTROL = "private, no-cache"
+# Allow short-lived client-side caching while still relying on backend cache
+# invalidation and ETag-based revalidation to make newly added articles visible
+# quickly.
+_NEWS_CACHE_CONTROL = "private, max-age=180"
 _LEGACY_NEWS_LIST_CACHE_KEY = "news:list"
 _LEGACY_NEWS_ITEM_PREFIX = "news:item"
 _CACHE_LOCALES: tuple[str, ...] = tuple(sorted({DEFAULT_LOCALE, *SUPPORTED_LOCALES}))

--- a/root/app/api/news.py
+++ b/root/app/api/news.py
@@ -40,7 +40,9 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/news", tags=["news"])
 
-_NEWS_CACHE_CONTROL = "private, max-age=180"
+# Disable client-side caching so new items appear immediately while still
+# allowing ETag-based revalidation handled by the backend cache layer.
+_NEWS_CACHE_CONTROL = "private, no-cache"
 _LEGACY_NEWS_LIST_CACHE_KEY = "news:list"
 _LEGACY_NEWS_ITEM_PREFIX = "news:item"
 _CACHE_LOCALES: tuple[str, ...] = tuple(sorted({DEFAULT_LOCALE, *SUPPORTED_LOCALES}))

--- a/root/tests/test_news_helpers.py
+++ b/root/tests/test_news_helpers.py
@@ -1,0 +1,53 @@
+import pytest
+
+from app.api import news
+from app.localization import DEFAULT_LOCALE
+
+
+def test_normalized_cache_locale_supported_and_default_fallback():
+    assert news._normalized_cache_locale("en") == "en"
+    assert news._normalized_cache_locale(" RU ") == "ru"
+    assert news._normalized_cache_locale(None) == DEFAULT_LOCALE
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("text", "text"),
+        ("   spaced   ", "   spaced   "),
+        ("   ", None),
+        (123, None),
+    ],
+)
+def test_non_empty_text(value, expected):
+    assert news._non_empty_text(value) == expected
+
+
+def test_localized_text_prefers_requested_locale_with_fallbacks():
+    # English takes English value first, falls back to Russian
+    assert (
+        news._localized_text("en", ru_value="Русский", en_value="English")
+        == "English"
+    )
+    assert news._localized_text("en", ru_value="Русский", en_value=None) == "Русский"
+
+    # Default locale uses English value first, then Russian fallback
+    assert (
+        news._localized_text(DEFAULT_LOCALE, ru_value="Русский", en_value="English")
+        == "English"
+    )
+    assert news._localized_text(DEFAULT_LOCALE, ru_value="", en_value="English") == "English"
+
+
+def test_news_cache_keys_include_all_locales_and_legacy_prefixes():
+    keys = news._news_cache_keys(news_id=42)
+
+    # Base list cache key and per-locale patterns
+    assert news._LEGACY_NEWS_LIST_CACHE_KEY in keys
+    for locale in news._CACHE_LOCALES:
+        assert f"{news._news_list_cache_key(locale)}*" in keys
+
+    # Item-specific cache keys include legacy and localized variants
+    assert news._legacy_news_item_cache_key(42) in keys
+    for locale in news._CACHE_LOCALES:
+        assert news._news_item_cache_key(42, locale) in keys

--- a/root/tests/test_news_helpers.py
+++ b/root/tests/test_news_helpers.py
@@ -26,8 +26,7 @@ def test_non_empty_text(value, expected):
 def test_localized_text_prefers_requested_locale_with_fallbacks():
     # English takes English value first, falls back to Russian
     assert (
-        news._localized_text("en", ru_value="Русский", en_value="English")
-        == "English"
+        news._localized_text("en", ru_value="Русский", en_value="English") == "English"
     )
     assert news._localized_text("en", ru_value="Русский", en_value=None) == "Русский"
 
@@ -36,7 +35,10 @@ def test_localized_text_prefers_requested_locale_with_fallbacks():
         news._localized_text(DEFAULT_LOCALE, ru_value="Русский", en_value="English")
         == "English"
     )
-    assert news._localized_text(DEFAULT_LOCALE, ru_value="", en_value="English") == "English"
+    assert (
+        news._localized_text(DEFAULT_LOCALE, ru_value="", en_value="English")
+        == "English"
+    )
 
 
 def test_news_cache_keys_include_all_locales_and_legacy_prefixes():


### PR DESCRIPTION
## Summary
- disable client-side caching for news endpoints while keeping ETag revalidation so newly added articles appear immediately

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b0e91f5f48327baac14447826dc00)