### PR TITLE
Enhance secret strength guidance and scanning

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -19,3 +19,15 @@ jobs:
       - uses: gitleaks/gitleaks-action@v2
         env:
           GITHUB_TOKEN: ${{ github.token }}
+
+  trufflehog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Run TruffleHog
+        uses: trufflesecurity/trufflehog@v3.78.1
+        with:
+          path: .
+          base: ""

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,3 +30,11 @@ repos:
     hooks:
       - id: gitleaks
         args: ["protect", "--staged"]
+
+  - repo: local
+    hooks:
+      - id: enforce-secret-strength
+        name: Enforce strong secrets in env files
+        entry: python scripts/enforce_secret_strength.py
+        language: system
+        files: "(\\.env(\\.example)?|docker-compose\\.yml)$"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     env_file:
       - root/.env
     environment:
-      DATABASE_URL: ${DATABASE_URL:-postgresql+psycopg://${POSTGRES_USER:-university}:${POSTGRES_PASSWORD:-university}@postgres:5432/${POSTGRES_DB:-university}}
+      DATABASE_URL: ${DATABASE_URL:-postgresql+psycopg://${POSTGRES_USER:-university}:${POSTGRES_PASSWORD:-local_dev_password_please_rotate}@postgres:5432/${POSTGRES_DB:-university}}
       FRONTEND_ORIGIN: http://localhost:8080
       FRONTEND_ORIGINS: http://localhost:8080
       NOTIFICATIONS_SCHEDULER_INLINE_ENABLED: "false"
@@ -61,7 +61,7 @@ services:
     env_file:
       - root/.env
     environment:
-      DATABASE_URL: ${DATABASE_URL:-postgresql+psycopg://${POSTGRES_USER:-university}:${POSTGRES_PASSWORD:-university}@postgres:5432/${POSTGRES_DB:-university}}
+      DATABASE_URL: ${DATABASE_URL:-postgresql+psycopg://${POSTGRES_USER:-university}:${POSTGRES_PASSWORD:-local_dev_password_please_rotate}@postgres:5432/${POSTGRES_DB:-university}}
       NOTIFICATIONS_WORKER_METRICS_HOST: 0.0.0.0
       NOTIFICATIONS_WORKER_METRICS_PORT: "9101"
       CACHE_ENABLED: "true"
@@ -89,7 +89,7 @@ services:
     image: postgres:16-alpine
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-university}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-university}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-local_dev_password_please_rotate}
       POSTGRES_DB: ${POSTGRES_DB:-university}
     volumes:
       - postgres-data:/var/lib/postgresql/data
@@ -118,10 +118,10 @@ services:
       dockerfile: root/backend.Dockerfile
       target: runtime
     command: alembic upgrade head
-    env_file:
-      - root/.env
-    environment:
-      DATABASE_URL: ${DATABASE_URL:-postgresql+psycopg://${POSTGRES_USER:-university}:${POSTGRES_PASSWORD:-university}@postgres:5432/${POSTGRES_DB:-university}}
+      env_file:
+        - root/.env
+      environment:
+        DATABASE_URL: ${DATABASE_URL:-postgresql+psycopg://${POSTGRES_USER:-university}:${POSTGRES_PASSWORD:-local_dev_password_please_rotate}@postgres:5432/${POSTGRES_DB:-university}}
     depends_on:
       postgres:
         condition: service_healthy

--- a/root/.env.example
+++ b/root/.env.example
@@ -1,10 +1,12 @@
 # ----- Core backend settings (copy to .env before running locally) -----
-# Non-default Docker Compose credentials; change these for any shared or remote deployment.
+# Use unique credentials per environment. Passwords/keys must be at least 24 characters with
+# a mix of upper/lowercase letters, numbers, and symbols; rotate every 90 days or after any
+# incident. Never commit real secrets to the repository.
 POSTGRES_USER=university
-POSTGRES_PASSWORD=devpassword
+POSTGRES_PASSWORD=change_me_with_min24_chars!
 POSTGRES_DB=university
 DATABASE_URL=postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@127.0.0.1:5432/${POSTGRES_DB}
-SECRET_KEY=Qj7p4R2zYx8N1a5Hk9V3u0Mw6Tg4Lr8Cz2Jv5Qw7Xn1Dk6Fh0Sg3Vb9Pp4Rz8Lm2
+SECRET_KEY=replace_with_a_unique_64_char_secret_key_value____________________
 ALGORITHM=HS256
 ACCESS_TOKEN_EXPIRE_MINUTES=30
 
@@ -41,14 +43,14 @@ SMTP_SECURITY=none
 MAIL_FROM=inf@guu.ru
 
 # ----- Third-party integrations -----
-SPOTIFY_CLIENT_ID=331521170c9d4dbcb9e09fc857c9b455
-SPOTIFY_CLIENT_SECRET=5ffc84824e4843bdb2ff8fcea71f2198
+SPOTIFY_CLIENT_ID=your_spotify_client_id
+SPOTIFY_CLIENT_SECRET=your_spotify_client_secret_with_min24_chars
 SPOTIFY_REDIRECT_URI=http://127.0.0.1:8000/spotify/callback
 SPOTIFY_SCOPES=user-read-email user-read-private user-top-read user-read-currently-playing user-read-playback-state
 
 # ----- Web push -----
-VAPID_PUBLIC_KEY=BEbE43DjWeAtOTJb4NQsEgZKNju9np1j58z0BqWKT57jfIfIYsNJooylDhLU_9iiferNGaRLoGedXsnYg4PZ2a8
-VAPID_PRIVATE_KEY=cqNPDGp24GDpbKW8q1nXvIiQ_bVBHYM8-hsg9ink280
+VAPID_PUBLIC_KEY=your_vapid_public_key_with_min32_chars
+VAPID_PRIVATE_KEY=your_vapid_private_key_with_min32_chars
 VAPID_SUBJECT=mailto:inf@guu.ru
 
 # ----- Observability -----
@@ -71,6 +73,7 @@ REQUEST_ID_HEADER=X-Request-ID
 
 # ----- Cache -----
 CACHE_ENABLED=false
+# For production, prefer a rediss:// URI with TLS and certificate verification enabled.
 CACHE_REDIS_URL=redis://127.0.0.1:6379/0
 CACHE_DEFAULT_TTL_SECONDS=300
 

--- a/scripts/enforce_secret_strength.py
+++ b/scripts/enforce_secret_strength.py
@@ -38,7 +38,7 @@ def _is_placeholder(value: str) -> bool:
 
 
 def _is_weak(value: str) -> bool:
-    normalized = value.strip().strip('"\'').lower()
+    normalized = value.strip().strip("\"'").lower()
     if not normalized:
         return False
     if normalized in BANNED_VALUES:

--- a/scripts/enforce_secret_strength.py
+++ b/scripts/enforce_secret_strength.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Fail CI/pre-commit when obviously weak secrets are committed.
+
+The check targets environment-like files and docker-compose manifests. It flags values
+for keys suggesting secrecy (PASSWORD/SECRET/KEY/TOKEN) when they are short or match a
+known weak placeholder. Optional fields are skipped if empty to avoid false alarms.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+TARGET_FILES = [
+    ROOT / "root/.env.example",
+    ROOT / "docker-compose.yml",
+]
+
+SENSITIVE_SUFFIXES = ("PASSWORD", "SECRET", "TOKEN", "KEY")
+SECRET_KEY_PATTERN = re.compile(r"^(?P<key>[A-Z0-9_]+)=(?P<value>.*)$")
+YAML_ENV_PATTERN = re.compile(r"^[ \t-]*([A-Z0-9_]+)\s*:\s*(.+)$")
+
+BANNED_VALUES = {
+    "password",
+    "devpassword",
+    "changeme",
+    "secret",
+    "university",
+}
+
+MIN_LENGTH = 24
+
+
+def _is_placeholder(value: str) -> bool:
+    return value.startswith("your_") or value.startswith("replace_with_")
+
+
+def _is_weak(value: str) -> bool:
+    normalized = value.strip().strip('"\'').lower()
+    if not normalized:
+        return False
+    if normalized in BANNED_VALUES:
+        return True
+    if len(normalized) < MIN_LENGTH and not _is_placeholder(normalized):
+        return True
+    return False
+
+
+def _check_lines(path: Path) -> list[str]:
+    weak: list[str] = []
+    for raw_line in path.read_text().splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+
+        match = SECRET_KEY_PATTERN.match(line)
+        if match:
+            key = match.group("key")
+            if key.endswith(SENSITIVE_SUFFIXES):
+                value = match.group("value")
+                if _is_weak(value):
+                    weak.append(f"{path}:{key} uses a weak value")
+            continue
+
+        yaml_match = YAML_ENV_PATTERN.match(raw_line)
+        if yaml_match:
+            key = yaml_match.group(1)
+            if key.endswith(SENSITIVE_SUFFIXES):
+                value = yaml_match.group(2)
+                if _is_weak(value):
+                    weak.append(f"{path}:{key} uses a weak value")
+
+    return weak
+
+
+def main() -> int:
+    failures: list[str] = []
+    for target in TARGET_FILES:
+        if target.exists():
+            failures.extend(_check_lines(target))
+
+    if failures:
+        print("::error::Weak secret values detected:\n- " + "\n- ".join(failures))
+        return 1
+
+    print("Secret strength checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- tighten sample environment variables with explicit rotation, complexity, and TLS guidance
- add trufflehog scanning alongside gitleaks to CI for secret detection
- introduce a pre-commit/CI gate to block obviously weak secret values in env and compose files

## Testing
- python scripts/enforce_secret_strength.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b61f2b5848327a9ada86bcbfeb73f)