### PR TITLE
Add router-level observability metrics and trace propagation

### DIFF
--- a/docs/observability/grafana-dashboard.json
+++ b/docs/observability/grafana-dashboard.json
@@ -1,0 +1,117 @@
+{
+  "title": "University Ecosystem Observability",
+  "schemaVersion": 39,
+  "version": 1,
+  "panels": [
+    {
+      "type": "graph",
+      "title": "HTTP Latency by Router",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(router_request_duration_seconds_bucket[5m])) by (le, router))",
+          "legendFormat": "{{router}} p95"
+        }
+      ],
+      "datasource": "Prometheus"
+    },
+    {
+      "type": "stat",
+      "title": "HTTP 5xx per Router",
+      "targets": [
+        {
+          "expr": "sum(increase(router_request_errors_total[5m])) by (router)",
+          "legendFormat": "{{router}}"
+        }
+      ],
+      "datasource": "Prometheus"
+    },
+    {
+      "type": "stat",
+      "title": "Redis Health",
+      "targets": [
+        {
+          "expr": "redis_health",
+          "legendFormat": "redis"
+        }
+      ],
+      "datasource": "Prometheus"
+    },
+    {
+      "type": "stat",
+      "title": "DB Health",
+      "targets": [
+        {
+          "expr": "db_health",
+          "legendFormat": "db"
+        }
+      ],
+      "datasource": "Prometheus"
+    },
+    {
+      "type": "graph",
+      "title": "Redis Command Latency",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(redis_command_duration_seconds_bucket[5m])) by (le, command))",
+          "legendFormat": "{{command}} p95"
+        }
+      ],
+      "datasource": "Prometheus"
+    },
+    {
+      "type": "graph",
+      "title": "DB Operation Latency",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(db_operation_duration_seconds_bucket[5m])) by (le, operation))",
+          "legendFormat": "{{operation}} p95"
+        }
+      ],
+      "datasource": "Prometheus"
+    },
+    {
+      "type": "stat",
+      "title": "Cache Entries",
+      "targets": [
+        {
+          "expr": "cache_entries",
+          "legendFormat": "entries"
+        }
+      ],
+      "datasource": "Prometheus"
+    },
+    {
+      "type": "stat",
+      "title": "Cache Memory",
+      "targets": [
+        {
+          "expr": "cache_memory_bytes",
+          "legendFormat": "bytes"
+        }
+      ],
+      "datasource": "Prometheus"
+    },
+    {
+      "type": "graph",
+      "title": "CPU Load",
+      "targets": [
+        {
+          "expr": "cpu_load_percent",
+          "legendFormat": "CPU"
+        }
+      ],
+      "datasource": "Prometheus"
+    },
+    {
+      "type": "graph",
+      "title": "GPU Load",
+      "targets": [
+        {
+          "expr": "gpu_load_percent",
+          "legendFormat": "GPU {{index}}"
+        }
+      ],
+      "datasource": "Prometheus"
+    }
+  ]
+}

--- a/docs/observability/prometheus-alerts.json
+++ b/docs/observability/prometheus-alerts.json
@@ -1,0 +1,47 @@
+{
+  "groups": [
+    {
+      "name": "observability.rules",
+      "rules": [
+        {
+          "alert": "HighRouterLatency",
+          "expr": "histogram_quantile(0.95, sum(rate(router_request_duration_seconds_bucket[5m])) by (le, router)) > 1",
+          "for": "5m",
+          "labels": {"severity": "warning"},
+          "annotations": {
+            "summary": "High router latency",
+            "description": "Router {{ $labels.router }} p95 latency above 1s"
+          }
+        },
+        {
+          "alert": "RedisDown",
+          "expr": "redis_health == 0",
+          "for": "2m",
+          "labels": {"severity": "critical"},
+          "annotations": {
+            "summary": "Redis health check failing"
+          }
+        },
+        {
+          "alert": "DatabaseDown",
+          "expr": "db_health == 0",
+          "for": "2m",
+          "labels": {"severity": "critical"},
+          "annotations": {
+            "summary": "Database health check failing"
+          }
+        },
+        {
+          "alert": "ErrorRateSpike",
+          "expr": "sum(increase(router_request_errors_total[5m])) by (router) > 5",
+          "for": "5m",
+          "labels": {"severity": "warning"},
+          "annotations": {
+            "summary": "Spike in 5xx responses",
+            "description": "Router {{ $labels.router }} reported more than 5 errors in 5 minutes"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/root/app/core/config.py
+++ b/root/app/core/config.py
@@ -254,6 +254,7 @@ class Settings(BaseSettings):
     sentry_environment: str = ""
     log_level: str = "INFO"
     request_id_header: str = "x-request-id"
+    trace_header: str = "x-trace-id"
     internal_allowed_ips: str | list[str] = "127.0.0.1,::1"
     internal_auth_header: str = "X-Internal-Token"
     internal_auth_token: str | None = None
@@ -758,7 +759,10 @@ class Settings(BaseSettings):
 
     @cached_property
     def cors_expose_headers_list(self) -> list[str]:
-        return _coerce_str_list(self.cors_expose_headers)
+        headers = {header.strip(): None for header in _coerce_str_list(self.cors_expose_headers)}
+        headers[self.request_id_header] = None
+        headers[self.trace_header] = None
+        return [key for key in headers.keys() if key]
 
     @cached_property
     def rate_limit_default_list(self) -> list[str]:

--- a/root/app/core/config.py
+++ b/root/app/core/config.py
@@ -759,7 +759,10 @@ class Settings(BaseSettings):
 
     @cached_property
     def cors_expose_headers_list(self) -> list[str]:
-        headers = {header.strip(): None for header in _coerce_str_list(self.cors_expose_headers)}
+        headers = {
+            header.strip(): None
+            for header in _coerce_str_list(self.cors_expose_headers)
+        }
         headers[self.request_id_header] = None
         headers[self.trace_header] = None
         return [key for key in headers.keys() if key]

--- a/root/app/core/metrics.py
+++ b/root/app/core/metrics.py
@@ -1,29 +1,38 @@
 from __future__ import annotations
 
+from __future__ import annotations
+
+import asyncio
 import base64
 import hmac
+import importlib.util
 import logging
 import time
 from collections.abc import Iterable
 from ipaddress import ip_address, ip_network
 
+import psutil
 from fastapi import FastAPI, Request
 from fastapi.responses import PlainTextResponse, Response
+from sqlalchemy import text
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from app.core.config import settings
+from app.core.database import engine
 
 try:  # pragma: no cover - optional dependency guard
     from prometheus_client import (  # type: ignore
         CONTENT_TYPE_LATEST,
         REGISTRY,
         Counter,
+        Gauge,
         Histogram,
         generate_latest,
     )
 except Exception:  # pragma: no cover - optional dependency guard
     CONTENT_TYPE_LATEST = "text/plain; version=0.0.4; charset=utf-8"
     Counter = None  # type: ignore[assignment]
+    Gauge = None  # type: ignore[assignment]
     Histogram = None  # type: ignore[assignment]
     REGISTRY = None  # type: ignore[assignment]
 
@@ -53,6 +62,28 @@ _REQUEST_DURATION = (
     else None
 )
 
+_ROUTER_DURATION = (
+    Histogram(
+        "router_request_duration_seconds",
+        "HTTP request duration per router",
+        ("router", "method", "path"),
+        registry=REGISTRY,
+    )
+    if Histogram is not None
+    else None
+)
+
+_ROUTER_ERRORS = (
+    Counter(
+        "router_request_errors_total",
+        "HTTP errors per router",
+        ("router", "method", "path", "status"),
+        registry=REGISTRY,
+    )
+    if Counter is not None
+    else None
+)
+
 _HEALTH_CHECK_DURATION = (
     Histogram(
         "healthcheck_duration_seconds",
@@ -75,6 +106,92 @@ _HEALTH_CHECK_STATUS = (
     else None
 )
 
+_REDIS_COMMAND_DURATION = (
+    Histogram(
+        "redis_command_duration_seconds",
+        "Redis command duration in seconds",
+        ("command",),
+        registry=REGISTRY,
+    )
+    if Histogram is not None
+    else None
+)
+
+_REDIS_COMMAND_ERRORS = (
+    Counter(
+        "redis_command_errors_total",
+        "Total Redis command failures",
+        ("command",),
+        registry=REGISTRY,
+    )
+    if Counter is not None
+    else None
+)
+
+_DB_OPERATION_DURATION = (
+    Histogram(
+        "db_operation_duration_seconds",
+        "Database operation duration in seconds",
+        ("operation",),
+        registry=REGISTRY,
+    )
+    if Histogram is not None
+    else None
+)
+
+_DB_OPERATION_ERRORS = (
+    Counter(
+        "db_operation_errors_total",
+        "Total database operation failures",
+        ("operation",),
+        registry=REGISTRY,
+    )
+    if Counter is not None
+    else None
+)
+
+_CACHE_ENTRIES = (
+    Gauge(
+        "cache_entries", "Number of cached entries", registry=REGISTRY
+    )
+    if Gauge is not None
+    else None
+)
+
+_CACHE_MEMORY_BYTES = (
+    Gauge(
+        "cache_memory_bytes",
+        "Memory consumption of cache backend",
+        registry=REGISTRY,
+    )
+    if Gauge is not None
+    else None
+)
+
+_REDIS_HEALTH = (
+    Gauge("redis_health", "Redis availability", registry=REGISTRY)
+    if Gauge is not None
+    else None
+)
+
+_DB_HEALTH = (
+    Gauge("db_health", "Database availability", registry=REGISTRY)
+    if Gauge is not None
+    else None
+)
+
+_CPU_LOAD = (
+    Gauge("cpu_load_percent", "CPU load percentage", registry=REGISTRY)
+    if Gauge is not None
+    else None
+)
+
+_GPU_LOAD = (
+    Gauge("gpu_load_percent", "GPU load percentage", ("index", "name"), registry=REGISTRY)
+    if Gauge is not None
+    else None
+)
+
 _CONFIGURED_ATTR = "_metrics_configured"
 _PLACEHOLDER_PASSWORDS = {"changeme"}
 logger = logging.getLogger(__name__)
@@ -87,6 +204,9 @@ class PrometheusRequestMetricsMiddleware(BaseHTTPMiddleware):
 
         start = time.perf_counter()
         status_code = "500"
+        router_label = _resolve_router_label(request)
+        path_template = _resolve_path_template(request)
+        method = request.method.upper()
         try:
             response = await call_next(request)
             status_code = str(response.status_code)
@@ -94,13 +214,22 @@ class PrometheusRequestMetricsMiddleware(BaseHTTPMiddleware):
         except Exception:
             raise
         finally:
-            path_template = _resolve_path_template(request)
-            method = request.method.upper()
             _REQUEST_COUNT.labels(
                 method=method, path=path_template, status=status_code
             ).inc()
             elapsed = max(time.perf_counter() - start, 0.0)
             _REQUEST_DURATION.labels(method=method, path=path_template).observe(elapsed)
+            if _ROUTER_DURATION is not None:
+                _ROUTER_DURATION.labels(
+                    router=router_label, method=method, path=path_template
+                ).observe(elapsed)
+            if _ROUTER_ERRORS is not None and status_code.startswith("5"):
+                _ROUTER_ERRORS.labels(
+                    router=router_label,
+                    method=method,
+                    path=path_template,
+                    status=status_code,
+                ).inc()
 
 
 def _resolve_path_template(request: Request) -> str:
@@ -111,6 +240,18 @@ def _resolve_path_template(request: Request) -> str:
             return str(path)
     raw_path = request.scope.get("path") or request.url.path
     return str(raw_path) if raw_path else "unknown"
+
+
+def _resolve_router_label(request: Request) -> str:
+    route = request.scope.get("route")
+    if route is not None:
+        for attr in ("router", "owner"):
+            router = getattr(route, attr, None)
+            if router is not None:
+                prefix = getattr(router, "prefix", None)
+                if prefix:
+                    return str(prefix)
+    return request.scope.get("root_path") or "root"
 
 
 def _authorization_header(request: Request) -> str:
@@ -186,6 +327,129 @@ def record_health_probe(component: str, status: str, elapsed_seconds: float) -> 
             logger.debug("Failed to record health check status", exc_info=True)
 
 
+def record_redis_command(command: str, elapsed_seconds: float, *, success: bool) -> None:
+    if _REDIS_COMMAND_DURATION is not None:
+        try:
+            _REDIS_COMMAND_DURATION.labels(command=command).observe(
+                max(elapsed_seconds, 0.0)
+            )
+        except Exception:  # pragma: no cover - defensive metrics guard
+            logger.debug("Failed to record redis command duration", exc_info=True)
+    if not success and _REDIS_COMMAND_ERRORS is not None:
+        try:
+            _REDIS_COMMAND_ERRORS.labels(command=command).inc()
+        except Exception:  # pragma: no cover - defensive metrics guard
+            logger.debug("Failed to record redis command error", exc_info=True)
+
+
+def record_db_operation(operation: str, elapsed_seconds: float, *, success: bool) -> None:
+    if _DB_OPERATION_DURATION is not None:
+        try:
+            _DB_OPERATION_DURATION.labels(operation=operation).observe(
+                max(elapsed_seconds, 0.0)
+            )
+        except Exception:  # pragma: no cover - defensive metrics guard
+            logger.debug("Failed to record db operation duration", exc_info=True)
+    if not success and _DB_OPERATION_ERRORS is not None:
+        try:
+            _DB_OPERATION_ERRORS.labels(operation=operation).inc()
+        except Exception:  # pragma: no cover - defensive metrics guard
+            logger.debug("Failed to record db operation error", exc_info=True)
+
+
+async def _record_cache_metrics() -> None:
+    if _CACHE_ENTRIES is None and _CACHE_MEMORY_BYTES is None and _REDIS_HEALTH is None:
+        return
+    from app.deps.cache import RedisCache, get_cache
+
+    backend = get_cache()
+    if isinstance(backend, RedisCache):
+        try:
+            client = await backend._get_client()  # noqa: SLF001 - metrics probe only
+            start = time.perf_counter()
+            pong = await client.ping()
+            latency = max(time.perf_counter() - start, 0.0)
+            record_redis_command("ping", latency, success=bool(pong))
+            info = await client.info(section="memory")
+            size = await client.dbsize()
+            if _CACHE_ENTRIES is not None:
+                _CACHE_ENTRIES.set(float(size))
+            if _CACHE_MEMORY_BYTES is not None:
+                used_memory = info.get("used_memory") if isinstance(info, dict) else None
+                if isinstance(used_memory, (int, float)):
+                    _CACHE_MEMORY_BYTES.set(float(used_memory))
+            if _REDIS_HEALTH is not None:
+                _REDIS_HEALTH.set(1)
+        except Exception:  # pragma: no cover - defensive metrics guard
+            if _REDIS_HEALTH is not None:
+                _REDIS_HEALTH.set(0)
+            record_redis_command("ping", 0.0, success=False)
+    else:
+        if _CACHE_ENTRIES is not None:
+            _CACHE_ENTRIES.set(0)
+        if _CACHE_MEMORY_BYTES is not None:
+            _CACHE_MEMORY_BYTES.set(0)
+        if _REDIS_HEALTH is not None:
+            _REDIS_HEALTH.set(0)
+
+
+async def _record_db_metrics() -> None:
+    if _DB_HEALTH is None and _DB_OPERATION_DURATION is None:
+        return
+    start = time.perf_counter()
+    success = False
+    try:
+        async with engine.connect() as conn:
+            await conn.execute(text("SELECT 1"))
+        success = True
+    except Exception:  # pragma: no cover - defensive metrics guard
+        success = False
+    finally:
+        elapsed = max(time.perf_counter() - start, 0.0)
+        record_db_operation("healthcheck", elapsed, success=success)
+        if _DB_HEALTH is not None:
+            _DB_HEALTH.set(1 if success else 0)
+
+
+def _load_gputil():
+    spec = importlib.util.find_spec("GPUtil")
+    if spec is None:
+        return None
+    module = importlib.util.module_from_spec(spec)
+    loader = spec.loader
+    if loader is None:
+        return None
+    loader.exec_module(module)  # type: ignore[arg-type]
+    return module
+
+
+def _record_system_metrics() -> None:
+    if _CPU_LOAD is not None:
+        try:
+            _CPU_LOAD.set(float(psutil.cpu_percent(interval=None)))
+        except Exception:  # pragma: no cover - defensive metrics guard
+            logger.debug("Failed to collect CPU metrics", exc_info=True)
+    if _GPU_LOAD is not None:
+        try:
+            module = _load_gputil()
+            if module is None:
+                _GPU_LOAD.clear()
+                return
+            gpus = module.getGPUs()
+            _GPU_LOAD.clear()
+            for gpu in gpus:
+                _GPU_LOAD.labels(index=str(gpu.id), name=str(gpu.name)).set(
+                    float(getattr(gpu, "load", 0.0)) * 100.0
+                )
+        except Exception:  # pragma: no cover - defensive metrics guard
+            logger.debug("Failed to collect GPU metrics", exc_info=True)
+
+
+async def refresh_runtime_metrics() -> None:
+    await asyncio.gather(_record_cache_metrics(), _record_db_metrics())
+    _record_system_metrics()
+
+
 async def metrics_endpoint(request: Request) -> Response:
     if not settings.enable_metrics_endpoint:
         return PlainTextResponse("Not Found", status_code=404)
@@ -202,6 +466,8 @@ async def metrics_endpoint(request: Request) -> Response:
 
     if REGISTRY is None:
         raise RuntimeError("prometheus-client is required to expose metrics")
+
+    await refresh_runtime_metrics()
 
     payload = generate_latest(REGISTRY)
     response = Response(content=payload, media_type=CONTENT_TYPE_LATEST)

--- a/root/app/core/metrics.py
+++ b/root/app/core/metrics.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from __future__ import annotations
-
 import asyncio
 import base64
 import hmac
@@ -151,9 +149,7 @@ _DB_OPERATION_ERRORS = (
 )
 
 _CACHE_ENTRIES = (
-    Gauge(
-        "cache_entries", "Number of cached entries", registry=REGISTRY
-    )
+    Gauge("cache_entries", "Number of cached entries", registry=REGISTRY)
     if Gauge is not None
     else None
 )
@@ -187,7 +183,9 @@ _CPU_LOAD = (
 )
 
 _GPU_LOAD = (
-    Gauge("gpu_load_percent", "GPU load percentage", ("index", "name"), registry=REGISTRY)
+    Gauge(
+        "gpu_load_percent", "GPU load percentage", ("index", "name"), registry=REGISTRY
+    )
     if Gauge is not None
     else None
 )
@@ -327,7 +325,9 @@ def record_health_probe(component: str, status: str, elapsed_seconds: float) -> 
             logger.debug("Failed to record health check status", exc_info=True)
 
 
-def record_redis_command(command: str, elapsed_seconds: float, *, success: bool) -> None:
+def record_redis_command(
+    command: str, elapsed_seconds: float, *, success: bool
+) -> None:
     if _REDIS_COMMAND_DURATION is not None:
         try:
             _REDIS_COMMAND_DURATION.labels(command=command).observe(
@@ -342,7 +342,9 @@ def record_redis_command(command: str, elapsed_seconds: float, *, success: bool)
             logger.debug("Failed to record redis command error", exc_info=True)
 
 
-def record_db_operation(operation: str, elapsed_seconds: float, *, success: bool) -> None:
+def record_db_operation(
+    operation: str, elapsed_seconds: float, *, success: bool
+) -> None:
     if _DB_OPERATION_DURATION is not None:
         try:
             _DB_OPERATION_DURATION.labels(operation=operation).observe(
@@ -375,7 +377,9 @@ async def _record_cache_metrics() -> None:
             if _CACHE_ENTRIES is not None:
                 _CACHE_ENTRIES.set(float(size))
             if _CACHE_MEMORY_BYTES is not None:
-                used_memory = info.get("used_memory") if isinstance(info, dict) else None
+                used_memory = (
+                    info.get("used_memory") if isinstance(info, dict) else None
+                )
                 if isinstance(used_memory, (int, float)):
                     _CACHE_MEMORY_BYTES.set(float(used_memory))
             if _REDIS_HEALTH is not None:

--- a/root/app/core/observability.py
+++ b/root/app/core/observability.py
@@ -86,26 +86,51 @@ _notification_queue_metrics: NotificationQueueMetrics | None = None
 _periodic_task_metrics: dict[str, PeriodicTaskMetrics] = {}
 
 _request_id_ctx: ContextVar[str | None] = ContextVar("request_id", default=None)
+_trace_id_ctx: ContextVar[str | None] = ContextVar("trace_id", default=None)
 
 
 def get_request_id() -> str | None:
     return _request_id_ctx.get(None)
 
 
+def get_trace_id() -> str | None:
+    return _trace_id_ctx.get(None)
+
+
+def _resolve_current_trace_id() -> str | None:
+    span = trace.get_current_span()
+    span_context = span.get_span_context()
+    if span_context is not None and span_context.is_valid:
+        return f"{span_context.trace_id:032x}"
+    return get_trace_id() or get_request_id()
+
+
 class CorrelationIdMiddleware(BaseHTTPMiddleware):
-    def __init__(self, app: FastAPI, header_name: str = "x-request-id") -> None:
+    def __init__(
+        self,
+        app: FastAPI,
+        header_name: str = "x-request-id",
+        trace_header_name: str = "x-trace-id",
+    ) -> None:
         super().__init__(app)
         self._header_name = header_name
+        self._trace_header_name = trace_header_name
 
     async def dispatch(self, request: Request, call_next):
         header_value = request.headers.get(self._header_name)
         request_id = header_value or uuid.uuid4().hex
-        token = _request_id_ctx.set(request_id)
+        trace_header_value = request.headers.get(self._trace_header_name)
+        trace_id = trace_header_value or request_id
+        request_token = _request_id_ctx.set(request_id)
+        trace_token = _trace_id_ctx.set(trace_id)
         try:
             response: Response = await call_next(request)
         finally:
-            _request_id_ctx.reset(token)
+            _request_id_ctx.reset(request_token)
+            _trace_id_ctx.reset(trace_token)
+        resolved_trace_id = _resolve_current_trace_id() or trace_id
         response.headers[self._header_name] = request_id
+        response.headers[self._trace_header_name] = resolved_trace_id
         return response
 
 
@@ -117,7 +142,7 @@ class TraceContextFilter(logging.Filter):
             record.trace_id = f"{span_context.trace_id:032x}"
             record.span_id = f"{span_context.span_id:016x}"
         else:
-            record.trace_id = ""
+            record.trace_id = _resolve_current_trace_id() or ""
             record.span_id = ""
         request_id = get_request_id()
         record.request_id = request_id or ""
@@ -310,7 +335,9 @@ def configure_observability(app: FastAPI, *, engine: AsyncEngine) -> None:
     if not getattr(app.state, "observability_configured", False):
         _configure_logging()
         app.add_middleware(
-            CorrelationIdMiddleware, header_name=settings.request_id_header
+            CorrelationIdMiddleware,
+            header_name=settings.request_id_header,
+            trace_header_name=settings.trace_header,
         )
         tracer_provider = _configure_otel(engine)
         _configure_sentry(tracer_provider)

--- a/root/app/deps/cache.py
+++ b/root/app/deps/cache.py
@@ -4,6 +4,7 @@ import asyncio
 import hashlib
 import json
 import logging
+import time as time_module
 from dataclasses import dataclass
 from datetime import date, datetime, time
 from typing import Any
@@ -12,6 +13,7 @@ from redis.asyncio import Redis
 from redis.exceptions import RedisError
 
 from app.core.config import settings
+from app.core.metrics import record_redis_command
 
 logger = logging.getLogger(__name__)
 
@@ -82,12 +84,21 @@ class RedisCache(BaseCache):
         if self._client is None:
             return
         client, self._client = self._client, None
+        start = time_module.perf_counter()
+        success = False
         try:
             await client.aclose()
+            success = True
         except (RedisError, OSError):
             logger.debug("Failed to close Redis client", exc_info=True)
+        finally:
+            record_redis_command(
+                "close", time_module.perf_counter() - start, success=success
+            )
 
     async def get(self, key: str) -> CacheEntry | None:
+        start = time_module.perf_counter()
+        success = False
         try:
             client = await self._get_client()
             raw = await client.get(key)
@@ -106,14 +117,20 @@ class RedisCache(BaseCache):
         payload = parsed.get("payload")
         if not etag:
             return None
+        success = True
         return CacheEntry(etag=etag, payload=payload)
-
+        finally:
+            record_redis_command(
+                "get", time_module.perf_counter() - start, success=success
+            )
     async def set(self, key: str, payload: Any, ttl: int | None = None) -> CacheEntry:
         normalized_payload, serialized = _normalize_payload(payload)
         etag = hashlib.sha256(serialized).hexdigest()
         envelope = json.dumps(
             {"etag": etag, "payload": normalized_payload}, ensure_ascii=False
         )
+        start = time_module.perf_counter()
+        success = False
         try:
             client = await self._get_client()
             expire = self._resolve_ttl(ttl)
@@ -121,14 +138,20 @@ class RedisCache(BaseCache):
                 await client.set(key, envelope, ex=expire)
             else:
                 await client.set(key, envelope)
+            success = True
         except (RedisError, OSError):
             logger.warning("Redis cache set failed for key %s", key, exc_info=True)
+        finally:
+            record_redis_command(
+                "set", time_module.perf_counter() - start, success=success
+            )
         return CacheEntry(etag=etag, payload=normalized_payload)
-
     async def invalidate(self, *keys: str) -> None:
         filtered = [str(key) for key in keys if key]
         if not filtered:
             return
+        start = time_module.perf_counter()
+        success = False
         try:
             client = await self._get_client()
 
@@ -156,9 +179,16 @@ class RedisCache(BaseCache):
                         await client.delete(*matches)
                     if cursor == 0:
                         break
+            success = True
         except (RedisError, OSError):
             logger.warning(
                 "Redis cache invalidate failed for keys %s", filtered, exc_info=True
+            )
+        finally:
+            record_redis_command(
+                "invalidate",
+                time_module.perf_counter() - start,
+                success=success,
             )
 
     def _resolve_ttl(self, ttl: int | None) -> int:

--- a/root/frontend/src/api/client.ts
+++ b/root/frontend/src/api/client.ts
@@ -6,9 +6,11 @@ import axios, {
 } from "axios"
 import type { paths } from "@/api/generated/schema"
 import i18n, { fallbackLng, supportedLngs } from "@/i18n/config"
+import { setTraceContext } from "@/app/logger"
 
 export const API_UNAUTHORIZED_EVENT = "auth:unauthorized"
 export const SKIP_UNAUTHORIZED_HEADER = "X-Client-Skip-Unauthorized"
+const TRACE_HEADER = (import.meta.env.VITE_TRACE_HEADER || "x-trace-id") as string
 
 const devBase = "/api/v1"
 const prodBase = `${import.meta.env.VITE_BACKEND_ORIGIN || ""}/api/v1`
@@ -112,6 +114,22 @@ let clientQueueTimer: ReturnType<typeof setTimeout> | null = null
 let clientQueueResetAt = 0
 
 const etagCache = new Map<string, string>()
+
+const updateTraceContext = (
+  headers: AxiosHeaders | Record<string, unknown> | undefined
+) => {
+  if (!headers) {
+    setTraceContext(null)
+    return
+  }
+  const normalized = AxiosHeaders.from(headers as AxiosHeaders)
+  const traceId = normalized.get(TRACE_HEADER) ?? normalized.get(TRACE_HEADER.toLowerCase())
+  if (typeof traceId === "string" && traceId.trim()) {
+    setTraceContext(traceId)
+  } else {
+    setTraceContext(null)
+  }
+}
 
 export const resetEtagCache = () => etagCache.clear()
 
@@ -392,25 +410,30 @@ api.interceptors.request.use(async (config) => {
 })
 
 api.interceptors.response.use(
-  (r) => {
-    const config = r.config as ApiRequestConfig | undefined
-    const etagKey = config?.etagCacheKey
-    if (etagKey) {
-      const responseHeaders = AxiosHeaders.from(
-        (r.headers ?? undefined) as AxiosHeaders | string | undefined
-      )
-      const tag = responseHeaders.get("etag") ?? responseHeaders.get("ETag")
-      if (typeof tag === "string" && tag.trim()) {
-        etagCache.set(etagKey, tag)
-      } else {
-        etagCache.delete(etagKey)
+    (r) => {
+      const config = r.config as ApiRequestConfig | undefined
+      const etagKey = config?.etagCacheKey
+      if (etagKey) {
+        const responseHeaders = AxiosHeaders.from(
+          (r.headers ?? undefined) as AxiosHeaders | string | undefined
+        )
+        const tag = responseHeaders.get("etag") ?? responseHeaders.get("ETag")
+        if (typeof tag === "string" && tag.trim()) {
+          etagCache.set(etagKey, tag)
+        } else {
+          etagCache.delete(etagKey)
+        }
       }
-    }
-    releaseClientQueueSlot(r.config as ApiRequestConfig | undefined)
-    return r
-  },
-  async (err) => {
-    releaseClientQueueSlot(err?.config as ApiRequestConfig | undefined)
+      updateTraceContext(r.headers as AxiosHeaders)
+      releaseClientQueueSlot(r.config as ApiRequestConfig | undefined)
+      return r
+    },
+    async (err) => {
+      releaseClientQueueSlot(err?.config as ApiRequestConfig | undefined)
+
+      if (err?.response?.headers) {
+        updateTraceContext(err.response.headers as AxiosHeaders)
+      }
 
     const config = err?.config as ApiRequestConfig | undefined
     const etagKey = config?.etagCacheKey

--- a/root/frontend/src/app/logger.ts
+++ b/root/frontend/src/app/logger.ts
@@ -2,6 +2,8 @@ import * as Sentry from "@sentry/react"
 
 type LogMethod = "error" | "warn" | "info" | "log"
 
+let currentTraceId: string | null = null
+
 function normalizeArg(value: unknown): unknown {
   if (value instanceof Error) {
     return {
@@ -44,6 +46,29 @@ function findFirstMessage(args: unknown[]): string | undefined {
   return typeof candidate === "string" ? candidate : undefined
 }
 
+function resolveTags() {
+  const tags: Record<string, string> = {
+    logger: "app",
+  }
+  if (currentTraceId) {
+    tags.trace_id = currentTraceId
+  }
+  return tags
+}
+
+export function setTraceContext(traceId: string | null | undefined): void {
+  currentTraceId = traceId && String(traceId).trim() ? String(traceId) : null
+  if (typeof Sentry.configureScope === "function") {
+    Sentry.configureScope((scope) => {
+      if (currentTraceId) {
+        scope.setTag("trace_id", currentTraceId)
+      } else {
+        scope.setTag("trace_id", "")
+      }
+    })
+  }
+}
+
 export function logError(...args: unknown[]): void {
   const error = findFirstError(args)
   try {
@@ -53,7 +78,7 @@ export function logError(...args: unknown[]): void {
           logArgs: args.map(normalizeArg),
         },
         tags: {
-          logger: "app",
+          ...resolveTags(),
           level: "error",
         },
       })
@@ -74,7 +99,9 @@ export function logWarning(...args: unknown[]): void {
   try {
     const message = findFirstMessage(args)
     if (message) {
-      Sentry.captureMessage(message, "warning")
+      Sentry.captureMessage(message, "warning", {
+        tags: resolveTags(),
+      })
     }
   } catch (sentryError) {
     callConsole("warn", ["[logger] Failed to forward warning to Sentry", sentryError])

--- a/root/requirements.txt
+++ b/root/requirements.txt
@@ -28,6 +28,8 @@ redis>=5
 aiosqlite>=0.19
 prometheus-client>=0.20
 pyotp>=2.9
+psutil>=6.0.0
+gputil>=1.4.0
 
 opentelemetry-api==1.39.0
 opentelemetry-sdk==1.39.0


### PR DESCRIPTION
## Summary
- extend Prometheus metrics with router-level, cache/Redis, database, and system gauges
- instrument Redis cache operations and export Grafana/Prometheus dashboard and alert configs
- propagate request/trace identifiers into logs and frontend logging context

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b716370b4832792866876534c90c7)