### PR TITLE
Optimize frontend performance budgets and routing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,11 @@ jobs:
             exit 1
           fi
           npm run format:check
+      - name: Build frontend with bundle budgets
+        working-directory: root/frontend
+        env:
+          CI: true
+        run: npm run build -- --report --logLevel warn --clearScreen false
 
   pip-audit:
     name: Pip audit

--- a/budget.json
+++ b/budget.json
@@ -2,19 +2,19 @@
   {
     "path": "/*",
     "resourceSizes": [
-      { "resourceType": "script", "budget": 200 },
-      { "resourceType": "stylesheet", "budget": 120 }
+      { "resourceType": "script", "budget": 180 },
+      { "resourceType": "stylesheet", "budget": 110 }
     ],
     "timings": [
-      { "metric": "largest-contentful-paint", "budget": 3500 },
-      { "metric": "total-blocking-time", "budget": 300 },
+      { "metric": "largest-contentful-paint", "budget": 3000 },
+      { "metric": "total-blocking-time", "budget": 250 },
       { "metric": "cumulative-layout-shift", "budget": 0.1 }
     ]
   },
   {
     "path": "/map",
     "resourceSizes": [
-      { "resourceType": "script", "budget": 250 }
+      { "resourceType": "script", "budget": 230 }
     ],
     "timings": []
   }

--- a/root/frontend/package.json
+++ b/root/frontend/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "node ./scripts/run-build.mjs",
+    "build:report": "npm run build -- --report",
     "preview": "vite preview",
     "lint": "eslint --max-warnings=0 --ext .ts,.tsx \"src\" \"tests\"",
     "lint:all": "npm run lint && npm run manifests:check",

--- a/root/frontend/scripts/check-bundle-budget.mjs
+++ b/root/frontend/scripts/check-bundle-budget.mjs
@@ -1,0 +1,108 @@
+import { promises as fs } from "node:fs"
+import path from "node:path"
+import { brotliCompressSync, gzipSync } from "node:zlib"
+
+const DIST_DIR = path.resolve(process.cwd(), "dist")
+const ASSET_EXTENSIONS = [".js", ".css"]
+
+const LIMITS = {
+  maxCompressedTotalKb: 1200,
+  maxIndividualCompressedKb: 420,
+  maxInitialJsKb: 620,
+}
+
+const formatKb = (bytes) => Math.round((bytes / 1024) * 100) / 100
+
+async function readFiles(dir) {
+  const entries = await fs.readdir(dir, { withFileTypes: true })
+  const files = await Promise.all(
+    entries.map(async (entry) => {
+      const resolved = path.join(dir, entry.name)
+      if (entry.isDirectory()) return readFiles(resolved)
+      return [resolved]
+    })
+  )
+  return files.flat()
+}
+
+function isAsset(filePath) {
+  return ASSET_EXTENSIONS.some((ext) => filePath.endsWith(ext))
+}
+
+async function collectAssetStats() {
+  const files = await readFiles(DIST_DIR)
+  const assetFiles = files.filter(isAsset)
+
+  const stats = await Promise.all(
+    assetFiles.map(async (filePath) => {
+      const content = await fs.readFile(filePath)
+      const gzipSize = gzipSync(content).byteLength
+      const brotliSize = brotliCompressSync(content).byteLength
+      return {
+        path: path.relative(DIST_DIR, filePath),
+        raw: content.byteLength,
+        gzip: gzipSize,
+        brotli: brotliSize,
+        isInitial: /\/assets\/index-[\w]+\.js$/.test(filePath),
+      }
+    })
+  )
+
+  return stats
+}
+
+function assertBudgets(stats) {
+  const totalCompressed = stats.reduce((acc, item) => acc + Math.min(item.gzip, item.brotli), 0)
+  const heaviest = stats.reduce((prev, curr) => (curr.gzip > prev.gzip ? curr : prev), stats[0])
+  const initialJsTotal = stats
+    .filter((item) => item.isInitial && item.path.endsWith(".js"))
+    .reduce((acc, item) => acc + Math.min(item.gzip, item.brotli), 0)
+
+  const violations = []
+
+  if (formatKb(totalCompressed) > LIMITS.maxCompressedTotalKb) {
+    violations.push(
+      `Total compressed assets exceed budget: ${formatKb(totalCompressed)}kb > ${LIMITS.maxCompressedTotalKb}kb`
+    )
+  }
+
+  if (formatKb(heaviest.gzip) > LIMITS.maxIndividualCompressedKb) {
+    violations.push(
+      `Largest asset '${heaviest.path}' exceeds budget: ${formatKb(heaviest.gzip)}kb > ${LIMITS.maxIndividualCompressedKb}kb`
+    )
+  }
+
+  if (formatKb(initialJsTotal) > LIMITS.maxInitialJsKb) {
+    violations.push(
+      `Initial JS entry exceeds budget: ${formatKb(initialJsTotal)}kb > ${LIMITS.maxInitialJsKb}kb`
+    )
+  }
+
+  if (violations.length) {
+    for (const violation of violations) {
+      console.error(violation)
+    }
+    throw new Error(`Bundle budgets violated (${violations.length} issue${violations.length === 1 ? "" : "s"})`)
+  }
+
+  return {
+    totalCompressedKb: formatKb(totalCompressed),
+    largestAssetKb: formatKb(heaviest.gzip),
+    initialJsKb: formatKb(initialJsTotal),
+  }
+}
+
+async function main() {
+  const stats = await collectAssetStats()
+  if (!stats.length) {
+    throw new Error(`No build assets found in ${DIST_DIR}. Did you run the build?`)
+  }
+
+  const summary = assertBudgets(stats)
+  console.log("Bundle budgets within limits:", summary)
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/root/frontend/scripts/run-build.mjs
+++ b/root/frontend/scripts/run-build.mjs
@@ -1,0 +1,37 @@
+import { spawn } from "node:child_process"
+import path from "node:path"
+import process from "node:process"
+
+const args = process.argv.slice(2)
+const wantsReport = args.includes("--report")
+const sanitizedArgs = args.filter((arg) => arg !== "--report")
+
+const env = {
+  ...process.env,
+  ...(wantsReport ? { BUILD_REPORT: "1", ANALYZE: process.env.ANALYZE ?? "1" } : {}),
+}
+
+function run(command, commandArgs, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, commandArgs, { stdio: "inherit", env, ...options })
+    child.on("close", (code) => {
+      if (code !== 0) {
+        reject(new Error(`${command} exited with code ${code}`))
+      } else {
+        resolve(undefined)
+      }
+    })
+  })
+}
+
+async function main() {
+  await run("vite", ["build", ...sanitizedArgs], { cwd: path.resolve(process.cwd()) })
+  if (wantsReport) {
+    await run("node", [path.resolve(process.cwd(), "scripts/check-bundle-budget.mjs")])
+  }
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/root/frontend/src/App.tsx
+++ b/root/frontend/src/App.tsx
@@ -4,7 +4,7 @@ import type { FutureConfig as RouterDataFutureConfig } from "@remix-run/router"
 import type { FutureConfig as RouterComponentFutureConfig } from "react-router"
 import Navbar from "./components/Navbar"
 import Footer from "./components/Footer"
-import { AuthProvider, currentUserQueryKey } from "./contexts/AuthContext"
+import { AuthProvider, currentUserQueryKey, useAuth } from "./contexts/AuthContext"
 import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider"
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs"
 import { LanguageProvider, useLanguage } from "./contexts/LanguageContext"
@@ -20,31 +20,55 @@ import { nowPlayingQueryKey } from "./hooks/useNowPlaying"
 import { useTranslation } from "react-i18next"
 import { AppShellProvider } from "./contexts/AppShellContext"
 import { AdminRoute, PrivateRoute } from "./components/RouteGuards"
+import { prefetchRouteModules } from "./utils/prefetchRoutes"
 
-const PageTransition = lazy(() => import("./components/PageTransition"))
-const Dashboard = lazy(() => import("./pages/Dashboard"))
-const News = lazy(() => import("./pages/News"))
-const NewsDetail = lazy(() => import("./pages/NewsDetail"))
-const Schedule = lazy(() => import("./pages/Schedule"))
-const Activity = lazy(() => import("./pages/Activity"))
-const Events = lazy(() => import("./pages/Events"))
-const EventDetail = lazy(() => import("./components/EventDetail"))
-const MapPage = lazy(() => import("./pages/Map"))
-const Profile = lazy(() => import("./pages/Profile"))
-const Login = lazy(() => import("./pages/Login"))
-const Register = lazy(() => import("./pages/Register"))
-const AdminUsers = lazy(() => import("./pages/AdminUsers"))
-const StoriesAdmin = lazy(() => import("./pages/StoriesAdmin"))
-const AdminNotifications = lazy(() => import("./pages/AdminNotifications"))
-const ForgotPassword = lazy(() => import("./pages/ForgotPassword"))
-const ResetPassword = lazy(() => import("./pages/ResetPassword"))
-const Settings = lazy(() => import("./pages/Settings"))
-const Messenger = lazy(() => import("./pages/Messenger"))
+const routeModules = {
+  PageTransition: () => import("./components/PageTransition"),
+  Dashboard: () => import("./pages/Dashboard"),
+  News: () => import("./pages/News"),
+  NewsDetail: () => import("./pages/NewsDetail"),
+  Schedule: () => import("./pages/Schedule"),
+  Activity: () => import("./pages/Activity"),
+  Events: () => import("./pages/Events"),
+  EventDetail: () => import("./components/EventDetail"),
+  MapPage: () => import("./pages/Map"),
+  Profile: () => import("./pages/Profile"),
+  Login: () => import("./pages/Login"),
+  Register: () => import("./pages/Register"),
+  AdminUsers: () => import("./pages/AdminUsers"),
+  StoriesAdmin: () => import("./pages/StoriesAdmin"),
+  AdminNotifications: () => import("./pages/AdminNotifications"),
+  ForgotPassword: () => import("./pages/ForgotPassword"),
+  ResetPassword: () => import("./pages/ResetPassword"),
+  Settings: () => import("./pages/Settings"),
+  Messenger: () => import("./pages/Messenger"),
+} as const
+
+const PageTransition = lazy(routeModules.PageTransition)
+const Dashboard = lazy(routeModules.Dashboard)
+const News = lazy(routeModules.News)
+const NewsDetail = lazy(routeModules.NewsDetail)
+const Schedule = lazy(routeModules.Schedule)
+const Activity = lazy(routeModules.Activity)
+const Events = lazy(routeModules.Events)
+const EventDetail = lazy(routeModules.EventDetail)
+const MapPage = lazy(routeModules.MapPage)
+const Profile = lazy(routeModules.Profile)
+const Login = lazy(routeModules.Login)
+const Register = lazy(routeModules.Register)
+const AdminUsers = lazy(routeModules.AdminUsers)
+const StoriesAdmin = lazy(routeModules.StoriesAdmin)
+const AdminNotifications = lazy(routeModules.AdminNotifications)
+const ForgotPassword = lazy(routeModules.ForgotPassword)
+const ResetPassword = lazy(routeModules.ResetPassword)
+const Settings = lazy(routeModules.Settings)
+const Messenger = lazy(routeModules.Messenger)
 
 function AppContent() {
   const location = useLocation()
   const queryClient = useQueryClient()
   const reduceMotion = useMediaQuery("(prefers-reduced-motion: reduce)")
+  const { isAuth } = useAuth()
 
   const hideNavbar =
     location.pathname === "/login" ||
@@ -64,6 +88,28 @@ function AppContent() {
     const next = location.pathname + (sp.toString() ? "?" + sp : "")
     window.history.replaceState({}, "", next)
   }, [location.pathname, location.search, queryClient])
+
+  useEffect(() => {
+    const publicLoaders = [routeModules.Login, routeModules.Register, routeModules.ForgotPassword, routeModules.ResetPassword]
+    const privateLoaders = [
+      routeModules.Dashboard,
+      routeModules.News,
+      routeModules.Schedule,
+      routeModules.MapPage,
+      routeModules.Profile,
+      routeModules.Settings,
+      routeModules.Activity,
+      routeModules.Events,
+    ]
+    const sharedLoaders = [routeModules.PageTransition, routeModules.Messenger]
+
+    if (isAuth) {
+      prefetchRouteModules([...privateLoaders, ...sharedLoaders], { timeoutMs: 800 })
+      return
+    }
+
+    prefetchRouteModules([...publicLoaders, ...sharedLoaders], { timeoutMs: 800 })
+  }, [isAuth])
 
   const wrap = (node: ReactElement) => {
     if (reduceMotion || hideNavbar) return node

--- a/root/frontend/src/app/logger.ts
+++ b/root/frontend/src/app/logger.ts
@@ -1,22 +1,22 @@
-import {
-  captureException as sentryCaptureException,
-  captureMessage as sentryCaptureMessage,
-  configureScope as sentryConfigureScope,
-} from "@sentry/react"
+import * as Sentry from "@sentry/react"
+
+const sentryCaptureException = Sentry.captureException
+const sentryCaptureMessage = Sentry.captureMessage
+const sentrySetTag = typeof Sentry.setTag === "function" ? Sentry.setTag : undefined
 
 type LogMethod = "error" | "warn" | "info" | "log"
 
 type SentryClient = {
   captureException?: typeof sentryCaptureException
   captureMessage?: typeof sentryCaptureMessage
-  configureScope?: typeof sentryConfigureScope
+  setTag?: typeof sentrySetTag
 }
 
 let currentTraceId: string | null = null
 let sentry: SentryClient = {
   captureException: sentryCaptureException,
   captureMessage: sentryCaptureMessage,
-  configureScope: sentryConfigureScope,
+  setTag: sentrySetTag,
 }
 
 export function setLoggerClient(overrides: Partial<SentryClient>): void {
@@ -77,14 +77,8 @@ function resolveTags() {
 
 export function setTraceContext(traceId: string | null | undefined): void {
   currentTraceId = traceId && String(traceId).trim() ? String(traceId) : null
-  if (typeof sentry.configureScope === "function") {
-    sentry.configureScope((scope) => {
-      if (currentTraceId) {
-        scope.setTag("trace_id", currentTraceId)
-      } else {
-        scope.setTag("trace_id", "")
-      }
-    })
+  if (typeof sentry.setTag === "function") {
+    sentry.setTag("trace_id", currentTraceId ?? "")
   }
 }
 

--- a/root/frontend/src/app/queryClient.ts
+++ b/root/frontend/src/app/queryClient.ts
@@ -1,7 +1,32 @@
 import { QueryClient } from "@tanstack/react-query"
 
+const DEFAULT_STALE_MS = 60_000
+const DEFAULT_CACHE_MS = 10 * 60_000
+
+const parseDuration = (value: string | number | undefined, fallback: number) => {
+  if (typeof value === "number") {
+    return Number.isFinite(value) && value > 0 ? value : fallback
+  }
+
+  if (!value) return fallback
+
+  const parsed = Number.parseInt(String(value), 10)
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback
+
+  return parsed
+}
+
+const staleTime = parseDuration(import.meta.env.VITE_QUERY_STALE_TIME_MS, DEFAULT_STALE_MS)
+const gcTime = parseDuration(import.meta.env.VITE_QUERY_CACHE_TTL_MS, DEFAULT_CACHE_MS)
+
 const defaultOptions = {
-  queries: { staleTime: 30000, retry: 1, refetchOnWindowFocus: false },
+  queries: {
+    staleTime,
+    gcTime,
+    retry: 1,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: "always",
+  },
   mutations: { retry: 0 },
 } as const
 

--- a/root/frontend/src/components/Footer.tsx
+++ b/root/frontend/src/components/Footer.tsx
@@ -3,6 +3,7 @@ import { IconButton, Typography } from "@mui/material"
 import TelegramIcon from "@mui/icons-material/Telegram"
 import EmailIcon from "@mui/icons-material/Email"
 import guuLogo from "@/assets/guu_logo.png"
+import SmartImage from "@/components/SmartImage"
 import { useTranslation } from "react-i18next"
 
 export default function Footer() {
@@ -31,13 +32,16 @@ export default function Footer() {
           <div className="footer-brand">
             <div className="footer-brand-head">
               <div className="footer-logo">
-                <img
-                  src={guuLogo}
+                <SmartImage
+                  srcRaw={guuLogo}
                   alt={t("navigation:brandAlt")}
                   width={48}
                   height={48}
                   loading="lazy"
+                  sizes="48px"
+                  responsiveWidths={[48, 64, 96]}
                   decoding="async"
+                  className="h-12 w-12"
                 />
               </div>
               <Typography className="footer-brand-title">{t("navigation:brandName")}</Typography>

--- a/root/frontend/src/components/Navbar.tsx
+++ b/root/frontend/src/components/Navbar.tsx
@@ -160,11 +160,14 @@ const Navbar = () => {
             }}
           >
             <div className="flex items-center justify-center rounded-full bg-white shadow-[0_0_8px_rgba(0,0,0,0.13)] w-[44px] h-[44px] min-[1351px]:w-[52px] min-[1351px]:h-[52px]">
-              <img
-                src={guuLogo}
+              <SmartImage
+                srcRaw={guuLogo}
                 alt={t("navigation:brandAlt")}
                 className="object-contain w-[34px] h-[34px] min-[1351px]:w-[42px] min-[1351px]:h-[42px]"
                 loading="eager"
+                fetchPriority="high"
+                sizes="(min-width: 1351px) 42px, 34px"
+                responsiveWidths={[48, 64, 88]}
                 decoding="async"
               />
             </div>

--- a/root/frontend/src/components/SmartImage.tsx
+++ b/root/frontend/src/components/SmartImage.tsx
@@ -4,20 +4,46 @@ import { addVersionParam, resolveMediaUrl } from "@/utils/media"
 
 const DEV = import.meta.env.DEV === true
 
+const RESPONSIVE_DEFAULT_WIDTHS = [320, 540, 768, 1024, 1440] as const
+
 export type SmartImageProps = {
   srcRaw?: string
   cacheV?: string | number
   fallback?: string
+  responsiveWidths?: number[]
 } & Omit<ImgHTMLAttributes<HTMLImageElement>, "src">
+
+function buildSrcSet(url: string, widths: number[]): string {
+  const uniqueWidths = Array.from(new Set(widths.filter((value) => Number.isFinite(value) && value > 0))).sort(
+    (a, b) => a - b
+  )
+
+  if (!uniqueWidths.length) return ""
+
+  return uniqueWidths
+    .map((width) => {
+      try {
+        const candidate = new URL(url, window.location.origin)
+        candidate.searchParams.set("w", String(width))
+        return `${candidate.toString()} ${width}w`
+      } catch {
+        const separator = url.includes("?") ? "&" : "?"
+        return `${url}${separator}w=${encodeURIComponent(width)} ${width}w`
+      }
+    })
+    .join(", ")
+}
 
 export default function SmartImage({
   srcRaw,
   cacheV,
   fallback = IMAGE_PLACEHOLDER_URL,
+  responsiveWidths = RESPONSIVE_DEFAULT_WIDTHS,
   alt = "",
   style,
   onError,
   onLoad,
+  sizes = "(max-width: 720px) 82vw, 460px",
   ...rest
 }: SmartImageProps) {
   const computed = useMemo(() => {
@@ -44,6 +70,10 @@ export default function SmartImage({
   }, [computed])
 
   const finalSrc = useFallback || !computed ? fallback : computed
+  const srcSet = useMemo(() => {
+    if (!computed) return ""
+    return buildSrcSet(computed, responsiveWidths)
+  }, [computed, responsiveWidths])
 
   useEffect(() => {
     if (!DEV) return
@@ -61,6 +91,8 @@ export default function SmartImage({
       decoding="async"
       style={mergedStyle}
       src={finalSrc}
+      srcSet={srcSet || undefined}
+      sizes={srcSet ? sizes : undefined}
       onLoad={(event) => {
         if (DEV) {
           console.info(`[SmartImage] status=loaded src=${finalSrc || "(empty)"}`)

--- a/root/frontend/src/pages/Settings.tsx
+++ b/root/frontend/src/pages/Settings.tsx
@@ -27,6 +27,7 @@ import {
 import TotpQrDisplay from "@/components/mfa/TotpQrDisplay"
 import OtpEntry from "@/components/mfa/OtpEntry"
 import StepUpDialog from "@/components/mfa/StepUpDialog"
+import SmartImage from "@/components/SmartImage"
 import type { User } from "@/types/User"
 import type { ActiveSession } from "@/types/Session"
 import type {
@@ -828,7 +829,14 @@ function Avatar({
       )}
     >
       <div className="relative h-full w-full overflow-hidden rounded-full bg-[color:color-mix(in_srgb,var(--card-bg)_94%,rgba(15,40,85,0.08)_6%)]">
-        <img src={src} alt={alt} className="h-full w-full object-cover" {...imgProps} />
+        <SmartImage
+          srcRaw={src}
+          alt={alt}
+          className="h-full w-full object-cover"
+          responsiveWidths={[64, 96, 128, 196]}
+          sizes="(max-width: 640px) 96px, 144px"
+          {...imgProps}
+        />
       </div>
     </div>
   )

--- a/root/frontend/src/utils/prefetchRoutes.ts
+++ b/root/frontend/src/utils/prefetchRoutes.ts
@@ -1,0 +1,34 @@
+const hasWindow = typeof window !== "undefined"
+
+type Loader = () => Promise<unknown>
+
+type PrefetchOptions = {
+  timeoutMs?: number
+}
+
+const scheduled = new WeakSet<Loader>()
+
+function schedule(fn: () => void, timeoutMs = 1200) {
+  if (!hasWindow) return
+  if (typeof window.requestIdleCallback === "function") {
+    window.requestIdleCallback(fn, { timeout: timeoutMs })
+    return
+  }
+  window.setTimeout(fn, timeoutMs)
+}
+
+export function prefetchRouteModules(loaders: Loader[], options: PrefetchOptions = {}): void {
+  if (!hasWindow) return
+
+  const uniqueLoaders = loaders.filter((loader) => {
+    if (scheduled.has(loader)) return false
+    scheduled.add(loader)
+    return true
+  })
+
+  if (!uniqueLoaders.length) return
+
+  schedule(() => {
+    void Promise.allSettled(uniqueLoaders.map((loader) => loader()))
+  }, options.timeoutMs)
+}

--- a/root/frontend/vite.config.mts
+++ b/root/frontend/vite.config.mts
@@ -98,7 +98,8 @@ const withStrictCspNonce = (): PluginOption => ({
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "")
   const target = (env.VITE_BACKEND_ORIGIN || "http://127.0.0.1:8000").replace(/\/$/, "")
-  const analyze = mode === "analyze" || process.env.ANALYZE === "1"
+  const buildReport = process.env.BUILD_REPORT === "1"
+  const analyze = mode === "analyze" || process.env.ANALYZE === "1" || buildReport
   const manifest = loadManifest()
 
   const mk = (rewrite = false) => ({
@@ -151,6 +152,7 @@ export default defineConfig(({ mode }) => {
       ...(manifest ? { manifest } : {}),
       injectManifest: {
         globPatterns: ["**/*.{js,css,html,ico,png,svg,webp,json}"],
+        globIgnores: ["**/bundle-stats.*"],
       },
       devOptions: {
         enabled: false,
@@ -167,6 +169,15 @@ export default defineConfig(({ mode }) => {
         gzipSize: true,
         brotliSize: true,
         open: false,
+      })
+    )
+    plugins.push(
+      visualizer({
+        filename: "dist/bundle-stats.json",
+        template: "sunburst",
+        json: true,
+        gzipSize: true,
+        brotliSize: true,
       })
     )
   }
@@ -211,7 +222,7 @@ export default defineConfig(({ mode }) => {
     modulepreload: { polyfill: false },
     build: {
       sourcemap: true,
-      chunkSizeWarningLimit: 1024,
+      chunkSizeWarningLimit: 768,
       rollupOptions: {
         output: {
           manualChunks(id) {


### PR DESCRIPTION
## Summary
- add route-level lazy modules with idle prefetching for critical navigation flows
- tighten web asset budgets, image handling, and client cache controls for better UX
- enable build-with-report CI job and bundle budget enforcement with new scripts

## Testing
- CI=1 npm run build -- --report --logLevel warn --clearScreen false


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693cc6346edc83279e0da07030214d15)