### PR TITLE
Add data retention policies and privacy self-service endpoints

### DIFF
--- a/root/alembic/versions/202507010001_add_data_access_logs.py
+++ b/root/alembic/versions/202507010001_add_data_access_logs.py
@@ -1,0 +1,78 @@
+"""Add data access logs table
+
+Revision ID: 202507010001
+Revises: 202506200001
+Create Date: 2025-07-01 00:01:00.000000
+"""
+
+from typing import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "202507010001"
+down_revision: str | None = "202506200001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _table_exists(inspector: sa.Inspector, table_name: str) -> bool:
+    return table_name in inspector.get_table_names()
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    table_name = "data_access_logs"
+
+    if not _table_exists(inspector, table_name):
+        op.create_table(
+            table_name,
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("actor_user_id", sa.Integer(), nullable=True),
+            sa.Column("subject_user_id", sa.Integer(), nullable=True),
+            sa.Column("resource_type", sa.String(length=64), nullable=False),
+            sa.Column("resource_id", sa.String(length=128), nullable=True),
+            sa.Column("action", sa.String(length=64), nullable=False),
+            sa.Column("context", sa.dialects.postgresql.JSONB(), nullable=True),
+            sa.Column("ip_address", sa.String(length=64), nullable=True),
+            sa.Column("user_agent", sa.String(length=512), nullable=True),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+            sa.ForeignKeyConstraint(
+                ["actor_user_id"], ["users.id"], ondelete="SET NULL"
+            ),
+            sa.ForeignKeyConstraint(
+                ["subject_user_id"], ["users.id"], ondelete="SET NULL"
+            ),
+        )
+
+    inspector = sa.inspect(bind)
+    existing_indexes = (
+        {index["name"] for index in inspector.get_indexes(table_name)}
+        if _table_exists(inspector, table_name)
+        else set()
+    )
+
+    indexes = {
+        "ix_data_access_logs_actor": ["actor_user_id"],
+        "ix_data_access_logs_subject": ["subject_user_id"],
+        "ix_data_access_logs_created_at": ["created_at"],
+        "ix_data_access_logs_resource": ["resource_type", "resource_id"],
+    }
+
+    for name, columns in indexes.items():
+        if name not in existing_indexes:
+            op.create_index(name, table_name, columns)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_data_access_logs_resource", table_name="data_access_logs")
+    op.drop_index("ix_data_access_logs_created_at", table_name="data_access_logs")
+    op.drop_index("ix_data_access_logs_subject", table_name="data_access_logs")
+    op.drop_index("ix_data_access_logs_actor", table_name="data_access_logs")
+    op.drop_table("data_access_logs")

--- a/root/alembic/versions/202507010001_add_data_access_logs.py
+++ b/root/alembic/versions/202507010001_add_data_access_logs.py
@@ -5,9 +5,10 @@ Revises: 202506200001
 Create Date: 2025-07-01 00:01:00.000000
 """
 
-from typing import Sequence
+from collections.abc import Sequence
 
 import sqlalchemy as sa
+
 from alembic import op
 
 revision: str = "202507010001"

--- a/root/app/api/users.py
+++ b/root/app/api/users.py
@@ -3,6 +3,7 @@ import hashlib
 import hmac
 import json
 import logging
+from datetime import datetime
 
 from fastapi import (
     APIRouter,
@@ -15,10 +16,12 @@ from fastapi import (
     UploadFile,
     status,
 )
+from fastapi.responses import Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps import (
     get_auth_service,
+    get_audit_service,
     get_current_user,
     get_user_service,
     require_fresh_mfa,
@@ -28,6 +31,12 @@ from app.localization import resolve_locale, translate
 from app.models import models
 from app.schemas import schemas
 from app.services.auth_service import AuthService, attach_pending_email
+from app.services.audit_service import AuditService
+from app.services.data_access import (
+    export_access_logs,
+    log_data_access,
+    serialize_access_logs_csv,
+)
 from app.services.notifications import create_notifications_for_users
 from app.services.user_service import UserService
 from app.utils.ratelimit import sensitive_route_limit
@@ -149,6 +158,15 @@ async def me(
 ):
     _enforce_profile_cache_integrity(request)
     await attach_pending_email(db, user)
+    await log_data_access(
+        db,
+        actor_user_id=user.id,
+        subject_user_id=user.id,
+        resource_type="profile",
+        resource_id=str(user.id),
+        action="read",
+        request=request,
+    )
     return user
 
 
@@ -198,6 +216,31 @@ async def change_password(
 ):
     ok, revoked = await auth_service.change_password(db, user, payload, request)
     return schemas.PasswordChangeOut(ok=ok, revoked_sessions=revoked)
+
+
+@users_router.post("/me/export", response_model=schemas.DataExportOut)
+async def export_me(
+    request: Request,
+    _: None = Depends(require_fresh_mfa),
+    db: AsyncSession = Depends(get_db),
+    user: models.User = Depends(get_current_user),
+    service: UserService = Depends(get_user_service),
+):
+    return await service.export_user_data(db, user, request)
+
+
+@users_router.post("/me/delete", response_model=schemas.DataDeletionOut)
+async def delete_me(
+    payload: schemas.DataDeletionRequest,
+    request: Request,
+    _: None = Depends(require_fresh_mfa),
+    db: AsyncSession = Depends(get_db),
+    user: models.User = Depends(get_current_user),
+    service: UserService = Depends(get_user_service),
+):
+    return await service.delete_user_data(
+        db, user, request, confirm=payload.confirm
+    )
 
 
 @users_router.post("/me/avatar", response_model=schemas.UserOut)
@@ -268,7 +311,7 @@ async def get_users(
     user: models.User = Depends(get_current_user),
     service: UserService = Depends(get_user_service),
 ):
-    return await service.get_users(
+    users = await service.get_users(
         db,
         request,
         user,
@@ -278,6 +321,44 @@ async def get_users(
         role=role,
         limit=limit,
         offset=offset,
+    )
+    for item in users:
+        await log_data_access(
+            db,
+            actor_user_id=user.id,
+            subject_user_id=item.id,
+            resource_type="profile",
+            resource_id=str(item.id),
+            action="read",
+            request=request,
+        )
+    return users
+
+
+@users_router.get("/audit/export")
+async def export_access_audit(
+    request: Request,
+    start_at: datetime | None = Query(None),
+    end_at: datetime | None = Query(None),
+    db: AsyncSession = Depends(get_db),
+    user: models.User = Depends(get_current_user),
+    audit: AuditService = Depends(get_audit_service),
+):
+    locale = resolve_locale(request=request, user=user)
+    if user.role != "admin":
+        raise HTTPException(
+            status_code=403,
+            detail=translate("errors.forbidden", locale=locale),
+        )
+    logs = await export_access_logs(
+        db, start_at=start_at, end_at=end_at, limit=20_000
+    )
+    audit.log("users.audit.export", request, user_id=user.id)
+    csv_payload = serialize_access_logs_csv(logs)
+    return Response(
+        content=csv_payload,
+        media_type="text/csv",
+        headers={"Content-Disposition": "attachment; filename=access_audit.csv"},
     )
 
 

--- a/root/app/api/users.py
+++ b/root/app/api/users.py
@@ -20,8 +20,8 @@ from fastapi.responses import Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps import (
-    get_auth_service,
     get_audit_service,
+    get_auth_service,
     get_current_user,
     get_user_service,
     require_fresh_mfa,
@@ -30,8 +30,8 @@ from app.core.database import get_db
 from app.localization import resolve_locale, translate
 from app.models import models
 from app.schemas import schemas
-from app.services.auth_service import AuthService, attach_pending_email
 from app.services.audit_service import AuditService
+from app.services.auth_service import AuthService, attach_pending_email
 from app.services.data_access import (
     export_access_logs,
     log_data_access,
@@ -238,9 +238,7 @@ async def delete_me(
     user: models.User = Depends(get_current_user),
     service: UserService = Depends(get_user_service),
 ):
-    return await service.delete_user_data(
-        db, user, request, confirm=payload.confirm
-    )
+    return await service.delete_user_data(db, user, request, confirm=payload.confirm)
 
 
 @users_router.post("/me/avatar", response_model=schemas.UserOut)
@@ -350,9 +348,7 @@ async def export_access_audit(
             status_code=403,
             detail=translate("errors.forbidden", locale=locale),
         )
-    logs = await export_access_logs(
-        db, start_at=start_at, end_at=end_at, limit=20_000
-    )
+    logs = await export_access_logs(db, start_at=start_at, end_at=end_at, limit=20_000)
     audit.log("users.audit.export", request, user_id=user.id)
     csv_payload = serialize_access_logs_csv(logs)
     return Response(

--- a/root/app/core/config.py
+++ b/root/app/core/config.py
@@ -371,6 +371,11 @@ class Settings(BaseSettings):
     password_reset_max_active_tokens: int = 1
     stories_cleanup_enabled: bool = True
     stories_retention_cleanup_interval_seconds: int = 86_400
+    privacy_cleanup_interval_seconds: int = 86_400
+    session_retention_days: int = 90
+    mfa_retention_days: int = 30
+    failed_login_retention_days: int = 30
+    access_log_retention_days: int = 180
     event_file_allowed_mime_types: str | list[str] = (
         "application/pdf,"
         "text/plain,"

--- a/root/app/core/lifespan.py
+++ b/root/app/core/lifespan.py
@@ -35,6 +35,11 @@ from app.services.password_reset_cleanup import (
     cleanup_stale_password_reset_tokens,
     start_password_reset_cleanup_scheduler,
 )
+from app.services.privacy_cleanup import (
+    PrivacyCleanupConfig,
+    cleanup_privacy_artifacts,
+    start_privacy_cleanup_scheduler,
+)
 from app.services.session_cleanup import (
     SessionCleanupConfig,
     cleanup_expired_sessions,
@@ -61,6 +66,7 @@ async def lifespan(app: FastAPI):
     stop_password_reset_cleanup = None
     stop_mfa_challenge_cleanup = None
     stop_email_change_cleanup = None
+    stop_privacy_cleanup = None
     if settings.is_development and settings.notifications_scheduler_inline_enabled:
         stop_scheduler = await start_notifications_scheduler(
             poll_seconds=settings.notifications_scheduler_poll_seconds,
@@ -82,6 +88,15 @@ async def lifespan(app: FastAPI):
         retention_minutes=settings.email_change_cleanup_retention_minutes
     )
     await cleanup_stale_mfa_challenges()
+    await cleanup_privacy_artifacts(
+        config=PrivacyCleanupConfig(
+            session_retention_days=settings.session_retention_days,
+            mfa_retention_days=settings.mfa_retention_days,
+            failed_login_retention_days=settings.failed_login_retention_days,
+            audit_log_retention_days=settings.access_log_retention_days,
+            interval_seconds=settings.privacy_cleanup_interval_seconds,
+        )
+    )
     if (
         settings.notifications_retention_days > 0
         and settings.notifications_retention_cleanup_interval_seconds > 0
@@ -138,6 +153,16 @@ async def lifespan(app: FastAPI):
                 interval_seconds=settings.stories_retention_cleanup_interval_seconds
             )
         )
+    if settings.privacy_cleanup_interval_seconds > 0:
+        stop_privacy_cleanup = await start_privacy_cleanup_scheduler(
+            config=PrivacyCleanupConfig(
+                session_retention_days=settings.session_retention_days,
+                mfa_retention_days=settings.mfa_retention_days,
+                failed_login_retention_days=settings.failed_login_retention_days,
+                audit_log_retention_days=settings.access_log_retention_days,
+                interval_seconds=settings.privacy_cleanup_interval_seconds,
+            )
+        )
     await warm_cache()
     try:
         yield
@@ -158,6 +183,8 @@ async def lifespan(app: FastAPI):
             await stop_email_change_cleanup()
         if stop_mfa_challenge_cleanup is not None:
             await stop_mfa_challenge_cleanup()
+        if stop_privacy_cleanup is not None:
+            await stop_privacy_cleanup()
         await notification_queue.shutdown_notification_queue()
         webpush.cleanup()
         await shutdown_cache()

--- a/root/app/models/models.py
+++ b/root/app/models/models.py
@@ -19,8 +19,7 @@ from sqlalchemy import (
     func,
     text,
 )
-from sqlalchemy.dialects.postgresql import JSONB
-from sqlalchemy.dialects.postgresql import TSVECTOR
+from sqlalchemy.dialects.postgresql import JSONB, TSVECTOR
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.orm import relationship
 

--- a/root/app/models/models.py
+++ b/root/app/models/models.py
@@ -19,6 +19,7 @@ from sqlalchemy import (
     func,
     text,
 )
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.dialects.postgresql import TSVECTOR
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.orm import relationship
@@ -416,6 +417,30 @@ class FailedLoginAttempt(Base):
             "attempted_at",
         ),
     )
+
+
+class DataAccessLog(Base):
+    __tablename__ = "data_access_logs"
+
+    id = Column(Integer, primary_key=True)
+    actor_user_id = Column(
+        Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    subject_user_id = Column(
+        Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    resource_type = Column(String(64), nullable=False, index=True)
+    resource_id = Column(String(128), nullable=True, index=True)
+    action = Column(String(64), nullable=False, index=True)
+    context = Column(JSONB, nullable=True)
+    ip_address = Column(String(64))
+    user_agent = Column(String(512))
+    created_at = Column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False, index=True
+    )
+
+    actor = relationship("User", foreign_keys=[actor_user_id])
+    subject = relationship("User", foreign_keys=[subject_user_id])
 
 
 class EventAttendance(Base):

--- a/root/app/schemas/schemas.py
+++ b/root/app/schemas/schemas.py
@@ -149,6 +149,24 @@ class SessionBulkRevokeOut(BaseModel):
     revoked: int = 0
 
 
+class DataExportOut(BaseModel):
+    profile: dict[str, Any]
+    sessions: list[dict[str, Any]] = Field(default_factory=list)
+    notifications: list[dict[str, Any]] = Field(default_factory=list)
+    mfa_challenges: list[dict[str, Any]] = Field(default_factory=list)
+    mfa_enrollments: list[dict[str, Any]] = Field(default_factory=list)
+    access_logs: list[dict[str, Any]] = Field(default_factory=list)
+
+
+class DataDeletionRequest(BaseModel):
+    confirm: bool = Field(..., description="Explicit consent to remove personal data")
+
+
+class DataDeletionOut(BaseModel):
+    deleted: bool
+    anonymized_email: EmailStr
+
+
 class UserProfileUpdate(BaseModel):
     full_name: str | None = None
     email: EmailStr | None = None

--- a/root/app/services/data_access.py
+++ b/root/app/services/data_access.py
@@ -1,7 +1,7 @@
 import csv
 import io
+from collections.abc import Iterable
 from datetime import UTC, datetime, timedelta
-from typing import Iterable
 
 from fastapi import Request
 from sqlalchemy import delete, select

--- a/root/app/services/data_access.py
+++ b/root/app/services/data_access.py
@@ -1,0 +1,120 @@
+import csv
+import io
+from datetime import UTC, datetime, timedelta
+from typing import Iterable
+
+from fastapi import Request
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import async_session
+from app.models.models import DataAccessLog
+
+
+def _normalize_time(value: datetime | None) -> datetime | None:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+async def log_data_access(
+    db: AsyncSession,
+    *,
+    actor_user_id: int | None,
+    subject_user_id: int | None,
+    resource_type: str,
+    action: str,
+    request: Request,
+    resource_id: str | None = None,
+    context: dict | None = None,
+) -> DataAccessLog:
+    log_entry = DataAccessLog(
+        actor_user_id=actor_user_id,
+        subject_user_id=subject_user_id,
+        resource_type=resource_type,
+        resource_id=resource_id,
+        action=action,
+        context=context or {},
+        ip_address=request.client.host if request.client else None,
+        user_agent=request.headers.get("user-agent"),
+    )
+    db.add(log_entry)
+    await db.commit()
+    await db.refresh(log_entry)
+    return log_entry
+
+
+async def cleanup_access_logs(
+    *, db: AsyncSession | None = None, retention_days: int = 180
+) -> int:
+    owns_session = db is None
+    retention = max(0, int(retention_days))
+    if retention <= 0:
+        return 0
+    cutoff = datetime.now(UTC) - timedelta(days=retention)
+    if owns_session:
+        async with async_session() as session:
+            return await cleanup_access_logs(db=session, retention_days=retention)
+    stmt = delete(DataAccessLog).where(DataAccessLog.created_at < cutoff)
+    result = await db.execute(stmt.execution_options(synchronize_session=False))
+    await db.commit()
+    return int(result.rowcount or 0)
+
+
+async def export_access_logs(
+    db: AsyncSession,
+    *,
+    start_at: datetime | None = None,
+    end_at: datetime | None = None,
+    limit: int = 10_000,
+    actor_user_id: int | None = None,
+    subject_user_id: int | None = None,
+) -> Iterable[DataAccessLog]:
+    start = _normalize_time(start_at)
+    end = _normalize_time(end_at)
+    stmt = select(DataAccessLog).order_by(DataAccessLog.created_at.desc()).limit(limit)
+    if start is not None:
+        stmt = stmt.where(DataAccessLog.created_at >= start)
+    if end is not None:
+        stmt = stmt.where(DataAccessLog.created_at <= end)
+    if actor_user_id is not None:
+        stmt = stmt.where(DataAccessLog.actor_user_id == actor_user_id)
+    if subject_user_id is not None:
+        stmt = stmt.where(DataAccessLog.subject_user_id == subject_user_id)
+    result = await db.execute(stmt)
+    return result.scalars().all()
+
+
+def serialize_access_logs_csv(entries: Iterable[DataAccessLog]) -> str:
+    buffer = io.StringIO()
+    writer = csv.writer(buffer)
+    writer.writerow(
+        [
+            "created_at",
+            "actor_user_id",
+            "subject_user_id",
+            "resource_type",
+            "resource_id",
+            "action",
+            "ip_address",
+            "user_agent",
+            "context",
+        ]
+    )
+    for entry in entries:
+        writer.writerow(
+            [
+                entry.created_at.isoformat() if entry.created_at else None,
+                entry.actor_user_id,
+                entry.subject_user_id,
+                entry.resource_type,
+                entry.resource_id,
+                entry.action,
+                entry.ip_address,
+                entry.user_agent,
+                entry.context,
+            ]
+        )
+    return buffer.getvalue()

--- a/root/app/services/privacy_cleanup.py
+++ b/root/app/services/privacy_cleanup.py
@@ -2,10 +2,10 @@
 
 import asyncio
 import logging
+from collections.abc import Awaitable, Callable
 from contextlib import suppress
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
-from typing import Awaitable, Callable
 
 from sqlalchemy import and_, delete, or_
 from sqlalchemy.ext.asyncio import AsyncSession

--- a/root/app/services/privacy_cleanup.py
+++ b/root/app/services/privacy_cleanup.py
@@ -1,0 +1,146 @@
+"""Retention helpers for privacy-sensitive artifacts."""
+
+import asyncio
+import logging
+from contextlib import suppress
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Awaitable, Callable
+
+from sqlalchemy import and_, delete, or_
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import async_session
+from app.core.observability import get_periodic_task_metrics
+from app.models.models import (
+    ActiveSession,
+    FailedLoginAttempt,
+    MfaChallenge,
+    MfaTotpEnrollment,
+)
+from app.services.data_access import cleanup_access_logs
+
+logger = logging.getLogger(__name__)
+
+_METRICS = get_periodic_task_metrics("privacy_cleanup")
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _cutoff(retention_days: int) -> datetime:
+    return _now() - timedelta(days=max(0, int(retention_days)))
+
+
+async def _cleanup_sessions(db: AsyncSession, retention_days: int) -> int:
+    cutoff = _cutoff(retention_days)
+    stmt = delete(ActiveSession).where(
+        and_(
+            ActiveSession.expires_at < cutoff,
+            or_(ActiveSession.revoked_at.is_(None), ActiveSession.revoked_at < cutoff),
+        )
+    )
+    result = await db.execute(stmt.execution_options(synchronize_session=False))
+    return int(result.rowcount or 0)
+
+
+async def _cleanup_mfa_challenges(db: AsyncSession, retention_days: int) -> int:
+    cutoff = _cutoff(retention_days)
+    stmt = delete(MfaChallenge).where(MfaChallenge.expires_at < cutoff)
+    result = await db.execute(stmt.execution_options(synchronize_session=False))
+    return int(result.rowcount or 0)
+
+
+async def _cleanup_mfa_enrollments(db: AsyncSession, retention_days: int) -> int:
+    cutoff = _cutoff(retention_days)
+    stmt = delete(MfaTotpEnrollment).where(
+        and_(
+            MfaTotpEnrollment.revoked_at.is_not(None),
+            MfaTotpEnrollment.revoked_at < cutoff,
+        )
+    )
+    result = await db.execute(stmt.execution_options(synchronize_session=False))
+    return int(result.rowcount or 0)
+
+
+async def _cleanup_failed_logins(db: AsyncSession, retention_days: int) -> int:
+    cutoff = _cutoff(retention_days)
+    stmt = delete(FailedLoginAttempt).where(FailedLoginAttempt.attempted_at < cutoff)
+    result = await db.execute(stmt.execution_options(synchronize_session=False))
+    return int(result.rowcount or 0)
+
+
+@dataclass(slots=True)
+class PrivacyCleanupConfig:
+    session_retention_days: int = 90
+    mfa_retention_days: int = 30
+    failed_login_retention_days: int = 30
+    audit_log_retention_days: int = 180
+    interval_seconds: int = 86_400
+
+    def normalized_interval(self) -> int:
+        return max(60, int(self.interval_seconds))
+
+
+async def cleanup_privacy_artifacts(
+    *, db: AsyncSession | None = None, config: PrivacyCleanupConfig
+) -> dict[str, int]:
+    owns_session = db is None
+    if owns_session:
+        async with async_session() as session:
+            return await cleanup_privacy_artifacts(db=session, config=config)
+
+    counts: dict[str, int] = {}
+    async with _METRICS.track_execution() as run:
+        counts["sessions"] = await _cleanup_sessions(db, config.session_retention_days)
+        counts["mfa_challenges"] = await _cleanup_mfa_challenges(
+            db, config.mfa_retention_days
+        )
+        counts["mfa_enrollments"] = await _cleanup_mfa_enrollments(
+            db, config.mfa_retention_days
+        )
+        counts["failed_logins"] = await _cleanup_failed_logins(
+            db, config.failed_login_retention_days
+        )
+        counts["access_logs"] = await cleanup_access_logs(
+            db=db, retention_days=config.audit_log_retention_days
+        )
+        run.observe_deleted(sum(counts.values()))
+    await db.commit()
+    return counts
+
+
+async def start_privacy_cleanup_scheduler(
+    *, config: PrivacyCleanupConfig
+) -> Callable[[], Awaitable[None]]:
+    interval = config.normalized_interval()
+
+    async def _loop() -> None:
+        try:
+            while True:
+                try:
+                    deleted = await cleanup_privacy_artifacts(config=config)
+                    logger.info("Privacy cleanup run completed: %s", deleted)
+                except asyncio.CancelledError:
+                    raise
+                except Exception:  # pragma: no cover - defensive
+                    logger.exception("Failed to run privacy cleanup")
+                await asyncio.sleep(interval)
+        except asyncio.CancelledError:
+            logger.info("Privacy cleanup loop cancelled")
+            raise
+
+    loop = asyncio.get_running_loop()
+    task = loop.create_task(_loop())
+
+    async def _stop() -> None:
+        if task.done():
+            with suppress(Exception):
+                task.result()
+            return
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+
+    return _stop

--- a/root/app/services/user_service.py
+++ b/root/app/services/user_service.py
@@ -385,7 +385,10 @@ class UserService:
         if not confirm:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail=translate("errors.users.confirmation_required", locale=resolve_locale(request=request, user=user)),
+                detail=translate(
+                    "errors.users.confirmation_required",
+                    locale=resolve_locale(request=request, user=user),
+                ),
             )
 
         db_user = await db.get(models.User, user.id, options=USER_MFA_LOAD_OPTIONS)
@@ -416,7 +419,9 @@ class UserService:
             delete(models.MfaChallenge).where(models.MfaChallenge.user_id == user.id)
         )
         await db.execute(
-            delete(models.MfaTotpEnrollment).where(models.MfaTotpEnrollment.user_id == user.id)
+            delete(models.MfaTotpEnrollment).where(
+                models.MfaTotpEnrollment.user_id == user.id
+            )
         )
         await db.execute(
             delete(models.Notification).where(models.Notification.user_id == user.id)

--- a/root/app/services/user_service.py
+++ b/root/app/services/user_service.py
@@ -2,7 +2,7 @@ import logging
 
 from fastapi import HTTPException, Request, UploadFile, status
 from pydantic import EmailStr, TypeAdapter
-from sqlalchemy import func, select
+from sqlalchemy import delete, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import crud
@@ -16,6 +16,7 @@ from app.models.user_loaders import (
 from app.schemas import schemas
 from app.services.audit_service import AuditService
 from app.services.auth_service import attach_pending_email
+from app.services.data_access import export_access_logs, log_data_access
 from app.services.notifications import create_notifications_for_users
 from app.utils.files import delete_static_file
 
@@ -269,3 +270,180 @@ class UserService:
         await db.refresh(db_user)
         await ensure_mfa_relationships_loaded(db, db_user)
         return db_user
+
+    async def export_user_data(
+        self, db: AsyncSession, user: models.User, request: Request
+    ) -> schemas.DataExportOut:
+        db_user = await db.get(models.User, user.id, options=USER_MFA_LOAD_OPTIONS)
+        await ensure_mfa_relationships_loaded(db, db_user)
+        await attach_pending_email(db, db_user)
+
+        profile = schemas.UserOut.from_orm(db_user).model_dump()
+
+        sessions_result = await db.execute(
+            select(models.ActiveSession).where(models.ActiveSession.user_id == user.id)
+        )
+        sessions = [
+            {
+                "id": session.id,
+                "created_at": session.created_at,
+                "expires_at": session.expires_at,
+                "revoked_at": session.revoked_at,
+                "ip_address": session.ip_address,
+                "user_agent": session.user_agent,
+                "last_seen_at": session.last_seen_at,
+                "mfa_completed_at": session.mfa_completed_at,
+            }
+            for session in sessions_result.scalars()
+        ]
+
+        notifications_result = await db.execute(
+            select(models.Notification).where(models.Notification.user_id == user.id)
+        )
+        notifications = [
+            {
+                "id": item.id,
+                "title": item.title,
+                "body": item.body,
+                "type": item.type,
+                "created_at": item.created_at,
+                "read_at": item.read_at,
+            }
+            for item in notifications_result.scalars()
+        ]
+
+        challenges = [
+            {
+                "id": challenge.id,
+                "type": challenge.challenge_type,
+                "expires_at": challenge.expires_at,
+                "consumed_at": challenge.consumed_at,
+                "created_at": challenge.created_at,
+            }
+            for challenge in db_user.mfa_challenges
+        ]
+
+        enrollments = [
+            {
+                "id": enrollment.id,
+                "label": enrollment.label,
+                "is_active": enrollment.is_active,
+                "confirmed_at": enrollment.confirmed_at,
+                "revoked_at": enrollment.revoked_at,
+                "created_at": enrollment.created_at,
+            }
+            for enrollment in db_user.totp_enrollments
+        ]
+
+        access_logs = await export_access_logs(
+            db,
+            actor_user_id=user.id,
+            subject_user_id=user.id,
+            limit=2000,
+        )
+        access_log_payload = [
+            {
+                "resource_type": log.resource_type,
+                "resource_id": log.resource_id,
+                "action": log.action,
+                "created_at": log.created_at,
+                "ip_address": log.ip_address,
+                "user_agent": log.user_agent,
+                "context": log.context,
+            }
+            for log in access_logs
+        ]
+
+        self.audit.log("users.data_export", request, user_id=user.id)
+        await log_data_access(
+            db,
+            actor_user_id=user.id,
+            subject_user_id=user.id,
+            resource_type="profile",
+            resource_id=str(user.id),
+            action="export",
+            request=request,
+        )
+
+        return schemas.DataExportOut(
+            profile=profile,
+            sessions=sessions,
+            notifications=notifications,
+            mfa_challenges=challenges,
+            mfa_enrollments=enrollments,
+            access_logs=access_log_payload,
+        )
+
+    async def delete_user_data(
+        self,
+        db: AsyncSession,
+        user: models.User,
+        request: Request,
+        *,
+        confirm: bool,
+    ) -> schemas.DataDeletionOut:
+        if not confirm:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=translate("errors.users.confirmation_required", locale=resolve_locale(request=request, user=user)),
+            )
+
+        db_user = await db.get(models.User, user.id, options=USER_MFA_LOAD_OPTIONS)
+        anonymized_email = f"deleted+{user.id}@anonymized.local"
+
+        await delete_static_file(db_user.avatar_url) if db_user.avatar_url else None
+        await delete_static_file(db_user.cover_url) if db_user.cover_url else None
+
+        db_user.full_name = None
+        db_user.email = anonymized_email
+        db_user.avatar_url = None
+        db_user.cover_url = None
+        db_user.about = None
+        db_user.telegram = None
+        db_user.achievements = None
+        db_user.record_book_number = None
+        db_user.hashed_password = "deleted"
+        db_user.is_active = False
+        db_user.status = "deleted"
+        db_user.mfa_required = False
+        db_user.mfa_default_method = None
+        db_user.mfa_last_verified_at = None
+
+        await db.execute(
+            delete(models.ActiveSession).where(models.ActiveSession.user_id == user.id)
+        )
+        await db.execute(
+            delete(models.MfaChallenge).where(models.MfaChallenge.user_id == user.id)
+        )
+        await db.execute(
+            delete(models.MfaTotpEnrollment).where(models.MfaTotpEnrollment.user_id == user.id)
+        )
+        await db.execute(
+            delete(models.Notification).where(models.Notification.user_id == user.id)
+        )
+        await db.execute(
+            delete(models.DataAccessLog).where(
+                or_(
+                    models.DataAccessLog.actor_user_id == user.id,
+                    models.DataAccessLog.subject_user_id == user.id,
+                )
+            )
+        )
+
+        db_user.preferences = None
+        db_user.spotify = None
+
+        self.audit.log("users.data_delete", request, user_id=user.id)
+        await log_data_access(
+            db,
+            actor_user_id=user.id,
+            subject_user_id=user.id,
+            resource_type="profile",
+            resource_id=str(user.id),
+            action="delete",
+            request=request,
+        )
+
+        await db.commit()
+        await db.refresh(db_user)
+        return schemas.DataDeletionOut(deleted=True, anonymized_email=anonymized_email)


### PR DESCRIPTION
## Summary
- add privacy cleanup scheduler covering sessions, MFA artifacts, failed logins, and audit trails with new configurable retention windows
- introduce database-backed data access logging with CSV export for administrators
- provide self-service data export and deletion endpoints that log and anonymize user data

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d78cfcac88327af776a22184a4632)