### PR TITLE
Fix migrations env config and add compose validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,15 @@ jobs:
           CI: true
         run: npm run build -- --report --logLevel warn --clearScreen false
 
+  compose-validate:
+    name: Validate docker-compose.yml
+    runs-on: ubuntu-latest
+    needs: run-hooks
+    steps:
+      - uses: actions/checkout@v5
+      - name: Validate docker compose configuration
+        run: docker compose -f docker-compose.yml config
+
   pip-audit:
     name: Pip audit
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ ROOT_DIR := $(CURDIR)/root
 FRONTEND_DIR := $(ROOT_DIR)/frontend
 ENV_FILE ?= $(ROOT_DIR)/.env
 
-.PHONY: install backend-install frontend-install lint lint-backend lint-frontend backend-test frontend-test test backend-typecheck frontend-typecheck frontend-build frontend-dev backend-serve generate-api alembic-check
+.PHONY: install backend-install frontend-install lint lint-backend lint-frontend backend-test frontend-test test backend-typecheck frontend-typecheck frontend-build frontend-dev backend-serve generate-api alembic-check compose-lint
 
 install: backend-install frontend-install
 
@@ -14,6 +14,9 @@ frontend-install:
 	npm ci --prefix $(FRONTEND_DIR)
 
 lint: lint-backend lint-frontend
+
+compose-lint:
+	docker compose -f $(CURDIR)/docker-compose.yml config
 
 lint-backend:
 	pre-commit run --all-files

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,10 +118,10 @@ services:
       dockerfile: root/backend.Dockerfile
       target: runtime
     command: alembic upgrade head
-      env_file:
-        - root/.env
-      environment:
-        DATABASE_URL: ${DATABASE_URL:-postgresql+psycopg://${POSTGRES_USER:-university}:${POSTGRES_PASSWORD:-local_dev_password_please_rotate}@postgres:5432/${POSTGRES_DB:-university}}
+    env_file:
+      - root/.env
+    environment:
+      DATABASE_URL: ${DATABASE_URL:-postgresql+psycopg://${POSTGRES_USER:-university}:${POSTGRES_PASSWORD:-local_dev_password_please_rotate}@postgres:5432/${POSTGRES_DB:-university}}
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- realign the migrations service env_file and environment blocks so Alembic reads .env variables
- add a compose-lint make target and CI job to validate docker-compose.yml formatting

## Testing
- make compose-lint *(fails locally: docker not available in CI environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693da6424e448327aae06b2a273bf782)