### PR TITLE
Report Alembic versions in health check

### DIFF
--- a/root/app/main.py
+++ b/root/app/main.py
@@ -189,13 +189,13 @@ def _get_alembic_script() -> ScriptDirectory:
     return ScriptDirectory.from_config(config)
 
 
-async def _migrations_are_current() -> bool:
+async def _migrations_are_current() -> tuple[bool, set[str], set[str]]:
     script = _get_alembic_script()
     expected_heads = set(script.get_heads())
     async with engine.connect() as conn:
         result = await conn.execute(text("SELECT version_num FROM alembic_version"))
         current_versions = {row[0] for row in result}
-    return current_versions == expected_heads
+    return current_versions == expected_heads, current_versions, expected_heads
 
 
 @app.get("/healthz")
@@ -211,14 +211,19 @@ async def healthz():
         db_status = "error"
     else:
         try:
-            migrations_current = await _migrations_are_current()
+            migrations_current, current_versions, expected_versions = (
+                await _migrations_are_current()
+            )
             if not migrations_current:
                 db_status = "error"
+                statuses["db_migrations"] = "error"
+                statuses["db_migrations_current"] = sorted(current_versions)
+                statuses["db_migrations_expected"] = sorted(expected_versions)
         except Exception:
             db_status = "error"
     statuses["db"] = db_status
     if db_status == "error":
-        statuses["db_migrations"] = "error"
+        statuses.setdefault("db_migrations", "error")
     record_health_probe("db", db_status, time.perf_counter() - db_start)
 
     cache_status = "disabled"

--- a/root/app/main.py
+++ b/root/app/main.py
@@ -211,9 +211,11 @@ async def healthz():
         db_status = "error"
     else:
         try:
-            migrations_current, current_versions, expected_versions = (
-                await _migrations_are_current()
-            )
+            (
+                migrations_current,
+                current_versions,
+                expected_versions,
+            ) = await _migrations_are_current()
             if not migrations_current:
                 db_status = "error"
                 statuses["db_migrations"] = "error"

--- a/root/tests/conftest.py
+++ b/root/tests/conftest.py
@@ -313,8 +313,8 @@ async def async_client(
         _start_password_reset_cleanup_scheduler,
     )
 
-    async def _mock_migrations_current() -> bool:
-        return True
+    async def _mock_migrations_current() -> tuple[bool, set[str], set[str]]:
+        return True, set(), set()
 
     monkeypatch.setattr(main, "_migrations_are_current", _mock_migrations_current)
 
@@ -400,8 +400,8 @@ async def root_client(
         _start_password_reset_cleanup_scheduler,
     )
 
-    async def _mock_migrations_current() -> bool:
-        return True
+    async def _mock_migrations_current() -> tuple[bool, set[str], set[str]]:
+        return True, set(), set()
 
     monkeypatch.setattr(main, "_migrations_are_current", _mock_migrations_current)
 

--- a/root/tests/test_health_endpoint.py
+++ b/root/tests/test_health_endpoint.py
@@ -158,6 +158,25 @@ async def test_healthcheck_notification_queue_missing_table(
 
 
 @pytest.mark.anyio("asyncio")
+async def test_healthcheck_reports_migration_versions_on_drift(
+    async_client, monkeypatch
+):
+    async def _mock_migrations_are_current() -> tuple[bool, set[str], set[str]]:
+        return False, {"current"}, {"expected"}
+
+    monkeypatch.setattr(main, "_migrations_are_current", _mock_migrations_are_current)
+
+    response = await async_client.get("http://testserver/healthz")
+    data = response.json()
+
+    assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+    assert data["db"] == "error"
+    assert data["db_migrations"] == "error"
+    assert data["db_migrations_current"] == ["current"]
+    assert data["db_migrations_expected"] == ["expected"]
+
+
+@pytest.mark.anyio("asyncio")
 async def test_healthcheck_file_scanner_success(async_client, monkeypatch):
     monkeypatch.setattr(main.settings, "event_file_scanner_enabled", True)
 


### PR DESCRIPTION
## Summary
- include current and expected Alembic revision identifiers when migrations are out of sync
- surface migration drift details in the /healthz response and adjust the migration helper signature accordingly
- extend health endpoint tests to cover migration drift reporting and update fixtures

## Testing
- pytest tests/test_health_endpoint.py *(fails: missing dependency `pytest_asyncio` in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693da84d069c83279970111d77c71a6f)