### PR TITLE
Add per-component latency metrics to health checks

### DIFF
--- a/root/app/main.py
+++ b/root/app/main.py
@@ -202,6 +202,8 @@ async def _migrations_are_current() -> tuple[bool, set[str], set[str]]:
 async def healthz():
     statuses: dict[str, str] = {}
 
+    latencies: dict[str, float] = {}
+
     db_status = "ok"
     db_start = time.perf_counter()
     try:
@@ -226,7 +228,9 @@ async def healthz():
     statuses["db"] = db_status
     if db_status == "error":
         statuses.setdefault("db_migrations", "error")
-    record_health_probe("db", db_status, time.perf_counter() - db_start)
+    db_elapsed = time.perf_counter() - db_start
+    latencies["db_latency_ms"] = max(db_elapsed * 1000, 0.0)
+    record_health_probe("db", db_status, db_elapsed)
 
     cache_status = "disabled"
     cache_start = time.perf_counter()
@@ -248,10 +252,13 @@ async def healthz():
             cache_status = "disabled"
     except Exception:
         cache_status = "error"
+    cache_elapsed = time.perf_counter() - cache_start
     statuses["cache"] = cache_status
-    record_health_probe("cache", cache_status, time.perf_counter() - cache_start)
+    latencies["cache_latency_ms"] = max(cache_elapsed * 1000, 0.0)
+    record_health_probe("cache", cache_status, cache_elapsed)
 
     storage_status = "ok"
+    storage_start = time.perf_counter()
     try:
         backend = _get_storage_backend()
         probe_name = f"healthz/{uuid.uuid4().hex}.txt"
@@ -268,9 +275,13 @@ async def healthz():
                 storage_status = "error"
     except Exception:
         storage_status = "error"
+    storage_elapsed = time.perf_counter() - storage_start
     statuses["storage"] = storage_status
+    latencies["storage_latency_ms"] = max(storage_elapsed * 1000, 0.0)
+    record_health_probe("storage", storage_status, storage_elapsed)
 
     queue_status = "ok"
+    queue_start = time.perf_counter()
     if getattr(settings, "notifications_queue_in_memory_only", False):
         queue_status = "ok"
     else:
@@ -281,23 +292,30 @@ async def healthz():
             queue_status = "error"
         except Exception:
             queue_status = "error"
+    queue_elapsed = time.perf_counter() - queue_start
     statuses["notification_queue"] = queue_status
+    latencies["notification_queue_latency_ms"] = max(queue_elapsed * 1000, 0.0)
+    record_health_probe("notification_queue", queue_status, queue_elapsed)
 
+    scanner_start = time.perf_counter()
     if getattr(settings, "event_file_scanner_enabled", False):
         scanner_status = "ok"
         try:
             await check_file_scanner_health()
         except Exception:
             scanner_status = "error"
-        statuses["file_scanner"] = scanner_status
     else:
-        statuses["file_scanner"] = "disabled"
+        scanner_status = "disabled"
+    scanner_elapsed = time.perf_counter() - scanner_start
+    statuses["file_scanner"] = scanner_status
+    latencies["file_scanner_latency_ms"] = max(scanner_elapsed * 1000, 0.0)
+    record_health_probe("file_scanner", scanner_status, scanner_elapsed)
 
     overall_ok = all(value != "error" for value in statuses.values())
     http_status = (
         status.HTTP_200_OK if overall_ok else status.HTTP_503_SERVICE_UNAVAILABLE
     )
-    payload = {"status": "ok" if overall_ok else "error", **statuses}
+    payload = {"status": "ok" if overall_ok else "error", **statuses, **latencies}
     return JSONResponse(status_code=http_status, content=payload)
 
 

--- a/root/tests/test_health_endpoint.py
+++ b/root/tests/test_health_endpoint.py
@@ -36,6 +36,12 @@ class _FailingSession:
         return False
 
 
+def _assert_latency_present(data: dict, key: str) -> None:
+    assert key in data
+    assert isinstance(data[key], (int, float))
+    assert 0 <= data[key] < 60_000
+
+
 @pytest.fixture
 def missing_table_operational_error(monkeypatch):
     class _UndefinedTableError(Exception):
@@ -72,6 +78,14 @@ async def test_healthcheck_reports_dependency_statuses(async_client):
     assert data["notification_queue"] == "ok"
     assert "cache" in data
     assert "file_scanner" in data
+    for component in [
+        "db_latency_ms",
+        "cache_latency_ms",
+        "storage_latency_ms",
+        "notification_queue_latency_ms",
+        "file_scanner_latency_ms",
+    ]:
+        _assert_latency_present(data, component)
 
 
 @pytest.mark.anyio("asyncio")
@@ -94,6 +108,7 @@ async def test_healthcheck_database_failure_returns_503(async_client, monkeypatc
     assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
     assert data["status"] == "error"
     assert data["db"] == "error"
+    _assert_latency_present(data, "db_latency_ms")
 
 
 @pytest.mark.anyio("asyncio")
@@ -105,6 +120,7 @@ async def test_healthcheck_cache_success(async_client, monkeypatch):
     data = response.json()
     assert response.status_code == status.HTTP_200_OK
     assert data["cache"] == "ok"
+    _assert_latency_present(data, "cache_latency_ms")
 
 
 @pytest.mark.anyio("asyncio")
@@ -115,6 +131,7 @@ async def test_healthcheck_cache_failure(async_client, monkeypatch):
     data = response.json()
     assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
     assert data["cache"] == "error"
+    _assert_latency_present(data, "cache_latency_ms")
 
 
 @pytest.mark.anyio("asyncio")
@@ -134,6 +151,7 @@ async def test_healthcheck_storage_failure(async_client, monkeypatch):
     data = response.json()
     assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
     assert data["storage"] == "error"
+    _assert_latency_present(data, "storage_latency_ms")
 
 
 @pytest.mark.anyio("asyncio")
@@ -144,6 +162,7 @@ async def test_healthcheck_notification_queue_failure(async_client, monkeypatch)
     data = response.json()
     assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
     assert data["notification_queue"] == "error"
+    _assert_latency_present(data, "notification_queue_latency_ms")
 
 
 @pytest.mark.anyio("asyncio")
@@ -155,6 +174,7 @@ async def test_healthcheck_notification_queue_missing_table(
     data = response.json()
     assert response.status_code == status.HTTP_200_OK
     assert data["notification_queue"] == "ok"
+    _assert_latency_present(data, "notification_queue_latency_ms")
 
 
 @pytest.mark.anyio("asyncio")
@@ -174,6 +194,7 @@ async def test_healthcheck_reports_migration_versions_on_drift(
     assert data["db_migrations"] == "error"
     assert data["db_migrations_current"] == ["current"]
     assert data["db_migrations_expected"] == ["expected"]
+    _assert_latency_present(data, "db_latency_ms")
 
 
 @pytest.mark.anyio("asyncio")
@@ -189,6 +210,7 @@ async def test_healthcheck_file_scanner_success(async_client, monkeypatch):
     data = response.json()
     assert response.status_code == status.HTTP_200_OK
     assert data["file_scanner"] == "ok"
+    _assert_latency_present(data, "file_scanner_latency_ms")
 
 
 @pytest.mark.anyio("asyncio")
@@ -204,6 +226,7 @@ async def test_healthcheck_file_scanner_failure(async_client, monkeypatch):
     data = response.json()
     assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
     assert data["file_scanner"] == "error"
+    _assert_latency_present(data, "file_scanner_latency_ms")
 
 
 @pytest.mark.anyio("asyncio")
@@ -227,3 +250,4 @@ async def test_healthcheck_file_scanner_uses_lightweight_probe(
     data = response.json()
     assert response.status_code == status.HTTP_200_OK
     assert data["file_scanner"] == "ok"
+    _assert_latency_present(data, "file_scanner_latency_ms")

--- a/root/tests/test_health_endpoint.py
+++ b/root/tests/test_health_endpoint.py
@@ -38,7 +38,7 @@ class _FailingSession:
 
 def _assert_latency_present(data: dict, key: str) -> None:
     assert key in data
-    assert isinstance(data[key], (int, float))
+    assert isinstance(data[key], int | float)
     assert 0 <= data[key] < 60_000
 
 


### PR DESCRIPTION
## Summary
- add millisecond latency fields to /healthz for database, cache, storage, queue, and file scanner probes while continuing to record metrics
- include health probe durations in the response payload alongside existing status flags
- expand health endpoint tests to validate latency fields are present and within expected ranges

## Testing
- pytest root/tests/test_health_endpoint.py -q *(fails: missing pytest_asyncio plugin in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ddd9fdb908327b4cb47b816a932e0)