### PR TITLE
Improve chat attachment validation and storage integration

### DIFF
--- a/root/app/api/chat.py
+++ b/root/app/api/chat.py
@@ -1,4 +1,4 @@
-import uuid
+import asyncio
 from datetime import UTC, datetime
 
 from fastapi import (
@@ -17,7 +17,9 @@ from sqlalchemy.orm import selectinload
 
 from app.api.deps import get_current_user
 from app.api.websocket import notify_new_message
+from app.core.config import settings
 from app.core.database import get_db
+from app.localization import translate
 from app.models.chat import Attachment, Chat, Message
 from app.models.models import User
 from app.schemas.chat import (
@@ -27,6 +29,7 @@ from app.schemas.chat import (
     MessageResponse,
     MessagesListOut,
 )
+from app.utils.files import delete_static_file, save_attachment
 
 router = APIRouter(prefix="/chats", tags=["chats"])
 
@@ -265,6 +268,45 @@ async def get_messages(
     )
 
 
+async def _cleanup_orphaned_files(urls: list[str]) -> None:
+    tasks = [delete_static_file(url) for url in urls if url]
+    if tasks:
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+
+async def _process_chat_upload(
+    upload: UploadFile, chat_id: str, *, locale: str | None
+) -> dict[str, object]:
+    meta = await save_attachment(
+        upload,
+        "chat_uploads",
+        f"chat_{chat_id}",
+        locale=locale,
+        allowed_mime_types=settings.chat_attachment_allowed_mime_types_set,
+        allowed_extensions=settings.chat_attachment_allowed_extensions_set,
+        max_size_bytes=settings.chat_attachment_max_size_bytes,
+        return_meta=True,
+    )
+    if not isinstance(meta, dict):
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to store attachment",
+        )
+    detected_type = str(meta.get("detected_type") or meta.get("content_type") or "")
+    file_type = "file"
+    if detected_type.startswith("image/"):
+        file_type = "image"
+    elif detected_type.startswith("video/"):
+        file_type = "video"
+
+    return {
+        "url": str(meta.get("url") or ""),
+        "file_type": file_type,
+        "filename": str(meta.get("filename") or upload.filename or "attachment"),
+        "size": int(meta.get("size") or 0),
+    }
+
+
 @router.post("/{chat_id}/messages", response_model=MessageResponse)
 async def send_message(
     chat_id: str,
@@ -287,6 +329,14 @@ async def send_message(
     if current_user not in chat.participants:
         raise HTTPException(status_code=403, detail="Not a participant")
 
+    locale = getattr(current_user, "preferred_locale", None)
+    uploads = files or []
+    if len(uploads) > int(settings.chat_attachment_max_files):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=translate("errors.files.too_many_attachments", locale=locale),
+        )
+
     message = Message(
         chat_id=chat_id,
         sender_id=current_user.id,
@@ -295,50 +345,30 @@ async def send_message(
     session.add(message)
     await session.flush()  # Flush to get message ID
 
-    # Handle file uploads
-    if files:
-        import os
-        import shutil
-
-        UPLOAD_DIR = "app/static/uploads"
-        os.makedirs(UPLOAD_DIR, exist_ok=True)
-
-        for file in files:
-            # Generate unique filename
-            file_ext = os.path.splitext(file.filename)[1]
-            unique_filename = f"{uuid.uuid4()}{file_ext}"
-            file_path = os.path.join(UPLOAD_DIR, unique_filename)
-
-            # Save file
-            with open(file_path, "wb") as buffer:
-                shutil.copyfileobj(file.file, buffer)
-
-            # Determine file type
-            file_type = "file"
-            if file.content_type.startswith("image/"):
-                file_type = "image"
-            elif file.content_type.startswith("video/"):
-                file_type = "video"
-
-            # Create attachment record
-            # URL should be accessible from frontend.
-            # Assuming static files are served from /static
-            url = f"http://localhost:8000/static/uploads/{unique_filename}"
-
+    saved_urls: list[str] = []
+    try:
+        for upload in uploads:
+            meta = await _process_chat_upload(upload, chat_id, locale=locale)
+            saved_urls.append(meta["url"])
             attachment = Attachment(
                 message_id=message.id,
-                url=url,
-                file_type=file_type,
-                filename=file.filename,
-                size=file.size or 0,
+                url=meta["url"],
+                file_type=meta["file_type"],
+                filename=meta["filename"],
+                size=meta["size"],
             )
             session.add(attachment)
 
-    # Update chat updated_at
-    chat.updated_at = datetime.now(UTC)
-    session.add(chat)
+        # Update chat updated_at
+        chat.updated_at = datetime.now(UTC)
+        session.add(chat)
 
-    await session.commit()
+        await session.commit()
+    except Exception:
+        await session.rollback()
+        await _cleanup_orphaned_files(saved_urls)
+        raise
+
     await session.refresh(message)
 
     # Eager load sender and attachments for response

--- a/root/app/core/config.py
+++ b/root/app/core/config.py
@@ -394,6 +394,16 @@ class Settings(BaseSettings):
     event_file_scanner_timeout: float = 30.0
     event_file_scanner_max_size_mb: float = Field(default=25.0, ge=0.0)
     event_file_scanner_max_duration_sec: float = Field(default=10.0, ge=0.0)
+    chat_attachment_allowed_mime_types: str | list[str] = (
+        "image/jpeg,image/png,image/webp,image/gif,"
+        "video/mp4,video/quicktime,"
+        "application/pdf,text/plain"
+    )
+    chat_attachment_allowed_extensions: str | list[str] = (
+        ".jpg,.jpeg,.png,.webp,.gif,.mp4,.mov,.pdf,.txt"
+    )
+    chat_attachment_max_size_bytes: int = 15 * 1024 * 1024
+    chat_attachment_max_files: int = 5
 
     @field_validator("auto_create_schema", mode="before")
     @classmethod
@@ -763,6 +773,26 @@ class Settings(BaseSettings):
     def event_file_allowed_extensions_set(self) -> set[str]:
         values: set[str] = set()
         for value in _coerce_str_list(self.event_file_allowed_extensions):
+            normalized = value.strip().lower()
+            if normalized.startswith("."):
+                normalized = normalized[1:]
+            if normalized:
+                values.add(normalized)
+        return values
+
+    @property
+    def chat_attachment_allowed_mime_types_set(self) -> set[str]:
+        values = {
+            value.strip().lower()
+            for value in _coerce_str_list(self.chat_attachment_allowed_mime_types)
+            if value
+        }
+        return values
+
+    @property
+    def chat_attachment_allowed_extensions_set(self) -> set[str]:
+        values: set[str] = set()
+        for value in _coerce_str_list(self.chat_attachment_allowed_extensions):
             normalized = value.strip().lower()
             if normalized.startswith("."):
                 normalized = normalized[1:]

--- a/root/app/localization.py
+++ b/root/app/localization.py
@@ -217,6 +217,10 @@ _TRANSLATIONS: Mapping[str, Mapping[str, str]] = {
         "ru": "Размер файла превышает допустимый предел",
         "en": "Uploaded file exceeds the allowed size",
     },
+    "errors.files.too_many_attachments": {
+        "ru": "Слишком много вложений в сообщении",
+        "en": "Too many attachments in the message",
+    },
     "errors.files.unsupported_type": {
         "ru": "Неподдерживаемый тип файла",
         "en": "Unsupported media type",

--- a/root/app/utils/files.py
+++ b/root/app/utils/files.py
@@ -288,11 +288,23 @@ async def save_image(
 
 
 async def save_attachment(
-    upload: UploadFile, subdir: str, prefix: str, *, locale: str | None = None
-) -> str:
+    upload: UploadFile,
+    subdir: str,
+    prefix: str,
+    *,
+    locale: str | None = None,
+    allowed_mime_types: set[str] | None = None,
+    allowed_extensions: set[str] | None = None,
+    max_size_bytes: int | None = None,
+    return_meta: bool = False,
+) -> str | dict[str, object]:
     declared_raw = (upload.content_type or "").strip()
     declared_type = _normalize_mime_type(declared_raw)
-    allowed_types = settings.event_file_allowed_mime_types_set
+    allowed_types = (
+        allowed_mime_types
+        if allowed_mime_types is not None
+        else settings.event_file_allowed_mime_types_set
+    )
     if declared_type and allowed_types and declared_type not in allowed_types:
         raise HTTPException(
             status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
@@ -303,12 +315,21 @@ async def save_attachment(
     ext = Path(original_name).suffix.lower()
     ext_without_dot = ext[1:] if ext.startswith(".") else ext
 
-    allowed_exts = settings.event_file_allowed_extensions_set
+    allowed_exts = (
+        allowed_extensions
+        if allowed_extensions is not None
+        else settings.event_file_allowed_extensions_set
+    )
 
     try:
-        limit = int(settings.event_file_max_size_bytes)
+        limit = int(max_size_bytes if max_size_bytes is not None else 0)
     except (TypeError, ValueError):
         limit = 0
+    if limit <= 0:
+        try:
+            limit = int(settings.event_file_max_size_bytes)
+        except (TypeError, ValueError):
+            limit = 0
     if limit <= 0:
         limit = 1
     data = await _read_limited(upload, limit, locale=locale)
@@ -424,9 +445,18 @@ async def save_attachment(
     backend = _get_storage_backend()
     await _prepare_local_storage(backend, sanitized_subdir)
     relative_path = f"{sanitized_subdir}/{name}" if sanitized_subdir else name
-    return await backend.save_file(
+    url = await backend.save_file(
         relative_path, data, content_type=declared_type or detected_type
     )
+    if return_meta:
+        return {
+            "url": url,
+            "content_type": declared_type or detected_type,
+            "size": len(data),
+            "filename": upload.filename or name,
+            "detected_type": detected_type,
+        }
+    return url
 
 
 async def delete_static_file(file_url: str) -> None:

--- a/root/tests/test_chat_uploads.py
+++ b/root/tests/test_chat_uploads.py
@@ -21,7 +21,9 @@ class _RecordingStorage:
     async def save_file(
         self, relative_path: str, data: bytes, *, content_type: str | None = None
     ) -> str:
-        self.calls.append(("save", (relative_path, data), {"content_type": content_type}))
+        self.calls.append(
+            ("save", (relative_path, data), {"content_type": content_type})
+        )
         return f"https://cdn.example/{relative_path}"
 
     async def delete_file(self, file_url: str) -> None:  # pragma: no cover - unused
@@ -100,7 +102,9 @@ async def test_send_message_generates_public_urls(
     monkeypatch.setattr(settings, "chat_attachment_max_size_bytes", 1024)
     monkeypatch.setattr(files, "storage_backend", backend)
     monkeypatch.setattr(files, "_default_storage_backend", backend)
-    monkeypatch.setattr(files, "_storage_backend_snapshot", files._storage_backend_signature())
+    monkeypatch.setattr(
+        files, "_storage_backend_snapshot", files._storage_backend_signature()
+    )
     monkeypatch.setattr(chat_api, "notify_new_message", lambda *_, **__: None)
 
     message = await chat_api.send_message(
@@ -117,7 +121,9 @@ async def test_send_message_generates_public_urls(
     assert attachment.url.startswith("https://cdn.example/chat_uploads/")
     assert attachment.size == 5
 
-    stored = await db_session.execute(select(Attachment).where(Attachment.id == attachment.id))
+    stored = await db_session.execute(
+        select(Attachment).where(Attachment.id == attachment.id)
+    )
     assert stored.scalar_one().url == attachment.url
 
     method, (relative_path, data), kwargs = backend.calls[0]

--- a/root/tests/test_chat_uploads.py
+++ b/root/tests/test_chat_uploads.py
@@ -1,0 +1,126 @@
+# ruff: noqa: E501
+
+import io
+
+import pytest
+from fastapi import HTTPException, UploadFile, status
+from sqlalchemy import select
+from starlette.datastructures import Headers
+
+from app.api import chat as chat_api
+from app.core.config import settings
+from app.localization import translate
+from app.models.chat import Attachment, Chat
+from app.utils import files
+
+
+class _RecordingStorage:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple[object, ...], dict[str, object]]] = []
+
+    async def save_file(
+        self, relative_path: str, data: bytes, *, content_type: str | None = None
+    ) -> str:
+        self.calls.append(("save", (relative_path, data), {"content_type": content_type}))
+        return f"https://cdn.example/{relative_path}"
+
+    async def delete_file(self, file_url: str) -> None:  # pragma: no cover - unused
+        self.calls.append(("delete", (file_url,), {}))
+
+
+@pytest.mark.anyio("asyncio")
+async def test_send_message_blocks_infected_file(
+    tmp_path, monkeypatch, db_session, user_factory
+):
+    sender = await user_factory()
+    recipient = await user_factory()
+    chat = Chat()
+    chat.participants.extend([sender, recipient])
+    db_session.add(chat)
+    await db_session.commit()
+    await db_session.refresh(chat)
+
+    payload = b"suspicious payload"
+    upload = UploadFile(
+        filename="exploit.txt",
+        file=io.BytesIO(payload),
+        headers=Headers({"content-type": "text/plain"}),
+    )
+
+    monkeypatch.setattr(settings, "static_dir_path", tmp_path)
+    monkeypatch.setattr(settings, "chat_attachment_allowed_mime_types", ["text/plain"])
+    monkeypatch.setattr(settings, "chat_attachment_allowed_extensions", [".txt"])
+    monkeypatch.setattr(settings, "chat_attachment_max_size_bytes", 1024)
+
+    async def infected_scan(*_args, **_kwargs):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=translate("errors.files.infected", locale="en"),
+        )
+
+    monkeypatch.setattr(files, "scan_for_malware", infected_scan)
+    monkeypatch.setattr(chat_api, "notify_new_message", lambda *_, **__: None)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await chat_api.send_message(
+            chat.id,
+            content="Hello",
+            files=[upload],
+            current_user=sender,
+            session=db_session,
+        )
+
+    assert excinfo.value.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    upload_dir = tmp_path / "chat_uploads"
+    assert not upload_dir.exists() or not any(upload_dir.iterdir())
+
+
+@pytest.mark.anyio("asyncio")
+async def test_send_message_generates_public_urls(
+    monkeypatch, db_session, user_factory
+):
+    sender = await user_factory()
+    recipient = await user_factory()
+    chat = Chat()
+    chat.participants.extend([sender, recipient])
+    db_session.add(chat)
+    await db_session.commit()
+    await db_session.refresh(chat)
+
+    upload = UploadFile(
+        filename="note.txt",
+        file=io.BytesIO(b"hello"),
+        headers=Headers({"content-type": "text/plain"}),
+    )
+
+    backend = _RecordingStorage()
+
+    monkeypatch.setattr(settings, "chat_attachment_allowed_mime_types", ["text/plain"])
+    monkeypatch.setattr(settings, "chat_attachment_allowed_extensions", [".txt"])
+    monkeypatch.setattr(settings, "chat_attachment_max_size_bytes", 1024)
+    monkeypatch.setattr(files, "storage_backend", backend)
+    monkeypatch.setattr(files, "_default_storage_backend", backend)
+    monkeypatch.setattr(files, "_storage_backend_snapshot", files._storage_backend_signature())
+    monkeypatch.setattr(chat_api, "notify_new_message", lambda *_, **__: None)
+
+    message = await chat_api.send_message(
+        chat.id,
+        content="Hello",
+        files=[upload],
+        current_user=sender,
+        session=db_session,
+    )
+
+    await db_session.refresh(message, ["attachments"])
+    attachment = message.attachments[0]
+
+    assert attachment.url.startswith("https://cdn.example/chat_uploads/")
+    assert attachment.size == 5
+
+    stored = await db_session.execute(select(Attachment).where(Attachment.id == attachment.id))
+    assert stored.scalar_one().url == attachment.url
+
+    method, (relative_path, data), kwargs = backend.calls[0]
+    assert method == "save"
+    assert relative_path.startswith("chat_uploads/")
+    assert kwargs["content_type"] == "text/plain"


### PR DESCRIPTION
## Summary
- enforce chat attachment limits, malware scanning, and MIME validation when sending chat messages
- route chat uploads through the storage backend with orphan cleanup and new localization/configuration knobs
- add coverage for blocking infected uploads and generating public attachment URLs

## Testing
- `pytest root/tests/test_chat_uploads.py` *(fails: SQLite test database cannot compile JSONB columns)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e00cfde508327a081d584a61914fa)