### PR TITLE
Add chat lifecycle management endpoints and UI actions

### DIFF
--- a/root/app/api/chat.py
+++ b/root/app/api/chat.py
@@ -24,11 +24,11 @@ from app.models.chat import Attachment, Chat, Message
 from app.models.models import User
 from app.schemas.chat import (
     ChatCreate,
+    ChatMaintenanceResult,
     ChatResponse,
     ChatsListOut,
     MessageResponse,
     MessagesListOut,
-    ChatMaintenanceResult,
 )
 from app.utils.files import delete_static_file, save_attachment
 
@@ -455,9 +455,7 @@ async def clear_chat_history(
 ):
     """Remove all messages (and attachments) from a chat for its participants."""
 
-    chat = await _get_chat_for_user(
-        session, chat_id, current_user, load_messages=True
-    )
+    chat = await _get_chat_for_user(session, chat_id, current_user, load_messages=True)
 
     attachment_urls = _collect_attachment_urls(chat)
     message_count = len(chat.messages)
@@ -491,9 +489,7 @@ async def delete_chat(
 ):
     """Delete a chat entirely for all participants (messages, attachments, links)."""
 
-    chat = await _get_chat_for_user(
-        session, chat_id, current_user, load_messages=True
-    )
+    chat = await _get_chat_for_user(session, chat_id, current_user, load_messages=True)
 
     attachment_urls = _collect_attachment_urls(chat)
     message_count = len(chat.messages)

--- a/root/app/api/chat.py
+++ b/root/app/api/chat.py
@@ -28,6 +28,7 @@ from app.schemas.chat import (
     ChatsListOut,
     MessageResponse,
     MessagesListOut,
+    ChatMaintenanceResult,
 )
 from app.utils.files import delete_static_file, save_attachment
 
@@ -50,6 +51,28 @@ def _decode_cursor(cursor: str | None) -> tuple[datetime, str] | None:
         return datetime.fromtimestamp(ts, tz=UTC), id_val
     except (ValueError, TypeError):
         return None
+
+
+async def _get_chat_for_user(
+    session: AsyncSession,
+    chat_id: str,
+    current_user: User,
+    *,
+    load_messages: bool = False,
+):
+    load_options = [selectinload(Chat.participants)]
+    if load_messages:
+        load_options.append(
+            selectinload(Chat.messages).selectinload(Message.attachments)
+        )
+
+    chat = await session.get(Chat, chat_id, options=load_options)
+    if not chat:
+        raise HTTPException(status_code=404, detail="Chat not found")
+
+    if current_user not in chat.participants:
+        raise HTTPException(status_code=403, detail="Not a participant")
+    return chat
 
 
 @router.get("", response_model=ChatsListOut)
@@ -274,6 +297,15 @@ async def _cleanup_orphaned_files(urls: list[str]) -> None:
         await asyncio.gather(*tasks, return_exceptions=True)
 
 
+def _collect_attachment_urls(chat: Chat) -> list[str]:
+    urls: list[str] = []
+    for message in chat.messages:
+        for attachment in message.attachments:
+            if attachment.url:
+                urls.append(attachment.url)
+    return urls
+
+
 async def _process_chat_upload(
     upload: UploadFile, chat_id: str, *, locale: str | None
 ) -> dict[str, object]:
@@ -413,3 +445,72 @@ async def mark_read(
 
     await session.commit()
     return {"status": "ok"}
+
+
+@router.post("/{chat_id}/clear", response_model=ChatMaintenanceResult)
+async def clear_chat_history(
+    chat_id: str,
+    current_user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db),
+):
+    """Remove all messages (and attachments) from a chat for its participants."""
+
+    chat = await _get_chat_for_user(
+        session, chat_id, current_user, load_messages=True
+    )
+
+    attachment_urls = _collect_attachment_urls(chat)
+    message_count = len(chat.messages)
+    attachment_count = len(attachment_urls)
+
+    try:
+        for message in list(chat.messages):
+            await session.delete(message)
+        chat.updated_at = datetime.now(UTC)
+        session.add(chat)
+        await session.commit()
+    except Exception:
+        await session.rollback()
+        raise
+
+    await _cleanup_orphaned_files(attachment_urls)
+
+    return ChatMaintenanceResult(
+        chat_id=chat.id,
+        status="cleared",
+        deleted_messages=message_count,
+        deleted_attachments=attachment_count,
+    )
+
+
+@router.delete("/{chat_id}", response_model=ChatMaintenanceResult)
+async def delete_chat(
+    chat_id: str,
+    current_user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db),
+):
+    """Delete a chat entirely for all participants (messages, attachments, links)."""
+
+    chat = await _get_chat_for_user(
+        session, chat_id, current_user, load_messages=True
+    )
+
+    attachment_urls = _collect_attachment_urls(chat)
+    message_count = len(chat.messages)
+    attachment_count = len(attachment_urls)
+
+    try:
+        await session.delete(chat)
+        await session.commit()
+    except Exception:
+        await session.rollback()
+        raise
+
+    await _cleanup_orphaned_files(attachment_urls)
+
+    return ChatMaintenanceResult(
+        chat_id=chat_id,
+        status="deleted",
+        deleted_messages=message_count,
+        deleted_attachments=attachment_count,
+    )

--- a/root/app/schemas/chat.py
+++ b/root/app/schemas/chat.py
@@ -80,3 +80,12 @@ class MessagesListOut(BaseModel):
     items: list[MessageResponse]
     has_more: bool = False
     next_cursor: str | None = None
+
+
+class ChatMaintenanceResult(BaseModel):
+    """Represents the result of a maintenance operation on a chat."""
+
+    chat_id: str
+    status: str
+    deleted_messages: int = 0
+    deleted_attachments: int = 0

--- a/root/frontend/src/api/chat.ts
+++ b/root/frontend/src/api/chat.ts
@@ -42,6 +42,13 @@ export interface MessagesListResponse {
   next_cursor: string | null
 }
 
+export interface ChatMaintenanceResult {
+  chat_id: string
+  status: string
+  deleted_messages: number
+  deleted_attachments: number
+}
+
 export const chatApi = {
   getChats: async (cursor?: string, limit: number = 20): Promise<ChatsListResponse> => {
     const params = new URLSearchParams()
@@ -84,6 +91,16 @@ export const chatApi = {
 
   markRead: async (chatId: string) => {
     const response = await client.post(`/chats/${chatId}/read`)
+    return response.data
+  },
+
+  clearChat: async (chatId: string) => {
+    const response = await client.post<ChatMaintenanceResult>(`/chats/${chatId}/clear`)
+    return response.data
+  },
+
+  deleteChat: async (chatId: string) => {
+    const response = await client.delete<ChatMaintenanceResult>(`/chats/${chatId}`)
     return response.data
   },
 }

--- a/root/frontend/src/api/generated/schema.ts
+++ b/root/frontend/src/api/generated/schema.ts
@@ -22,6 +22,40 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  "/healthz": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** Healthz */
+    get: operations["healthz_healthz_get"]
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/ready": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** Ready */
+    get: operations["ready_ready_get"]
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   "/api/v1/auth/login": {
     parameters: {
       query?: never
@@ -56,7 +90,7 @@ export interface paths {
     patch?: never
     trace?: never
   }
-  "/api/v1/auth/logout": {
+  "/api/v1/auth/mfa/totp/start": {
     parameters: {
       query?: never
       header?: never
@@ -65,45 +99,8 @@ export interface paths {
     }
     get?: never
     put?: never
-    /**
-     * Logout
-     * @description Terminate the client session.
-     */
-    post: operations["logout_api_v1_auth_logout_post"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/v1/auth/mfa/step-up": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Request Step Up */
-    post: operations["request_step_up_api_v1_auth_mfa_step_up_post"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/v1/auth/mfa/totp": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** List Totp Enrollments */
-    get: operations["list_totp_enrollments_api_v1_auth_mfa_totp_get"]
-    put?: never
-    post?: never
+    /** Start Totp Enrollment Endpoint */
+    post: operations["start_totp_enrollment_endpoint_api_v1_auth_mfa_totp_start_post"]
     delete?: never
     options?: never
     head?: never
@@ -127,6 +124,23 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  "/api/v1/auth/mfa/totp": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** List Totp Enrollments */
+    get: operations["list_totp_enrollments_api_v1_auth_mfa_totp_get"]
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   "/api/v1/auth/mfa/totp/pending/{enrollment_id}": {
     parameters: {
       query?: never
@@ -139,23 +153,6 @@ export interface paths {
     post?: never
     /** Delete Pending Totp Enrollment */
     delete: operations["delete_pending_totp_enrollment_api_v1_auth_mfa_totp_pending__enrollment_id__delete"]
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/v1/auth/mfa/totp/start": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Start Totp Enrollment Endpoint */
-    post: operations["start_totp_enrollment_endpoint_api_v1_auth_mfa_totp_start_post"]
-    delete?: never
     options?: never
     head?: never
     patch?: never
@@ -195,7 +192,7 @@ export interface paths {
     patch?: never
     trace?: never
   }
-  "/api/v1/auth/register": {
+  "/api/v1/auth/mfa/step-up": {
     parameters: {
       query?: never
       header?: never
@@ -204,8 +201,8 @@ export interface paths {
     }
     get?: never
     put?: never
-    /** Register */
-    post: operations["register_api_v1_auth_register_post"]
+    /** Request Step Up */
+    post: operations["request_step_up_api_v1_auth_mfa_step_up_post"]
     delete?: never
     options?: never
     head?: never
@@ -229,6 +226,111 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  "/api/v1/auth/register": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Register */
+    post: operations["register_api_v1_auth_register_post"]
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/api/v1/auth/logout": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /**
+     * Logout
+     * @description Terminate the client session.
+     */
+    post: operations["logout_api_v1_auth_logout_post"]
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/api/v1/spotify/auth-url": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** Spotify Auth Url */
+    get: operations["spotify_auth_url_api_v1_spotify_auth_url_get"]
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/api/v1/spotify/callback": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** Spotify Callback */
+    get: operations["spotify_callback_api_v1_spotify_callback_get"]
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/api/v1/spotify/now-playing": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** Now Playing */
+    get: operations["now_playing_api_v1_spotify_now_playing_get"]
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/api/v1/spotify/disconnect": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Disconnect */
+    post: operations["disconnect_api_v1_spotify_disconnect_post"]
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   "/api/v1/auth/sessions": {
     parameters: {
       query?: never
@@ -241,6 +343,23 @@ export interface paths {
     put?: never
     post?: never
     delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/api/v1/auth/sessions/{session_id}": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    post?: never
+    /** Revoke Session */
+    delete: operations["revoke_session_api_v1_auth_sessions__session_id__delete"]
     options?: never
     head?: never
     patch?: never
@@ -263,7 +382,25 @@ export interface paths {
     patch?: never
     trace?: never
   }
-  "/api/v1/auth/sessions/{session_id}": {
+  "/api/v1/notifications": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** List Notifications */
+    get: operations["list_notifications_api_v1_notifications_get"]
+    put?: never
+    post?: never
+    /** Clear Notifications */
+    delete: operations["clear_notifications_api_v1_notifications_delete"]
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/api/v1/notifications/{notif_id}/read": {
     parameters: {
       query?: never
       header?: never
@@ -273,8 +410,836 @@ export interface paths {
     get?: never
     put?: never
     post?: never
-    /** Revoke Session */
-    delete: operations["revoke_session_api_v1_auth_sessions__session_id__delete"]
+    delete?: never
+    options?: never
+    head?: never
+    /** Mark Read Single */
+    patch: operations["mark_read_single_api_v1_notifications__notif_id__read_patch"]
+    trace?: never
+  }
+  "/api/v1/notifications/read-all": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Mark All Read */
+    post: operations["mark_all_read_api_v1_notifications_read_all_post"]
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/api/v1/notifications/check-schedule": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Check Schedule And Generate */
+    post: operations["check_schedule_and_generate_api_v1_notifications_check_schedule_post"]
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/api/v1/push/vapid-public-key": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Get Vapid Public Key
+     * @description Return configured VAPID public key.
+     */
+    get: operations["get_vapid_public_key_api_v1_push_vapid_public_key_get"]
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/api/v1/push/subscribe": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Subscribe */
+    post: operations["subscribe_api_v1_push_subscribe_post"]
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/api/v1/push/subscribe/topics": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    /** Update Subscription Topics */
+    patch: operations["update_subscription_topics_api_v1_push_subscribe_topics_patch"]
+    trace?: never
+  }
+  "/api/v1/push/unsubscribe": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Unsubscribe */
+    post: operations["unsubscribe_api_v1_push_unsubscribe_post"]
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/api/v1/push/topics": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** Get Push Topics */
+    get: operations["get_push_topics_api_v1_push_topics_get"]
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/api/v1/push/test": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Send Test */
+    post: operations["send_test_api_v1_push_test_post"]
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/api/v1/push/admin/topics/{user_id}": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** Admin Get User Topics */
+    get: operations["admin_get_user_topics_api_v1_push_admin_topics__user_id__get"]
+    /** Admin Update User Topics */
+    put: operations["admin_update_user_topics_api_v1_push_admin_topics__user_id__put"]
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/api/v1/push/admin/disable-user": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Disable User Push */
+    post: operations["disable_user_push_api_v1_push_admin_disable_user_post"]
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/api/v1/push/broadcast": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Broadcast */
+    post: operations["broadcast_api_v1_push_broadcast_post"]
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/api/v1/schedule/ics": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** Download Schedule Ics */
+    get: operations["download_schedule_ics_api_v1_schedule_ics_get"]
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/api/v1/users/me": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** Me */
+    get: operations["me_api_v1_users_me_get"]
+    /** Update Me */
+    put: operations["update_me_api_v1_users_me_put"]
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/api/v1/users/me/email": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Change Email */
+    post: operations["change_email_api_v1_users_me_email_post"]
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/api/v1/users/me/email/confirm": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Confirm Email Change */
+    post: operations["confirm_email_change_api_v1_users_me_email_confirm_post"]
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/api/v1/users/me/password": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Change Password */
+    post: operations["change_password_api_v1_users_me_password_post"]
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/api/v1/users/me/export": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Export Me */
+    post: operations["export_me_api_v1_users_me_export_post"]
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/api/v1/users/me/delete": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Delete Me */
+    post: operations["delete_me_api_v1_users_me_delete_post"]
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/api/v1/users/me/avatar": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Upload Avatar */
+    post: operations["upload_avatar_api_v1_users_me_avatar_post"]
+    /** Delete Avatar */
+    delete: operations["delete_avatar_api_v1_users_me_avatar_delete"]
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/api/v1/users/me/cover": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Upload Cover */
+    post: operations["upload_cover_api_v1_users_me_cover_post"]
+    /** Delete Cover */
+    delete: operations["delete_cover_api_v1_users_me_cover_delete"]
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/api/v1/users": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** Get Users */
+    get: operations["get_users_api_v1_users_get"]
+    put?: never
+    /** Create User */
+    post: operations["create_user_api_v1_users_post"]
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/api/v1/users/audit/export": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** Export Access Audit */
+    get: operations["export_access_audit_api_v1_users_audit_export_get"]
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/api/v1/users/{user_id}": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    /** Update User Admin */
+    patch: operations["update_user_admin_api_v1_users__user_id__patch"]
+    trace?: never
+  }
+  "/api/v1/password/forgot": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Forgot Password */
+    post: operations["forgot_password_api_v1_password_forgot_post"]
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/api/v1/password/reset": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Reset Password */
+    post: operations["reset_password_api_v1_password_reset_post"]
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/api/v1/groups": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** Get Groups */
+    get: operations["get_groups_api_v1_groups_get"]
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/api/v1/events": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * List Events
+     * @description Get a paginated list of events.
+     */
+    get: operations["all_events_api_v1_events_get"]
+    put?: never
+    /** Create Event */
+    post: operations["create_event_api_v1_events_post"]
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/api/v1/events/attendance": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /**
+     * Attend Event
+     * @description Register attendance for an event.
+     */
+    post: operations["attend_api_v1_events_attendance_post"]
+    /** Unregister Event */
+    delete: operations["unregister_event_api_v1_events_attendance_delete"]
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/api/v1/events/my": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** My Events */
+    get: operations["my_events_api_v1_events_my_get"]
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/api/v1/events/{id}/upload_file": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Upload Event File */
+    post: operations["upload_event_file_api_v1_events__id__upload_file_post"]
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/api/v1/events/{id}/files": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** Get Event Files */
+    get: operations["get_event_files_api_v1_events__id__files_get"]
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/api/v1/events/upload_image": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Upload Event Image */
+    post: operations["upload_event_image_api_v1_events_upload_image_post"]
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/api/v1/events/{event_id}": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    post?: never
+    /** Delete Event */
+    delete: operations["delete_event_api_v1_events__event_id__delete"]
+    options?: never
+    head?: never
+    /** Update Event */
+    patch: operations["update_event_api_v1_events__event_id__patch"]
+    trace?: never
+  }
+  "/api/v1/events/{id}": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** Get Event */
+    get: operations["get_event_api_v1_events__id__get"]
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/api/v1/events/file/{file_id}": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    post?: never
+    /** Delete Event File */
+    delete: operations["delete_event_file_api_v1_events_file__file_id__delete"]
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/api/v1/news": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * List News
+     * @description Get a paginated list of news articles.
+     */
+    get: operations["news_list_api_v1_news_get"]
+    put?: never
+    /** Create News */
+    post: operations["create_news_api_v1_news_post"]
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/api/v1/news/{id}": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Get News Item
+     * @description Get a specific news article by ID.
+     */
+    get: operations["get_news_api_v1_news__id__get"]
+    put?: never
+    post?: never
+    /** Delete News */
+    delete: operations["delete_news_api_v1_news__id__delete"]
+    options?: never
+    head?: never
+    /** Update News */
+    patch: operations["update_news_api_v1_news__id__patch"]
+    trace?: never
+  }
+  "/api/v1/news/upload_image": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Upload News Image */
+    post: operations["upload_news_image_api_v1_news_upload_image_post"]
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/api/v1/stories": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** List Stories */
+    get: operations["list_stories_api_v1_stories_get"]
+    put?: never
+    /** Create Story */
+    post: operations["create_story_api_v1_stories_post"]
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/api/v1/stories/{story_id}": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    post?: never
+    /** Delete Story */
+    delete: operations["delete_story_api_v1_stories__story_id__delete"]
+    options?: never
+    head?: never
+    /** Update Story */
+    patch: operations["update_story_api_v1_stories__story_id__patch"]
+    trace?: never
+  }
+  "/api/v1/stories/upload_cover": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Upload Story Cover */
+    post: operations["upload_story_cover_api_v1_stories_upload_cover_post"]
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/api/v1/schedule": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Add Schedule */
+    post: operations["add_schedule_api_v1_schedule_post"]
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/api/v1/schedule/{group_id}": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** Get Schedule */
+    get: operations["get_schedule_api_v1_schedule__group_id__get"]
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/api/v1/schedule/{schedule_id}": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    post?: never
+    /** Delete Schedule */
+    delete: operations["delete_schedule_api_v1_schedule__schedule_id__delete"]
+    options?: never
+    head?: never
+    /** Update Schedule */
+    patch: operations["update_schedule_api_v1_schedule__schedule_id__patch"]
+    trace?: never
+  }
+  "/api/v1/stats/attendance": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** Attendance Summary */
+    get: operations["attendance_summary_api_v1_stats_attendance_get"]
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/api/v1/stats/grades": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** Grade Summary */
+    get: operations["grade_summary_api_v1_stats_grades_get"]
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/api/v1/stats/participation": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** Participation Summary */
+    get: operations["participation_summary_api_v1_stats_participation_get"]
+    put?: never
+    post?: never
+    delete?: never
     options?: never
     head?: never
     patch?: never
@@ -357,28 +1322,7 @@ export interface paths {
     patch?: never
     trace?: never
   }
-  "/api/v1/events": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /**
-     * List Events
-     * @description Get a paginated list of events.
-     */
-    get: operations["all_events_api_v1_events_get"]
-    put?: never
-    /** Create Event */
-    post: operations["create_event_api_v1_events_post"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/v1/events/attendance": {
+  "/api/v1/chats/{chat_id}/clear": {
     parameters: {
       query?: never
       header?: never
@@ -388,18 +1332,17 @@ export interface paths {
     get?: never
     put?: never
     /**
-     * Attend Event
-     * @description Register attendance for an event.
+     * Clear Chat History
+     * @description Remove all messages (and attachments) from a chat for its participants.
      */
-    post: operations["attend_api_v1_events_attendance_post"]
-    /** Unregister Event */
-    delete: operations["unregister_event_api_v1_events_attendance_delete"]
+    post: operations["clear_chat_history_api_v1_chats__chat_id__clear_post"]
+    delete?: never
     options?: never
     head?: never
     patch?: never
     trace?: never
   }
-  "/api/v1/events/file/{file_id}": {
+  "/api/v1/chats/{chat_id}": {
     parameters: {
       query?: never
       header?: never
@@ -409,434 +1352,17 @@ export interface paths {
     get?: never
     put?: never
     post?: never
-    /** Delete Event File */
-    delete: operations["delete_event_file_api_v1_events_file__file_id__delete"]
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/v1/events/my": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** My Events */
-    get: operations["my_events_api_v1_events_my_get"]
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/v1/events/upload_image": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Upload Event Image */
-    post: operations["upload_event_image_api_v1_events_upload_image_post"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/v1/events/{event_id}": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    post?: never
-    /** Delete Event */
-    delete: operations["delete_event_api_v1_events__event_id__delete"]
-    options?: never
-    head?: never
-    /** Update Event */
-    patch: operations["update_event_api_v1_events__event_id__patch"]
-    trace?: never
-  }
-  "/api/v1/events/{id}": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Get Event */
-    get: operations["get_event_api_v1_events__id__get"]
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/v1/events/{id}/files": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Get Event Files */
-    get: operations["get_event_files_api_v1_events__id__files_get"]
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/v1/events/{id}/upload_file": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Upload Event File */
-    post: operations["upload_event_file_api_v1_events__id__upload_file_post"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/v1/groups": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Get Groups */
-    get: operations["get_groups_api_v1_groups_get"]
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/v1/news": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
     /**
-     * List News
-     * @description Get a paginated list of news articles.
+     * Delete Chat
+     * @description Delete a chat entirely for all participants (messages, attachments, links).
      */
-    get: operations["news_list_api_v1_news_get"]
-    put?: never
-    /** Create News */
-    post: operations["create_news_api_v1_news_post"]
-    delete?: never
+    delete: operations["delete_chat_api_v1_chats__chat_id__delete"]
     options?: never
     head?: never
     patch?: never
     trace?: never
   }
-  "/api/v1/news/upload_image": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Upload News Image */
-    post: operations["upload_news_image_api_v1_news_upload_image_post"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/v1/news/{id}": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /**
-     * Get News Item
-     * @description Get a specific news article by ID.
-     */
-    get: operations["get_news_api_v1_news__id__get"]
-    put?: never
-    post?: never
-    /** Delete News */
-    delete: operations["delete_news_api_v1_news__id__delete"]
-    options?: never
-    head?: never
-    /** Update News */
-    patch: operations["update_news_api_v1_news__id__patch"]
-    trace?: never
-  }
-  "/api/v1/notifications": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** List Notifications */
-    get: operations["list_notifications_api_v1_notifications_get"]
-    put?: never
-    post?: never
-    /** Clear Notifications */
-    delete: operations["clear_notifications_api_v1_notifications_delete"]
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/v1/notifications/check-schedule": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Check Schedule And Generate */
-    post: operations["check_schedule_and_generate_api_v1_notifications_check_schedule_post"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/v1/notifications/read-all": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Mark All Read */
-    post: operations["mark_all_read_api_v1_notifications_read_all_post"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/v1/notifications/{notif_id}/read": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    /** Mark Read Single */
-    patch: operations["mark_read_single_api_v1_notifications__notif_id__read_patch"]
-    trace?: never
-  }
-  "/api/v1/password/forgot": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Forgot Password */
-    post: operations["forgot_password_api_v1_password_forgot_post"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/v1/password/reset": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Reset Password */
-    post: operations["reset_password_api_v1_password_reset_post"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/v1/push/admin/disable-user": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Disable User Push */
-    post: operations["disable_user_push_api_v1_push_admin_disable_user_post"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/v1/push/admin/topics/{user_id}": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Admin Get User Topics */
-    get: operations["admin_get_user_topics_api_v1_push_admin_topics__user_id__get"]
-    /** Admin Update User Topics */
-    put: operations["admin_update_user_topics_api_v1_push_admin_topics__user_id__put"]
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/v1/push/broadcast": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Broadcast */
-    post: operations["broadcast_api_v1_push_broadcast_post"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/v1/push/subscribe": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Subscribe */
-    post: operations["subscribe_api_v1_push_subscribe_post"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/v1/push/subscribe/topics": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    /** Update Subscription Topics */
-    patch: operations["update_subscription_topics_api_v1_push_subscribe_topics_patch"]
-    trace?: never
-  }
-  "/api/v1/push/test": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Send Test */
-    post: operations["send_test_api_v1_push_test_post"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/v1/push/topics": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Get Push Topics */
-    get: operations["get_push_topics_api_v1_push_topics_get"]
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/v1/push/unsubscribe": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Unsubscribe */
-    post: operations["unsubscribe_api_v1_push_unsubscribe_post"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/v1/push/vapid-public-key": {
+  "/webpush/vapid-public-key": {
     parameters: {
       query?: never
       header?: never
@@ -847,475 +1373,9 @@ export interface paths {
      * Get Vapid Public Key
      * @description Return configured VAPID public key.
      */
-    get: operations["get_vapid_public_key_api_v1_push_vapid_public_key_get"]
+    get: operations["get_vapid_public_key_webpush_vapid_public_key_get"]
     put?: never
     post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/v1/schedule": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Add Schedule */
-    post: operations["add_schedule_api_v1_schedule_post"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/v1/schedule/ics": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Download Schedule Ics */
-    get: operations["download_schedule_ics_api_v1_schedule_ics_get"]
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/v1/schedule/{group_id}": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Get Schedule */
-    get: operations["get_schedule_api_v1_schedule__group_id__get"]
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/v1/schedule/{schedule_id}": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    post?: never
-    /** Delete Schedule */
-    delete: operations["delete_schedule_api_v1_schedule__schedule_id__delete"]
-    options?: never
-    head?: never
-    /** Update Schedule */
-    patch: operations["update_schedule_api_v1_schedule__schedule_id__patch"]
-    trace?: never
-  }
-  "/api/v1/spotify/auth-url": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Spotify Auth Url */
-    get: operations["spotify_auth_url_api_v1_spotify_auth_url_get"]
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/v1/spotify/callback": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Spotify Callback */
-    get: operations["spotify_callback_api_v1_spotify_callback_get"]
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/v1/spotify/disconnect": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Disconnect */
-    post: operations["disconnect_api_v1_spotify_disconnect_post"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/v1/spotify/now-playing": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Now Playing */
-    get: operations["now_playing_api_v1_spotify_now_playing_get"]
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/v1/stats/attendance": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Attendance Summary */
-    get: operations["attendance_summary_api_v1_stats_attendance_get"]
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/v1/stats/grades": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Grade Summary */
-    get: operations["grade_summary_api_v1_stats_grades_get"]
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/v1/stats/participation": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Participation Summary */
-    get: operations["participation_summary_api_v1_stats_participation_get"]
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/v1/stories": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** List Stories */
-    get: operations["list_stories_api_v1_stories_get"]
-    put?: never
-    /** Create Story */
-    post: operations["create_story_api_v1_stories_post"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/v1/stories/upload_cover": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Upload Story Cover */
-    post: operations["upload_story_cover_api_v1_stories_upload_cover_post"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/v1/stories/{story_id}": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    post?: never
-    /** Delete Story */
-    delete: operations["delete_story_api_v1_stories__story_id__delete"]
-    options?: never
-    head?: never
-    /** Update Story */
-    patch: operations["update_story_api_v1_stories__story_id__patch"]
-    trace?: never
-  }
-  "/api/v1/users": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Get Users */
-    get: operations["get_users_api_v1_users_get"]
-    put?: never
-    /** Create User */
-    post: operations["create_user_api_v1_users_post"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/v1/users/me": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Me */
-    get: operations["me_api_v1_users_me_get"]
-    /** Update Me */
-    put: operations["update_me_api_v1_users_me_put"]
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/v1/users/me/avatar": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Upload Avatar */
-    post: operations["upload_avatar_api_v1_users_me_avatar_post"]
-    /** Delete Avatar */
-    delete: operations["delete_avatar_api_v1_users_me_avatar_delete"]
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/v1/users/me/cover": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Upload Cover */
-    post: operations["upload_cover_api_v1_users_me_cover_post"]
-    /** Delete Cover */
-    delete: operations["delete_cover_api_v1_users_me_cover_delete"]
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/v1/users/me/email": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Change Email */
-    post: operations["change_email_api_v1_users_me_email_post"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/v1/users/me/email/confirm": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Confirm Email Change */
-    post: operations["confirm_email_change_api_v1_users_me_email_confirm_post"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/v1/users/me/password": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Change Password */
-    post: operations["change_password_api_v1_users_me_password_post"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/v1/users/{user_id}": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    /** Update User Admin */
-    patch: operations["update_user_admin_api_v1_users__user_id__patch"]
-    trace?: never
-  }
-  "/healthz": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Healthz */
-    get: operations["healthz_healthz_get"]
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/ready": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Ready */
-    get: operations["ready_ready_get"]
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/webpush/admin/disable-user": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Disable User Push */
-    post: operations["disable_user_push_webpush_admin_disable_user_post"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/webpush/broadcast": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Broadcast */
-    post: operations["broadcast_webpush_broadcast_post"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/webpush/send-test": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Send Test */
-    post: operations["send_test_webpush_send_test_post"]
     delete?: never
     options?: never
     head?: never
@@ -1373,44 +1433,7 @@ export interface paths {
     patch?: never
     trace?: never
   }
-  "/webpush/vapid-public-key": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /**
-     * Get Vapid Public Key
-     * @description Return configured VAPID public key.
-     */
-    get: operations["get_vapid_public_key_webpush_vapid_public_key_get"]
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/v1/notifications/admin/dead-letter": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** List Dead Letter Queue */
-    get: operations["list_dead_letter_queue_api_v1_notifications_admin_dead_letter_get"]
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/v1/notifications/admin/dead-letter/retry": {
+  "/webpush/send-test": {
     parameters: {
       query?: never
       header?: never
@@ -1419,15 +1442,15 @@ export interface paths {
     }
     get?: never
     put?: never
-    /** Retry Dead Letter Queue */
-    post: operations["retry_dead_letter_queue_api_v1_notifications_admin_dead_letter_retry_post"]
+    /** Send Test */
+    post: operations["send_test_webpush_send_test_post"]
     delete?: never
     options?: never
     head?: never
     patch?: never
     trace?: never
   }
-  "/api/v1/notifications/admin/dead-letter/purge": {
+  "/webpush/admin/disable-user": {
     parameters: {
       query?: never
       header?: never
@@ -1436,8 +1459,25 @@ export interface paths {
     }
     get?: never
     put?: never
-    /** Purge Dead Letter Queue */
-    post: operations["purge_dead_letter_queue_api_v1_notifications_admin_dead_letter_purge_post"]
+    /** Disable User Push */
+    post: operations["disable_user_push_webpush_admin_disable_user_post"]
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/webpush/broadcast": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Broadcast */
+    post: operations["broadcast_webpush_broadcast_post"]
     delete?: never
     options?: never
     head?: never
@@ -1450,6 +1490,12 @@ export interface components {
   schemas: {
     /** ActiveSessionOut */
     ActiveSessionOut: {
+      /** Id */
+      id: number
+      /** User Id */
+      user_id: number
+      /** Jti */
+      jti: string
       /**
        * Created At
        * Format: date-time
@@ -1460,49 +1506,43 @@ export interface components {
        * Format: date-time
        */
       expires_at: string
-      /** Id */
-      id: number
+      /** Revoked At */
+      revoked_at?: string | null
       /** Ip Address */
       ip_address?: string | null
-      /**
-       * Is Current
-       * @default false
-       */
-      is_current: boolean
-      /** Jti */
-      jti: string
+      /** User Agent */
+      user_agent?: string | null
       /** Last Seen At */
       last_seen_at?: string | null
-      /** Mfa Completed At */
-      mfa_completed_at?: string | null
-      /** Mfa Method */
-      mfa_method?: string | null
       /**
        * Mfa Required
        * @default false
        */
       mfa_required: boolean
+      /** Mfa Completed At */
+      mfa_completed_at?: string | null
+      /** Mfa Method */
+      mfa_method?: string | null
       /** Mfa Verified At */
       mfa_verified_at?: string | null
-      /** Revoked At */
-      revoked_at?: string | null
-      /** User Agent */
-      user_agent?: string | null
-      /** User Id */
-      user_id: number
+      /**
+       * Is Current
+       * @default false
+       */
+      is_current: boolean
     }
     /** AdminUserTopicsResponse */
     AdminUserTopicsResponse: {
-      /** Allowed Topics */
-      allowed_topics: string[]
+      /** User Id */
+      user_id: number
       /** Email */
       email: string
       /** Topics */
       topics: string[]
+      /** Allowed Topics */
+      allowed_topics: string[]
       /** Updated At */
       updated_at?: string | null
-      /** User Id */
-      user_id: number
     }
     /** AdminUserTopicsUpdate */
     AdminUserTopicsUpdate: {
@@ -1511,28 +1551,28 @@ export interface components {
     }
     /** AttachmentResponse */
     AttachmentResponse: {
+      /** Id */
+      id: string
+      /** Url */
+      url: string
       /** File Type */
       file_type: string
       /** Filename */
       filename: string
-      /** Id */
-      id: string
       /** Size */
       size: number
-      /** Url */
-      url: string
     }
     /** Body_login_api_v1_auth_login_post */
     Body_login_api_v1_auth_login_post: {
-      /** Client Id */
-      client_id?: string | null
       /**
-       * Client Secret
-       * Format: password
+       * Trust Device
+       * @default false
        */
-      client_secret?: string | null
+      trust_device: boolean
       /** Grant Type */
       grant_type?: string | null
+      /** Username */
+      username: string
       /**
        * Password
        * Format: password
@@ -1543,13 +1583,13 @@ export interface components {
        * @default
        */
       scope: string
+      /** Client Id */
+      client_id?: string | null
       /**
-       * Trust Device
-       * @default false
+       * Client Secret
+       * Format: password
        */
-      trust_device: boolean
-      /** Username */
-      username: string
+      client_secret?: string | null
     }
     /** Body_send_message_api_v1_chats__chat_id__messages_post */
     Body_send_message_api_v1_chats__chat_id__messages_post: {
@@ -1614,36 +1654,56 @@ export interface components {
       /** Participant Id */
       participant_id: number
     }
+    /**
+     * ChatMaintenanceResult
+     * @description Represents the result of a maintenance operation on a chat.
+     */
+    ChatMaintenanceResult: {
+      /** Chat Id */
+      chat_id: string
+      /** Status */
+      status: string
+      /**
+       * Deleted Messages
+       * @default 0
+       */
+      deleted_messages: number
+      /**
+       * Deleted Attachments
+       * @default 0
+       */
+      deleted_attachments: number
+    }
     /** ChatParticipant */
     ChatParticipant: {
-      /** Avatar Url */
-      avatar_url?: string | null
+      /** Id */
+      id: number
       /** Email */
       email: string
       /** Full Name */
       full_name: string
-      /** Id */
-      id: number
+      /** Avatar Url */
+      avatar_url?: string | null
       /** Is Active */
       is_active: boolean
     }
     /** ChatResponse */
     ChatResponse: {
-      /**
-       * Created At
-       * Format: date-time
-       */
-      created_at: string
       /** Id */
       id: string
-      last_message?: components["schemas"]["MessageResponse"] | null
       /** Participants */
       participants: components["schemas"]["ChatParticipant"][]
+      last_message?: components["schemas"]["MessageResponse"] | null
       /**
        * Unread Count
        * @default 0
        */
       unread_count: number
+      /**
+       * Created At
+       * Format: date-time
+       */
+      created_at: string
       /**
        * Updated At
        * Format: date-time
@@ -1655,15 +1715,60 @@ export interface components {
      * @description Paginated list of chats.
      */
     ChatsListOut: {
+      /** Items */
+      items: components["schemas"]["ChatResponse"][]
       /**
        * Has More
        * @default false
        */
       has_more: boolean
-      /** Items */
-      items: components["schemas"]["ChatResponse"][]
       /** Next Cursor */
       next_cursor?: string | null
+    }
+    /** DataDeletionOut */
+    DataDeletionOut: {
+      /** Deleted */
+      deleted: boolean
+      /**
+       * Anonymized Email
+       * Format: email
+       */
+      anonymized_email: string
+    }
+    /** DataDeletionRequest */
+    DataDeletionRequest: {
+      /**
+       * Confirm
+       * @description Explicit consent to remove personal data
+       */
+      confirm: boolean
+    }
+    /** DataExportOut */
+    DataExportOut: {
+      /** Profile */
+      profile: {
+        [key: string]: unknown
+      }
+      /** Sessions */
+      sessions?: {
+        [key: string]: unknown
+      }[]
+      /** Notifications */
+      notifications?: {
+        [key: string]: unknown
+      }[]
+      /** Mfa Challenges */
+      mfa_challenges?: {
+        [key: string]: unknown
+      }[]
+      /** Mfa Enrollments */
+      mfa_enrollments?: {
+        [key: string]: unknown
+      }[]
+      /** Access Logs */
+      access_logs?: {
+        [key: string]: unknown
+      }[]
     }
     /** DisableUserPushRequest */
     DisableUserPushRequest: {
@@ -1680,159 +1785,159 @@ export interface components {
     }
     /** EventAttendanceOut */
     EventAttendanceOut: {
-      /** Event Id */
-      event_id: number
       /** Id */
       id: number
-      /** Qr Token */
-      qr_token?: string | null
+      /** User Id */
+      user_id: number
+      /** Event Id */
+      event_id: number
       /**
        * Registered At
        * Format: date-time
        */
       registered_at: string
-      /** User Id */
-      user_id: number
+      /** Qr Token */
+      qr_token?: string | null
     }
     /** EventCreate */
     EventCreate: {
-      /** About */
-      about?: string | null
-      /** About En */
-      about_en?: string | null
+      /** Title */
+      title: string
       /** Description */
       description?: string | null
+      /** Title En */
+      title_en?: string | null
       /** Description En */
       description_en?: string | null
-      /**
-       * Ends At
-       * Format: date-time
-       */
-      ends_at: string
-      /** Event Type */
-      event_type?: string | null
-      /** Event Type En */
-      event_type_en?: string | null
-      /** Image Url */
-      image_url?: string | null
       /** Location */
       location?: string | null
       /** Location En */
       location_en?: string | null
-      /** Speaker */
-      speaker?: string | null
+      /** Event Type */
+      event_type?: string | null
+      /** Event Type En */
+      event_type_en?: string | null
       /**
        * Starts At
        * Format: date-time
        */
       starts_at: string
-      /** Title */
-      title: string
-      /** Title En */
-      title_en?: string | null
-    }
-    /** EventFileOut */
-    EventFileOut: {
-      /** Description */
-      description?: string | null
-      /** Event Id */
-      event_id: number
-      /** File Url */
-      file_url: string
-      /** Id */
-      id: number
-    }
-    /** EventOut */
-    EventOut: {
+      /**
+       * Ends At
+       * Format: date-time
+       */
+      ends_at: string
+      /** Speaker */
+      speaker?: string | null
+      /** Image Url */
+      image_url?: string | null
       /** About */
       about?: string | null
       /** About En */
       about_en?: string | null
+    }
+    /** EventFileOut */
+    EventFileOut: {
+      /** Id */
+      id: number
+      /** Event Id */
+      event_id: number
+      /** File Url */
+      file_url: string
+      /** Description */
+      description?: string | null
+    }
+    /** EventOut */
+    EventOut: {
+      /** Id */
+      id: number
+      /** Title */
+      title: string
+      /** Description */
+      description?: string | null
+      /** Title En */
+      title_en?: string | null
+      /** Description En */
+      description_en?: string | null
+      /** Location */
+      location?: string | null
+      /** Location En */
+      location_en?: string | null
+      /** Event Type */
+      event_type?: string | null
+      /** Event Type En */
+      event_type_en?: string | null
+      /**
+       * Starts At
+       * Format: date-time
+       */
+      starts_at: string
+      /**
+       * Ends At
+       * Format: date-time
+       */
+      ends_at: string
+      /** Created By */
+      created_by: number
       /**
        * Created At
        * Format: date-time
        */
       created_at: string
-      /** Created By */
-      created_by: number
-      /** Description */
-      description?: string | null
-      /** Description En */
-      description_en?: string | null
-      /**
-       * Ends At
-       * Format: date-time
-       */
-      ends_at: string
-      /** Event Type */
-      event_type?: string | null
-      /** Event Type En */
-      event_type_en?: string | null
-      /** Files */
-      files?: components["schemas"]["EventFileOut"][]
-      /** Id */
-      id: number
-      /** Image Url */
-      image_url?: string | null
       /** Is Active */
       is_active: boolean
-      /** Is Registered */
-      is_registered?: boolean | null
-      /** Location */
-      location?: string | null
-      /** Location En */
-      location_en?: string | null
-      /** My Qr Token */
-      my_qr_token?: string | null
+      /** Speaker */
+      speaker?: string | null
+      /** Image Url */
+      image_url?: string | null
+      /** About */
+      about?: string | null
+      /** About En */
+      about_en?: string | null
+      /** Files */
+      files?: components["schemas"]["EventFileOut"][]
       /**
        * Participant Count
        * @default 0
        */
       participant_count: number
-      /** Speaker */
-      speaker?: string | null
-      /**
-       * Starts At
-       * Format: date-time
-       */
-      starts_at: string
-      /** Title */
-      title: string
-      /** Title En */
-      title_en?: string | null
+      /** Is Registered */
+      is_registered?: boolean | null
+      /** My Qr Token */
+      my_qr_token?: string | null
     }
     /** EventUpdate */
     EventUpdate: {
-      /** About */
-      about?: string | null
-      /** About En */
-      about_en?: string | null
+      /** Title */
+      title?: string | null
       /** Description */
       description?: string | null
+      /** Title En */
+      title_en?: string | null
       /** Description En */
       description_en?: string | null
-      /** Ends At */
-      ends_at?: string | null
-      /** Event Type */
-      event_type?: string | null
-      /** Event Type En */
-      event_type_en?: string | null
-      /** Image Url */
-      image_url?: string | null
-      /** Is Active */
-      is_active?: boolean | null
       /** Location */
       location?: string | null
       /** Location En */
       location_en?: string | null
-      /** Speaker */
-      speaker?: string | null
+      /** Event Type */
+      event_type?: string | null
+      /** Event Type En */
+      event_type_en?: string | null
       /** Starts At */
       starts_at?: string | null
-      /** Title */
-      title?: string | null
-      /** Title En */
-      title_en?: string | null
+      /** Ends At */
+      ends_at?: string | null
+      /** Is Active */
+      is_active?: boolean | null
+      /** Speaker */
+      speaker?: string | null
+      /** Image Url */
+      image_url?: string | null
+      /** About */
+      about?: string | null
+      /** About En */
+      about_en?: string | null
     }
     /** ForgotPasswordIn */
     ForgotPasswordIn: {
@@ -1844,14 +1949,14 @@ export interface components {
     }
     /** GroupOut */
     GroupOut: {
-      /** Course */
-      course?: number | null
-      /** Faculty */
-      faculty?: string | null
       /** Id */
       id: number
       /** Name */
       name: string
+      /** Course */
+      course?: number | null
+      /** Faculty */
+      faculty?: string | null
     }
     /** HTTPValidationError */
     HTTPValidationError: {
@@ -1875,52 +1980,60 @@ export interface components {
     }
     /** MessageResponse */
     MessageResponse: {
-      /**
-       * Attachments
-       * @default []
-       */
-      attachments: components["schemas"]["AttachmentResponse"][]
-      /** Chat Id */
-      chat_id: string
       /** Content */
       content: string
+      /** Id */
+      id: string
+      /** Chat Id */
+      chat_id: string
+      /** Sender Id */
+      sender_id: number
       /**
        * Created At
        * Format: date-time
        */
       created_at: string
-      /** Id */
-      id: string
       /** Read Status */
       read_status: boolean
       sender?: components["schemas"]["ChatParticipant"] | null
-      /** Sender Id */
-      sender_id: number
+      /**
+       * Attachments
+       * @default []
+       */
+      attachments: components["schemas"]["AttachmentResponse"][]
     }
     /**
      * MessagesListOut
      * @description Paginated list of messages.
      */
     MessagesListOut: {
+      /** Items */
+      items: components["schemas"]["MessageResponse"][]
       /**
        * Has More
        * @default false
        */
       has_more: boolean
-      /** Items */
-      items: components["schemas"]["MessageResponse"][]
       /** Next Cursor */
       next_cursor?: string | null
     }
     /** MfaChallengeOut */
     MfaChallengeOut: {
-      /**
-       * Attempt Count
-       * @default 0
-       */
-      attempt_count: number
+      /** Id */
+      id: number
+      /** User Id */
+      user_id: number
+      /** Session Id */
+      session_id?: number | null
       /** Challenge Type */
       challenge_type: string
+      /** Token */
+      token: string
+      /**
+       * Expires At
+       * Format: date-time
+       */
+      expires_at: string
       /** Consumed At */
       consumed_at?: string | null
       /**
@@ -1928,23 +2041,15 @@ export interface components {
        * Format: date-time
        */
       created_at: string
-      /**
-       * Expires At
-       * Format: date-time
-       */
-      expires_at: string
-      /** Id */
-      id: number
       /** Payload */
       payload?: {
         [key: string]: unknown
       } | null
-      /** Session Id */
-      session_id?: number | null
-      /** Token */
-      token: string
-      /** User Id */
-      user_id: number
+      /**
+       * Attempt Count
+       * @default 0
+       */
+      attempt_count: number
     }
     /** MfaFactorStatusOut */
     MfaFactorStatusOut: {
@@ -1960,60 +2065,60 @@ export interface components {
     }
     /** MfaMethodChallengeOut */
     MfaMethodChallengeOut: {
-      /** Attempt Count */
-      attempt_count?: number | null
-      /** Attempt Limit */
-      attempt_limit?: number | null
+      /**
+       * Method
+       * @constant
+       */
+      method: "totp"
+      /** Challenge Token */
+      challenge_token: string
       /**
        * Challenge Expires At
        * Format: date-time
        */
       challenge_expires_at: string
-      /** Challenge Token */
-      challenge_token: string
-      /**
-       * Method
-       * @constant
-       */
-      method: "totp"
       /** Options */
       options?: {
         [key: string]: unknown
       } | null
+      /** Attempt Count */
+      attempt_count?: number | null
+      /** Attempt Limit */
+      attempt_limit?: number | null
       /** Remaining Attempts */
       remaining_attempts?: number | null
     }
     /** MfaTotpEnrollmentOut */
     MfaTotpEnrollmentOut: {
+      /** Id */
+      id: number
+      /** User Id */
+      user_id: number
+      /** Label */
+      label?: string | null
+      /** Is Active */
+      is_active: boolean
       /** Confirmed At */
       confirmed_at?: string | null
+      /** Revoked At */
+      revoked_at?: string | null
       /**
        * Created At
        * Format: date-time
        */
       created_at: string
-      /** Id */
-      id: number
-      /** Is Active */
-      is_active: boolean
-      /** Label */
-      label?: string | null
-      /** Revoked At */
-      revoked_at?: string | null
-      /** User Id */
-      user_id: number
     }
     /** MfaVerifyIn */
     MfaVerifyIn: {
-      /** Challenge Token */
-      challenge_token: string
-      /** Code */
-      code?: string | null
       /**
        * Method
        * @constant
        */
       method: "totp"
+      /** Challenge Token */
+      challenge_token: string
+      /** Code */
+      code?: string | null
       /**
        * Trust Device
        * @default false
@@ -2022,49 +2127,49 @@ export interface components {
     }
     /** NewsCreate */
     NewsCreate: {
+      /** Title */
+      title: string
       /** Content */
       content: string
+      /** Title En */
+      title_en?: string | null
       /** Content En */
       content_en?: string | null
       /** Image Url */
       image_url?: string | null
-      /** Title */
-      title: string
-      /** Title En */
-      title_en?: string | null
     }
     /** NewsOut */
     NewsOut: {
+      /** Title */
+      title: string
       /** Content */
       content: string
+      /** Title En */
+      title_en?: string | null
       /** Content En */
       content_en?: string | null
+      /** Image Url */
+      image_url?: string | null
+      /** Id */
+      id: number
       /**
        * Created At
        * Format: date-time
        */
       created_at: string
-      /** Id */
-      id: number
-      /** Image Url */
-      image_url?: string | null
-      /** Title */
-      title: string
-      /** Title En */
-      title_en?: string | null
     }
     /** NewsUpdate */
     NewsUpdate: {
+      /** Title */
+      title?: string | null
       /** Content */
       content?: string | null
+      /** Title En */
+      title_en?: string | null
       /** Content En */
       content_en?: string | null
       /** Image Url */
       image_url?: string | null
-      /** Title */
-      title?: string | null
-      /** Title En */
-      title_en?: string | null
     }
     /** NotificationAction */
     NotificationAction: {
@@ -2073,11 +2178,6 @@ export interface components {
        * @description Notification action identifier
        */
       action: string
-      /**
-       * Icon
-       * @description Optional icon URL
-       */
-      icon?: string | null
       /**
        * Title
        * @description Action button title
@@ -2088,98 +2188,103 @@ export interface components {
        * @description Optional URL to open
        */
       url?: string | null
+      /**
+       * Icon
+       * @description Optional icon URL
+       */
+      icon?: string | null
     }
     /** NotificationOut */
     NotificationOut: {
+      /** Id */
+      id: number
+      /** Title */
+      title: string
       /** Body */
       body?: string | null
+      /** Title En */
+      title_en?: string | null
       /** Body En */
       body_en?: string | null
+      /** Type */
+      type?: string | null
+      /** Url */
+      url?: string | null
       /**
        * Created At
        * Format: date-time
        */
       created_at: string
-      /** Id */
-      id: number
       /** Read */
       read: boolean
       /** Read At */
       read_at?: string | null
-      /** Title */
-      title: string
-      /** Title En */
-      title_en?: string | null
-      /** Type */
-      type?: string | null
-      /** Url */
-      url?: string | null
     }
     /** NotificationsListOut */
     NotificationsListOut: {
-      /** Has More */
-      has_more: boolean
       /** Items */
       items: components["schemas"]["NotificationOut"][]
-      /** Next Cursor */
-      next_cursor?: string | null
       /** Unread Count */
       unread_count: number
+      /** Has More */
+      has_more: boolean
+      /** Next Cursor */
+      next_cursor?: string | null
     }
     /** NotifyBody */
     NotifyBody: {
-      /** Actions */
-      actions?: components["schemas"]["NotificationAction"][] | null
-      /** Badge */
-      badge?: string | null
-      /** Body */
-      body?: string | null
-      /** Data */
-      data?: {
-        [key: string]: unknown
-      } | null
-      /** Tag */
-      tag?: string | null
       /** Title */
       title: string
-      /** Topic */
-      topic?: string | null
-      /** Ttl */
-      ttl?: number | null
+      /** Body */
+      body?: string | null
+      /** Url */
+      url?: string | null
+      /** Tag */
+      tag?: string | null
+      /** Badge */
+      badge?: string | null
       /** Type */
       type?: string | null
+      /** Ttl */
+      ttl?: number | null
       /**
        * Urgency
        * @default normal
        */
       urgency: string | null
-      /** Url */
-      url?: string | null
+      /** Topic */
+      topic?: string | null
+      /** Actions */
+      actions?: components["schemas"]["NotificationAction"][] | null
+      /** Data */
+      data?: {
+        [key: string]: unknown
+      } | null
     }
     /** PaginatedEvents */
     PaginatedEvents: {
-      /** Cursor */
-      cursor?: string | null
-      /** Has More */
-      has_more: boolean
       /** Items */
       items: components["schemas"]["EventOut"][]
-      /** Limit */
-      limit: number
-      /** Next Cursor */
-      next_cursor?: string | null
       /** Total */
       total?: number | null
+      /** Limit */
+      limit: number
+      /** Cursor */
+      cursor?: string | null
+      /** Next Cursor */
+      next_cursor?: string | null
+      /** Has More */
+      has_more: boolean
     }
     /**
      * PaginatedNews
      * @description Paginated news response with cursor-based pagination.
      */
     PaginatedNews: {
-      /** Has More */
-      has_more: boolean
       /** Items */
       items: components["schemas"]["NewsOut"][]
+      /** Has More */
+      has_more: boolean
       /** Next Cursor */
       next_cursor?: string | null
     }
@@ -2195,12 +2300,6 @@ export interface components {
     }
     /** PendingMfaResponse */
     PendingMfaResponse: {
-      /** Default Method */
-      default_method?: "totp" | null
-      /** Methods */
-      methods: components["schemas"]["MfaMethodChallengeOut"][]
-      /** Session Id */
-      session_id?: number | null
       /**
        * Status
        * @default mfa_required
@@ -2209,6 +2308,12 @@ export interface components {
       status: "mfa_required"
       /** User Id */
       user_id: number
+      /** Session Id */
+      session_id?: number | null
+      /** Default Method */
+      default_method?: "totp" | null
+      /** Methods */
+      methods: components["schemas"]["MfaMethodChallengeOut"][]
     }
     /** PushSubscriptionDelete */
     PushSubscriptionDelete: {
@@ -2237,18 +2342,26 @@ export interface components {
     /** PushSubscriptionKeys */
     PushSubscriptionKeys: {
       /**
-       * Auth
-       * @description Authentication secret
-       */
-      auth: string
-      /**
        * P256Dh
        * @description Base64-encoded public key
        */
       p256dh: string
+      /**
+       * Auth
+       * @description Authentication secret
+       */
+      auth: string
     }
     /** PushSubscriptionOut */
     PushSubscriptionOut: {
+      /** Id */
+      id: number
+      /** User Id */
+      user_id: number
+      /** Endpoint */
+      endpoint: string
+      /** P256Dh */
+      p256dh: string
       /** Auth */
       auth: string
       /**
@@ -2256,22 +2369,14 @@ export interface components {
        * Format: date-time
        */
       created_at: string
-      /** Endpoint */
-      endpoint: string
-      /** Id */
-      id: number
-      /** Last Seen At */
-      last_seen_at?: string | null
-      /** P256Dh */
-      p256dh: string
-      /** Topics */
-      topics?: string[]
-      /** Updated At */
-      updated_at?: string | null
       /** User Agent */
       user_agent?: string | null
-      /** User Id */
-      user_id: number
+      /** Last Seen At */
+      last_seen_at?: string | null
+      /** Updated At */
+      updated_at?: string | null
+      /** Topics */
+      topics?: string[]
     }
     /** PushSubscriptionTopicsUpdate */
     PushSubscriptionTopicsUpdate: {
@@ -2282,44 +2387,44 @@ export interface components {
     }
     /** PushTestRequest */
     PushTestRequest: {
-      /** Actions */
-      actions?: components["schemas"]["NotificationAction"][] | null
-      /** Badge */
-      badge?: string | null
-      /**
-       * Body
-       * @description Notification body
-       * @default Delivery check
-       */
-      body: string | null
-      /** Data */
-      data?: {
-        [key: string]: unknown
-      } | null
-      /** Tag */
-      tag?: string | null
       /**
        * Title
        * @description Notification title
        * @default Test web push notification
        */
       title: string
-      /** Topic */
-      topic?: string | null
-      /** Ttl */
-      ttl?: number | null
-      /** Type */
-      type?: string | null
       /**
-       * Urgency
-       * @default normal
+       * Body
+       * @description Notification body
+       * @default Delivery check
        */
-      urgency: string | null
+      body: string | null
       /**
        * Url
        * @description URL to open when clicking the notification
        */
       url?: string | null
+      /** Tag */
+      tag?: string | null
+      /** Badge */
+      badge?: string | null
+      /** Type */
+      type?: string | null
+      /** Ttl */
+      ttl?: number | null
+      /**
+       * Urgency
+       * @default normal
+       */
+      urgency: string | null
+      /** Topic */
+      topic?: string | null
+      /** Actions */
+      actions?: components["schemas"]["NotificationAction"][] | null
+      /** Data */
+      data?: {
+        [key: string]: unknown
+      } | null
       /**
        * User Id
        * @description Target user id for testing
@@ -2330,123 +2435,123 @@ export interface components {
     PushTopicsResponse: {
       /** Allowed */
       allowed: string[]
+      /** Topics */
+      topics: string[]
       /**
        * Has Preferences
        * @default false
        */
       has_preferences: boolean
-      /** Topics */
-      topics: string[]
       /** Updated At */
       updated_at?: string | null
     }
     /** ResetPasswordIn */
     ResetPasswordIn: {
-      /** Password */
-      password: string
       /** Token */
       token: string
+      /** Password */
+      password: string
     }
     /** ScheduleCreate */
     ScheduleCreate: {
-      /**
-       * End Time
-       * Format: date-time
-       */
-      end_time: string
       /** Group Id */
       group_id: number
-      /** Lesson Type */
-      lesson_type?: string | null
-      /**
-       * Parity
-       * @default both
-       */
-      parity: string | null
+      /** Subject */
+      subject: string
+      /** Teacher */
+      teacher?: string | null
       /** Room */
       room?: string | null
+      /** Weekday */
+      weekday: string
       /**
        * Start Time
        * Format: date-time
        */
       start_time: string
-      /** Subject */
-      subject: string
-      /** Teacher */
-      teacher?: string | null
-      /** Weekday */
-      weekday: string
+      /**
+       * End Time
+       * Format: date-time
+       */
+      end_time: string
+      /**
+       * Parity
+       * @default both
+       */
+      parity: string | null
+      /** Lesson Type */
+      lesson_type?: string | null
     }
     /** ScheduleOut */
     ScheduleOut: {
-      /**
-       * End Time
-       * Format: date-time
-       */
-      end_time: string
       /** Group Id */
       group_id: number
-      /** Id */
-      id: number
-      /** Lesson Type */
-      lesson_type?: string | null
-      /** Lesson Type Display */
-      lesson_type_display?: string | null
-      /**
-       * Parity
-       * @default both
-       */
-      parity: string | null
+      /** Subject */
+      subject: string
+      /** Teacher */
+      teacher?: string | null
       /** Room */
       room?: string | null
+      /** Weekday */
+      weekday: string
       /**
        * Start Time
        * Format: date-time
        */
       start_time: string
-      /** Subject */
-      subject: string
-      /** Teacher */
-      teacher?: string | null
-      /** Weekday */
-      weekday: string
+      /**
+       * End Time
+       * Format: date-time
+       */
+      end_time: string
+      /**
+       * Parity
+       * @default both
+       */
+      parity: string | null
+      /** Lesson Type */
+      lesson_type?: string | null
+      /** Id */
+      id: number
+      /** Lesson Type Display */
+      lesson_type_display?: string | null
     }
     /** ScheduleUpdate */
     ScheduleUpdate: {
-      /** End Time */
-      end_time?: string | null
       /** Group Id */
       group_id?: number | null
-      /** Lesson Type */
-      lesson_type?: string | null
-      /** Parity */
-      parity?: string | null
-      /** Room */
-      room?: string | null
-      /** Start Time */
-      start_time?: string | null
       /** Subject */
       subject?: string | null
       /** Teacher */
       teacher?: string | null
+      /** Room */
+      room?: string | null
       /** Weekday */
       weekday?: string | null
+      /** Start Time */
+      start_time?: string | null
+      /** End Time */
+      end_time?: string | null
+      /** Parity */
+      parity?: string | null
+      /** Lesson Type */
+      lesson_type?: string | null
     }
     /** SendTestResponse */
     SendTestResponse: {
-      /** Detail */
-      detail?: string | null
-      /** Failed */
-      failed: number
-      /** Removed */
-      removed: number
-      /** Sent */
-      sent: number
       /**
        * Total
        * @default 0
        */
       total: number
+      /** Sent */
+      sent: number
+      /** Removed */
+      removed: number
+      /** Failed */
+      failed: number
+      /** Detail */
+      detail?: string | null
     }
     /** SessionBulkRevokeOut */
     SessionBulkRevokeOut: {
@@ -2468,38 +2573,48 @@ export interface components {
     }
     /** SpotifyNowPlayingOut */
     SpotifyNowPlayingOut: {
-      /** Album Image Url */
-      album_image_url?: string | null
-      /** Album Name */
-      album_name?: string | null
-      /** Artists */
-      artists?: string[]
+      /** Is Playing */
+      is_playing: boolean
+      /** Progress Ms */
+      progress_ms?: number | null
       /** Duration Ms */
       duration_ms?: number | null
+      /** Track Id */
+      track_id?: string | null
+      /** Track Name */
+      track_name?: string | null
+      /** Artists */
+      artists?: string[]
+      /** Album Name */
+      album_name?: string | null
+      /** Album Image Url */
+      album_image_url?: string | null
+      /** Track Url */
+      track_url?: string | null
+      /** Preview Url */
+      preview_url?: string | null
       /**
        * Fetched At
        * Format: date-time
        */
       fetched_at: string
-      /** Is Playing */
-      is_playing: boolean
-      /** Preview Url */
-      preview_url?: string | null
-      /** Progress Ms */
-      progress_ms?: number | null
-      /** Track Id */
-      track_id?: string | null
-      /** Track Name */
-      track_name?: string | null
-      /** Track Url */
-      track_url?: string | null
     }
     /** StoryCreate */
     StoryCreate: {
+      /** Title */
+      title: string
+      /** Title En */
+      title_en?: string | null
+      /** Short Text */
+      short_text: string
+      /** Short Text En */
+      short_text_en?: string | null
       /** Cover Url */
       cover_url?: string | null
       /** Cta Url */
       cta_url?: string | null
+      /** Published At */
+      published_at?: string | null
       /** Expires At */
       expires_at?: string | null
       /**
@@ -2507,92 +2622,82 @@ export interface components {
        * @default true
        */
       is_active: boolean
-      /** Published At */
-      published_at?: string | null
-      /** Short Text */
-      short_text: string
-      /** Short Text En */
-      short_text_en?: string | null
+    }
+    /** StoryOut */
+    StoryOut: {
+      /** Id */
+      id: number
       /** Title */
       title: string
       /** Title En */
       title_en?: string | null
-    }
-    /** StoryOut */
-    StoryOut: {
+      /** Short Text */
+      short_text: string
+      /** Short Text En */
+      short_text_en?: string | null
       /** Cover Url */
       cover_url?: string | null
-      /**
-       * Created At
-       * Format: date-time
-       */
-      created_at: string
-      /** Created By */
-      created_by?: number | null
       /** Cta Url */
       cta_url?: string | null
-      /**
-       * Expires At
-       * Format: date-time
-       */
-      expires_at: string
-      /** Id */
-      id: number
-      /** Is Active */
-      is_active: boolean
       /**
        * Published At
        * Format: date-time
        */
       published_at: string
-      /** Short Text */
-      short_text: string
-      /** Short Text En */
-      short_text_en?: string | null
-      /** Title */
-      title: string
-      /** Title En */
-      title_en?: string | null
+      /**
+       * Expires At
+       * Format: date-time
+       */
+      expires_at: string
+      /** Is Active */
+      is_active: boolean
+      /** Created By */
+      created_by?: number | null
+      /**
+       * Created At
+       * Format: date-time
+       */
+      created_at: string
     }
     /** StoryUpdate */
     StoryUpdate: {
-      /** Cover Url */
-      cover_url?: string | null
-      /** Cta Url */
-      cta_url?: string | null
-      /** Expires At */
-      expires_at?: string | null
-      /** Is Active */
-      is_active?: boolean | null
-      /** Published At */
-      published_at?: string | null
-      /** Short Text */
-      short_text?: string | null
-      /** Short Text En */
-      short_text_en?: string | null
       /** Title */
       title?: string | null
       /** Title En */
       title_en?: string | null
+      /** Short Text */
+      short_text?: string | null
+      /** Short Text En */
+      short_text_en?: string | null
+      /** Cover Url */
+      cover_url?: string | null
+      /** Cta Url */
+      cta_url?: string | null
+      /** Published At */
+      published_at?: string | null
+      /** Expires At */
+      expires_at?: string | null
+      /** Is Active */
+      is_active?: boolean | null
     }
     /** TokenWithProfile */
     TokenWithProfile: {
       /** Access Token */
       access_token: string
-      session?: components["schemas"]["SessionSigningKeyOut"] | null
       /**
        * Token Type
        * @default bearer
        */
       token_type: string
       user: components["schemas"]["UserOut"]
+      session?: components["schemas"]["SessionSigningKeyOut"] | null
     }
     /** TotpEnrollmentConfirmIn */
     TotpEnrollmentConfirmIn: {
-      /** Code */
-      code: string
       /** Enrollment Id */
       enrollment_id: number
+      /** Code */
+      code: string
     }
     /** TotpEnrollmentStartIn */
     TotpEnrollmentStartIn: {
@@ -2607,48 +2712,25 @@ export interface components {
     /** TotpEnrollmentStartOut */
     TotpEnrollmentStartOut: {
       enrollment: components["schemas"]["MfaTotpEnrollmentOut"]
-      /** Otpauth Url */
-      otpauth_url: string
       /** Secret */
       secret: string
+      /** Otpauth Url */
+      otpauth_url: string
     }
     /** UserAdminUpdate */
     UserAdminUpdate: {
-      /** Email */
-      email?: string | null
       /** Full Name */
       full_name?: string | null
+      /** Email */
+      email?: string | null
+      role?: components["schemas"]["UserRole"] | null
       /** Group Id */
       group_id?: number | null
       /** Reset Mfa */
       reset_mfa?: boolean | null
-      role?: components["schemas"]["UserRole"] | null
     }
     /** UserCreate */
     UserCreate: {
-      /** About */
-      about?: string | null
-      /** Achievements */
-      achievements?: string | null
-      /** Avatar Url */
-      avatar_url?: string | null
-      /** Course */
-      course?: string | null
-      /** Cover Url */
-      cover_url?: string | null
-      /** Department */
-      department?: string | null
-      /**
-       * Dnd Enabled
-       * @default false
-       */
-      dnd_enabled: boolean
-      /** Dnd End */
-      dnd_end?: string | null
-      /** Dnd Start */
-      dnd_start?: string | null
-      /** Education Level */
-      education_level?: string | null
       /**
        * Email
        * Format: email
@@ -2656,22 +2738,38 @@ export interface components {
       email: string
       /** Full Name */
       full_name?: string | null
-      /** Group Id */
-      group_id?: number | null
-      /** Institute */
-      institute?: string | null
-      /** Invite Code */
-      invite_code?: string | null
-      /** Password */
-      password: string
-      /** Position */
-      position?: string | null
-      /** Program */
-      program?: string | null
-      /** Record Book Number */
-      record_book_number?: string | null
       /** @default student */
       role: components["schemas"]["UserRole"]
+      /** Group Id */
+      group_id?: number | null
+      /** Avatar Url */
+      avatar_url?: string | null
+      /** Cover Url */
+      cover_url?: string | null
+      /** About */
+      about?: string | null
+      /** Record Book Number */
+      record_book_number?: string | null
+      /** Status */
+      status?: string | null
+      /** Institute */
+      institute?: string | null
+      /** Course */
+      course?: string | null
+      /** Education Level */
+      education_level?: string | null
+      /** Track */
+      track?: string | null
+      /** Program */
+      program?: string | null
+      /** Telegram */
+      telegram?: string | null
+      /** Achievements */
+      achievements?: string | null
+      /** Department */
+      department?: string | null
+      /** Position */
+      position?: string | null
       /**
        * Spotify Connected
        * @default false
@@ -2679,14 +2777,21 @@ export interface components {
       spotify_connected: boolean
       /** Spotify Display Name */
       spotify_display_name?: string | null
-      /** Status */
-      status?: string | null
-      /** Telegram */
-      telegram?: string | null
+      /**
+       * Dnd Enabled
+       * @default false
+       */
+      dnd_enabled: boolean
+      /** Dnd Start */
+      dnd_start?: string | null
+      /** Dnd End */
+      dnd_end?: string | null
       /** Timezone */
       timezone?: string | null
-      /** Track */
-      track?: string | null
+      /** Password */
+      password: string
+      /** Invite Code */
+      invite_code?: string | null
     }
     /** UserEmailChangeIn */
     UserEmailChangeIn: {
@@ -2705,29 +2810,6 @@ export interface components {
     }
     /** UserOut */
     UserOut: {
-      /** About */
-      about?: string | null
-      /** Achievements */
-      achievements?: string | null
-      /** Avatar Url */
-      avatar_url?: string | null
-      /** Course */
-      course?: string | null
-      /** Cover Url */
-      cover_url?: string | null
-      /** Department */
-      department?: string | null
-      /**
-       * Dnd Enabled
-       * @default false
-       */
-      dnd_enabled: boolean
-      /** Dnd End */
-      dnd_end?: string | null
-      /** Dnd Start */
-      dnd_start?: string | null
-      /** Education Level */
-      education_level?: string | null
       /**
        * Email
        * Format: email
@@ -2735,35 +2817,38 @@ export interface components {
       email: string
       /** Full Name */
       full_name?: string | null
-      /** Group Id */
-      group_id?: number | null
-      /** Id */
-      id: number
-      /** Institute */
-      institute?: string | null
-      /** Is Active */
-      is_active: boolean
-      /** Mfa Challenges */
-      mfa_challenges?: components["schemas"]["MfaChallengeOut"][]
-      /** Mfa Default Method */
-      mfa_default_method?: string | null
-      /** Mfa Last Verified At */
-      mfa_last_verified_at?: string | null
-      /**
-       * Mfa Required
-       * @default false
-       */
-      mfa_required: boolean
-      /** Pending Email */
-      pending_email?: string | null
-      /** Position */
-      position?: string | null
-      /** Program */
-      program?: string | null
-      /** Record Book Number */
-      record_book_number?: string | null
       /** @default student */
       role: components["schemas"]["UserRole"]
+      /** Group Id */
+      group_id?: number | null
+      /** Avatar Url */
+      avatar_url?: string | null
+      /** Cover Url */
+      cover_url?: string | null
+      /** About */
+      about?: string | null
+      /** Record Book Number */
+      record_book_number?: string | null
+      /** Status */
+      status?: string | null
+      /** Institute */
+      institute?: string | null
+      /** Course */
+      course?: string | null
+      /** Education Level */
+      education_level?: string | null
+      /** Track */
+      track?: string | null
+      /** Program */
+      program?: string | null
+      /** Telegram */
+      telegram?: string | null
+      /** Achievements */
+      achievements?: string | null
+      /** Department */
+      department?: string | null
+      /** Position */
+      position?: string | null
       /**
        * Spotify Connected
        * @default false
@@ -2771,18 +2856,38 @@ export interface components {
       spotify_connected: boolean
       /** Spotify Display Name */
       spotify_display_name?: string | null
-      /** Spotify Is Connected */
-      spotify_is_connected?: boolean | null
-      /** Status */
-      status?: string | null
-      /** Telegram */
-      telegram?: string | null
+      /**
+       * Dnd Enabled
+       * @default false
+       */
+      dnd_enabled: boolean
+      /** Dnd Start */
+      dnd_start?: string | null
+      /** Dnd End */
+      dnd_end?: string | null
       /** Timezone */
       timezone?: string | null
+      /** Id */
+      id: number
+      /** Is Active */
+      is_active: boolean
+      /** Pending Email */
+      pending_email?: string | null
+      /** Spotify Is Connected */
+      spotify_is_connected?: boolean | null
+      /**
+       * Mfa Required
+       * @default false
+       */
+      mfa_required: boolean
+      /** Mfa Default Method */
+      mfa_default_method?: string | null
+      /** Mfa Last Verified At */
+      mfa_last_verified_at?: string | null
       /** Totp Enrollments */
       totp_enrollments?: components["schemas"]["MfaTotpEnrollmentOut"][]
-      /** Track */
-      track?: string | null
+      /** Mfa Challenges */
+      mfa_challenges?: components["schemas"]["MfaChallengeOut"][]
     }
     /** UserPasswordChangeIn */
     UserPasswordChangeIn: {
@@ -2793,42 +2898,42 @@ export interface components {
     }
     /** UserProfileUpdate */
     UserProfileUpdate: {
-      /** About */
-      about?: string | null
-      /** Achievements */
-      achievements?: string | null
-      /** Course */
-      course?: string | null
-      /** Department */
-      department?: string | null
-      /** Dnd Enabled */
-      dnd_enabled?: boolean | null
-      /** Dnd End */
-      dnd_end?: string | null
-      /** Dnd Start */
-      dnd_start?: string | null
-      /** Education Level */
-      education_level?: string | null
-      /** Email */
-      email?: string | null
       /** Full Name */
       full_name?: string | null
-      /** Institute */
-      institute?: string | null
-      /** Position */
-      position?: string | null
-      /** Program */
-      program?: string | null
+      /** Email */
+      email?: string | null
+      /** About */
+      about?: string | null
       /** Record Book Number */
       record_book_number?: string | null
       /** Status */
       status?: string | null
-      /** Telegram */
-      telegram?: string | null
-      /** Timezone */
-      timezone?: string | null
+      /** Institute */
+      institute?: string | null
+      /** Course */
+      course?: string | null
+      /** Education Level */
+      education_level?: string | null
       /** Track */
       track?: string | null
+      /** Program */
+      program?: string | null
+      /** Telegram */
+      telegram?: string | null
+      /** Achievements */
+      achievements?: string | null
+      /** Department */
+      department?: string | null
+      /** Position */
+      position?: string | null
+      /** Dnd Enabled */
+      dnd_enabled?: boolean | null
+      /** Dnd Start */
+      dnd_start?: string | null
+      /** Dnd End */
+      dnd_end?: string | null
+      /** Timezone */
+      timezone?: string | null
     }
     /**
      * UserRole
@@ -2845,47 +2950,6 @@ export interface components {
       /** Error Type */
       type: string
     }
-    /** NotificationDeadLetterJobOut */
-    NotificationDeadLetterJobOut: {
-      /** Id */
-      id: number
-      /** Kind */
-      kind: string
-      /** Record Id */
-      record_id: number
-      /** Locale */
-      locale?: string | null
-      /**
-       * Enqueued At
-       * Format: date-time
-       */
-      enqueued_at: string
-      /** Claimed At */
-      claimed_at?: string | null
-      /** Attempts */
-      attempts: number
-      /** Last Error */
-      last_error?: string | null
-      /** Next Retry At */
-      next_retry_at?: string | null
-    }
-    /** NotificationDeadLetterListOut */
-    NotificationDeadLetterListOut: {
-      /** Items */
-      items: components["schemas"]["NotificationDeadLetterJobOut"][]
-      /** Total */
-      total: number
-    }
-    /** NotificationDeadLetterPurgeIn */
-    NotificationDeadLetterPurgeIn: {
-      /** Job Ids */
-      job_ids: number[]
-    }
-    /** NotificationDeadLetterReplayIn */
-    NotificationDeadLetterReplayIn: {
-      /** Job Ids */
-      job_ids: number[]
-    }
   }
   responses: never
   parameters: never
@@ -2896,6 +2960,46 @@ export interface components {
 export type $defs = Record<string, never>
 export interface operations {
   root__get: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": unknown
+        }
+      }
+    }
+  }
+  healthz_healthz_get: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": unknown
+        }
+      }
+    }
+  }
+  ready_ready_get: {
     parameters: {
       query?: never
       header?: never
@@ -2999,14 +3103,18 @@ export interface operations {
       }
     }
   }
-  logout_api_v1_auth_logout_post: {
+  start_totp_enrollment_endpoint_api_v1_auth_mfa_totp_start_post: {
     parameters: {
       query?: never
       header?: never
       path?: never
       cookie?: never
     }
-    requestBody?: never
+    requestBody?: {
+      content: {
+        "application/json": components["schemas"]["TotpEnrollmentStartIn"] | null
+      }
+    }
     responses: {
       /** @description Successful Response */
       200: {
@@ -3014,56 +3122,16 @@ export interface operations {
           [name: string]: unknown
         }
         content: {
-          "application/json": unknown
+          "application/json": components["schemas"]["TotpEnrollmentStartOut"]
         }
       }
-    }
-  }
-  request_step_up_api_v1_auth_mfa_step_up_post: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
+      /** @description Validation Error */
+      422: {
         headers: {
           [name: string]: unknown
         }
         content: {
-          "application/json": components["schemas"]["PendingMfaResponse"]
-        }
-      }
-      /** @description Accepted */
-      202: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["PendingMfaResponse"]
-        }
-      }
-    }
-  }
-  list_totp_enrollments_api_v1_auth_mfa_totp_get: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["MfaTotpEnrollmentOut"][]
+          "application/json": components["schemas"]["HTTPValidationError"]
         }
       }
     }
@@ -3101,6 +3169,26 @@ export interface operations {
       }
     }
   }
+  list_totp_enrollments_api_v1_auth_mfa_totp_get: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["MfaTotpEnrollmentOut"][]
+        }
+      }
+    }
+  }
   delete_pending_totp_enrollment_api_v1_auth_mfa_totp_pending__enrollment_id__delete: {
     parameters: {
       query?: never
@@ -3118,39 +3206,6 @@ export interface operations {
           [name: string]: unknown
         }
         content?: never
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  start_totp_enrollment_endpoint_api_v1_auth_mfa_totp_start_post: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: {
-      content: {
-        "application/json": components["schemas"]["TotpEnrollmentStartIn"] | null
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["TotpEnrollmentStartOut"]
-        }
       }
       /** @description Validation Error */
       422: {
@@ -3227,6 +3282,55 @@ export interface operations {
       }
     }
   }
+  request_step_up_api_v1_auth_mfa_step_up_post: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["PendingMfaResponse"]
+        }
+      }
+      /** @description Accepted */
+      202: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["PendingMfaResponse"]
+        }
+      }
+    }
+  }
+  get_session_signing_key_api_v1_auth_session_signing_key_get: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["SessionSigningKeyOut"]
+        }
+      }
+    }
+  }
   register_api_v1_auth_register_post: {
     parameters: {
       query?: never
@@ -3260,7 +3364,7 @@ export interface operations {
       }
     }
   }
-  get_session_signing_key_api_v1_auth_session_signing_key_get: {
+  logout_api_v1_auth_logout_post: {
     parameters: {
       query?: never
       header?: never
@@ -3275,7 +3379,99 @@ export interface operations {
           [name: string]: unknown
         }
         content: {
-          "application/json": components["schemas"]["SessionSigningKeyOut"]
+          "application/json": unknown
+        }
+      }
+    }
+  }
+  spotify_auth_url_api_v1_spotify_auth_url_get: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["SpotifyAuthURL"]
+        }
+      }
+    }
+  }
+  spotify_callback_api_v1_spotify_callback_get: {
+    parameters: {
+      query: {
+        code: string
+        state: string
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": unknown
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  now_playing_api_v1_spotify_now_playing_get: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["SpotifyNowPlayingOut"]
+        }
+      }
+    }
+  }
+  disconnect_api_v1_spotify_disconnect_post: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": unknown
         }
       }
     }
@@ -3298,6 +3494,37 @@ export interface operations {
         }
         content: {
           "application/json": components["schemas"]["ActiveSessionOut"][]
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  revoke_session_api_v1_auth_sessions__session_id__delete: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        session_id: number
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["ActiveSessionOut"]
         }
       }
       /** @description Validation Error */
@@ -3342,12 +3569,64 @@ export interface operations {
       }
     }
   }
-  revoke_session_api_v1_auth_sessions__session_id__delete: {
+  list_notifications_api_v1_notifications_get: {
+    parameters: {
+      query?: {
+        cursor?: string | null
+        limit?: number
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["NotificationsListOut"]
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  clear_notifications_api_v1_notifications_delete: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": unknown
+        }
+      }
+    }
+  }
+  mark_read_single_api_v1_notifications__notif_id__read_patch: {
     parameters: {
       query?: never
       header?: never
       path: {
-        session_id: number
+        notif_id: number
       }
       cookie?: never
     }
@@ -3359,7 +3638,1938 @@ export interface operations {
           [name: string]: unknown
         }
         content: {
-          "application/json": components["schemas"]["ActiveSessionOut"]
+          "application/json": unknown
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  mark_all_read_api_v1_notifications_read_all_post: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": unknown
+        }
+      }
+    }
+  }
+  check_schedule_and_generate_api_v1_notifications_check_schedule_post: {
+    parameters: {
+      query?: {
+        lookahead_minutes?: number
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["NotificationsListOut"]
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  get_vapid_public_key_api_v1_push_vapid_public_key_get: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            [key: string]: string
+          }
+        }
+      }
+    }
+  }
+  subscribe_api_v1_push_subscribe_post: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["PushSubscriptionIn"]
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["PushSubscriptionOut"]
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  update_subscription_topics_api_v1_push_subscribe_topics_patch: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["PushSubscriptionTopicsUpdate"]
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["PushSubscriptionOut"]
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  unsubscribe_api_v1_push_unsubscribe_post: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["PushSubscriptionDelete"]
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            [key: string]: boolean
+          }
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  get_push_topics_api_v1_push_topics_get: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["PushTopicsResponse"]
+        }
+      }
+    }
+  }
+  send_test_api_v1_push_test_post: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: {
+      content: {
+        "application/json": components["schemas"]["PushTestRequest"] | null
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["SendTestResponse"]
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  admin_get_user_topics_api_v1_push_admin_topics__user_id__get: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        user_id: number
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["AdminUserTopicsResponse"]
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  admin_update_user_topics_api_v1_push_admin_topics__user_id__put: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        user_id: number
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["AdminUserTopicsUpdate"]
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["AdminUserTopicsResponse"]
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  disable_user_push_api_v1_push_admin_disable_user_post: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["DisableUserPushRequest"]
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            [key: string]: number | boolean
+          }
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  broadcast_api_v1_push_broadcast_post: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["NotifyBody"]
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["SendTestResponse"]
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  download_schedule_ics_api_v1_schedule_ics_get: {
+    parameters: {
+      query: {
+        /** @description Group identifier */
+        group: number
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  me_api_v1_users_me_get: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["UserOut"]
+        }
+      }
+    }
+  }
+  update_me_api_v1_users_me_put: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["UserProfileUpdate"]
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["UserOut"]
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  change_email_api_v1_users_me_email_post: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["UserEmailChangeIn"]
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["UserOut"]
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  confirm_email_change_api_v1_users_me_email_confirm_post: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["UserEmailConfirmIn"]
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["UserOut"]
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  change_password_api_v1_users_me_password_post: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["UserPasswordChangeIn"]
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["PasswordChangeOut"]
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  export_me_api_v1_users_me_export_post: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["DataExportOut"]
+        }
+      }
+    }
+  }
+  delete_me_api_v1_users_me_delete_post: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["DataDeletionRequest"]
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["DataDeletionOut"]
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  upload_avatar_api_v1_users_me_avatar_post: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "multipart/form-data": components["schemas"]["Body_upload_avatar_api_v1_users_me_avatar_post"]
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["UserOut"]
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  delete_avatar_api_v1_users_me_avatar_delete: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["UserOut"]
+        }
+      }
+    }
+  }
+  upload_cover_api_v1_users_me_cover_post: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "multipart/form-data": components["schemas"]["Body_upload_cover_api_v1_users_me_cover_post"]
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["UserOut"]
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  delete_cover_api_v1_users_me_cover_delete: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["UserOut"]
+        }
+      }
+    }
+  }
+  get_users_api_v1_users_get: {
+    parameters: {
+      query?: {
+        full_name?: string | null
+        search?: string | null
+        group_id?: number | null
+        role?: string | null
+        limit?: number | null
+        offset?: number | null
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["UserOut"][]
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  create_user_api_v1_users_post: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["UserCreate"]
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["UserOut"]
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  export_access_audit_api_v1_users_audit_export_get: {
+    parameters: {
+      query?: {
+        start_at?: string | null
+        end_at?: string | null
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": unknown
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  update_user_admin_api_v1_users__user_id__patch: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        user_id: number
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["UserAdminUpdate"]
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["UserOut"]
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  forgot_password_api_v1_password_forgot_post: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["ForgotPasswordIn"]
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": unknown
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  reset_password_api_v1_password_reset_post: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["ResetPasswordIn"]
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": unknown
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  get_groups_api_v1_groups_get: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["GroupOut"][]
+        }
+      }
+    }
+  }
+  all_events_api_v1_events_get: {
+    parameters: {
+      query?: {
+        search?: string
+        type?: string
+        location?: string
+        is_active?: boolean
+        limit?: number
+        cursor?: string | null
+      }
+      header?: {
+        "if-none-match"?: string | null
+      }
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["PaginatedEvents"]
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  create_event_api_v1_events_post: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["EventCreate"]
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["EventOut"]
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  attend_api_v1_events_attendance_post: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["EventAttendanceCreate"]
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["EventAttendanceOut"]
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  unregister_event_api_v1_events_attendance_delete: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["EventAttendanceCreate"]
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            [key: string]: unknown
+          }
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  my_events_api_v1_events_my_get: {
+    parameters: {
+      query?: never
+      header?: {
+        "if-none-match"?: string | null
+      }
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["EventOut"][]
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  upload_event_file_api_v1_events__id__upload_file_post: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        id: number
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "multipart/form-data": components["schemas"]["Body_upload_event_file_api_v1_events__id__upload_file_post"]
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["EventFileOut"]
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  get_event_files_api_v1_events__id__files_get: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        id: number
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["EventFileOut"][]
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  upload_event_image_api_v1_events_upload_image_post: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "multipart/form-data": components["schemas"]["Body_upload_event_image_api_v1_events_upload_image_post"]
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": unknown
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  delete_event_api_v1_events__event_id__delete: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        event_id: number
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            [key: string]: unknown
+          }
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  update_event_api_v1_events__event_id__patch: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        event_id: number
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["EventUpdate"]
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["EventOut"]
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  get_event_api_v1_events__id__get: {
+    parameters: {
+      query?: never
+      header?: {
+        "if-none-match"?: string | null
+      }
+      path: {
+        id: number
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["EventOut"]
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  delete_event_file_api_v1_events_file__file_id__delete: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        file_id: number
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            [key: string]: unknown
+          }
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  news_list_api_v1_news_get: {
+    parameters: {
+      query?: {
+        /** @description Number of items to return */
+        limit?: number
+        /** @description Pagination cursor */
+        cursor?: string | null
+      }
+      header?: {
+        "if-none-match"?: string | null
+      }
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["PaginatedNews"]
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  create_news_api_v1_news_post: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["NewsCreate"]
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["NewsOut"]
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  get_news_api_v1_news__id__get: {
+    parameters: {
+      query?: never
+      header?: {
+        "if-none-match"?: string | null
+      }
+      path: {
+        id: number
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["NewsOut"]
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  delete_news_api_v1_news__id__delete: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        id: number
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            [key: string]: unknown
+          }
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  update_news_api_v1_news__id__patch: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        id: number
+      }
+      cookie?: never
+    }
+    requestBody?: {
+      content: {
+        "application/json": components["schemas"]["NewsUpdate"] | null
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["NewsOut"]
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  upload_news_image_api_v1_news_upload_image_post: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "multipart/form-data": components["schemas"]["Body_upload_news_image_api_v1_news_upload_image_post"]
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": unknown
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  list_stories_api_v1_stories_get: {
+    parameters: {
+      query?: never
+      header?: {
+        "if-none-match"?: string | null
+      }
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["StoryOut"][]
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  create_story_api_v1_stories_post: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["StoryCreate"]
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["StoryOut"]
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  delete_story_api_v1_stories__story_id__delete: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        story_id: number
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            [key: string]: unknown
+          }
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  update_story_api_v1_stories__story_id__patch: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        story_id: number
+      }
+      cookie?: never
+    }
+    requestBody?: {
+      content: {
+        "application/json": components["schemas"]["StoryUpdate"] | null
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["StoryOut"]
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  upload_story_cover_api_v1_stories_upload_cover_post: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "multipart/form-data": components["schemas"]["Body_upload_story_cover_api_v1_stories_upload_cover_post"]
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": unknown
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  add_schedule_api_v1_schedule_post: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["ScheduleCreate"]
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["ScheduleOut"]
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  get_schedule_api_v1_schedule__group_id__get: {
+    parameters: {
+      query?: never
+      header?: {
+        "if-none-match"?: string | null
+      }
+      path: {
+        group_id: number
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["ScheduleOut"][]
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  delete_schedule_api_v1_schedule__schedule_id__delete: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        schedule_id: number
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": {
+            [key: string]: unknown
+          }
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  update_schedule_api_v1_schedule__schedule_id__patch: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        schedule_id: number
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["ScheduleUpdate"]
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["ScheduleOut"]
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  attendance_summary_api_v1_stats_attendance_get: {
+    parameters: {
+      query?: {
+        period?: string
+        skip_cache?: boolean
+      }
+      header?: {
+        "if-none-match"?: string | null
+      }
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": unknown
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  grade_summary_api_v1_stats_grades_get: {
+    parameters: {
+      query?: {
+        period?: string
+        skip_cache?: boolean
+      }
+      header?: {
+        "if-none-match"?: string | null
+      }
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": unknown
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  participation_summary_api_v1_stats_participation_get: {
+    parameters: {
+      query?: {
+        period?: string
+        skip_cache?: boolean
+      }
+      header?: {
+        "if-none-match"?: string | null
+      }
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": unknown
         }
       }
       /** @description Validation Error */
@@ -3542,151 +5752,12 @@ export interface operations {
       }
     }
   }
-  all_events_api_v1_events_get: {
-    parameters: {
-      query?: {
-        search?: string
-        type?: string
-        location?: string
-        is_active?: boolean
-        limit?: number
-        cursor?: string | null
-      }
-      header?: {
-        "if-none-match"?: string | null
-      }
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["PaginatedEvents"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  create_event_api_v1_events_post: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["EventCreate"]
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["EventOut"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  attend_api_v1_events_attendance_post: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["EventAttendanceCreate"]
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["EventAttendanceOut"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  unregister_event_api_v1_events_attendance_delete: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["EventAttendanceCreate"]
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": {
-            [key: string]: unknown
-          }
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  delete_event_file_api_v1_events_file__file_id__delete: {
+  clear_chat_history_api_v1_chats__chat_id__clear_post: {
     parameters: {
       query?: never
       header?: never
       path: {
-        file_id: number
+        chat_id: string
       }
       cookie?: never
     }
@@ -3698,9 +5769,7 @@ export interface operations {
           [name: string]: unknown
         }
         content: {
-          "application/json": {
-            [key: string]: unknown
-          }
+          "application/json": components["schemas"]["ChatMaintenanceResult"]
         }
       }
       /** @description Validation Error */
@@ -3714,76 +5783,12 @@ export interface operations {
       }
     }
   }
-  my_events_api_v1_events_my_get: {
-    parameters: {
-      query?: never
-      header?: {
-        "if-none-match"?: string | null
-      }
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["EventOut"][]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  upload_event_image_api_v1_events_upload_image_post: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "multipart/form-data": components["schemas"]["Body_upload_event_image_api_v1_events_upload_image_post"]
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": unknown
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  delete_event_api_v1_events__event_id__delete: {
+  delete_chat_api_v1_chats__chat_id__delete: {
     parameters: {
       query?: never
       header?: never
       path: {
-        event_id: number
+        chat_id: string
       }
       cookie?: never
     }
@@ -3795,9 +5800,7 @@ export interface operations {
           [name: string]: unknown
         }
         content: {
-          "application/json": {
-            [key: string]: unknown
-          }
+          "application/json": components["schemas"]["ChatMaintenanceResult"]
         }
       }
       /** @description Validation Error */
@@ -3811,852 +5814,7 @@ export interface operations {
       }
     }
   }
-  update_event_api_v1_events__event_id__patch: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        event_id: number
-      }
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["EventUpdate"]
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["EventOut"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  get_event_api_v1_events__id__get: {
-    parameters: {
-      query?: never
-      header?: {
-        "if-none-match"?: string | null
-      }
-      path: {
-        id: number
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["EventOut"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  get_event_files_api_v1_events__id__files_get: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        id: number
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["EventFileOut"][]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  upload_event_file_api_v1_events__id__upload_file_post: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        id: number
-      }
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "multipart/form-data": components["schemas"]["Body_upload_event_file_api_v1_events__id__upload_file_post"]
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["EventFileOut"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  get_groups_api_v1_groups_get: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["GroupOut"][]
-        }
-      }
-    }
-  }
-  news_list_api_v1_news_get: {
-    parameters: {
-      query?: {
-        /** @description Number of items to return */
-        limit?: number
-        /** @description Pagination cursor */
-        cursor?: string | null
-      }
-      header?: {
-        "if-none-match"?: string | null
-      }
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["PaginatedNews"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  create_news_api_v1_news_post: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["NewsCreate"]
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["NewsOut"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  upload_news_image_api_v1_news_upload_image_post: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "multipart/form-data": components["schemas"]["Body_upload_news_image_api_v1_news_upload_image_post"]
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": unknown
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  get_news_api_v1_news__id__get: {
-    parameters: {
-      query?: never
-      header?: {
-        "if-none-match"?: string | null
-      }
-      path: {
-        id: number
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["NewsOut"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  delete_news_api_v1_news__id__delete: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        id: number
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": {
-            [key: string]: unknown
-          }
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  update_news_api_v1_news__id__patch: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        id: number
-      }
-      cookie?: never
-    }
-    requestBody?: {
-      content: {
-        "application/json": components["schemas"]["NewsUpdate"] | null
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["NewsOut"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  list_notifications_api_v1_notifications_get: {
-    parameters: {
-      query?: {
-        cursor?: string | null
-        limit?: number
-      }
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["NotificationsListOut"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  clear_notifications_api_v1_notifications_delete: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": unknown
-        }
-      }
-    }
-  }
-  check_schedule_and_generate_api_v1_notifications_check_schedule_post: {
-    parameters: {
-      query?: {
-        lookahead_minutes?: number
-      }
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["NotificationsListOut"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  mark_all_read_api_v1_notifications_read_all_post: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": unknown
-        }
-      }
-    }
-  }
-  mark_read_single_api_v1_notifications__notif_id__read_patch: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        notif_id: number
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": unknown
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  forgot_password_api_v1_password_forgot_post: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["ForgotPasswordIn"]
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": unknown
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  reset_password_api_v1_password_reset_post: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["ResetPasswordIn"]
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": unknown
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  disable_user_push_api_v1_push_admin_disable_user_post: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["DisableUserPushRequest"]
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": {
-            [key: string]: number | boolean
-          }
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  admin_get_user_topics_api_v1_push_admin_topics__user_id__get: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        user_id: number
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["AdminUserTopicsResponse"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  admin_update_user_topics_api_v1_push_admin_topics__user_id__put: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        user_id: number
-      }
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["AdminUserTopicsUpdate"]
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["AdminUserTopicsResponse"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  broadcast_api_v1_push_broadcast_post: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["NotifyBody"]
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["SendTestResponse"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  subscribe_api_v1_push_subscribe_post: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["PushSubscriptionIn"]
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["PushSubscriptionOut"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  update_subscription_topics_api_v1_push_subscribe_topics_patch: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["PushSubscriptionTopicsUpdate"]
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["PushSubscriptionOut"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  send_test_api_v1_push_test_post: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: {
-      content: {
-        "application/json": components["schemas"]["PushTestRequest"] | null
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["SendTestResponse"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  get_push_topics_api_v1_push_topics_get: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["PushTopicsResponse"]
-        }
-      }
-    }
-  }
-  unsubscribe_api_v1_push_unsubscribe_post: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["PushSubscriptionDelete"]
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": {
-            [key: string]: boolean
-          }
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  get_vapid_public_key_api_v1_push_vapid_public_key_get: {
+  get_vapid_public_key_webpush_vapid_public_key_get: {
     parameters: {
       query?: never
       header?: never
@@ -4674,1032 +5832,6 @@ export interface operations {
           "application/json": {
             [key: string]: string
           }
-        }
-      }
-    }
-  }
-  add_schedule_api_v1_schedule_post: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["ScheduleCreate"]
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["ScheduleOut"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  download_schedule_ics_api_v1_schedule_ics_get: {
-    parameters: {
-      query: {
-        /** @description Group identifier */
-        group: number
-      }
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  get_schedule_api_v1_schedule__group_id__get: {
-    parameters: {
-      query?: never
-      header?: {
-        "if-none-match"?: string | null
-      }
-      path: {
-        group_id: number
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["ScheduleOut"][]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  delete_schedule_api_v1_schedule__schedule_id__delete: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        schedule_id: number
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": {
-            [key: string]: unknown
-          }
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  update_schedule_api_v1_schedule__schedule_id__patch: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        schedule_id: number
-      }
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["ScheduleUpdate"]
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["ScheduleOut"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  spotify_auth_url_api_v1_spotify_auth_url_get: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["SpotifyAuthURL"]
-        }
-      }
-    }
-  }
-  spotify_callback_api_v1_spotify_callback_get: {
-    parameters: {
-      query: {
-        code: string
-        state: string
-      }
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": unknown
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  disconnect_api_v1_spotify_disconnect_post: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": unknown
-        }
-      }
-    }
-  }
-  now_playing_api_v1_spotify_now_playing_get: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["SpotifyNowPlayingOut"]
-        }
-      }
-    }
-  }
-  attendance_summary_api_v1_stats_attendance_get: {
-    parameters: {
-      query?: {
-        period?: string
-        skip_cache?: boolean
-      }
-      header?: {
-        "if-none-match"?: string | null
-      }
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": unknown
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  grade_summary_api_v1_stats_grades_get: {
-    parameters: {
-      query?: {
-        period?: string
-        skip_cache?: boolean
-      }
-      header?: {
-        "if-none-match"?: string | null
-      }
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": unknown
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  participation_summary_api_v1_stats_participation_get: {
-    parameters: {
-      query?: {
-        period?: string
-        skip_cache?: boolean
-      }
-      header?: {
-        "if-none-match"?: string | null
-      }
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": unknown
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  list_stories_api_v1_stories_get: {
-    parameters: {
-      query?: never
-      header?: {
-        "if-none-match"?: string | null
-      }
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["StoryOut"][]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  create_story_api_v1_stories_post: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["StoryCreate"]
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["StoryOut"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  upload_story_cover_api_v1_stories_upload_cover_post: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "multipart/form-data": components["schemas"]["Body_upload_story_cover_api_v1_stories_upload_cover_post"]
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": unknown
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  delete_story_api_v1_stories__story_id__delete: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        story_id: number
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": {
-            [key: string]: unknown
-          }
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  update_story_api_v1_stories__story_id__patch: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        story_id: number
-      }
-      cookie?: never
-    }
-    requestBody?: {
-      content: {
-        "application/json": components["schemas"]["StoryUpdate"] | null
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["StoryOut"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  get_users_api_v1_users_get: {
-    parameters: {
-      query?: {
-        full_name?: string | null
-        search?: string | null
-        group_id?: number | null
-        role?: string | null
-        limit?: number | null
-        offset?: number | null
-      }
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["UserOut"][]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  create_user_api_v1_users_post: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["UserCreate"]
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["UserOut"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  me_api_v1_users_me_get: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["UserOut"]
-        }
-      }
-    }
-  }
-  update_me_api_v1_users_me_put: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["UserProfileUpdate"]
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["UserOut"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  upload_avatar_api_v1_users_me_avatar_post: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "multipart/form-data": components["schemas"]["Body_upload_avatar_api_v1_users_me_avatar_post"]
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["UserOut"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  delete_avatar_api_v1_users_me_avatar_delete: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["UserOut"]
-        }
-      }
-    }
-  }
-  upload_cover_api_v1_users_me_cover_post: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "multipart/form-data": components["schemas"]["Body_upload_cover_api_v1_users_me_cover_post"]
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["UserOut"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  delete_cover_api_v1_users_me_cover_delete: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["UserOut"]
-        }
-      }
-    }
-  }
-  change_email_api_v1_users_me_email_post: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["UserEmailChangeIn"]
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["UserOut"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  confirm_email_change_api_v1_users_me_email_confirm_post: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["UserEmailConfirmIn"]
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["UserOut"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  change_password_api_v1_users_me_password_post: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["UserPasswordChangeIn"]
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["PasswordChangeOut"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  update_user_admin_api_v1_users__user_id__patch: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        user_id: number
-      }
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["UserAdminUpdate"]
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["UserOut"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  healthz_healthz_get: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": unknown
-        }
-      }
-    }
-  }
-  ready_ready_get: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": unknown
-        }
-      }
-    }
-  }
-  disable_user_push_webpush_admin_disable_user_post: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["DisableUserPushRequest"]
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": {
-            [key: string]: number | boolean
-          }
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  broadcast_webpush_broadcast_post: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["NotifyBody"]
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["SendTestResponse"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  send_test_webpush_send_test_post: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: {
-      content: {
-        "application/json": components["schemas"]["PushTestRequest"] | null
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["SendTestResponse"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
         }
       }
     }
@@ -5805,14 +5937,51 @@ export interface operations {
       }
     }
   }
-  get_vapid_public_key_webpush_vapid_public_key_get: {
+  send_test_webpush_send_test_post: {
     parameters: {
       query?: never
       header?: never
       path?: never
       cookie?: never
     }
-    requestBody?: never
+    requestBody?: {
+      content: {
+        "application/json": components["schemas"]["PushTestRequest"] | null
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["SendTestResponse"]
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  disable_user_push_webpush_admin_disable_user_post: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["DisableUserPushRequest"]
+      }
+    }
     responses: {
       /** @description Successful Response */
       200: {
@@ -5821,33 +5990,10 @@ export interface operations {
         }
         content: {
           "application/json": {
-            [key: string]: string
+            [key: string]: number | boolean
           }
         }
       }
-    }
-  }
-  list_dead_letter_queue_api_v1_notifications_admin_dead_letter_get: {
-    parameters: {
-      query?: {
-        limit?: number
-        offset?: number
-      }
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["NotificationDeadLetterListOut"]
-        }
-      }
       /** @description Validation Error */
       422: {
         headers: {
@@ -5859,7 +6005,7 @@ export interface operations {
       }
     }
   }
-  retry_dead_letter_queue_api_v1_notifications_admin_dead_letter_retry_post: {
+  broadcast_webpush_broadcast_post: {
     parameters: {
       query?: never
       header?: never
@@ -5868,7 +6014,7 @@ export interface operations {
     }
     requestBody: {
       content: {
-        "application/json": components["schemas"]["NotificationDeadLetterReplayIn"]
+        "application/json": components["schemas"]["NotifyBody"]
       }
     }
     responses: {
@@ -5878,40 +6024,7 @@ export interface operations {
           [name: string]: unknown
         }
         content: {
-          "application/json": unknown
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  purge_dead_letter_queue_api_v1_notifications_admin_dead_letter_purge_post: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["NotificationDeadLetterPurgeIn"]
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": unknown
+          "application/json": components["schemas"]["SendTestResponse"]
         }
       }
       /** @description Validation Error */

--- a/root/frontend/src/pages/Messenger.tsx
+++ b/root/frontend/src/pages/Messenger.tsx
@@ -9,13 +9,22 @@ import {
 import { useMediaQuery } from "@mui/material"
 import { useAuth } from "../contexts/AuthContext"
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
-import { chatApi, type Chat, type Message } from "../api/chat"
+import {
+  chatApi,
+  type Chat,
+  type ChatMaintenanceResult,
+  type ChatsListResponse,
+  type Message,
+  type MessagesListResponse,
+} from "../api/chat"
 import { useChatWebSocket } from "../hooks/useChatWebSocket"
 import SmartImage from "@/components/SmartImage"
 import { AVATAR_PLACEHOLDER_URL } from "@/constants/placeholders"
+import type { User } from "@/types/User"
+import client from "@/api/client"
 
 export default function Messenger() {
-  const { t } = useTranslation(["messenger"])
+  const { t } = useTranslation(["messenger", "common"])
   const { user } = useAuth()
   const isMobile = useMediaQuery("(max-width: 768px)")
   const queryClient = useQueryClient()
@@ -25,6 +34,9 @@ export default function Messenger() {
   const [showSearchInChat, setShowSearchInChat] = useState(false)
   const [searchQuery, setSearchQuery] = useState("")
   const [showChatMenu, setShowChatMenu] = useState(false)
+  const [profileUser, setProfileUser] = useState<User | null>(null)
+  const [isProfileLoading, setIsProfileLoading] = useState(false)
+  const [profileError, setProfileError] = useState<string | null>(null)
 
   // WebSocket for real-time updates (uses cookie-based auth)
   const { isConnected, sendTyping, sendRead, getTypingUsersForChat } = useChatWebSocket({
@@ -55,10 +67,17 @@ export default function Messenger() {
     mutationFn: ({ chatId, content, files }: { chatId: string; content: string; files?: File[] }) =>
       chatApi.sendMessage(chatId, content, files),
     onSuccess: (newMessage) => {
-      queryClient.setQueryData(["messages", selectedChatId], (old: Message[] = []) => [
-        ...old,
-        newMessage,
-      ])
+      queryClient.setQueryData<MessagesListResponse | undefined>(
+        ["messages", selectedChatId],
+        (old) => {
+          const items = old?.items ?? []
+          return {
+            has_more: old?.has_more ?? false,
+            next_cursor: old?.next_cursor ?? null,
+            items: [...items, newMessage],
+          }
+        }
+      )
       queryClient.invalidateQueries({ queryKey: ["chats"] })
     },
   })
@@ -78,6 +97,92 @@ export default function Messenger() {
       queryClient.invalidateQueries({ queryKey: ["chats"] })
       setSelectedChatId(newChat.id)
       setIsNewChatModalOpen(false)
+    },
+  })
+
+  const clearChatMutation = useMutation({
+    mutationFn: (chatId: string) => chatApi.clearChat(chatId),
+    onMutate: async (chatId) => {
+      await queryClient.cancelQueries({ queryKey: ["messages", chatId] })
+      await queryClient.cancelQueries({ queryKey: ["chats"] })
+
+      const previousMessages = queryClient.getQueryData<MessagesListResponse>([
+        "messages",
+        chatId,
+      ])
+      const previousChats = queryClient.getQueryData<ChatsListResponse>(["chats"])
+
+      queryClient.setQueryData<MessagesListResponse>(["messages", chatId], {
+        items: [],
+        has_more: false,
+        next_cursor: null,
+      })
+
+      if (previousChats) {
+        queryClient.setQueryData<ChatsListResponse>(["chats"], {
+          ...previousChats,
+          items: previousChats.items.map((chat) =>
+            chat.id === chatId
+              ? {
+                  ...chat,
+                  last_message: undefined,
+                  unread_count: 0,
+                  updated_at: new Date().toISOString(),
+                }
+              : chat
+          ),
+        })
+      }
+
+      return { previousMessages, previousChats }
+    },
+    onError: (_error, chatId, context) => {
+      if (context?.previousMessages) {
+        queryClient.setQueryData(["messages", chatId], context.previousMessages)
+      }
+      if (context?.previousChats) {
+        queryClient.setQueryData(["chats"], context.previousChats)
+      }
+    },
+    onSuccess: () => {
+      setShowChatMenu(false)
+    },
+    onSettled: (data, error, chatId) => {
+      queryClient.invalidateQueries({ queryKey: ["messages", chatId] })
+      queryClient.invalidateQueries({ queryKey: ["chats"] })
+    },
+  })
+
+  const deleteChatMutation = useMutation({
+    mutationFn: (chatId: string) => chatApi.deleteChat(chatId),
+    onMutate: async (chatId) => {
+      await queryClient.cancelQueries({ queryKey: ["chats"] })
+      const previousChats = queryClient.getQueryData<ChatsListResponse>(["chats"])
+
+      if (previousChats) {
+        queryClient.setQueryData<ChatsListResponse>(["chats"], {
+          ...previousChats,
+          items: previousChats.items.filter((chat) => chat.id !== chatId),
+        })
+      }
+
+      if (selectedChatId === chatId) {
+        setSelectedChatId(null)
+      }
+
+      return { previousChats }
+    },
+    onError: (_error, chatId, context) => {
+      if (context?.previousChats) {
+        queryClient.setQueryData(["chats"], context.previousChats)
+      }
+    },
+    onSuccess: (_data: ChatMaintenanceResult, chatId) => {
+      queryClient.removeQueries({ queryKey: ["messages", chatId] })
+      setShowChatMenu(false)
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["chats"] })
     },
   })
 
@@ -106,21 +211,38 @@ export default function Messenger() {
   }
 
   const handleClearChat = () => {
-    // TODO: Implement clear chat functionality
-    console.log("Clear chat")
-    setShowChatMenu(false)
+    if (!selectedChatId) return
+    const confirmed = window.confirm(
+      t("messenger:confirmClear", "Clear chat history for everyone?")
+    )
+    if (!confirmed) return
+    clearChatMutation.mutate(selectedChatId)
   }
 
   const handleDeleteChat = () => {
-    // TODO: Implement delete chat functionality
-    console.log("Delete chat")
-    setShowChatMenu(false)
+    if (!selectedChatId) return
+    const confirmed = window.confirm(
+      t("messenger:confirmDelete", "Delete this chat for all participants?")
+    )
+    if (!confirmed) return
+    deleteChatMutation.mutate(selectedChatId)
   }
 
   const handleViewProfile = () => {
-    // TODO: Implement view profile functionality
-    console.log("View profile")
     setShowChatMenu(false)
+    const other = activeChat && getOtherParticipant(activeChat)
+    if (!other) return
+    setIsProfileLoading(true)
+    setProfileError(null)
+    client
+      .get<User>(`/users/${other.id}`)
+      .then((response) => setProfileUser(response.data))
+      .catch(() =>
+        setProfileError(
+          t("messenger:profileLoadError", "Unable to load participant profile")
+        )
+      )
+      .finally(() => setIsProfileLoading(false))
   }
 
   // Transform chats for ContactList component
@@ -436,6 +558,80 @@ export default function Messenger() {
         onClose={() => setIsNewChatModalOpen(false)}
         onSelect={(userId) => createChatMutation.mutate(userId)}
       />
+
+      {(profileUser || isProfileLoading || profileError) && (
+        <div className="fixed inset-0 bg-black/40 backdrop-blur-sm flex items-center justify-center z-30 p-4">
+          <div className="bg-white dark:bg-gray-900 rounded-xl shadow-2xl w-full max-w-md p-6 space-y-4 border border-gray-200 dark:border-gray-800">
+            <div className="flex items-center justify-between">
+              <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+                {profileUser?.full_name || t("messenger:profile", "Profile")}
+              </h3>
+              <button
+                onClick={() => {
+                  setProfileUser(null)
+                  setProfileError(null)
+                }}
+                className="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-800"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  strokeWidth={1.5}
+                  stroke="currentColor"
+                  className="w-5 h-5"
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+
+            {isProfileLoading && (
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                {t("messenger:loadingProfile", "Loading profile...")}
+              </p>
+            )}
+
+            {profileError && (
+              <p className="text-sm text-red-600 dark:text-red-400">{profileError}</p>
+            )}
+
+            {profileUser && (
+              <div className="space-y-3">
+                <div className="flex items-center gap-3">
+                  <SmartImage
+                    srcRaw={profileUser.avatar_url || AVATAR_PLACEHOLDER_URL}
+                    fallback={AVATAR_PLACEHOLDER_URL}
+                    alt={profileUser.full_name}
+                    className="w-14 h-14 rounded-full object-cover border border-gray-200 dark:border-gray-700"
+                  />
+                  <div>
+                    <p className="font-semibold text-gray-900 dark:text-gray-100">
+                      {profileUser.full_name}
+                    </p>
+                    <p className="text-sm text-gray-500 dark:text-gray-400">{profileUser.email}</p>
+                  </div>
+                </div>
+                <div className="text-sm text-gray-600 dark:text-gray-300 space-y-1">
+                  <p>
+                    {t("messenger:status", "Status")}: {profileUser.is_active ? t("common:active", "Active") : t("common:inactive", "Inactive")}
+                  </p>
+                  {profileUser.avatar_url && (
+                    <a
+                      className="text-blue-600 dark:text-blue-400 underline"
+                      href={profileUser.avatar_url}
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      {t("messenger:viewAvatar", "Open avatar")}
+                    </a>
+                  )}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/root/tests/contracts/snapshots/api_openapi_v1.json
+++ b/root/tests/contracts/snapshots/api_openapi_v1.json
@@ -1,21 +1,4809 @@
 {
+  "openapi": "3.1.0",
+  "info": {
+    "title": "University Ecosystem API",
+    "description": "REST API for university life management platform - schedules, news, events, notifications, and more.",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "summary": "Root",
+        "operationId": "root__get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/healthz": {
+      "get": {
+        "summary": "Healthz",
+        "operationId": "healthz_healthz_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ready": {
+      "get": {
+        "summary": "Ready",
+        "operationId": "ready_ready_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/login": {
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Login",
+        "operationId": "login_api_v1_auth_login_post",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_login_api_v1_auth_login_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TokenWithProfile"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PendingMfaResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/login-json": {
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Login Json",
+        "operationId": "login_json_api_v1_auth_login_json_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LoginIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TokenWithProfile"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PendingMfaResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/mfa/totp/start": {
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Start Totp Enrollment Endpoint",
+        "operationId": "start_totp_enrollment_endpoint_api_v1_auth_mfa_totp_start_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/TotpEnrollmentStartIn"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Payload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TotpEnrollmentStartOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/auth/mfa/totp/confirm": {
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Confirm Totp Enrollment",
+        "operationId": "confirm_totp_enrollment_api_v1_auth_mfa_totp_confirm_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TotpEnrollmentConfirmIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MfaTotpEnrollmentOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/auth/mfa/totp": {
+      "get": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "List Totp Enrollments",
+        "operationId": "list_totp_enrollments_api_v1_auth_mfa_totp_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/MfaTotpEnrollmentOut"
+                  },
+                  "type": "array",
+                  "title": "Response List Totp Enrollments Api V1 Auth Mfa Totp Get"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/auth/mfa/totp/pending/{enrollment_id}": {
+      "delete": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Delete Pending Totp Enrollment",
+        "operationId": "delete_pending_totp_enrollment_api_v1_auth_mfa_totp_pending__enrollment_id__delete",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "enrollment_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Enrollment Id"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/mfa/totp/{enrollment_id}": {
+      "delete": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Delete Totp Enrollment",
+        "operationId": "delete_totp_enrollment_api_v1_auth_mfa_totp__enrollment_id__delete",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "enrollment_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Enrollment Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MfaFactorStatusOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/mfa/verify": {
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Verify Mfa Challenge",
+        "operationId": "verify_mfa_challenge_api_v1_auth_mfa_verify_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MfaVerifyIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TokenWithProfile"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/mfa/step-up": {
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Request Step Up",
+        "operationId": "request_step_up_api_v1_auth_mfa_step_up_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PendingMfaResponse"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PendingMfaResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/auth/session/signing-key": {
+      "get": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Get Session Signing Key",
+        "operationId": "get_session_signing_key_api_v1_auth_session_signing_key_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionSigningKeyOut"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/auth/register": {
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Register",
+        "operationId": "register_api_v1_auth_register_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UserCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/logout": {
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Logout",
+        "description": "Terminate the client session.",
+        "operationId": "logout_api_v1_auth_logout_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/spotify/auth-url": {
+      "get": {
+        "tags": [
+          "spotify"
+        ],
+        "summary": "Spotify Auth Url",
+        "operationId": "spotify_auth_url_api_v1_spotify_auth_url_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SpotifyAuthURL"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/spotify/callback": {
+      "get": {
+        "tags": [
+          "spotify"
+        ],
+        "summary": "Spotify Callback",
+        "operationId": "spotify_callback_api_v1_spotify_callback_get",
+        "parameters": [
+          {
+            "name": "code",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Code"
+            }
+          },
+          {
+            "name": "state",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "State"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/spotify/now-playing": {
+      "get": {
+        "tags": [
+          "spotify"
+        ],
+        "summary": "Now Playing",
+        "operationId": "now_playing_api_v1_spotify_now_playing_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SpotifyNowPlayingOut"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/spotify/disconnect": {
+      "post": {
+        "tags": [
+          "spotify"
+        ],
+        "summary": "Disconnect",
+        "operationId": "disconnect_api_v1_spotify_disconnect_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/auth/sessions": {
+      "get": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "List Sessions",
+        "operationId": "list_sessions_api_v1_auth_sessions_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "user_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "User Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ActiveSessionOut"
+                  },
+                  "title": "Response List Sessions Api V1 Auth Sessions Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/sessions/{session_id}": {
+      "delete": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Revoke Session",
+        "operationId": "revoke_session_api_v1_auth_sessions__session_id__delete",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Session Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActiveSessionOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/sessions/revoke-others": {
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Revoke Other Sessions",
+        "operationId": "revoke_other_sessions_api_v1_auth_sessions_revoke_others_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "user_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "User Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionBulkRevokeOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/notifications": {
+      "get": {
+        "tags": [
+          "notifications"
+        ],
+        "summary": "List Notifications",
+        "operationId": "list_notifications_api_v1_notifications_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 20,
+              "title": "Limit"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationsListOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "notifications"
+        ],
+        "summary": "Clear Notifications",
+        "operationId": "clear_notifications_api_v1_notifications_delete",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/notifications/{notif_id}/read": {
+      "patch": {
+        "tags": [
+          "notifications"
+        ],
+        "summary": "Mark Read Single",
+        "operationId": "mark_read_single_api_v1_notifications__notif_id__read_patch",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "notif_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Notif Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/notifications/read-all": {
+      "post": {
+        "tags": [
+          "notifications"
+        ],
+        "summary": "Mark All Read",
+        "operationId": "mark_all_read_api_v1_notifications_read_all_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/notifications/check-schedule": {
+      "post": {
+        "tags": [
+          "notifications"
+        ],
+        "summary": "Check Schedule And Generate",
+        "operationId": "check_schedule_and_generate_api_v1_notifications_check_schedule_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "lookahead_minutes",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 180,
+              "minimum": 1,
+              "default": 15,
+              "title": "Lookahead Minutes"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationsListOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/push/vapid-public-key": {
+      "get": {
+        "tags": [
+          "push"
+        ],
+        "summary": "Get Vapid Public Key",
+        "description": "Return configured VAPID public key.",
+        "operationId": "get_vapid_public_key_api_v1_push_vapid_public_key_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "title": "Response Get Vapid Public Key Api V1 Push Vapid Public Key Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/push/subscribe": {
+      "post": {
+        "tags": [
+          "push"
+        ],
+        "summary": "Subscribe",
+        "operationId": "subscribe_api_v1_push_subscribe_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PushSubscriptionIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PushSubscriptionOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/push/subscribe/topics": {
+      "patch": {
+        "tags": [
+          "push"
+        ],
+        "summary": "Update Subscription Topics",
+        "operationId": "update_subscription_topics_api_v1_push_subscribe_topics_patch",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PushSubscriptionTopicsUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PushSubscriptionOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/push/unsubscribe": {
+      "post": {
+        "tags": [
+          "push"
+        ],
+        "summary": "Unsubscribe",
+        "operationId": "unsubscribe_api_v1_push_unsubscribe_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PushSubscriptionDelete"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "boolean"
+                  },
+                  "type": "object",
+                  "title": "Response Unsubscribe Api V1 Push Unsubscribe Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/push/topics": {
+      "get": {
+        "tags": [
+          "push"
+        ],
+        "summary": "Get Push Topics",
+        "operationId": "get_push_topics_api_v1_push_topics_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PushTopicsResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/push/test": {
+      "post": {
+        "tags": [
+          "push"
+        ],
+        "summary": "Send Test",
+        "operationId": "send_test_api_v1_push_test_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/PushTestRequest"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Payload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SendTestResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/push/admin/topics/{user_id}": {
+      "get": {
+        "tags": [
+          "push"
+        ],
+        "summary": "Admin Get User Topics",
+        "operationId": "admin_get_user_topics_api_v1_push_admin_topics__user_id__get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "user_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "User Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdminUserTopicsResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "push"
+        ],
+        "summary": "Admin Update User Topics",
+        "operationId": "admin_update_user_topics_api_v1_push_admin_topics__user_id__put",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "user_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "User Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AdminUserTopicsUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdminUserTopicsResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/push/admin/disable-user": {
+      "post": {
+        "tags": [
+          "push"
+        ],
+        "summary": "Disable User Push",
+        "operationId": "disable_user_push_api_v1_push_admin_disable_user_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DisableUserPushRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "boolean"
+                      }
+                    ]
+                  },
+                  "type": "object",
+                  "title": "Response Disable User Push Api V1 Push Admin Disable User Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/push/broadcast": {
+      "post": {
+        "tags": [
+          "push"
+        ],
+        "summary": "Broadcast",
+        "operationId": "broadcast_api_v1_push_broadcast_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NotifyBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SendTestResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/schedule/ics": {
+      "get": {
+        "tags": [
+          "schedule"
+        ],
+        "summary": "Download Schedule Ics",
+        "operationId": "download_schedule_ics_api_v1_schedule_ics_get",
+        "parameters": [
+          {
+            "name": "group",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "description": "Group identifier",
+              "title": "Group"
+            },
+            "description": "Group identifier"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/users/me": {
+      "get": {
+        "tags": [
+          "users"
+        ],
+        "summary": "Me",
+        "operationId": "me_api_v1_users_me_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserOut"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      },
+      "put": {
+        "tags": [
+          "users"
+        ],
+        "summary": "Update Me",
+        "operationId": "update_me_api_v1_users_me_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UserProfileUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/users/me/email": {
+      "post": {
+        "tags": [
+          "users"
+        ],
+        "summary": "Change Email",
+        "operationId": "change_email_api_v1_users_me_email_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UserEmailChangeIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/users/me/email/confirm": {
+      "post": {
+        "tags": [
+          "users"
+        ],
+        "summary": "Confirm Email Change",
+        "operationId": "confirm_email_change_api_v1_users_me_email_confirm_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UserEmailConfirmIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/users/me/password": {
+      "post": {
+        "tags": [
+          "users"
+        ],
+        "summary": "Change Password",
+        "operationId": "change_password_api_v1_users_me_password_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UserPasswordChangeIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PasswordChangeOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/users/me/export": {
+      "post": {
+        "tags": [
+          "users"
+        ],
+        "summary": "Export Me",
+        "operationId": "export_me_api_v1_users_me_export_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DataExportOut"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/users/me/delete": {
+      "post": {
+        "tags": [
+          "users"
+        ],
+        "summary": "Delete Me",
+        "operationId": "delete_me_api_v1_users_me_delete_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DataDeletionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DataDeletionOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/users/me/avatar": {
+      "post": {
+        "tags": [
+          "users"
+        ],
+        "summary": "Upload Avatar",
+        "operationId": "upload_avatar_api_v1_users_me_avatar_post",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_upload_avatar_api_v1_users_me_avatar_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "users"
+        ],
+        "summary": "Delete Avatar",
+        "operationId": "delete_avatar_api_v1_users_me_avatar_delete",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserOut"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/users/me/cover": {
+      "post": {
+        "tags": [
+          "users"
+        ],
+        "summary": "Upload Cover",
+        "operationId": "upload_cover_api_v1_users_me_cover_post",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_upload_cover_api_v1_users_me_cover_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "users"
+        ],
+        "summary": "Delete Cover",
+        "operationId": "delete_cover_api_v1_users_me_cover_delete",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserOut"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/users": {
+      "post": {
+        "tags": [
+          "users"
+        ],
+        "summary": "Create User",
+        "operationId": "create_user_api_v1_users_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UserCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "users"
+        ],
+        "summary": "Get Users",
+        "operationId": "get_users_api_v1_users_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "full_name",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Full Name"
+            }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Search"
+            }
+          },
+          {
+            "name": "group_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Group Id"
+            }
+          },
+          {
+            "name": "role",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Role"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer",
+                  "maximum": 100,
+                  "minimum": 1
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Offset"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/UserOut"
+                  },
+                  "title": "Response Get Users Api V1 Users Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/users/audit/export": {
+      "get": {
+        "tags": [
+          "users"
+        ],
+        "summary": "Export Access Audit",
+        "operationId": "export_access_audit_api_v1_users_audit_export_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "start_at",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start At"
+            }
+          },
+          {
+            "name": "end_at",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End At"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/users/{user_id}": {
+      "patch": {
+        "tags": [
+          "users"
+        ],
+        "summary": "Update User Admin",
+        "operationId": "update_user_admin_api_v1_users__user_id__patch",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "user_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "User Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UserAdminUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/password/forgot": {
+      "post": {
+        "tags": [
+          "password"
+        ],
+        "summary": "Forgot Password",
+        "operationId": "forgot_password_api_v1_password_forgot_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ForgotPasswordIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/password/reset": {
+      "post": {
+        "tags": [
+          "password"
+        ],
+        "summary": "Reset Password",
+        "operationId": "reset_password_api_v1_password_reset_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ResetPasswordIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/groups": {
+      "get": {
+        "tags": [
+          "groups"
+        ],
+        "summary": "Get Groups",
+        "operationId": "get_groups_api_v1_groups_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/GroupOut"
+                  },
+                  "type": "array",
+                  "title": "Response Get Groups Api V1 Groups Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/events": {
+      "post": {
+        "tags": [
+          "events"
+        ],
+        "summary": "Create Event",
+        "operationId": "create_event_api_v1_events_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EventCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EventOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "events"
+        ],
+        "summary": "List Events",
+        "description": "Get a paginated list of events.",
+        "operationId": "all_events_api_v1_events_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "search",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "",
+              "title": "Search"
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "",
+              "title": "Type"
+            }
+          },
+          {
+            "name": "location",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "",
+              "title": "Location"
+            }
+          },
+          {
+            "name": "is_active",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": true,
+              "title": "Is Active"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 50,
+              "minimum": 1,
+              "default": 20,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "name": "if-none-match",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "If-None-Match"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedEvents"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/events/attendance": {
+      "post": {
+        "tags": [
+          "events"
+        ],
+        "summary": "Attend Event",
+        "description": "Register attendance for an event.",
+        "operationId": "attend_api_v1_events_attendance_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EventAttendanceCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EventAttendanceOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "events"
+        ],
+        "summary": "Unregister Event",
+        "operationId": "unregister_event_api_v1_events_attendance_delete",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EventAttendanceCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Unregister Event Api V1 Events Attendance Delete"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/events/my": {
+      "get": {
+        "tags": [
+          "events"
+        ],
+        "summary": "My Events",
+        "operationId": "my_events_api_v1_events_my_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "if-none-match",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "If-None-Match"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/EventOut"
+                  },
+                  "title": "Response My Events Api V1 Events My Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/events/{id}/upload_file": {
+      "post": {
+        "tags": [
+          "events"
+        ],
+        "summary": "Upload Event File",
+        "operationId": "upload_event_file_api_v1_events__id__upload_file_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_upload_event_file_api_v1_events__id__upload_file_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EventFileOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/events/{id}/files": {
+      "get": {
+        "tags": [
+          "events"
+        ],
+        "summary": "Get Event Files",
+        "operationId": "get_event_files_api_v1_events__id__files_get",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/EventFileOut"
+                  },
+                  "title": "Response Get Event Files Api V1 Events  Id  Files Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/events/upload_image": {
+      "post": {
+        "tags": [
+          "events"
+        ],
+        "summary": "Upload Event Image",
+        "operationId": "upload_event_image_api_v1_events_upload_image_post",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_upload_event_image_api_v1_events_upload_image_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/events/{event_id}": {
+      "patch": {
+        "tags": [
+          "events"
+        ],
+        "summary": "Update Event",
+        "operationId": "update_event_api_v1_events__event_id__patch",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "event_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Event Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EventUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EventOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "events"
+        ],
+        "summary": "Delete Event",
+        "operationId": "delete_event_api_v1_events__event_id__delete",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "event_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Event Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Delete Event Api V1 Events  Event Id  Delete"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/events/{id}": {
+      "get": {
+        "tags": [
+          "events"
+        ],
+        "summary": "Get Event",
+        "operationId": "get_event_api_v1_events__id__get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Id"
+            }
+          },
+          {
+            "name": "if-none-match",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "If-None-Match"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EventOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/events/file/{file_id}": {
+      "delete": {
+        "tags": [
+          "events"
+        ],
+        "summary": "Delete Event File",
+        "operationId": "delete_event_file_api_v1_events_file__file_id__delete",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "File Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Delete Event File Api V1 Events File  File Id  Delete"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/news": {
+      "post": {
+        "tags": [
+          "news"
+        ],
+        "summary": "Create News",
+        "operationId": "create_news_api_v1_news_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewsCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NewsOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "news"
+        ],
+        "summary": "List News",
+        "description": "Get a paginated list of news articles.",
+        "operationId": "news_list_api_v1_news_get",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
+              "description": "Number of items to return",
+              "default": 20,
+              "title": "Limit"
+            },
+            "description": "Number of items to return"
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Pagination cursor",
+              "title": "Cursor"
+            },
+            "description": "Pagination cursor"
+          },
+          {
+            "name": "if-none-match",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "If-None-Match"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedNews"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/news/{id}": {
+      "get": {
+        "tags": [
+          "news"
+        ],
+        "summary": "Get News Item",
+        "description": "Get a specific news article by ID.",
+        "operationId": "get_news_api_v1_news__id__get",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Id"
+            }
+          },
+          {
+            "name": "if-none-match",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "If-None-Match"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NewsOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "news"
+        ],
+        "summary": "Update News",
+        "operationId": "update_news_api_v1_news__id__patch",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/NewsUpdate"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Data"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NewsOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "news"
+        ],
+        "summary": "Delete News",
+        "operationId": "delete_news_api_v1_news__id__delete",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Delete News Api V1 News  Id  Delete"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/news/upload_image": {
+      "post": {
+        "tags": [
+          "news"
+        ],
+        "summary": "Upload News Image",
+        "operationId": "upload_news_image_api_v1_news_upload_image_post",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_upload_news_image_api_v1_news_upload_image_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/stories": {
+      "get": {
+        "tags": [
+          "stories"
+        ],
+        "summary": "List Stories",
+        "operationId": "list_stories_api_v1_stories_get",
+        "parameters": [
+          {
+            "name": "if-none-match",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "If-None-Match"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/StoryOut"
+                  },
+                  "title": "Response List Stories Api V1 Stories Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "stories"
+        ],
+        "summary": "Create Story",
+        "operationId": "create_story_api_v1_stories_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StoryCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StoryOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/stories/{story_id}": {
+      "patch": {
+        "tags": [
+          "stories"
+        ],
+        "summary": "Update Story",
+        "operationId": "update_story_api_v1_stories__story_id__patch",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "story_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Story Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/StoryUpdate"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Data"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StoryOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "stories"
+        ],
+        "summary": "Delete Story",
+        "operationId": "delete_story_api_v1_stories__story_id__delete",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "story_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Story Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Delete Story Api V1 Stories  Story Id  Delete"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/stories/upload_cover": {
+      "post": {
+        "tags": [
+          "stories"
+        ],
+        "summary": "Upload Story Cover",
+        "operationId": "upload_story_cover_api_v1_stories_upload_cover_post",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_upload_story_cover_api_v1_stories_upload_cover_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/schedule": {
+      "post": {
+        "tags": [
+          "schedule"
+        ],
+        "summary": "Add Schedule",
+        "operationId": "add_schedule_api_v1_schedule_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ScheduleCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ScheduleOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/schedule/{group_id}": {
+      "get": {
+        "tags": [
+          "schedule"
+        ],
+        "summary": "Get Schedule",
+        "operationId": "get_schedule_api_v1_schedule__group_id__get",
+        "parameters": [
+          {
+            "name": "group_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Group Id"
+            }
+          },
+          {
+            "name": "if-none-match",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "If-None-Match"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ScheduleOut"
+                  },
+                  "title": "Response Get Schedule Api V1 Schedule  Group Id  Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/schedule/{schedule_id}": {
+      "patch": {
+        "tags": [
+          "schedule"
+        ],
+        "summary": "Update Schedule",
+        "operationId": "update_schedule_api_v1_schedule__schedule_id__patch",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "schedule_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Schedule Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ScheduleUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ScheduleOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "schedule"
+        ],
+        "summary": "Delete Schedule",
+        "operationId": "delete_schedule_api_v1_schedule__schedule_id__delete",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "schedule_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Schedule Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Delete Schedule Api V1 Schedule  Schedule Id  Delete"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/stats/attendance": {
+      "get": {
+        "tags": [
+          "stats"
+        ],
+        "summary": "Attendance Summary",
+        "operationId": "attendance_summary_api_v1_stats_attendance_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "period",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "30d",
+              "title": "Period"
+            }
+          },
+          {
+            "name": "skip_cache",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Skip Cache"
+            }
+          },
+          {
+            "name": "if-none-match",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "If-None-Match"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/stats/grades": {
+      "get": {
+        "tags": [
+          "stats"
+        ],
+        "summary": "Grade Summary",
+        "operationId": "grade_summary_api_v1_stats_grades_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "period",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "30d",
+              "title": "Period"
+            }
+          },
+          {
+            "name": "skip_cache",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Skip Cache"
+            }
+          },
+          {
+            "name": "if-none-match",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "If-None-Match"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/stats/participation": {
+      "get": {
+        "tags": [
+          "stats"
+        ],
+        "summary": "Participation Summary",
+        "operationId": "participation_summary_api_v1_stats_participation_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "period",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "30d",
+              "title": "Period"
+            }
+          },
+          {
+            "name": "skip_cache",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Skip Cache"
+            }
+          },
+          {
+            "name": "if-none-match",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "If-None-Match"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/chats": {
+      "get": {
+        "tags": [
+          "chats"
+        ],
+        "summary": "Get Chats",
+        "description": "Get all chats for the current user with cursor-based pagination.\n\nReturns chats ordered by last message timestamp (newest first).\nUse the `next_cursor` from the response to fetch the next page.",
+        "operationId": "get_chats_api_v1_chats_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Pagination cursor",
+              "title": "Cursor"
+            },
+            "description": "Pagination cursor"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
+              "description": "Number of chats to return",
+              "default": 20,
+              "title": "Limit"
+            },
+            "description": "Number of chats to return"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChatsListOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "chats"
+        ],
+        "summary": "Create Chat",
+        "description": "Create a new chat with a user. If a chat already exists, return it.",
+        "operationId": "create_chat_api_v1_chats_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChatCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChatResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/chats/{chat_id}/messages": {
+      "get": {
+        "tags": [
+          "chats"
+        ],
+        "summary": "Get Messages",
+        "description": "Get messages for a chat with cursor-based pagination.\n\nMessages are returned in ascending order (oldest first).\nUse the `next_cursor` from the response to fetch older messages.",
+        "operationId": "get_messages_api_v1_chats__chat_id__messages_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "chat_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Chat Id"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Pagination cursor",
+              "title": "Cursor"
+            },
+            "description": "Pagination cursor"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
+              "description": "Number of messages to return",
+              "default": 50,
+              "title": "Limit"
+            },
+            "description": "Number of messages to return"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessagesListOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "chats"
+        ],
+        "summary": "Send Message",
+        "description": "Send a message to a chat.\n\nThe message is saved to the database and all chat participants\nare notified via WebSocket in real-time.",
+        "operationId": "send_message_api_v1_chats__chat_id__messages_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "chat_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Chat Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_send_message_api_v1_chats__chat_id__messages_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/chats/{chat_id}/read": {
+      "post": {
+        "tags": [
+          "chats"
+        ],
+        "summary": "Mark Read",
+        "description": "Mark all messages in a chat as read.",
+        "operationId": "mark_read_api_v1_chats__chat_id__read_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "chat_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Chat Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/chats/{chat_id}/clear": {
+      "post": {
+        "tags": [
+          "chats"
+        ],
+        "summary": "Clear Chat History",
+        "description": "Remove all messages (and attachments) from a chat for its participants.",
+        "operationId": "clear_chat_history_api_v1_chats__chat_id__clear_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "chat_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Chat Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChatMaintenanceResult"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/chats/{chat_id}": {
+      "delete": {
+        "tags": [
+          "chats"
+        ],
+        "summary": "Delete Chat",
+        "description": "Delete a chat entirely for all participants (messages, attachments, links).",
+        "operationId": "delete_chat_api_v1_chats__chat_id__delete",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "chat_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Chat Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChatMaintenanceResult"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/webpush/vapid-public-key": {
+      "get": {
+        "tags": [
+          "webpush"
+        ],
+        "summary": "Get Vapid Public Key",
+        "description": "Return configured VAPID public key.",
+        "operationId": "get_vapid_public_key_webpush_vapid_public_key_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "title": "Response Get Vapid Public Key Webpush Vapid Public Key Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/webpush/subscribe": {
+      "post": {
+        "tags": [
+          "webpush"
+        ],
+        "summary": "Subscribe",
+        "operationId": "subscribe_webpush_subscribe_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PushSubscriptionIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PushSubscriptionOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/webpush/subscribe/topics": {
+      "patch": {
+        "tags": [
+          "webpush"
+        ],
+        "summary": "Update Subscription Topics",
+        "operationId": "update_subscription_topics_webpush_subscribe_topics_patch",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PushSubscriptionTopicsUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PushSubscriptionOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/webpush/unsubscribe": {
+      "post": {
+        "tags": [
+          "webpush"
+        ],
+        "summary": "Unsubscribe",
+        "operationId": "unsubscribe_webpush_unsubscribe_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PushSubscriptionDelete"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "boolean"
+                  },
+                  "type": "object",
+                  "title": "Response Unsubscribe Webpush Unsubscribe Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/webpush/send-test": {
+      "post": {
+        "tags": [
+          "webpush"
+        ],
+        "summary": "Send Test",
+        "operationId": "send_test_webpush_send_test_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/PushTestRequest"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Payload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SendTestResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/webpush/admin/disable-user": {
+      "post": {
+        "tags": [
+          "webpush"
+        ],
+        "summary": "Disable User Push",
+        "operationId": "disable_user_push_webpush_admin_disable_user_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DisableUserPushRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "boolean"
+                      }
+                    ]
+                  },
+                  "type": "object",
+                  "title": "Response Disable User Push Webpush Admin Disable User Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/webpush/broadcast": {
+      "post": {
+        "tags": [
+          "webpush"
+        ],
+        "summary": "Broadcast",
+        "operationId": "broadcast_webpush_broadcast_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NotifyBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SendTestResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    }
+  },
   "components": {
     "schemas": {
       "ActiveSessionOut": {
         "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "user_id": {
+            "type": "integer",
+            "title": "User Id"
+          },
+          "jti": {
+            "type": "string",
+            "title": "Jti"
+          },
           "created_at": {
+            "type": "string",
             "format": "date-time",
-            "title": "Created At",
-            "type": "string"
+            "title": "Created At"
           },
           "expires_at": {
+            "type": "string",
             "format": "date-time",
-            "title": "Expires At",
-            "type": "string"
+            "title": "Expires At"
           },
-          "id": {
-            "title": "Id",
-            "type": "integer"
+          "revoked_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Revoked At"
           },
           "ip_address": {
             "anyOf": [
@@ -28,20 +4816,22 @@
             ],
             "title": "Ip Address"
           },
-          "is_current": {
-            "default": false,
-            "title": "Is Current",
-            "type": "boolean"
-          },
-          "jti": {
-            "title": "Jti",
-            "type": "string"
+          "user_agent": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Agent"
           },
           "last_seen_at": {
             "anyOf": [
               {
-                "format": "date-time",
-                "type": "string"
+                "type": "string",
+                "format": "date-time"
               },
               {
                 "type": "null"
@@ -49,11 +4839,16 @@
             ],
             "title": "Last Seen At"
           },
+          "mfa_required": {
+            "type": "boolean",
+            "title": "Mfa Required",
+            "default": false
+          },
           "mfa_completed_at": {
             "anyOf": [
               {
-                "format": "date-time",
-                "type": "string"
+                "type": "string",
+                "format": "date-time"
               },
               {
                 "type": "null"
@@ -72,16 +4867,11 @@
             ],
             "title": "Mfa Method"
           },
-          "mfa_required": {
-            "default": false,
-            "title": "Mfa Required",
-            "type": "boolean"
-          },
           "mfa_verified_at": {
             "anyOf": [
               {
-                "format": "date-time",
-                "type": "string"
+                "type": "string",
+                "format": "date-time"
               },
               {
                 "type": "null"
@@ -89,34 +4879,13 @@
             ],
             "title": "Mfa Verified At"
           },
-          "revoked_at": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Revoked At"
-          },
-          "user_agent": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "User Agent"
-          },
-          "user_id": {
-            "title": "User Id",
-            "type": "integer"
+          "is_current": {
+            "type": "boolean",
+            "title": "Is Current",
+            "default": false
           }
         },
+        "type": "object",
         "required": [
           "id",
           "user_id",
@@ -124,54 +4893,53 @@
           "created_at",
           "expires_at"
         ],
-        "title": "ActiveSessionOut",
-        "type": "object"
+        "title": "ActiveSessionOut"
       },
       "AdminUserTopicsResponse": {
         "properties": {
-          "allowed_topics": {
-            "items": {
-              "type": "string"
-            },
-            "title": "Allowed Topics",
-            "type": "array"
+          "user_id": {
+            "type": "integer",
+            "title": "User Id"
           },
           "email": {
-            "title": "Email",
-            "type": "string"
+            "type": "string",
+            "title": "Email"
           },
           "topics": {
             "items": {
               "type": "string"
             },
-            "title": "Topics",
-            "type": "array"
+            "type": "array",
+            "title": "Topics"
+          },
+          "allowed_topics": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Allowed Topics"
           },
           "updated_at": {
             "anyOf": [
               {
-                "format": "date-time",
-                "type": "string"
+                "type": "string",
+                "format": "date-time"
               },
               {
                 "type": "null"
               }
             ],
             "title": "Updated At"
-          },
-          "user_id": {
-            "title": "User Id",
-            "type": "integer"
           }
         },
+        "type": "object",
         "required": [
           "user_id",
           "email",
           "topics",
           "allowed_topics"
         ],
-        "title": "AdminUserTopicsResponse",
-        "type": "object"
+        "title": "AdminUserTopicsResponse"
       },
       "AdminUserTopicsUpdate": {
         "properties": {
@@ -179,36 +4947,37 @@
             "items": {
               "type": "string"
             },
-            "title": "Topics",
-            "type": "array"
+            "type": "array",
+            "title": "Topics"
           }
         },
-        "title": "AdminUserTopicsUpdate",
-        "type": "object"
+        "type": "object",
+        "title": "AdminUserTopicsUpdate"
       },
       "AttachmentResponse": {
         "properties": {
-          "file_type": {
-            "title": "File Type",
-            "type": "string"
-          },
-          "filename": {
-            "title": "Filename",
-            "type": "string"
-          },
           "id": {
-            "title": "Id",
-            "type": "string"
-          },
-          "size": {
-            "title": "Size",
-            "type": "integer"
+            "type": "string",
+            "title": "Id"
           },
           "url": {
-            "title": "Url",
-            "type": "string"
+            "type": "string",
+            "title": "Url"
+          },
+          "file_type": {
+            "type": "string",
+            "title": "File Type"
+          },
+          "filename": {
+            "type": "string",
+            "title": "Filename"
+          },
+          "size": {
+            "type": "integer",
+            "title": "Size"
           }
         },
+        "type": "object",
         "required": [
           "id",
           "url",
@@ -216,11 +4985,41 @@
           "filename",
           "size"
         ],
-        "title": "AttachmentResponse",
-        "type": "object"
+        "title": "AttachmentResponse"
       },
       "Body_login_api_v1_auth_login_post": {
         "properties": {
+          "trust_device": {
+            "type": "boolean",
+            "title": "Trust Device",
+            "default": false
+          },
+          "grant_type": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^password$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Grant Type"
+          },
+          "username": {
+            "type": "string",
+            "title": "Username"
+          },
+          "password": {
+            "type": "string",
+            "format": "password",
+            "title": "Password"
+          },
+          "scope": {
+            "type": "string",
+            "title": "Scope",
+            "default": ""
+          },
           "client_id": {
             "anyOf": [
               {
@@ -243,167 +5042,177 @@
             ],
             "format": "password",
             "title": "Client Secret"
-          },
-          "grant_type": {
-            "anyOf": [
-              {
-                "pattern": "^password$",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Grant Type"
-          },
-          "password": {
-            "format": "password",
-            "title": "Password",
-            "type": "string"
-          },
-          "scope": {
-            "default": "",
-            "title": "Scope",
-            "type": "string"
-          },
-          "trust_device": {
-            "default": false,
-            "title": "Trust Device",
-            "type": "boolean"
-          },
-          "username": {
-            "title": "Username",
-            "type": "string"
           }
         },
+        "type": "object",
         "required": [
           "username",
           "password"
         ],
-        "title": "Body_login_api_v1_auth_login_post",
-        "type": "object"
+        "title": "Body_login_api_v1_auth_login_post"
       },
       "Body_send_message_api_v1_chats__chat_id__messages_post": {
         "properties": {
           "content": {
-            "title": "Content",
-            "type": "string"
+            "type": "string",
+            "title": "Content"
           },
           "files": {
-            "default": [],
             "items": {
-              "format": "binary",
-              "type": "string"
+              "type": "string",
+              "format": "binary"
             },
+            "type": "array",
             "title": "Files",
-            "type": "array"
+            "default": []
           }
         },
+        "type": "object",
         "required": [
           "content"
         ],
-        "title": "Body_send_message_api_v1_chats__chat_id__messages_post",
-        "type": "object"
+        "title": "Body_send_message_api_v1_chats__chat_id__messages_post"
       },
       "Body_upload_avatar_api_v1_users_me_avatar_post": {
         "properties": {
           "file": {
+            "type": "string",
             "format": "binary",
-            "title": "File",
-            "type": "string"
+            "title": "File"
           }
         },
+        "type": "object",
         "required": [
           "file"
         ],
-        "title": "Body_upload_avatar_api_v1_users_me_avatar_post",
-        "type": "object"
+        "title": "Body_upload_avatar_api_v1_users_me_avatar_post"
       },
       "Body_upload_cover_api_v1_users_me_cover_post": {
         "properties": {
           "file": {
+            "type": "string",
             "format": "binary",
-            "title": "File",
-            "type": "string"
+            "title": "File"
           }
         },
+        "type": "object",
         "required": [
           "file"
         ],
-        "title": "Body_upload_cover_api_v1_users_me_cover_post",
-        "type": "object"
+        "title": "Body_upload_cover_api_v1_users_me_cover_post"
       },
       "Body_upload_event_file_api_v1_events__id__upload_file_post": {
         "properties": {
           "file": {
+            "type": "string",
             "format": "binary",
-            "title": "File",
-            "type": "string"
+            "title": "File"
           }
         },
+        "type": "object",
         "required": [
           "file"
         ],
-        "title": "Body_upload_event_file_api_v1_events__id__upload_file_post",
-        "type": "object"
+        "title": "Body_upload_event_file_api_v1_events__id__upload_file_post"
       },
       "Body_upload_event_image_api_v1_events_upload_image_post": {
         "properties": {
           "file": {
+            "type": "string",
             "format": "binary",
-            "title": "File",
-            "type": "string"
+            "title": "File"
           }
         },
+        "type": "object",
         "required": [
           "file"
         ],
-        "title": "Body_upload_event_image_api_v1_events_upload_image_post",
-        "type": "object"
+        "title": "Body_upload_event_image_api_v1_events_upload_image_post"
       },
       "Body_upload_news_image_api_v1_news_upload_image_post": {
         "properties": {
           "file": {
+            "type": "string",
             "format": "binary",
-            "title": "File",
-            "type": "string"
+            "title": "File"
           }
         },
+        "type": "object",
         "required": [
           "file"
         ],
-        "title": "Body_upload_news_image_api_v1_news_upload_image_post",
-        "type": "object"
+        "title": "Body_upload_news_image_api_v1_news_upload_image_post"
       },
       "Body_upload_story_cover_api_v1_stories_upload_cover_post": {
         "properties": {
           "file": {
+            "type": "string",
             "format": "binary",
-            "title": "File",
-            "type": "string"
+            "title": "File"
           }
         },
+        "type": "object",
         "required": [
           "file"
         ],
-        "title": "Body_upload_story_cover_api_v1_stories_upload_cover_post",
-        "type": "object"
+        "title": "Body_upload_story_cover_api_v1_stories_upload_cover_post"
       },
       "ChatCreate": {
         "properties": {
           "participant_id": {
-            "title": "Participant Id",
-            "type": "integer"
+            "type": "integer",
+            "title": "Participant Id"
           }
         },
+        "type": "object",
         "required": [
           "participant_id"
         ],
-        "title": "ChatCreate",
-        "type": "object"
+        "title": "ChatCreate"
+      },
+      "ChatMaintenanceResult": {
+        "properties": {
+          "chat_id": {
+            "type": "string",
+            "title": "Chat Id"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "deleted_messages": {
+            "type": "integer",
+            "title": "Deleted Messages",
+            "default": 0
+          },
+          "deleted_attachments": {
+            "type": "integer",
+            "title": "Deleted Attachments",
+            "default": 0
+          }
+        },
+        "type": "object",
+        "required": [
+          "chat_id",
+          "status"
+        ],
+        "title": "ChatMaintenanceResult",
+        "description": "Represents the result of a maintenance operation on a chat."
       },
       "ChatParticipant": {
         "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "email": {
+            "type": "string",
+            "title": "Email"
+          },
+          "full_name": {
+            "type": "string",
+            "title": "Full Name"
+          },
           "avatar_url": {
             "anyOf": [
               {
@@ -415,42 +5224,32 @@
             ],
             "title": "Avatar Url"
           },
-          "email": {
-            "title": "Email",
-            "type": "string"
-          },
-          "full_name": {
-            "title": "Full Name",
-            "type": "string"
-          },
-          "id": {
-            "title": "Id",
-            "type": "integer"
-          },
           "is_active": {
-            "title": "Is Active",
-            "type": "boolean"
+            "type": "boolean",
+            "title": "Is Active"
           }
         },
+        "type": "object",
         "required": [
           "id",
           "email",
           "full_name",
           "is_active"
         ],
-        "title": "ChatParticipant",
-        "type": "object"
+        "title": "ChatParticipant"
       },
       "ChatResponse": {
         "properties": {
-          "created_at": {
-            "format": "date-time",
-            "title": "Created At",
-            "type": "string"
-          },
           "id": {
-            "title": "Id",
-            "type": "string"
+            "type": "string",
+            "title": "Id"
+          },
+          "participants": {
+            "items": {
+              "$ref": "#/components/schemas/ChatParticipant"
+            },
+            "type": "array",
+            "title": "Participants"
           },
           "last_message": {
             "anyOf": [
@@ -462,47 +5261,44 @@
               }
             ]
           },
-          "participants": {
-            "items": {
-              "$ref": "#/components/schemas/ChatParticipant"
-            },
-            "title": "Participants",
-            "type": "array"
-          },
           "unread_count": {
-            "default": 0,
+            "type": "integer",
             "title": "Unread Count",
-            "type": "integer"
+            "default": 0
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
           },
           "updated_at": {
+            "type": "string",
             "format": "date-time",
-            "title": "Updated At",
-            "type": "string"
+            "title": "Updated At"
           }
         },
+        "type": "object",
         "required": [
           "id",
           "participants",
           "created_at",
           "updated_at"
         ],
-        "title": "ChatResponse",
-        "type": "object"
+        "title": "ChatResponse"
       },
       "ChatsListOut": {
-        "description": "Paginated list of chats.",
         "properties": {
-          "has_more": {
-            "default": false,
-            "title": "Has More",
-            "type": "boolean"
-          },
           "items": {
             "items": {
               "$ref": "#/components/schemas/ChatResponse"
             },
-            "title": "Items",
-            "type": "array"
+            "type": "array",
+            "title": "Items"
+          },
+          "has_more": {
+            "type": "boolean",
+            "title": "Has More",
+            "default": false
           },
           "next_cursor": {
             "anyOf": [
@@ -516,49 +5312,146 @@
             "title": "Next Cursor"
           }
         },
+        "type": "object",
         "required": [
           "items"
         ],
         "title": "ChatsListOut",
-        "type": "object"
+        "description": "Paginated list of chats."
+      },
+      "DataDeletionOut": {
+        "properties": {
+          "deleted": {
+            "type": "boolean",
+            "title": "Deleted"
+          },
+          "anonymized_email": {
+            "type": "string",
+            "format": "email",
+            "title": "Anonymized Email"
+          }
+        },
+        "type": "object",
+        "required": [
+          "deleted",
+          "anonymized_email"
+        ],
+        "title": "DataDeletionOut"
+      },
+      "DataDeletionRequest": {
+        "properties": {
+          "confirm": {
+            "type": "boolean",
+            "title": "Confirm",
+            "description": "Explicit consent to remove personal data"
+          }
+        },
+        "type": "object",
+        "required": [
+          "confirm"
+        ],
+        "title": "DataDeletionRequest"
+      },
+      "DataExportOut": {
+        "properties": {
+          "profile": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Profile"
+          },
+          "sessions": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": "array",
+            "title": "Sessions"
+          },
+          "notifications": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": "array",
+            "title": "Notifications"
+          },
+          "mfa_challenges": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": "array",
+            "title": "Mfa Challenges"
+          },
+          "mfa_enrollments": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": "array",
+            "title": "Mfa Enrollments"
+          },
+          "access_logs": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": "array",
+            "title": "Access Logs"
+          }
+        },
+        "type": "object",
+        "required": [
+          "profile"
+        ],
+        "title": "DataExportOut"
       },
       "DisableUserPushRequest": {
         "properties": {
           "user_id": {
-            "description": "User ID for which push notifications should be disabled",
+            "type": "integer",
             "minimum": 1.0,
             "title": "User Id",
-            "type": "integer"
+            "description": "User ID for which push notifications should be disabled"
           }
         },
+        "type": "object",
         "required": [
           "user_id"
         ],
-        "title": "DisableUserPushRequest",
-        "type": "object"
+        "title": "DisableUserPushRequest"
       },
       "EventAttendanceCreate": {
         "properties": {
           "event_id": {
-            "title": "Event Id",
-            "type": "integer"
+            "type": "integer",
+            "title": "Event Id"
           }
         },
+        "type": "object",
         "required": [
           "event_id"
         ],
-        "title": "EventAttendanceCreate",
-        "type": "object"
+        "title": "EventAttendanceCreate"
       },
       "EventAttendanceOut": {
         "properties": {
-          "event_id": {
-            "title": "Event Id",
-            "type": "integer"
-          },
           "id": {
-            "title": "Id",
-            "type": "integer"
+            "type": "integer",
+            "title": "Id"
+          },
+          "user_id": {
+            "type": "integer",
+            "title": "User Id"
+          },
+          "event_id": {
+            "type": "integer",
+            "title": "Event Id"
+          },
+          "registered_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Registered At"
           },
           "qr_token": {
             "anyOf": [
@@ -570,49 +5463,22 @@
               }
             ],
             "title": "Qr Token"
-          },
-          "registered_at": {
-            "format": "date-time",
-            "title": "Registered At",
-            "type": "string"
-          },
-          "user_id": {
-            "title": "User Id",
-            "type": "integer"
           }
         },
+        "type": "object",
         "required": [
           "id",
           "user_id",
           "event_id",
           "registered_at"
         ],
-        "title": "EventAttendanceOut",
-        "type": "object"
+        "title": "EventAttendanceOut"
       },
       "EventCreate": {
         "properties": {
-          "about": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "About"
-          },
-          "about_en": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "About En"
+          "title": {
+            "type": "string",
+            "title": "Title"
           },
           "description": {
             "anyOf": [
@@ -625,6 +5491,17 @@
             ],
             "title": "Description"
           },
+          "title_en": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title En"
+          },
           "description_en": {
             "anyOf": [
               {
@@ -635,44 +5512,6 @@
               }
             ],
             "title": "Description En"
-          },
-          "ends_at": {
-            "format": "date-time",
-            "title": "Ends At",
-            "type": "string"
-          },
-          "event_type": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Event Type"
-          },
-          "event_type_en": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Event Type En"
-          },
-          "image_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Image Url"
           },
           "location": {
             "anyOf": [
@@ -696,6 +5535,38 @@
             ],
             "title": "Location En"
           },
+          "event_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Event Type"
+          },
+          "event_type_en": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Event Type En"
+          },
+          "starts_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Starts At"
+          },
+          "ends_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Ends At"
+          },
           "speaker": {
             "anyOf": [
               {
@@ -707,16 +5578,7 @@
             ],
             "title": "Speaker"
           },
-          "starts_at": {
-            "format": "date-time",
-            "title": "Starts At",
-            "type": "string"
-          },
-          "title": {
-            "title": "Title",
-            "type": "string"
-          },
-          "title_en": {
+          "image_url": {
             "anyOf": [
               {
                 "type": "string"
@@ -725,53 +5587,8 @@
                 "type": "null"
               }
             ],
-            "title": "Title En"
-          }
-        },
-        "required": [
-          "title",
-          "starts_at",
-          "ends_at"
-        ],
-        "title": "EventCreate",
-        "type": "object"
-      },
-      "EventFileOut": {
-        "properties": {
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Description"
+            "title": "Image Url"
           },
-          "event_id": {
-            "title": "Event Id",
-            "type": "integer"
-          },
-          "file_url": {
-            "title": "File Url",
-            "type": "string"
-          },
-          "id": {
-            "title": "Id",
-            "type": "integer"
-          }
-        },
-        "required": [
-          "id",
-          "event_id",
-          "file_url"
-        ],
-        "title": "EventFileOut",
-        "type": "object"
-      },
-      "EventOut": {
-        "properties": {
           "about": {
             "anyOf": [
               {
@@ -793,15 +5610,59 @@
               }
             ],
             "title": "About En"
+          }
+        },
+        "type": "object",
+        "required": [
+          "title",
+          "starts_at",
+          "ends_at"
+        ],
+        "title": "EventCreate"
+      },
+      "EventFileOut": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
           },
-          "created_at": {
-            "format": "date-time",
-            "title": "Created At",
-            "type": "string"
+          "event_id": {
+            "type": "integer",
+            "title": "Event Id"
           },
-          "created_by": {
-            "title": "Created By",
-            "type": "integer"
+          "file_url": {
+            "type": "string",
+            "title": "File Url"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "event_id",
+          "file_url"
+        ],
+        "title": "EventFileOut"
+      },
+      "EventOut": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
           },
           "description": {
             "anyOf": [
@@ -814,6 +5675,17 @@
             ],
             "title": "Description"
           },
+          "title_en": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title En"
+          },
           "description_en": {
             "anyOf": [
               {
@@ -825,10 +5697,27 @@
             ],
             "title": "Description En"
           },
-          "ends_at": {
-            "format": "date-time",
-            "title": "Ends At",
-            "type": "string"
+          "location": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Location"
+          },
+          "location_en": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Location En"
           },
           "event_type": {
             "anyOf": [
@@ -852,16 +5741,39 @@
             ],
             "title": "Event Type En"
           },
-          "files": {
-            "items": {
-              "$ref": "#/components/schemas/EventFileOut"
-            },
-            "title": "Files",
-            "type": "array"
+          "starts_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Starts At"
           },
-          "id": {
-            "title": "Id",
-            "type": "integer"
+          "ends_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Ends At"
+          },
+          "created_by": {
+            "type": "integer",
+            "title": "Created By"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active"
+          },
+          "speaker": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Speaker"
           },
           "image_url": {
             "anyOf": [
@@ -874,9 +5786,39 @@
             ],
             "title": "Image Url"
           },
-          "is_active": {
-            "title": "Is Active",
-            "type": "boolean"
+          "about": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "About"
+          },
+          "about_en": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "About En"
+          },
+          "files": {
+            "items": {
+              "$ref": "#/components/schemas/EventFileOut"
+            },
+            "type": "array",
+            "title": "Files"
+          },
+          "participant_count": {
+            "type": "integer",
+            "title": "Participant Count",
+            "default": 0
           },
           "is_registered": {
             "anyOf": [
@@ -889,6 +5831,76 @@
             ],
             "title": "Is Registered"
           },
+          "my_qr_token": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "My Qr Token"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "title",
+          "starts_at",
+          "ends_at",
+          "created_by",
+          "created_at",
+          "is_active"
+        ],
+        "title": "EventOut"
+      },
+      "EventUpdate": {
+        "properties": {
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "title_en": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title En"
+          },
+          "description_en": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description En"
+          },
           "location": {
             "anyOf": [
               {
@@ -910,124 +5922,6 @@
               }
             ],
             "title": "Location En"
-          },
-          "my_qr_token": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "My Qr Token"
-          },
-          "participant_count": {
-            "default": 0,
-            "title": "Participant Count",
-            "type": "integer"
-          },
-          "speaker": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Speaker"
-          },
-          "starts_at": {
-            "format": "date-time",
-            "title": "Starts At",
-            "type": "string"
-          },
-          "title": {
-            "title": "Title",
-            "type": "string"
-          },
-          "title_en": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Title En"
-          }
-        },
-        "required": [
-          "id",
-          "title",
-          "starts_at",
-          "ends_at",
-          "created_by",
-          "created_at",
-          "is_active"
-        ],
-        "title": "EventOut",
-        "type": "object"
-      },
-      "EventUpdate": {
-        "properties": {
-          "about": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "About"
-          },
-          "about_en": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "About En"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Description"
-          },
-          "description_en": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Description En"
-          },
-          "ends_at": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Ends At"
           },
           "event_type": {
             "anyOf": [
@@ -1051,16 +5945,29 @@
             ],
             "title": "Event Type En"
           },
-          "image_url": {
+          "starts_at": {
             "anyOf": [
               {
-                "type": "string"
+                "type": "string",
+                "format": "date-time"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Image Url"
+            "title": "Starts At"
+          },
+          "ends_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ends At"
           },
           "is_active": {
             "anyOf": [
@@ -1073,28 +5980,6 @@
             ],
             "title": "Is Active"
           },
-          "location": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Location"
-          },
-          "location_en": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Location En"
-          },
           "speaker": {
             "anyOf": [
               {
@@ -1106,19 +5991,18 @@
             ],
             "title": "Speaker"
           },
-          "starts_at": {
+          "image_url": {
             "anyOf": [
               {
-                "format": "date-time",
                 "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Starts At"
+            "title": "Image Url"
           },
-          "title": {
+          "about": {
             "anyOf": [
               {
                 "type": "string"
@@ -1127,9 +6011,9 @@
                 "type": "null"
               }
             ],
-            "title": "Title"
+            "title": "About"
           },
-          "title_en": {
+          "about_en": {
             "anyOf": [
               {
                 "type": "string"
@@ -1138,28 +6022,36 @@
                 "type": "null"
               }
             ],
-            "title": "Title En"
+            "title": "About En"
           }
         },
-        "title": "EventUpdate",
-        "type": "object"
+        "type": "object",
+        "title": "EventUpdate"
       },
       "ForgotPasswordIn": {
         "properties": {
           "email": {
+            "type": "string",
             "format": "email",
-            "title": "Email",
-            "type": "string"
+            "title": "Email"
           }
         },
+        "type": "object",
         "required": [
           "email"
         ],
-        "title": "ForgotPasswordIn",
-        "type": "object"
+        "title": "ForgotPasswordIn"
       },
       "GroupOut": {
         "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
           "course": {
             "anyOf": [
               {
@@ -1181,22 +6073,14 @@
               }
             ],
             "title": "Faculty"
-          },
-          "id": {
-            "title": "Id",
-            "type": "integer"
-          },
-          "name": {
-            "title": "Name",
-            "type": "string"
           }
         },
+        "type": "object",
         "required": [
           "id",
           "name"
         ],
-        "title": "GroupOut",
-        "type": "object"
+        "title": "GroupOut"
       },
       "HTTPValidationError": {
         "properties": {
@@ -1204,67 +6088,63 @@
             "items": {
               "$ref": "#/components/schemas/ValidationError"
             },
-            "title": "Detail",
-            "type": "array"
+            "type": "array",
+            "title": "Detail"
           }
         },
-        "title": "HTTPValidationError",
-        "type": "object"
+        "type": "object",
+        "title": "HTTPValidationError"
       },
       "LoginIn": {
         "properties": {
           "email": {
+            "type": "string",
             "format": "email",
-            "title": "Email",
-            "type": "string"
+            "title": "Email"
           },
           "password": {
-            "title": "Password",
-            "type": "string"
+            "type": "string",
+            "title": "Password"
           },
           "trust_device": {
-            "default": false,
+            "type": "boolean",
             "title": "Trust Device",
-            "type": "boolean"
+            "default": false
           }
         },
+        "type": "object",
         "required": [
           "email",
           "password"
         ],
-        "title": "LoginIn",
-        "type": "object"
+        "title": "LoginIn"
       },
       "MessageResponse": {
         "properties": {
-          "attachments": {
-            "default": [],
-            "items": {
-              "$ref": "#/components/schemas/AttachmentResponse"
-            },
-            "title": "Attachments",
-            "type": "array"
-          },
-          "chat_id": {
-            "title": "Chat Id",
-            "type": "string"
-          },
           "content": {
-            "title": "Content",
-            "type": "string"
-          },
-          "created_at": {
-            "format": "date-time",
-            "title": "Created At",
-            "type": "string"
+            "type": "string",
+            "title": "Content"
           },
           "id": {
-            "title": "Id",
-            "type": "string"
+            "type": "string",
+            "title": "Id"
+          },
+          "chat_id": {
+            "type": "string",
+            "title": "Chat Id"
+          },
+          "sender_id": {
+            "type": "integer",
+            "title": "Sender Id"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
           },
           "read_status": {
-            "title": "Read Status",
-            "type": "boolean"
+            "type": "boolean",
+            "title": "Read Status"
           },
           "sender": {
             "anyOf": [
@@ -1276,11 +6156,16 @@
               }
             ]
           },
-          "sender_id": {
-            "title": "Sender Id",
-            "type": "integer"
+          "attachments": {
+            "items": {
+              "$ref": "#/components/schemas/AttachmentResponse"
+            },
+            "type": "array",
+            "title": "Attachments",
+            "default": []
           }
         },
+        "type": "object",
         "required": [
           "content",
           "id",
@@ -1289,23 +6174,21 @@
           "created_at",
           "read_status"
         ],
-        "title": "MessageResponse",
-        "type": "object"
+        "title": "MessageResponse"
       },
       "MessagesListOut": {
-        "description": "Paginated list of messages.",
         "properties": {
-          "has_more": {
-            "default": false,
-            "title": "Has More",
-            "type": "boolean"
-          },
           "items": {
             "items": {
               "$ref": "#/components/schemas/MessageResponse"
             },
-            "title": "Items",
-            "type": "array"
+            "type": "array",
+            "title": "Items"
+          },
+          "has_more": {
+            "type": "boolean",
+            "title": "Has More",
+            "default": false
           },
           "next_cursor": {
             "anyOf": [
@@ -1319,28 +6202,52 @@
             "title": "Next Cursor"
           }
         },
+        "type": "object",
         "required": [
           "items"
         ],
         "title": "MessagesListOut",
-        "type": "object"
+        "description": "Paginated list of messages."
       },
       "MfaChallengeOut": {
         "properties": {
-          "attempt_count": {
-            "default": 0,
-            "title": "Attempt Count",
-            "type": "integer"
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "user_id": {
+            "type": "integer",
+            "title": "User Id"
+          },
+          "session_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Session Id"
           },
           "challenge_type": {
-            "title": "Challenge Type",
-            "type": "string"
+            "type": "string",
+            "title": "Challenge Type"
+          },
+          "token": {
+            "type": "string",
+            "title": "Token"
+          },
+          "expires_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Expires At"
           },
           "consumed_at": {
             "anyOf": [
               {
-                "format": "date-time",
-                "type": "string"
+                "type": "string",
+                "format": "date-time"
               },
               {
                 "type": "null"
@@ -1349,18 +6256,9 @@
             "title": "Consumed At"
           },
           "created_at": {
+            "type": "string",
             "format": "date-time",
-            "title": "Created At",
-            "type": "string"
-          },
-          "expires_at": {
-            "format": "date-time",
-            "title": "Expires At",
-            "type": "string"
-          },
-          "id": {
-            "title": "Id",
-            "type": "integer"
+            "title": "Created At"
           },
           "payload": {
             "anyOf": [
@@ -1374,26 +6272,13 @@
             ],
             "title": "Payload"
           },
-          "session_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Session Id"
-          },
-          "token": {
-            "title": "Token",
-            "type": "string"
-          },
-          "user_id": {
-            "title": "User Id",
-            "type": "integer"
+          "attempt_count": {
+            "type": "integer",
+            "title": "Attempt Count",
+            "default": 0
           }
         },
+        "type": "object",
         "required": [
           "id",
           "user_id",
@@ -1402,14 +6287,13 @@
           "expires_at",
           "created_at"
         ],
-        "title": "MfaChallengeOut",
-        "type": "object"
+        "title": "MfaChallengeOut"
       },
       "MfaFactorStatusOut": {
         "properties": {
           "disabled": {
-            "title": "Disabled",
-            "type": "boolean"
+            "type": "boolean",
+            "title": "Disabled"
           },
           "mfa_default_method": {
             "anyOf": [
@@ -1423,19 +6307,45 @@
             "title": "Mfa Default Method"
           },
           "mfa_required": {
-            "default": false,
+            "type": "boolean",
             "title": "Mfa Required",
-            "type": "boolean"
+            "default": false
           }
         },
+        "type": "object",
         "required": [
           "disabled"
         ],
-        "title": "MfaFactorStatusOut",
-        "type": "object"
+        "title": "MfaFactorStatusOut"
       },
       "MfaMethodChallengeOut": {
         "properties": {
+          "method": {
+            "type": "string",
+            "const": "totp",
+            "title": "Method"
+          },
+          "challenge_token": {
+            "type": "string",
+            "title": "Challenge Token"
+          },
+          "challenge_expires_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Challenge Expires At"
+          },
+          "options": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Options"
+          },
           "attempt_count": {
             "anyOf": [
               {
@@ -1458,32 +6368,6 @@
             ],
             "title": "Attempt Limit"
           },
-          "challenge_expires_at": {
-            "format": "date-time",
-            "title": "Challenge Expires At",
-            "type": "string"
-          },
-          "challenge_token": {
-            "title": "Challenge Token",
-            "type": "string"
-          },
-          "method": {
-            "const": "totp",
-            "title": "Method",
-            "type": "string"
-          },
-          "options": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Options"
-          },
           "remaining_attempts": {
             "anyOf": [
               {
@@ -1496,40 +6380,23 @@
             "title": "Remaining Attempts"
           }
         },
+        "type": "object",
         "required": [
           "method",
           "challenge_token",
           "challenge_expires_at"
         ],
-        "title": "MfaMethodChallengeOut",
-        "type": "object"
+        "title": "MfaMethodChallengeOut"
       },
       "MfaTotpEnrollmentOut": {
         "properties": {
-          "confirmed_at": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Confirmed At"
-          },
-          "created_at": {
-            "format": "date-time",
-            "title": "Created At",
-            "type": "string"
-          },
           "id": {
-            "title": "Id",
-            "type": "integer"
+            "type": "integer",
+            "title": "Id"
           },
-          "is_active": {
-            "title": "Is Active",
-            "type": "boolean"
+          "user_id": {
+            "type": "integer",
+            "title": "User Id"
           },
           "label": {
             "anyOf": [
@@ -1542,11 +6409,27 @@
             ],
             "title": "Label"
           },
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active"
+          },
+          "confirmed_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Confirmed At"
+          },
           "revoked_at": {
             "anyOf": [
               {
-                "format": "date-time",
-                "type": "string"
+                "type": "string",
+                "format": "date-time"
               },
               {
                 "type": "null"
@@ -1554,25 +6437,31 @@
             ],
             "title": "Revoked At"
           },
-          "user_id": {
-            "title": "User Id",
-            "type": "integer"
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
           }
         },
+        "type": "object",
         "required": [
           "id",
           "user_id",
           "is_active",
           "created_at"
         ],
-        "title": "MfaTotpEnrollmentOut",
-        "type": "object"
+        "title": "MfaTotpEnrollmentOut"
       },
       "MfaVerifyIn": {
         "properties": {
+          "method": {
+            "type": "string",
+            "const": "totp",
+            "title": "Method"
+          },
           "challenge_token": {
-            "title": "Challenge Token",
-            "type": "string"
+            "type": "string",
+            "title": "Challenge Token"
           },
           "code": {
             "anyOf": [
@@ -1585,29 +6474,39 @@
             ],
             "title": "Code"
           },
-          "method": {
-            "const": "totp",
-            "title": "Method",
-            "type": "string"
-          },
           "trust_device": {
-            "default": false,
+            "type": "boolean",
             "title": "Trust Device",
-            "type": "boolean"
+            "default": false
           }
         },
+        "type": "object",
         "required": [
           "method",
           "challenge_token"
         ],
-        "title": "MfaVerifyIn",
-        "type": "object"
+        "title": "MfaVerifyIn"
       },
       "NewsCreate": {
         "properties": {
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
           "content": {
-            "title": "Content",
-            "type": "string"
+            "type": "string",
+            "title": "Content"
+          },
+          "title_en": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title En"
           },
           "content_en": {
             "anyOf": [
@@ -1630,35 +6529,35 @@
               }
             ],
             "title": "Image Url"
-          },
-          "title": {
-            "title": "Title",
-            "type": "string"
-          },
-          "title_en": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Title En"
           }
         },
+        "type": "object",
         "required": [
           "title",
           "content"
         ],
-        "title": "NewsCreate",
-        "type": "object"
+        "title": "NewsCreate"
       },
       "NewsOut": {
         "properties": {
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
           "content": {
-            "title": "Content",
-            "type": "string"
+            "type": "string",
+            "title": "Content"
+          },
+          "title_en": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title En"
           },
           "content_en": {
             "anyOf": [
@@ -1671,15 +6570,6 @@
             ],
             "title": "Content En"
           },
-          "created_at": {
-            "format": "date-time",
-            "title": "Created At",
-            "type": "string"
-          },
-          "id": {
-            "title": "Id",
-            "type": "integer"
-          },
           "image_url": {
             "anyOf": [
               {
@@ -1691,66 +6581,27 @@
             ],
             "title": "Image Url"
           },
-          "title": {
-            "title": "Title",
-            "type": "string"
+          "id": {
+            "type": "integer",
+            "title": "Id"
           },
-          "title_en": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Title En"
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
           }
         },
+        "type": "object",
         "required": [
           "title",
           "content",
           "id",
           "created_at"
         ],
-        "title": "NewsOut",
-        "type": "object"
+        "title": "NewsOut"
       },
       "NewsUpdate": {
         "properties": {
-          "content": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Content"
-          },
-          "content_en": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Content En"
-          },
-          "image_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Image Url"
-          },
           "title": {
             "anyOf": [
               {
@@ -1762,6 +6613,17 @@
             ],
             "title": "Title"
           },
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Content"
+          },
           "title_en": {
             "anyOf": [
               {
@@ -1772,19 +6634,8 @@
               }
             ],
             "title": "Title En"
-          }
-        },
-        "title": "NewsUpdate",
-        "type": "object"
-      },
-      "NotificationAction": {
-        "properties": {
-          "action": {
-            "description": "Notification action identifier",
-            "title": "Action",
-            "type": "string"
           },
-          "icon": {
+          "content_en": {
             "anyOf": [
               {
                 "type": "string"
@@ -1793,13 +6644,34 @@
                 "type": "null"
               }
             ],
-            "description": "Optional icon URL",
-            "title": "Icon"
+            "title": "Content En"
+          },
+          "image_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Image Url"
+          }
+        },
+        "type": "object",
+        "title": "NewsUpdate"
+      },
+      "NotificationAction": {
+        "properties": {
+          "action": {
+            "type": "string",
+            "title": "Action",
+            "description": "Notification action identifier"
           },
           "title": {
-            "description": "Action button title",
+            "type": "string",
             "title": "Title",
-            "type": "string"
+            "description": "Action button title"
           },
           "url": {
             "anyOf": [
@@ -1810,19 +6682,39 @@
                 "type": "null"
               }
             ],
-            "description": "Optional URL to open",
-            "title": "Url"
+            "title": "Url",
+            "description": "Optional URL to open"
+          },
+          "icon": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Icon",
+            "description": "Optional icon URL"
           }
         },
+        "type": "object",
         "required": [
           "action",
           "title"
         ],
-        "title": "NotificationAction",
-        "type": "object"
+        "title": "NotificationAction"
       },
       "NotificationOut": {
         "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
           "body": {
             "anyOf": [
               {
@@ -1834,46 +6726,6 @@
             ],
             "title": "Body"
           },
-          "body_en": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Body En"
-          },
-          "created_at": {
-            "format": "date-time",
-            "title": "Created At",
-            "type": "string"
-          },
-          "id": {
-            "title": "Id",
-            "type": "integer"
-          },
-          "read": {
-            "title": "Read",
-            "type": "boolean"
-          },
-          "read_at": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Read At"
-          },
-          "title": {
-            "title": "Title",
-            "type": "string"
-          },
           "title_en": {
             "anyOf": [
               {
@@ -1884,6 +6736,17 @@
               }
             ],
             "title": "Title En"
+          },
+          "body_en": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Body En"
           },
           "type": {
             "anyOf": [
@@ -1906,29 +6769,54 @@
               }
             ],
             "title": "Url"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "read": {
+            "type": "boolean",
+            "title": "Read"
+          },
+          "read_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Read At"
           }
         },
+        "type": "object",
         "required": [
           "id",
           "title",
           "created_at",
           "read"
         ],
-        "title": "NotificationOut",
-        "type": "object"
+        "title": "NotificationOut"
       },
       "NotificationsListOut": {
         "properties": {
-          "has_more": {
-            "title": "Has More",
-            "type": "boolean"
-          },
           "items": {
             "items": {
               "$ref": "#/components/schemas/NotificationOut"
             },
-            "title": "Items",
-            "type": "array"
+            "type": "array",
+            "title": "Items"
+          },
+          "unread_count": {
+            "type": "integer",
+            "title": "Unread Count"
+          },
+          "has_more": {
+            "type": "boolean",
+            "title": "Has More"
           },
           "next_cursor": {
             "anyOf": [
@@ -1940,22 +6828,111 @@
               }
             ],
             "title": "Next Cursor"
-          },
-          "unread_count": {
-            "title": "Unread Count",
-            "type": "integer"
           }
         },
+        "type": "object",
         "required": [
           "items",
           "unread_count",
           "has_more"
         ],
-        "title": "NotificationsListOut",
-        "type": "object"
+        "title": "NotificationsListOut"
       },
       "NotifyBody": {
         "properties": {
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "body": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Body"
+          },
+          "url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Url"
+          },
+          "tag": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tag"
+          },
+          "badge": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Badge"
+          },
+          "type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Type"
+          },
+          "ttl": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ttl"
+          },
+          "urgency": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Urgency",
+            "default": "normal"
+          },
+          "topic": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Topic"
+          },
           "actions": {
             "anyOf": [
               {
@@ -1970,28 +6947,6 @@
             ],
             "title": "Actions"
           },
-          "badge": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Badge"
-          },
-          "body": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Body"
-          },
           "data": {
             "anyOf": [
               {
@@ -2003,123 +6958,22 @@
               }
             ],
             "title": "Data"
-          },
-          "tag": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Tag"
-          },
-          "title": {
-            "title": "Title",
-            "type": "string"
-          },
-          "topic": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Topic"
-          },
-          "ttl": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Ttl"
-          },
-          "type": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Type"
-          },
-          "urgency": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": "normal",
-            "title": "Urgency"
-          },
-          "url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Url"
           }
         },
+        "type": "object",
         "required": [
           "title"
         ],
-        "title": "NotifyBody",
-        "type": "object"
+        "title": "NotifyBody"
       },
       "PaginatedEvents": {
         "properties": {
-          "cursor": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Cursor"
-          },
-          "has_more": {
-            "title": "Has More",
-            "type": "boolean"
-          },
           "items": {
             "items": {
               "$ref": "#/components/schemas/EventOut"
             },
-            "title": "Items",
-            "type": "array"
-          },
-          "limit": {
-            "title": "Limit",
-            "type": "integer"
-          },
-          "next_cursor": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Next Cursor"
+            "type": "array",
+            "title": "Items"
           },
           "total": {
             "anyOf": [
@@ -2131,29 +6985,58 @@
               }
             ],
             "title": "Total"
+          },
+          "limit": {
+            "type": "integer",
+            "title": "Limit"
+          },
+          "cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cursor"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Cursor"
+          },
+          "has_more": {
+            "type": "boolean",
+            "title": "Has More"
           }
         },
+        "type": "object",
         "required": [
           "items",
           "limit",
           "has_more"
         ],
-        "title": "PaginatedEvents",
-        "type": "object"
+        "title": "PaginatedEvents"
       },
       "PaginatedNews": {
-        "description": "Paginated news response with cursor-based pagination.",
         "properties": {
-          "has_more": {
-            "title": "Has More",
-            "type": "boolean"
-          },
           "items": {
             "items": {
               "$ref": "#/components/schemas/NewsOut"
             },
-            "title": "Items",
-            "type": "array"
+            "type": "array",
+            "title": "Items"
+          },
+          "has_more": {
+            "type": "boolean",
+            "title": "Has More"
           },
           "next_cursor": {
             "anyOf": [
@@ -2167,51 +7050,43 @@
             "title": "Next Cursor"
           }
         },
+        "type": "object",
         "required": [
           "items",
           "has_more"
         ],
         "title": "PaginatedNews",
-        "type": "object"
+        "description": "Paginated news response with cursor-based pagination."
       },
       "PasswordChangeOut": {
         "properties": {
           "ok": {
-            "title": "Ok",
-            "type": "boolean"
+            "type": "boolean",
+            "title": "Ok"
           },
           "revoked_sessions": {
-            "default": 0,
+            "type": "integer",
             "title": "Revoked Sessions",
-            "type": "integer"
+            "default": 0
           }
         },
+        "type": "object",
         "required": [
           "ok"
         ],
-        "title": "PasswordChangeOut",
-        "type": "object"
+        "title": "PasswordChangeOut"
       },
       "PendingMfaResponse": {
         "properties": {
-          "default_method": {
-            "anyOf": [
-              {
-                "const": "totp",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Default Method"
+          "status": {
+            "type": "string",
+            "const": "mfa_required",
+            "title": "Status",
+            "default": "mfa_required"
           },
-          "methods": {
-            "items": {
-              "$ref": "#/components/schemas/MfaMethodChallengeOut"
-            },
-            "title": "Methods",
-            "type": "array"
+          "user_id": {
+            "type": "integer",
+            "title": "User Id"
           },
           "session_id": {
             "anyOf": [
@@ -2224,43 +7099,52 @@
             ],
             "title": "Session Id"
           },
-          "status": {
-            "const": "mfa_required",
-            "default": "mfa_required",
-            "title": "Status",
-            "type": "string"
+          "default_method": {
+            "anyOf": [
+              {
+                "type": "string",
+                "const": "totp"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Default Method"
           },
-          "user_id": {
-            "title": "User Id",
-            "type": "integer"
+          "methods": {
+            "items": {
+              "$ref": "#/components/schemas/MfaMethodChallengeOut"
+            },
+            "type": "array",
+            "title": "Methods"
           }
         },
+        "type": "object",
         "required": [
           "user_id",
           "methods"
         ],
-        "title": "PendingMfaResponse",
-        "type": "object"
+        "title": "PendingMfaResponse"
       },
       "PushSubscriptionDelete": {
         "properties": {
           "endpoint": {
-            "title": "Endpoint",
-            "type": "string"
+            "type": "string",
+            "title": "Endpoint"
           }
         },
+        "type": "object",
         "required": [
           "endpoint"
         ],
-        "title": "PushSubscriptionDelete",
-        "type": "object"
+        "title": "PushSubscriptionDelete"
       },
       "PushSubscriptionIn": {
         "properties": {
           "endpoint": {
-            "description": "Push subscription endpoint URL",
+            "type": "string",
             "title": "Endpoint",
-            "type": "string"
+            "description": "Push subscription endpoint URL"
           },
           "keys": {
             "$ref": "#/components/schemas/PushSubscriptionKeys"
@@ -2277,8 +7161,8 @@
                 "type": "null"
               }
             ],
-            "description": "Optional list of topics",
-            "title": "Topics"
+            "title": "Topics",
+            "description": "Optional list of topics"
           },
           "user_agent": {
             "anyOf": [
@@ -2289,61 +7173,80 @@
                 "type": "null"
               }
             ],
-            "description": "User agent override",
-            "title": "User Agent"
+            "title": "User Agent",
+            "description": "User agent override"
           }
         },
+        "type": "object",
         "required": [
           "endpoint",
           "keys"
         ],
-        "title": "PushSubscriptionIn",
-        "type": "object"
+        "title": "PushSubscriptionIn"
       },
       "PushSubscriptionKeys": {
         "properties": {
-          "auth": {
-            "description": "Authentication secret",
-            "title": "Auth",
-            "type": "string"
-          },
           "p256dh": {
-            "description": "Base64-encoded public key",
+            "type": "string",
             "title": "P256Dh",
-            "type": "string"
+            "description": "Base64-encoded public key"
+          },
+          "auth": {
+            "type": "string",
+            "title": "Auth",
+            "description": "Authentication secret"
           }
         },
+        "type": "object",
         "required": [
           "p256dh",
           "auth"
         ],
-        "title": "PushSubscriptionKeys",
-        "type": "object"
+        "title": "PushSubscriptionKeys"
       },
       "PushSubscriptionOut": {
         "properties": {
-          "auth": {
-            "title": "Auth",
-            "type": "string"
+          "id": {
+            "type": "integer",
+            "title": "Id"
           },
-          "created_at": {
-            "format": "date-time",
-            "title": "Created At",
-            "type": "string"
+          "user_id": {
+            "type": "integer",
+            "title": "User Id"
           },
           "endpoint": {
-            "title": "Endpoint",
-            "type": "string"
+            "type": "string",
+            "title": "Endpoint"
           },
-          "id": {
-            "title": "Id",
-            "type": "integer"
+          "p256dh": {
+            "type": "string",
+            "title": "P256Dh"
+          },
+          "auth": {
+            "type": "string",
+            "title": "Auth"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "user_agent": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Agent"
           },
           "last_seen_at": {
             "anyOf": [
               {
-                "format": "date-time",
-                "type": "string"
+                "type": "string",
+                "format": "date-time"
               },
               {
                 "type": "null"
@@ -2351,22 +7254,11 @@
             ],
             "title": "Last Seen At"
           },
-          "p256dh": {
-            "title": "P256Dh",
-            "type": "string"
-          },
-          "topics": {
-            "items": {
-              "type": "string"
-            },
-            "title": "Topics",
-            "type": "array"
-          },
           "updated_at": {
             "anyOf": [
               {
-                "format": "date-time",
-                "type": "string"
+                "type": "string",
+                "format": "date-time"
               },
               {
                 "type": "null"
@@ -2374,22 +7266,15 @@
             ],
             "title": "Updated At"
           },
-          "user_agent": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "User Agent"
-          },
-          "user_id": {
-            "title": "User Id",
-            "type": "integer"
+          "topics": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Topics"
           }
         },
+        "type": "object",
         "required": [
           "id",
           "user_id",
@@ -2398,31 +7283,128 @@
           "auth",
           "created_at"
         ],
-        "title": "PushSubscriptionOut",
-        "type": "object"
+        "title": "PushSubscriptionOut"
       },
       "PushSubscriptionTopicsUpdate": {
         "properties": {
           "endpoint": {
-            "title": "Endpoint",
-            "type": "string"
+            "type": "string",
+            "title": "Endpoint"
           },
           "topics": {
             "items": {
               "type": "string"
             },
-            "title": "Topics",
-            "type": "array"
+            "type": "array",
+            "title": "Topics"
           }
         },
+        "type": "object",
         "required": [
           "endpoint"
         ],
-        "title": "PushSubscriptionTopicsUpdate",
-        "type": "object"
+        "title": "PushSubscriptionTopicsUpdate"
       },
       "PushTestRequest": {
         "properties": {
+          "title": {
+            "type": "string",
+            "title": "Title",
+            "description": "Notification title",
+            "default": "Test web push notification"
+          },
+          "body": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Body",
+            "description": "Notification body",
+            "default": "Delivery check"
+          },
+          "url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Url",
+            "description": "URL to open when clicking the notification"
+          },
+          "tag": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tag"
+          },
+          "badge": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Badge"
+          },
+          "type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Type"
+          },
+          "ttl": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ttl"
+          },
+          "urgency": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Urgency",
+            "default": "normal"
+          },
+          "topic": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Topic"
+          },
           "actions": {
             "anyOf": [
               {
@@ -2437,30 +7419,6 @@
             ],
             "title": "Actions"
           },
-          "badge": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Badge"
-          },
-          "body": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": "Delivery check",
-            "description": "Notification body",
-            "title": "Body"
-          },
           "data": {
             "anyOf": [
               {
@@ -2473,96 +7431,22 @@
             ],
             "title": "Data"
           },
-          "tag": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Tag"
-          },
-          "title": {
-            "default": "Test web push notification",
-            "description": "Notification title",
-            "title": "Title",
-            "type": "string"
-          },
-          "topic": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Topic"
-          },
-          "ttl": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Ttl"
-          },
-          "type": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Type"
-          },
-          "urgency": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": "normal",
-            "title": "Urgency"
-          },
-          "url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "URL to open when clicking the notification",
-            "title": "Url"
-          },
           "user_id": {
             "anyOf": [
               {
-                "minimum": 1.0,
-                "type": "integer"
+                "type": "integer",
+                "minimum": 1.0
               },
               {
                 "type": "null"
               }
             ],
-            "description": "Target user id for testing",
-            "title": "User Id"
+            "title": "User Id",
+            "description": "Target user id for testing"
           }
         },
-        "title": "PushTestRequest",
-        "type": "object"
+        "type": "object",
+        "title": "PushTestRequest"
       },
       "PushTopicsResponse": {
         "properties": {
@@ -2570,26 +7454,26 @@
             "items": {
               "type": "string"
             },
-            "title": "Allowed",
-            "type": "array"
-          },
-          "has_preferences": {
-            "default": false,
-            "title": "Has Preferences",
-            "type": "boolean"
+            "type": "array",
+            "title": "Allowed"
           },
           "topics": {
             "items": {
               "type": "string"
             },
-            "title": "Topics",
-            "type": "array"
+            "type": "array",
+            "title": "Topics"
+          },
+          "has_preferences": {
+            "type": "boolean",
+            "title": "Has Preferences",
+            "default": false
           },
           "updated_at": {
             "anyOf": [
               {
-                "format": "date-time",
-                "type": "string"
+                "type": "string",
+                "format": "date-time"
               },
               {
                 "type": "null"
@@ -2598,86 +7482,42 @@
             "title": "Updated At"
           }
         },
+        "type": "object",
         "required": [
           "allowed",
           "topics"
         ],
-        "title": "PushTopicsResponse",
-        "type": "object"
+        "title": "PushTopicsResponse"
       },
       "ResetPasswordIn": {
         "properties": {
+          "token": {
+            "type": "string",
+            "title": "Token"
+          },
           "password": {
+            "type": "string",
             "maxLength": 200,
             "minLength": 8,
-            "title": "Password",
-            "type": "string"
-          },
-          "token": {
-            "title": "Token",
-            "type": "string"
+            "title": "Password"
           }
         },
+        "type": "object",
         "required": [
           "token",
           "password"
         ],
-        "title": "ResetPasswordIn",
-        "type": "object"
+        "title": "ResetPasswordIn"
       },
       "ScheduleCreate": {
         "properties": {
-          "end_time": {
-            "format": "date-time",
-            "title": "End Time",
-            "type": "string"
-          },
           "group_id": {
-            "title": "Group Id",
-            "type": "integer"
-          },
-          "lesson_type": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Lesson Type"
-          },
-          "parity": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": "both",
-            "title": "Parity"
-          },
-          "room": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Room"
-          },
-          "start_time": {
-            "format": "date-time",
-            "title": "Start Time",
-            "type": "string"
+            "type": "integer",
+            "title": "Group Id"
           },
           "subject": {
-            "title": "Subject",
-            "type": "string"
+            "type": "string",
+            "title": "Subject"
           },
           "teacher": {
             "anyOf": [
@@ -2690,35 +7530,42 @@
             ],
             "title": "Teacher"
           },
+          "room": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Room"
+          },
           "weekday": {
-            "title": "Weekday",
-            "type": "string"
-          }
-        },
-        "required": [
-          "group_id",
-          "subject",
-          "weekday",
-          "start_time",
-          "end_time"
-        ],
-        "title": "ScheduleCreate",
-        "type": "object"
-      },
-      "ScheduleOut": {
-        "properties": {
-          "end_time": {
+            "type": "string",
+            "title": "Weekday"
+          },
+          "start_time": {
+            "type": "string",
             "format": "date-time",
-            "title": "End Time",
-            "type": "string"
+            "title": "Start Time"
           },
-          "group_id": {
-            "title": "Group Id",
-            "type": "integer"
+          "end_time": {
+            "type": "string",
+            "format": "date-time",
+            "title": "End Time"
           },
-          "id": {
-            "title": "Id",
-            "type": "integer"
+          "parity": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Parity",
+            "default": "both"
           },
           "lesson_type": {
             "anyOf": [
@@ -2730,6 +7577,90 @@
               }
             ],
             "title": "Lesson Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "group_id",
+          "subject",
+          "weekday",
+          "start_time",
+          "end_time"
+        ],
+        "title": "ScheduleCreate"
+      },
+      "ScheduleOut": {
+        "properties": {
+          "group_id": {
+            "type": "integer",
+            "title": "Group Id"
+          },
+          "subject": {
+            "type": "string",
+            "title": "Subject"
+          },
+          "teacher": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Teacher"
+          },
+          "room": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Room"
+          },
+          "weekday": {
+            "type": "string",
+            "title": "Weekday"
+          },
+          "start_time": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Start Time"
+          },
+          "end_time": {
+            "type": "string",
+            "format": "date-time",
+            "title": "End Time"
+          },
+          "parity": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Parity",
+            "default": "both"
+          },
+          "lesson_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Lesson Type"
+          },
+          "id": {
+            "type": "integer",
+            "title": "Id"
           },
           "lesson_type_display": {
             "anyOf": [
@@ -2741,55 +7672,9 @@
               }
             ],
             "title": "Lesson Type Display"
-          },
-          "parity": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": "both",
-            "title": "Parity"
-          },
-          "room": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Room"
-          },
-          "start_time": {
-            "format": "date-time",
-            "title": "Start Time",
-            "type": "string"
-          },
-          "subject": {
-            "title": "Subject",
-            "type": "string"
-          },
-          "teacher": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Teacher"
-          },
-          "weekday": {
-            "title": "Weekday",
-            "type": "string"
           }
         },
+        "type": "object",
         "required": [
           "group_id",
           "subject",
@@ -2798,23 +7683,10 @@
           "end_time",
           "id"
         ],
-        "title": "ScheduleOut",
-        "type": "object"
+        "title": "ScheduleOut"
       },
       "ScheduleUpdate": {
         "properties": {
-          "end_time": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "End Time"
-          },
           "group_id": {
             "anyOf": [
               {
@@ -2825,51 +7697,6 @@
               }
             ],
             "title": "Group Id"
-          },
-          "lesson_type": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Lesson Type"
-          },
-          "parity": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Parity"
-          },
-          "room": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Room"
-          },
-          "start_time": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Start Time"
           },
           "subject": {
             "anyOf": [
@@ -2893,6 +7720,17 @@
             ],
             "title": "Teacher"
           },
+          "room": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Room"
+          },
           "weekday": {
             "anyOf": [
               {
@@ -2903,13 +7741,76 @@
               }
             ],
             "title": "Weekday"
+          },
+          "start_time": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Start Time"
+          },
+          "end_time": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "End Time"
+          },
+          "parity": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Parity"
+          },
+          "lesson_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Lesson Type"
           }
         },
-        "title": "ScheduleUpdate",
-        "type": "object"
+        "type": "object",
+        "title": "ScheduleUpdate"
       },
       "SendTestResponse": {
         "properties": {
+          "total": {
+            "type": "integer",
+            "title": "Total",
+            "default": 0
+          },
+          "sent": {
+            "type": "integer",
+            "title": "Sent"
+          },
+          "removed": {
+            "type": "integer",
+            "title": "Removed"
+          },
+          "failed": {
+            "type": "integer",
+            "title": "Failed"
+          },
           "detail": {
             "anyOf": [
               {
@@ -2920,131 +7821,58 @@
               }
             ],
             "title": "Detail"
-          },
-          "failed": {
-            "title": "Failed",
-            "type": "integer"
-          },
-          "removed": {
-            "title": "Removed",
-            "type": "integer"
-          },
-          "sent": {
-            "title": "Sent",
-            "type": "integer"
-          },
-          "total": {
-            "default": 0,
-            "title": "Total",
-            "type": "integer"
           }
         },
+        "type": "object",
         "required": [
           "sent",
           "removed",
           "failed"
         ],
-        "title": "SendTestResponse",
-        "type": "object"
+        "title": "SendTestResponse"
       },
       "SessionBulkRevokeOut": {
         "properties": {
           "revoked": {
-            "default": 0,
+            "type": "integer",
             "title": "Revoked",
-            "type": "integer"
+            "default": 0
           }
         },
-        "title": "SessionBulkRevokeOut",
-        "type": "object"
+        "type": "object",
+        "title": "SessionBulkRevokeOut"
       },
       "SessionSigningKeyOut": {
         "properties": {
           "signing_key": {
-            "title": "Signing Key",
-            "type": "string"
+            "type": "string",
+            "title": "Signing Key"
           }
         },
+        "type": "object",
         "required": [
           "signing_key"
         ],
-        "title": "SessionSigningKeyOut",
-        "type": "object"
+        "title": "SessionSigningKeyOut"
       },
       "SpotifyAuthURL": {
         "properties": {
           "url": {
-            "title": "Url",
-            "type": "string"
+            "type": "string",
+            "title": "Url"
           }
         },
+        "type": "object",
         "required": [
           "url"
         ],
-        "title": "SpotifyAuthURL",
-        "type": "object"
+        "title": "SpotifyAuthURL"
       },
       "SpotifyNowPlayingOut": {
         "properties": {
-          "album_image_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Album Image Url"
-          },
-          "album_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Album Name"
-          },
-          "artists": {
-            "items": {
-              "type": "string"
-            },
-            "title": "Artists",
-            "type": "array"
-          },
-          "duration_ms": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Duration Ms"
-          },
-          "fetched_at": {
-            "format": "date-time",
-            "title": "Fetched At",
-            "type": "string"
-          },
           "is_playing": {
-            "title": "Is Playing",
-            "type": "boolean"
-          },
-          "preview_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Preview Url"
+            "type": "boolean",
+            "title": "Is Playing"
           },
           "progress_ms": {
             "anyOf": [
@@ -3056,6 +7884,17 @@
               }
             ],
             "title": "Progress Ms"
+          },
+          "duration_ms": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Duration Ms"
           },
           "track_id": {
             "anyOf": [
@@ -3079,6 +7918,35 @@
             ],
             "title": "Track Name"
           },
+          "artists": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Artists"
+          },
+          "album_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Album Name"
+          },
+          "album_image_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Album Image Url"
+          },
           "track_url": {
             "anyOf": [
               {
@@ -3089,17 +7957,63 @@
               }
             ],
             "title": "Track Url"
+          },
+          "preview_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Preview Url"
+          },
+          "fetched_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Fetched At"
           }
         },
+        "type": "object",
         "required": [
           "is_playing",
           "fetched_at"
         ],
-        "title": "SpotifyNowPlayingOut",
-        "type": "object"
+        "title": "SpotifyNowPlayingOut"
       },
       "StoryCreate": {
         "properties": {
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "title_en": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title En"
+          },
+          "short_text": {
+            "type": "string",
+            "title": "Short Text"
+          },
+          "short_text_en": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Short Text En"
+          },
           "cover_url": {
             "anyOf": [
               {
@@ -3122,11 +8036,23 @@
             ],
             "title": "Cta Url"
           },
+          "published_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Published At"
+          },
           "expires_at": {
             "anyOf": [
               {
-                "format": "date-time",
-                "type": "string"
+                "type": "string",
+                "format": "date-time"
               },
               {
                 "type": "null"
@@ -3135,25 +8061,42 @@
             "title": "Expires At"
           },
           "is_active": {
-            "default": true,
+            "type": "boolean",
             "title": "Is Active",
-            "type": "boolean"
+            "default": true
+          }
+        },
+        "type": "object",
+        "required": [
+          "title",
+          "short_text"
+        ],
+        "title": "StoryCreate"
+      },
+      "StoryOut": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
           },
-          "published_at": {
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "title_en": {
             "anyOf": [
               {
-                "format": "date-time",
                 "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Published At"
+            "title": "Title En"
           },
           "short_text": {
-            "title": "Short Text",
-            "type": "string"
+            "type": "string",
+            "title": "Short Text"
           },
           "short_text_en": {
             "anyOf": [
@@ -3166,31 +8109,6 @@
             ],
             "title": "Short Text En"
           },
-          "title": {
-            "title": "Title",
-            "type": "string"
-          },
-          "title_en": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Title En"
-          }
-        },
-        "required": [
-          "title",
-          "short_text"
-        ],
-        "title": "StoryCreate",
-        "type": "object"
-      },
-      "StoryOut": {
-        "properties": {
           "cover_url": {
             "anyOf": [
               {
@@ -3202,10 +8120,30 @@
             ],
             "title": "Cover Url"
           },
-          "created_at": {
+          "cta_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cta Url"
+          },
+          "published_at": {
+            "type": "string",
             "format": "date-time",
-            "title": "Created At",
-            "type": "string"
+            "title": "Published At"
+          },
+          "expires_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Expires At"
+          },
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active"
           },
           "created_by": {
             "anyOf": [
@@ -3218,53 +8156,36 @@
             ],
             "title": "Created By"
           },
-          "cta_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Cta Url"
-          },
-          "expires_at": {
+          "created_at": {
+            "type": "string",
             "format": "date-time",
-            "title": "Expires At",
-            "type": "string"
-          },
-          "id": {
-            "title": "Id",
-            "type": "integer"
-          },
-          "is_active": {
-            "title": "Is Active",
-            "type": "boolean"
-          },
-          "published_at": {
-            "format": "date-time",
-            "title": "Published At",
-            "type": "string"
-          },
-          "short_text": {
-            "title": "Short Text",
-            "type": "string"
-          },
-          "short_text_en": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Short Text En"
-          },
+            "title": "Created At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "title",
+          "short_text",
+          "published_at",
+          "expires_at",
+          "is_active",
+          "created_at"
+        ],
+        "title": "StoryOut"
+      },
+      "StoryUpdate": {
+        "properties": {
           "title": {
-            "title": "Title",
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
           },
           "title_en": {
             "anyOf": [
@@ -3276,78 +8197,6 @@
               }
             ],
             "title": "Title En"
-          }
-        },
-        "required": [
-          "id",
-          "title",
-          "short_text",
-          "published_at",
-          "expires_at",
-          "is_active",
-          "created_at"
-        ],
-        "title": "StoryOut",
-        "type": "object"
-      },
-      "StoryUpdate": {
-        "properties": {
-          "cover_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Cover Url"
-          },
-          "cta_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Cta Url"
-          },
-          "expires_at": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Expires At"
-          },
-          "is_active": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Is Active"
-          },
-          "published_at": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Published At"
           },
           "short_text": {
             "anyOf": [
@@ -3371,7 +8220,7 @@
             ],
             "title": "Short Text En"
           },
-          "title": {
+          "cover_url": {
             "anyOf": [
               {
                 "type": "string"
@@ -3380,9 +8229,9 @@
                 "type": "null"
               }
             ],
-            "title": "Title"
+            "title": "Cover Url"
           },
-          "title_en": {
+          "cta_url": {
             "anyOf": [
               {
                 "type": "string"
@@ -3391,17 +8240,60 @@
                 "type": "null"
               }
             ],
-            "title": "Title En"
+            "title": "Cta Url"
+          },
+          "published_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Published At"
+          },
+          "expires_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expires At"
+          },
+          "is_active": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Active"
           }
         },
-        "title": "StoryUpdate",
-        "type": "object"
+        "type": "object",
+        "title": "StoryUpdate"
       },
       "TokenWithProfile": {
         "properties": {
           "access_token": {
-            "title": "Access Token",
-            "type": "string"
+            "type": "string",
+            "title": "Access Token"
+          },
+          "token_type": {
+            "type": "string",
+            "title": "Token Type",
+            "default": "bearer"
+          },
+          "user": {
+            "$ref": "#/components/schemas/UserOut"
           },
           "session": {
             "anyOf": [
@@ -3412,40 +8304,32 @@
                 "type": "null"
               }
             ]
-          },
-          "token_type": {
-            "default": "bearer",
-            "title": "Token Type",
-            "type": "string"
-          },
-          "user": {
-            "$ref": "#/components/schemas/UserOut"
           }
         },
+        "type": "object",
         "required": [
           "access_token",
           "user"
         ],
-        "title": "TokenWithProfile",
-        "type": "object"
+        "title": "TokenWithProfile"
       },
       "TotpEnrollmentConfirmIn": {
         "properties": {
-          "code": {
-            "title": "Code",
-            "type": "string"
-          },
           "enrollment_id": {
-            "title": "Enrollment Id",
-            "type": "integer"
+            "type": "integer",
+            "title": "Enrollment Id"
+          },
+          "code": {
+            "type": "string",
+            "title": "Code"
           }
         },
+        "type": "object",
         "required": [
           "enrollment_id",
           "code"
         ],
-        "title": "TotpEnrollmentConfirmIn",
-        "type": "object"
+        "title": "TotpEnrollmentConfirmIn"
       },
       "TotpEnrollmentStartIn": {
         "properties": {
@@ -3469,49 +8353,37 @@
                 "type": "null"
               }
             ],
-            "default": false,
-            "title": "Reuse Existing"
+            "title": "Reuse Existing",
+            "default": false
           }
         },
-        "title": "TotpEnrollmentStartIn",
-        "type": "object"
+        "type": "object",
+        "title": "TotpEnrollmentStartIn"
       },
       "TotpEnrollmentStartOut": {
         "properties": {
           "enrollment": {
             "$ref": "#/components/schemas/MfaTotpEnrollmentOut"
           },
-          "otpauth_url": {
-            "title": "Otpauth Url",
-            "type": "string"
-          },
           "secret": {
-            "title": "Secret",
-            "type": "string"
+            "type": "string",
+            "title": "Secret"
+          },
+          "otpauth_url": {
+            "type": "string",
+            "title": "Otpauth Url"
           }
         },
+        "type": "object",
         "required": [
           "enrollment",
           "secret",
           "otpauth_url"
         ],
-        "title": "TotpEnrollmentStartOut",
-        "type": "object"
+        "title": "TotpEnrollmentStartOut"
       },
       "UserAdminUpdate": {
         "properties": {
-          "email": {
-            "anyOf": [
-              {
-                "format": "email",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Email"
-          },
           "full_name": {
             "anyOf": [
               {
@@ -3522,6 +8394,28 @@
               }
             ],
             "title": "Full Name"
+          },
+          "email": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "email"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Email"
+          },
+          "role": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/UserRole"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "group_id": {
             "anyOf": [
@@ -3544,133 +8438,17 @@
               }
             ],
             "title": "Reset Mfa"
-          },
-          "role": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/UserRole"
-              },
-              {
-                "type": "null"
-              }
-            ]
           }
         },
-        "title": "UserAdminUpdate",
-        "type": "object"
+        "type": "object",
+        "title": "UserAdminUpdate"
       },
       "UserCreate": {
         "properties": {
-          "about": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "About"
-          },
-          "achievements": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Achievements"
-          },
-          "avatar_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Avatar Url"
-          },
-          "course": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Course"
-          },
-          "cover_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Cover Url"
-          },
-          "department": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Department"
-          },
-          "dnd_enabled": {
-            "default": false,
-            "title": "Dnd Enabled",
-            "type": "boolean"
-          },
-          "dnd_end": {
-            "anyOf": [
-              {
-                "format": "time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Dnd End"
-          },
-          "dnd_start": {
-            "anyOf": [
-              {
-                "format": "time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Dnd Start"
-          },
-          "education_level": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Education Level"
-          },
           "email": {
+            "type": "string",
             "format": "email",
-            "title": "Email",
-            "type": "string"
+            "title": "Email"
           },
           "full_name": {
             "anyOf": [
@@ -3683,6 +8461,10 @@
             ],
             "title": "Full Name"
           },
+          "role": {
+            "$ref": "#/components/schemas/UserRole",
+            "default": "student"
+          },
           "group_id": {
             "anyOf": [
               {
@@ -3694,7 +8476,7 @@
             ],
             "title": "Group Id"
           },
-          "institute": {
+          "avatar_url": {
             "anyOf": [
               {
                 "type": "string"
@@ -3703,9 +8485,9 @@
                 "type": "null"
               }
             ],
-            "title": "Institute"
+            "title": "Avatar Url"
           },
-          "invite_code": {
+          "cover_url": {
             "anyOf": [
               {
                 "type": "string"
@@ -3714,15 +8496,9 @@
                 "type": "null"
               }
             ],
-            "title": "Invite Code"
+            "title": "Cover Url"
           },
-          "password": {
-            "maxLength": 200,
-            "minLength": 8,
-            "title": "Password",
-            "type": "string"
-          },
-          "position": {
+          "about": {
             "anyOf": [
               {
                 "type": "string"
@@ -3731,18 +8507,7 @@
                 "type": "null"
               }
             ],
-            "title": "Position"
-          },
-          "program": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Program"
+            "title": "About"
           },
           "record_book_number": {
             "anyOf": [
@@ -3755,26 +8520,6 @@
             ],
             "title": "Record Book Number"
           },
-          "role": {
-            "$ref": "#/components/schemas/UserRole",
-            "default": "student"
-          },
-          "spotify_connected": {
-            "default": false,
-            "title": "Spotify Connected",
-            "type": "boolean"
-          },
-          "spotify_display_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Spotify Display Name"
-          },
           "status": {
             "anyOf": [
               {
@@ -3785,218 +8530,6 @@
               }
             ],
             "title": "Status"
-          },
-          "telegram": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Telegram"
-          },
-          "timezone": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Timezone"
-          },
-          "track": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Track"
-          }
-        },
-        "required": [
-          "email",
-          "password"
-        ],
-        "title": "UserCreate",
-        "type": "object"
-      },
-      "UserEmailChangeIn": {
-        "properties": {
-          "email": {
-            "format": "email",
-            "title": "Email",
-            "type": "string"
-          },
-          "password": {
-            "title": "Password",
-            "type": "string"
-          }
-        },
-        "required": [
-          "email",
-          "password"
-        ],
-        "title": "UserEmailChangeIn",
-        "type": "object"
-      },
-      "UserEmailConfirmIn": {
-        "properties": {
-          "token": {
-            "title": "Token",
-            "type": "string"
-          }
-        },
-        "required": [
-          "token"
-        ],
-        "title": "UserEmailConfirmIn",
-        "type": "object"
-      },
-      "UserOut": {
-        "properties": {
-          "about": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "About"
-          },
-          "achievements": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Achievements"
-          },
-          "avatar_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Avatar Url"
-          },
-          "course": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Course"
-          },
-          "cover_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Cover Url"
-          },
-          "department": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Department"
-          },
-          "dnd_enabled": {
-            "default": false,
-            "title": "Dnd Enabled",
-            "type": "boolean"
-          },
-          "dnd_end": {
-            "anyOf": [
-              {
-                "format": "time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Dnd End"
-          },
-          "dnd_start": {
-            "anyOf": [
-              {
-                "format": "time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Dnd Start"
-          },
-          "education_level": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Education Level"
-          },
-          "email": {
-            "format": "email",
-            "title": "Email",
-            "type": "string"
-          },
-          "full_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Full Name"
-          },
-          "group_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Group Id"
-          },
-          "id": {
-            "title": "Id",
-            "type": "integer"
           },
           "institute": {
             "anyOf": [
@@ -4009,16 +8542,485 @@
             ],
             "title": "Institute"
           },
-          "is_active": {
-            "title": "Is Active",
-            "type": "boolean"
+          "course": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Course"
           },
-          "mfa_challenges": {
-            "items": {
-              "$ref": "#/components/schemas/MfaChallengeOut"
-            },
-            "title": "Mfa Challenges",
-            "type": "array"
+          "education_level": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Education Level"
+          },
+          "track": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Track"
+          },
+          "program": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Program"
+          },
+          "telegram": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Telegram"
+          },
+          "achievements": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Achievements"
+          },
+          "department": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Department"
+          },
+          "position": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Position"
+          },
+          "spotify_connected": {
+            "type": "boolean",
+            "title": "Spotify Connected",
+            "default": false
+          },
+          "spotify_display_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spotify Display Name"
+          },
+          "dnd_enabled": {
+            "type": "boolean",
+            "title": "Dnd Enabled",
+            "default": false
+          },
+          "dnd_start": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dnd Start"
+          },
+          "dnd_end": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dnd End"
+          },
+          "timezone": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Timezone"
+          },
+          "password": {
+            "type": "string",
+            "maxLength": 200,
+            "minLength": 8,
+            "title": "Password"
+          },
+          "invite_code": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Invite Code"
+          }
+        },
+        "type": "object",
+        "required": [
+          "email",
+          "password"
+        ],
+        "title": "UserCreate"
+      },
+      "UserEmailChangeIn": {
+        "properties": {
+          "email": {
+            "type": "string",
+            "format": "email",
+            "title": "Email"
+          },
+          "password": {
+            "type": "string",
+            "title": "Password"
+          }
+        },
+        "type": "object",
+        "required": [
+          "email",
+          "password"
+        ],
+        "title": "UserEmailChangeIn"
+      },
+      "UserEmailConfirmIn": {
+        "properties": {
+          "token": {
+            "type": "string",
+            "title": "Token"
+          }
+        },
+        "type": "object",
+        "required": [
+          "token"
+        ],
+        "title": "UserEmailConfirmIn"
+      },
+      "UserOut": {
+        "properties": {
+          "email": {
+            "type": "string",
+            "format": "email",
+            "title": "Email"
+          },
+          "full_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Full Name"
+          },
+          "role": {
+            "$ref": "#/components/schemas/UserRole",
+            "default": "student"
+          },
+          "group_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Group Id"
+          },
+          "avatar_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Avatar Url"
+          },
+          "cover_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cover Url"
+          },
+          "about": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "About"
+          },
+          "record_book_number": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Record Book Number"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status"
+          },
+          "institute": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Institute"
+          },
+          "course": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Course"
+          },
+          "education_level": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Education Level"
+          },
+          "track": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Track"
+          },
+          "program": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Program"
+          },
+          "telegram": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Telegram"
+          },
+          "achievements": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Achievements"
+          },
+          "department": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Department"
+          },
+          "position": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Position"
+          },
+          "spotify_connected": {
+            "type": "boolean",
+            "title": "Spotify Connected",
+            "default": false
+          },
+          "spotify_display_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spotify Display Name"
+          },
+          "dnd_enabled": {
+            "type": "boolean",
+            "title": "Dnd Enabled",
+            "default": false
+          },
+          "dnd_start": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dnd Start"
+          },
+          "dnd_end": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dnd End"
+          },
+          "timezone": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Timezone"
+          },
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active"
+          },
+          "pending_email": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "email"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pending Email"
+          },
+          "spotify_is_connected": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spotify Is Connected"
+          },
+          "mfa_required": {
+            "type": "boolean",
+            "title": "Mfa Required",
+            "default": false
           },
           "mfa_default_method": {
             "anyOf": [
@@ -4034,8 +9036,8 @@
           "mfa_last_verified_at": {
             "anyOf": [
               {
-                "format": "date-time",
-                "type": "string"
+                "type": "string",
+                "format": "date-time"
               },
               {
                 "type": "null"
@@ -4043,24 +9045,75 @@
             ],
             "title": "Mfa Last Verified At"
           },
-          "mfa_required": {
-            "default": false,
-            "title": "Mfa Required",
-            "type": "boolean"
+          "totp_enrollments": {
+            "items": {
+              "$ref": "#/components/schemas/MfaTotpEnrollmentOut"
+            },
+            "type": "array",
+            "title": "Totp Enrollments"
           },
-          "pending_email": {
+          "mfa_challenges": {
+            "items": {
+              "$ref": "#/components/schemas/MfaChallengeOut"
+            },
+            "type": "array",
+            "title": "Mfa Challenges"
+          }
+        },
+        "type": "object",
+        "required": [
+          "email",
+          "id",
+          "is_active"
+        ],
+        "title": "UserOut"
+      },
+      "UserPasswordChangeIn": {
+        "properties": {
+          "current_password": {
+            "type": "string",
+            "title": "Current Password"
+          },
+          "new_password": {
+            "type": "string",
+            "maxLength": 200,
+            "minLength": 8,
+            "title": "New Password"
+          }
+        },
+        "type": "object",
+        "required": [
+          "current_password",
+          "new_password"
+        ],
+        "title": "UserPasswordChangeIn"
+      },
+      "UserProfileUpdate": {
+        "properties": {
+          "full_name": {
             "anyOf": [
               {
-                "format": "email",
                 "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Pending Email"
+            "title": "Full Name"
           },
-          "position": {
+          "email": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "email"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Email"
+          },
+          "about": {
             "anyOf": [
               {
                 "type": "string"
@@ -4069,18 +9122,7 @@
                 "type": "null"
               }
             ],
-            "title": "Position"
-          },
-          "program": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Program"
+            "title": "About"
           },
           "record_book_number": {
             "anyOf": [
@@ -4093,37 +9135,6 @@
             ],
             "title": "Record Book Number"
           },
-          "role": {
-            "$ref": "#/components/schemas/UserRole",
-            "default": "student"
-          },
-          "spotify_connected": {
-            "default": false,
-            "title": "Spotify Connected",
-            "type": "boolean"
-          },
-          "spotify_display_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Spotify Display Name"
-          },
-          "spotify_is_connected": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Spotify Is Connected"
-          },
           "status": {
             "anyOf": [
               {
@@ -4134,190 +9145,6 @@
               }
             ],
             "title": "Status"
-          },
-          "telegram": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Telegram"
-          },
-          "timezone": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Timezone"
-          },
-          "totp_enrollments": {
-            "items": {
-              "$ref": "#/components/schemas/MfaTotpEnrollmentOut"
-            },
-            "title": "Totp Enrollments",
-            "type": "array"
-          },
-          "track": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Track"
-          }
-        },
-        "required": [
-          "email",
-          "id",
-          "is_active"
-        ],
-        "title": "UserOut",
-        "type": "object"
-      },
-      "UserPasswordChangeIn": {
-        "properties": {
-          "current_password": {
-            "title": "Current Password",
-            "type": "string"
-          },
-          "new_password": {
-            "maxLength": 200,
-            "minLength": 8,
-            "title": "New Password",
-            "type": "string"
-          }
-        },
-        "required": [
-          "current_password",
-          "new_password"
-        ],
-        "title": "UserPasswordChangeIn",
-        "type": "object"
-      },
-      "UserProfileUpdate": {
-        "properties": {
-          "about": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "About"
-          },
-          "achievements": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Achievements"
-          },
-          "course": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Course"
-          },
-          "department": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Department"
-          },
-          "dnd_enabled": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Dnd Enabled"
-          },
-          "dnd_end": {
-            "anyOf": [
-              {
-                "format": "time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Dnd End"
-          },
-          "dnd_start": {
-            "anyOf": [
-              {
-                "format": "time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Dnd Start"
-          },
-          "education_level": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Education Level"
-          },
-          "email": {
-            "anyOf": [
-              {
-                "format": "email",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Email"
-          },
-          "full_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Full Name"
           },
           "institute": {
             "anyOf": [
@@ -4330,7 +9157,7 @@
             ],
             "title": "Institute"
           },
-          "position": {
+          "course": {
             "anyOf": [
               {
                 "type": "string"
@@ -4339,7 +9166,29 @@
                 "type": "null"
               }
             ],
-            "title": "Position"
+            "title": "Course"
+          },
+          "education_level": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Education Level"
+          },
+          "track": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Track"
           },
           "program": {
             "anyOf": [
@@ -4352,28 +9201,6 @@
             ],
             "title": "Program"
           },
-          "record_book_number": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Record Book Number"
-          },
-          "status": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Status"
-          },
           "telegram": {
             "anyOf": [
               {
@@ -4385,6 +9212,74 @@
             ],
             "title": "Telegram"
           },
+          "achievements": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Achievements"
+          },
+          "department": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Department"
+          },
+          "position": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Position"
+          },
+          "dnd_enabled": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dnd Enabled"
+          },
+          "dnd_start": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dnd Start"
+          },
+          "dnd_end": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dnd End"
+          },
           "timezone": {
             "anyOf": [
               {
@@ -4395,31 +9290,20 @@
               }
             ],
             "title": "Timezone"
-          },
-          "track": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Track"
           }
         },
-        "title": "UserProfileUpdate",
-        "type": "object"
+        "type": "object",
+        "title": "UserProfileUpdate"
       },
       "UserRole": {
-        "description": "Available roles for users within the system.",
+        "type": "string",
         "enum": [
           "student",
           "teacher",
           "admin"
         ],
         "title": "UserRole",
-        "type": "string"
+        "description": "Available roles for users within the system."
       },
       "ValidationError": {
         "properties": {
@@ -4434,4815 +9318,34 @@
                 }
               ]
             },
-            "title": "Location",
-            "type": "array"
+            "type": "array",
+            "title": "Location"
           },
           "msg": {
-            "title": "Message",
-            "type": "string"
+            "type": "string",
+            "title": "Message"
           },
           "type": {
-            "title": "Error Type",
-            "type": "string"
+            "type": "string",
+            "title": "Error Type"
           }
         },
+        "type": "object",
         "required": [
           "loc",
           "msg",
           "type"
         ],
-        "title": "ValidationError",
-        "type": "object"
-      },
-      "NotificationDeadLetterJobOut": {
-        "title": "NotificationDeadLetterJobOut",
-        "required": [
-          "id",
-          "kind",
-          "record_id",
-          "enqueued_at",
-          "attempts"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "Id",
-            "type": "integer"
-          },
-          "kind": {
-            "title": "Kind",
-            "type": "string"
-          },
-          "record_id": {
-            "title": "Record Id",
-            "type": "integer"
-          },
-          "locale": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Locale"
-          },
-          "enqueued_at": {
-            "title": "Enqueued At",
-            "type": "string",
-            "format": "date-time"
-          },
-          "claimed_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Claimed At"
-          },
-          "attempts": {
-            "title": "Attempts",
-            "type": "integer"
-          },
-          "last_error": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Last Error"
-          },
-          "next_retry_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Next Retry At"
-          }
-        }
-      },
-      "NotificationDeadLetterListOut": {
-        "title": "NotificationDeadLetterListOut",
-        "required": [
-          "items",
-          "total"
-        ],
-        "type": "object",
-        "properties": {
-          "items": {
-            "items": {
-              "$ref": "#/components/schemas/NotificationDeadLetterJobOut"
-            },
-            "title": "Items",
-            "type": "array"
-          },
-          "total": {
-            "title": "Total",
-            "type": "integer"
-          }
-        }
-      },
-      "NotificationDeadLetterPurgeIn": {
-        "title": "NotificationDeadLetterPurgeIn",
-        "required": [
-          "job_ids"
-        ],
-        "type": "object",
-        "properties": {
-          "job_ids": {
-            "items": {
-              "type": "integer"
-            },
-            "title": "Job Ids",
-            "type": "array"
-          }
-        }
-      },
-      "NotificationDeadLetterReplayIn": {
-        "title": "NotificationDeadLetterReplayIn",
-        "required": [
-          "job_ids"
-        ],
-        "type": "object",
-        "properties": {
-          "job_ids": {
-            "items": {
-              "type": "integer"
-            },
-            "title": "Job Ids",
-            "type": "array"
-          }
-        }
+        "title": "ValidationError"
       }
     },
     "securitySchemes": {
       "OAuth2PasswordBearer": {
+        "type": "oauth2",
         "flows": {
           "password": {
             "scopes": {},
             "tokenUrl": "/auth/login"
-          }
-        },
-        "type": "oauth2"
-      }
-    }
-  },
-  "info": {
-    "description": "REST API for university life management platform - schedules, news, events, notifications, and more.",
-    "title": "University Ecosystem API",
-    "version": "1.0.0"
-  },
-  "openapi": "3.1.0",
-  "paths": {
-    "/": {
-      "get": {
-        "operationId": "root__get",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "summary": "Root"
-      }
-    },
-    "/api/v1/auth/login": {
-      "post": {
-        "operationId": "login_api_v1_auth_login_post",
-        "requestBody": {
-          "content": {
-            "application/x-www-form-urlencoded": {
-              "schema": {
-                "$ref": "#/components/schemas/Body_login_api_v1_auth_login_post"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TokenWithProfile"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "202": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PendingMfaResponse"
-                }
-              }
-            },
-            "description": "Accepted"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Login",
-        "tags": [
-          "auth"
-        ]
-      }
-    },
-    "/api/v1/auth/login-json": {
-      "post": {
-        "operationId": "login_json_api_v1_auth_login_json_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/LoginIn"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TokenWithProfile"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "202": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PendingMfaResponse"
-                }
-              }
-            },
-            "description": "Accepted"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Login Json",
-        "tags": [
-          "auth"
-        ]
-      }
-    },
-    "/api/v1/auth/logout": {
-      "post": {
-        "description": "Terminate the client session.",
-        "operationId": "logout_api_v1_auth_logout_post",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "summary": "Logout",
-        "tags": [
-          "auth"
-        ]
-      }
-    },
-    "/api/v1/auth/mfa/step-up": {
-      "post": {
-        "operationId": "request_step_up_api_v1_auth_mfa_step_up_post",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PendingMfaResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "202": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PendingMfaResponse"
-                }
-              }
-            },
-            "description": "Accepted"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Request Step Up",
-        "tags": [
-          "auth"
-        ]
-      }
-    },
-    "/api/v1/auth/mfa/totp": {
-      "get": {
-        "operationId": "list_totp_enrollments_api_v1_auth_mfa_totp_get",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/MfaTotpEnrollmentOut"
-                  },
-                  "title": "Response List Totp Enrollments Api V1 Auth Mfa Totp Get",
-                  "type": "array"
-                }
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "List Totp Enrollments",
-        "tags": [
-          "auth"
-        ]
-      }
-    },
-    "/api/v1/auth/mfa/totp/confirm": {
-      "post": {
-        "operationId": "confirm_totp_enrollment_api_v1_auth_mfa_totp_confirm_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/TotpEnrollmentConfirmIn"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MfaTotpEnrollmentOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Confirm Totp Enrollment",
-        "tags": [
-          "auth"
-        ]
-      }
-    },
-    "/api/v1/auth/mfa/totp/pending/{enrollment_id}": {
-      "delete": {
-        "operationId": "delete_pending_totp_enrollment_api_v1_auth_mfa_totp_pending__enrollment_id__delete",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "enrollment_id",
-            "required": true,
-            "schema": {
-              "title": "Enrollment Id",
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Delete Pending Totp Enrollment",
-        "tags": [
-          "auth"
-        ]
-      }
-    },
-    "/api/v1/auth/mfa/totp/start": {
-      "post": {
-        "operationId": "start_totp_enrollment_endpoint_api_v1_auth_mfa_totp_start_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/TotpEnrollmentStartIn"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "title": "Payload"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TotpEnrollmentStartOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Start Totp Enrollment Endpoint",
-        "tags": [
-          "auth"
-        ]
-      }
-    },
-    "/api/v1/auth/mfa/totp/{enrollment_id}": {
-      "delete": {
-        "operationId": "delete_totp_enrollment_api_v1_auth_mfa_totp__enrollment_id__delete",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "enrollment_id",
-            "required": true,
-            "schema": {
-              "title": "Enrollment Id",
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MfaFactorStatusOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Delete Totp Enrollment",
-        "tags": [
-          "auth"
-        ]
-      }
-    },
-    "/api/v1/auth/mfa/verify": {
-      "post": {
-        "operationId": "verify_mfa_challenge_api_v1_auth_mfa_verify_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MfaVerifyIn"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TokenWithProfile"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Verify Mfa Challenge",
-        "tags": [
-          "auth"
-        ]
-      }
-    },
-    "/api/v1/auth/register": {
-      "post": {
-        "operationId": "register_api_v1_auth_register_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UserCreate"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Register",
-        "tags": [
-          "auth"
-        ]
-      }
-    },
-    "/api/v1/auth/session/signing-key": {
-      "get": {
-        "operationId": "get_session_signing_key_api_v1_auth_session_signing_key_get",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SessionSigningKeyOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Get Session Signing Key",
-        "tags": [
-          "auth"
-        ]
-      }
-    },
-    "/api/v1/auth/sessions": {
-      "get": {
-        "operationId": "list_sessions_api_v1_auth_sessions_get",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "user_id",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/ActiveSessionOut"
-                  },
-                  "title": "Response List Sessions Api V1 Auth Sessions Get",
-                  "type": "array"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "List Sessions",
-        "tags": [
-          "auth"
-        ]
-      }
-    },
-    "/api/v1/auth/sessions/revoke-others": {
-      "post": {
-        "operationId": "revoke_other_sessions_api_v1_auth_sessions_revoke_others_post",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "user_id",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SessionBulkRevokeOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Revoke Other Sessions",
-        "tags": [
-          "auth"
-        ]
-      }
-    },
-    "/api/v1/auth/sessions/{session_id}": {
-      "delete": {
-        "operationId": "revoke_session_api_v1_auth_sessions__session_id__delete",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "session_id",
-            "required": true,
-            "schema": {
-              "title": "Session Id",
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ActiveSessionOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Revoke Session",
-        "tags": [
-          "auth"
-        ]
-      }
-    },
-    "/api/v1/chats": {
-      "get": {
-        "description": "Get all chats for the current user with cursor-based pagination.\n\nReturns chats ordered by last message timestamp (newest first).\nUse the `next_cursor` from the response to fetch the next page.",
-        "operationId": "get_chats_api_v1_chats_get",
-        "parameters": [
-          {
-            "description": "Pagination cursor",
-            "in": "query",
-            "name": "cursor",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Pagination cursor",
-              "title": "Cursor"
-            }
-          },
-          {
-            "description": "Number of chats to return",
-            "in": "query",
-            "name": "limit",
-            "required": false,
-            "schema": {
-              "default": 20,
-              "description": "Number of chats to return",
-              "maximum": 100,
-              "minimum": 1,
-              "title": "Limit",
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ChatsListOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Get Chats",
-        "tags": [
-          "chats"
-        ]
-      },
-      "post": {
-        "description": "Create a new chat with a user. If a chat already exists, return it.",
-        "operationId": "create_chat_api_v1_chats_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ChatCreate"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ChatResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Create Chat",
-        "tags": [
-          "chats"
-        ]
-      }
-    },
-    "/api/v1/chats/{chat_id}/messages": {
-      "get": {
-        "description": "Get messages for a chat with cursor-based pagination.\n\nMessages are returned in ascending order (oldest first).\nUse the `next_cursor` from the response to fetch older messages.",
-        "operationId": "get_messages_api_v1_chats__chat_id__messages_get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "chat_id",
-            "required": true,
-            "schema": {
-              "title": "Chat Id",
-              "type": "string"
-            }
-          },
-          {
-            "description": "Pagination cursor",
-            "in": "query",
-            "name": "cursor",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Pagination cursor",
-              "title": "Cursor"
-            }
-          },
-          {
-            "description": "Number of messages to return",
-            "in": "query",
-            "name": "limit",
-            "required": false,
-            "schema": {
-              "default": 50,
-              "description": "Number of messages to return",
-              "maximum": 100,
-              "minimum": 1,
-              "title": "Limit",
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MessagesListOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Get Messages",
-        "tags": [
-          "chats"
-        ]
-      },
-      "post": {
-        "description": "Send a message to a chat.\n\nThe message is saved to the database and all chat participants\nare notified via WebSocket in real-time.",
-        "operationId": "send_message_api_v1_chats__chat_id__messages_post",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "chat_id",
-            "required": true,
-            "schema": {
-              "title": "Chat Id",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "$ref": "#/components/schemas/Body_send_message_api_v1_chats__chat_id__messages_post"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MessageResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Send Message",
-        "tags": [
-          "chats"
-        ]
-      }
-    },
-    "/api/v1/chats/{chat_id}/read": {
-      "post": {
-        "description": "Mark all messages in a chat as read.",
-        "operationId": "mark_read_api_v1_chats__chat_id__read_post",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "chat_id",
-            "required": true,
-            "schema": {
-              "title": "Chat Id",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Mark Read",
-        "tags": [
-          "chats"
-        ]
-      }
-    },
-    "/api/v1/events": {
-      "get": {
-        "description": "Get a paginated list of events.",
-        "operationId": "all_events_api_v1_events_get",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "search",
-            "required": false,
-            "schema": {
-              "default": "",
-              "title": "Search",
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "type",
-            "required": false,
-            "schema": {
-              "default": "",
-              "title": "Type",
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "location",
-            "required": false,
-            "schema": {
-              "default": "",
-              "title": "Location",
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "is_active",
-            "required": false,
-            "schema": {
-              "default": true,
-              "title": "Is Active",
-              "type": "boolean"
-            }
-          },
-          {
-            "in": "query",
-            "name": "limit",
-            "required": false,
-            "schema": {
-              "default": 20,
-              "maximum": 50,
-              "minimum": 1,
-              "title": "Limit",
-              "type": "integer"
-            }
-          },
-          {
-            "in": "query",
-            "name": "cursor",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Cursor"
-            }
-          },
-          {
-            "in": "header",
-            "name": "if-none-match",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "If-None-Match"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaginatedEvents"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "List Events",
-        "tags": [
-          "events"
-        ]
-      },
-      "post": {
-        "operationId": "create_event_api_v1_events_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/EventCreate"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EventOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Create Event",
-        "tags": [
-          "events"
-        ]
-      }
-    },
-    "/api/v1/events/attendance": {
-      "delete": {
-        "operationId": "unregister_event_api_v1_events_attendance_delete",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/EventAttendanceCreate"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "additionalProperties": true,
-                  "title": "Response Unregister Event Api V1 Events Attendance Delete",
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Unregister Event",
-        "tags": [
-          "events"
-        ]
-      },
-      "post": {
-        "description": "Register attendance for an event.",
-        "operationId": "attend_api_v1_events_attendance_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/EventAttendanceCreate"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EventAttendanceOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Attend Event",
-        "tags": [
-          "events"
-        ]
-      }
-    },
-    "/api/v1/events/file/{file_id}": {
-      "delete": {
-        "operationId": "delete_event_file_api_v1_events_file__file_id__delete",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "file_id",
-            "required": true,
-            "schema": {
-              "title": "File Id",
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "additionalProperties": true,
-                  "title": "Response Delete Event File Api V1 Events File  File Id  Delete",
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Delete Event File",
-        "tags": [
-          "events"
-        ]
-      }
-    },
-    "/api/v1/events/my": {
-      "get": {
-        "operationId": "my_events_api_v1_events_my_get",
-        "parameters": [
-          {
-            "in": "header",
-            "name": "if-none-match",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "If-None-Match"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/EventOut"
-                  },
-                  "title": "Response My Events Api V1 Events My Get",
-                  "type": "array"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "My Events",
-        "tags": [
-          "events"
-        ]
-      }
-    },
-    "/api/v1/events/upload_image": {
-      "post": {
-        "operationId": "upload_event_image_api_v1_events_upload_image_post",
-        "requestBody": {
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "$ref": "#/components/schemas/Body_upload_event_image_api_v1_events_upload_image_post"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Upload Event Image",
-        "tags": [
-          "events"
-        ]
-      }
-    },
-    "/api/v1/events/{event_id}": {
-      "delete": {
-        "operationId": "delete_event_api_v1_events__event_id__delete",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "event_id",
-            "required": true,
-            "schema": {
-              "title": "Event Id",
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "additionalProperties": true,
-                  "title": "Response Delete Event Api V1 Events  Event Id  Delete",
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Delete Event",
-        "tags": [
-          "events"
-        ]
-      },
-      "patch": {
-        "operationId": "update_event_api_v1_events__event_id__patch",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "event_id",
-            "required": true,
-            "schema": {
-              "title": "Event Id",
-              "type": "integer"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/EventUpdate"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EventOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Update Event",
-        "tags": [
-          "events"
-        ]
-      }
-    },
-    "/api/v1/events/{id}": {
-      "get": {
-        "operationId": "get_event_api_v1_events__id__get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "schema": {
-              "title": "Id",
-              "type": "integer"
-            }
-          },
-          {
-            "in": "header",
-            "name": "if-none-match",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "If-None-Match"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EventOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Get Event",
-        "tags": [
-          "events"
-        ]
-      }
-    },
-    "/api/v1/events/{id}/files": {
-      "get": {
-        "operationId": "get_event_files_api_v1_events__id__files_get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "schema": {
-              "title": "Id",
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/EventFileOut"
-                  },
-                  "title": "Response Get Event Files Api V1 Events  Id  Files Get",
-                  "type": "array"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Get Event Files",
-        "tags": [
-          "events"
-        ]
-      }
-    },
-    "/api/v1/events/{id}/upload_file": {
-      "post": {
-        "operationId": "upload_event_file_api_v1_events__id__upload_file_post",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "schema": {
-              "title": "Id",
-              "type": "integer"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "$ref": "#/components/schemas/Body_upload_event_file_api_v1_events__id__upload_file_post"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EventFileOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Upload Event File",
-        "tags": [
-          "events"
-        ]
-      }
-    },
-    "/api/v1/groups": {
-      "get": {
-        "operationId": "get_groups_api_v1_groups_get",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/GroupOut"
-                  },
-                  "title": "Response Get Groups Api V1 Groups Get",
-                  "type": "array"
-                }
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "summary": "Get Groups",
-        "tags": [
-          "groups"
-        ]
-      }
-    },
-    "/api/v1/news": {
-      "get": {
-        "description": "Get a paginated list of news articles.",
-        "operationId": "news_list_api_v1_news_get",
-        "parameters": [
-          {
-            "description": "Number of items to return",
-            "in": "query",
-            "name": "limit",
-            "required": false,
-            "schema": {
-              "default": 20,
-              "description": "Number of items to return",
-              "maximum": 100,
-              "minimum": 1,
-              "title": "Limit",
-              "type": "integer"
-            }
-          },
-          {
-            "description": "Pagination cursor",
-            "in": "query",
-            "name": "cursor",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Pagination cursor",
-              "title": "Cursor"
-            }
-          },
-          {
-            "in": "header",
-            "name": "if-none-match",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "If-None-Match"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaginatedNews"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "List News",
-        "tags": [
-          "news"
-        ]
-      },
-      "post": {
-        "operationId": "create_news_api_v1_news_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/NewsCreate"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NewsOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Create News",
-        "tags": [
-          "news"
-        ]
-      }
-    },
-    "/api/v1/news/upload_image": {
-      "post": {
-        "operationId": "upload_news_image_api_v1_news_upload_image_post",
-        "requestBody": {
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "$ref": "#/components/schemas/Body_upload_news_image_api_v1_news_upload_image_post"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Upload News Image",
-        "tags": [
-          "news"
-        ]
-      }
-    },
-    "/api/v1/news/{id}": {
-      "delete": {
-        "operationId": "delete_news_api_v1_news__id__delete",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "schema": {
-              "title": "Id",
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "additionalProperties": true,
-                  "title": "Response Delete News Api V1 News  Id  Delete",
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Delete News",
-        "tags": [
-          "news"
-        ]
-      },
-      "get": {
-        "description": "Get a specific news article by ID.",
-        "operationId": "get_news_api_v1_news__id__get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "schema": {
-              "title": "Id",
-              "type": "integer"
-            }
-          },
-          {
-            "in": "header",
-            "name": "if-none-match",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "If-None-Match"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NewsOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Get News Item",
-        "tags": [
-          "news"
-        ]
-      },
-      "patch": {
-        "operationId": "update_news_api_v1_news__id__patch",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "schema": {
-              "title": "Id",
-              "type": "integer"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/NewsUpdate"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "title": "Data"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NewsOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Update News",
-        "tags": [
-          "news"
-        ]
-      }
-    },
-    "/api/v1/notifications": {
-      "delete": {
-        "operationId": "clear_notifications_api_v1_notifications_delete",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Clear Notifications",
-        "tags": [
-          "notifications"
-        ]
-      },
-      "get": {
-        "operationId": "list_notifications_api_v1_notifications_get",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "cursor",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Cursor"
-            }
-          },
-          {
-            "in": "query",
-            "name": "limit",
-            "required": false,
-            "schema": {
-              "default": 20,
-              "maximum": 100,
-              "minimum": 1,
-              "title": "Limit",
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotificationsListOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "List Notifications",
-        "tags": [
-          "notifications"
-        ]
-      }
-    },
-    "/api/v1/notifications/check-schedule": {
-      "post": {
-        "operationId": "check_schedule_and_generate_api_v1_notifications_check_schedule_post",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "lookahead_minutes",
-            "required": false,
-            "schema": {
-              "default": 15,
-              "maximum": 180,
-              "minimum": 1,
-              "title": "Lookahead Minutes",
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotificationsListOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Check Schedule And Generate",
-        "tags": [
-          "notifications"
-        ]
-      }
-    },
-    "/api/v1/notifications/read-all": {
-      "post": {
-        "operationId": "mark_all_read_api_v1_notifications_read_all_post",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Mark All Read",
-        "tags": [
-          "notifications"
-        ]
-      }
-    },
-    "/api/v1/notifications/{notif_id}/read": {
-      "patch": {
-        "operationId": "mark_read_single_api_v1_notifications__notif_id__read_patch",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "notif_id",
-            "required": true,
-            "schema": {
-              "title": "Notif Id",
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Mark Read Single",
-        "tags": [
-          "notifications"
-        ]
-      }
-    },
-    "/api/v1/password/forgot": {
-      "post": {
-        "operationId": "forgot_password_api_v1_password_forgot_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ForgotPasswordIn"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Forgot Password",
-        "tags": [
-          "password"
-        ]
-      }
-    },
-    "/api/v1/password/reset": {
-      "post": {
-        "operationId": "reset_password_api_v1_password_reset_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ResetPasswordIn"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Reset Password",
-        "tags": [
-          "password"
-        ]
-      }
-    },
-    "/api/v1/push/admin/disable-user": {
-      "post": {
-        "operationId": "disable_user_push_api_v1_push_admin_disable_user_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/DisableUserPushRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "additionalProperties": {
-                    "anyOf": [
-                      {
-                        "type": "integer"
-                      },
-                      {
-                        "type": "boolean"
-                      }
-                    ]
-                  },
-                  "title": "Response Disable User Push Api V1 Push Admin Disable User Post",
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Disable User Push",
-        "tags": [
-          "push"
-        ]
-      }
-    },
-    "/api/v1/push/admin/topics/{user_id}": {
-      "get": {
-        "operationId": "admin_get_user_topics_api_v1_push_admin_topics__user_id__get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "user_id",
-            "required": true,
-            "schema": {
-              "title": "User Id",
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AdminUserTopicsResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Admin Get User Topics",
-        "tags": [
-          "push"
-        ]
-      },
-      "put": {
-        "operationId": "admin_update_user_topics_api_v1_push_admin_topics__user_id__put",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "user_id",
-            "required": true,
-            "schema": {
-              "title": "User Id",
-              "type": "integer"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AdminUserTopicsUpdate"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AdminUserTopicsResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Admin Update User Topics",
-        "tags": [
-          "push"
-        ]
-      }
-    },
-    "/api/v1/push/broadcast": {
-      "post": {
-        "operationId": "broadcast_api_v1_push_broadcast_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/NotifyBody"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SendTestResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Broadcast",
-        "tags": [
-          "push"
-        ]
-      }
-    },
-    "/api/v1/push/subscribe": {
-      "post": {
-        "operationId": "subscribe_api_v1_push_subscribe_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PushSubscriptionIn"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PushSubscriptionOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Subscribe",
-        "tags": [
-          "push"
-        ]
-      }
-    },
-    "/api/v1/push/subscribe/topics": {
-      "patch": {
-        "operationId": "update_subscription_topics_api_v1_push_subscribe_topics_patch",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PushSubscriptionTopicsUpdate"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PushSubscriptionOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Update Subscription Topics",
-        "tags": [
-          "push"
-        ]
-      }
-    },
-    "/api/v1/push/test": {
-      "post": {
-        "operationId": "send_test_api_v1_push_test_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/PushTestRequest"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "title": "Payload"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SendTestResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Send Test",
-        "tags": [
-          "push"
-        ]
-      }
-    },
-    "/api/v1/push/topics": {
-      "get": {
-        "operationId": "get_push_topics_api_v1_push_topics_get",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PushTopicsResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Get Push Topics",
-        "tags": [
-          "push"
-        ]
-      }
-    },
-    "/api/v1/push/unsubscribe": {
-      "post": {
-        "operationId": "unsubscribe_api_v1_push_unsubscribe_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PushSubscriptionDelete"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "additionalProperties": {
-                    "type": "boolean"
-                  },
-                  "title": "Response Unsubscribe Api V1 Push Unsubscribe Post",
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Unsubscribe",
-        "tags": [
-          "push"
-        ]
-      }
-    },
-    "/api/v1/push/vapid-public-key": {
-      "get": {
-        "description": "Return configured VAPID public key.",
-        "operationId": "get_vapid_public_key_api_v1_push_vapid_public_key_get",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "additionalProperties": {
-                    "type": "string"
-                  },
-                  "title": "Response Get Vapid Public Key Api V1 Push Vapid Public Key Get",
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "summary": "Get Vapid Public Key",
-        "tags": [
-          "push"
-        ]
-      }
-    },
-    "/api/v1/schedule": {
-      "post": {
-        "operationId": "add_schedule_api_v1_schedule_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ScheduleCreate"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ScheduleOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Add Schedule",
-        "tags": [
-          "schedule"
-        ]
-      }
-    },
-    "/api/v1/schedule/ics": {
-      "get": {
-        "operationId": "download_schedule_ics_api_v1_schedule_ics_get",
-        "parameters": [
-          {
-            "description": "Group identifier",
-            "in": "query",
-            "name": "group",
-            "required": true,
-            "schema": {
-              "description": "Group identifier",
-              "title": "Group",
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Download Schedule Ics",
-        "tags": [
-          "schedule"
-        ]
-      }
-    },
-    "/api/v1/schedule/{group_id}": {
-      "get": {
-        "operationId": "get_schedule_api_v1_schedule__group_id__get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "group_id",
-            "required": true,
-            "schema": {
-              "title": "Group Id",
-              "type": "integer"
-            }
-          },
-          {
-            "in": "header",
-            "name": "if-none-match",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "If-None-Match"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/ScheduleOut"
-                  },
-                  "title": "Response Get Schedule Api V1 Schedule  Group Id  Get",
-                  "type": "array"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Get Schedule",
-        "tags": [
-          "schedule"
-        ]
-      }
-    },
-    "/api/v1/schedule/{schedule_id}": {
-      "delete": {
-        "operationId": "delete_schedule_api_v1_schedule__schedule_id__delete",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "schedule_id",
-            "required": true,
-            "schema": {
-              "title": "Schedule Id",
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "additionalProperties": true,
-                  "title": "Response Delete Schedule Api V1 Schedule  Schedule Id  Delete",
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Delete Schedule",
-        "tags": [
-          "schedule"
-        ]
-      },
-      "patch": {
-        "operationId": "update_schedule_api_v1_schedule__schedule_id__patch",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "schedule_id",
-            "required": true,
-            "schema": {
-              "title": "Schedule Id",
-              "type": "integer"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ScheduleUpdate"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ScheduleOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Update Schedule",
-        "tags": [
-          "schedule"
-        ]
-      }
-    },
-    "/api/v1/spotify/auth-url": {
-      "get": {
-        "operationId": "spotify_auth_url_api_v1_spotify_auth_url_get",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SpotifyAuthURL"
-                }
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Spotify Auth Url",
-        "tags": [
-          "spotify"
-        ]
-      }
-    },
-    "/api/v1/spotify/callback": {
-      "get": {
-        "operationId": "spotify_callback_api_v1_spotify_callback_get",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "code",
-            "required": true,
-            "schema": {
-              "title": "Code",
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "state",
-            "required": true,
-            "schema": {
-              "title": "State",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Spotify Callback",
-        "tags": [
-          "spotify"
-        ]
-      }
-    },
-    "/api/v1/spotify/disconnect": {
-      "post": {
-        "operationId": "disconnect_api_v1_spotify_disconnect_post",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Disconnect",
-        "tags": [
-          "spotify"
-        ]
-      }
-    },
-    "/api/v1/spotify/now-playing": {
-      "get": {
-        "operationId": "now_playing_api_v1_spotify_now_playing_get",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SpotifyNowPlayingOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Now Playing",
-        "tags": [
-          "spotify"
-        ]
-      }
-    },
-    "/api/v1/stats/attendance": {
-      "get": {
-        "operationId": "attendance_summary_api_v1_stats_attendance_get",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "period",
-            "required": false,
-            "schema": {
-              "default": "30d",
-              "title": "Period",
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "skip_cache",
-            "required": false,
-            "schema": {
-              "default": false,
-              "title": "Skip Cache",
-              "type": "boolean"
-            }
-          },
-          {
-            "in": "header",
-            "name": "if-none-match",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "If-None-Match"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Attendance Summary",
-        "tags": [
-          "stats"
-        ]
-      }
-    },
-    "/api/v1/stats/grades": {
-      "get": {
-        "operationId": "grade_summary_api_v1_stats_grades_get",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "period",
-            "required": false,
-            "schema": {
-              "default": "30d",
-              "title": "Period",
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "skip_cache",
-            "required": false,
-            "schema": {
-              "default": false,
-              "title": "Skip Cache",
-              "type": "boolean"
-            }
-          },
-          {
-            "in": "header",
-            "name": "if-none-match",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "If-None-Match"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Grade Summary",
-        "tags": [
-          "stats"
-        ]
-      }
-    },
-    "/api/v1/stats/participation": {
-      "get": {
-        "operationId": "participation_summary_api_v1_stats_participation_get",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "period",
-            "required": false,
-            "schema": {
-              "default": "30d",
-              "title": "Period",
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "skip_cache",
-            "required": false,
-            "schema": {
-              "default": false,
-              "title": "Skip Cache",
-              "type": "boolean"
-            }
-          },
-          {
-            "in": "header",
-            "name": "if-none-match",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "If-None-Match"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Participation Summary",
-        "tags": [
-          "stats"
-        ]
-      }
-    },
-    "/api/v1/stories": {
-      "get": {
-        "operationId": "list_stories_api_v1_stories_get",
-        "parameters": [
-          {
-            "in": "header",
-            "name": "if-none-match",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "If-None-Match"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/StoryOut"
-                  },
-                  "title": "Response List Stories Api V1 Stories Get",
-                  "type": "array"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "List Stories",
-        "tags": [
-          "stories"
-        ]
-      },
-      "post": {
-        "operationId": "create_story_api_v1_stories_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/StoryCreate"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StoryOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Create Story",
-        "tags": [
-          "stories"
-        ]
-      }
-    },
-    "/api/v1/stories/upload_cover": {
-      "post": {
-        "operationId": "upload_story_cover_api_v1_stories_upload_cover_post",
-        "requestBody": {
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "$ref": "#/components/schemas/Body_upload_story_cover_api_v1_stories_upload_cover_post"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Upload Story Cover",
-        "tags": [
-          "stories"
-        ]
-      }
-    },
-    "/api/v1/stories/{story_id}": {
-      "delete": {
-        "operationId": "delete_story_api_v1_stories__story_id__delete",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "story_id",
-            "required": true,
-            "schema": {
-              "title": "Story Id",
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "additionalProperties": true,
-                  "title": "Response Delete Story Api V1 Stories  Story Id  Delete",
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Delete Story",
-        "tags": [
-          "stories"
-        ]
-      },
-      "patch": {
-        "operationId": "update_story_api_v1_stories__story_id__patch",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "story_id",
-            "required": true,
-            "schema": {
-              "title": "Story Id",
-              "type": "integer"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/StoryUpdate"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "title": "Data"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StoryOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Update Story",
-        "tags": [
-          "stories"
-        ]
-      }
-    },
-    "/api/v1/users": {
-      "get": {
-        "operationId": "get_users_api_v1_users_get",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "full_name",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Full Name"
-            }
-          },
-          {
-            "in": "query",
-            "name": "search",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Search"
-            }
-          },
-          {
-            "in": "query",
-            "name": "group_id",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Group Id"
-            }
-          },
-          {
-            "in": "query",
-            "name": "role",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Role"
-            }
-          },
-          {
-            "in": "query",
-            "name": "limit",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "maximum": 100,
-                  "minimum": 1,
-                  "type": "integer"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Limit"
-            }
-          },
-          {
-            "in": "query",
-            "name": "offset",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "minimum": 0,
-                  "type": "integer"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Offset"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/UserOut"
-                  },
-                  "title": "Response Get Users Api V1 Users Get",
-                  "type": "array"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Get Users",
-        "tags": [
-          "users"
-        ]
-      },
-      "post": {
-        "operationId": "create_user_api_v1_users_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UserCreate"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UserOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Create User",
-        "tags": [
-          "users"
-        ]
-      }
-    },
-    "/api/v1/users/me": {
-      "get": {
-        "operationId": "me_api_v1_users_me_get",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UserOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Me",
-        "tags": [
-          "users"
-        ]
-      },
-      "put": {
-        "operationId": "update_me_api_v1_users_me_put",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UserProfileUpdate"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UserOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Update Me",
-        "tags": [
-          "users"
-        ]
-      }
-    },
-    "/api/v1/users/me/avatar": {
-      "delete": {
-        "operationId": "delete_avatar_api_v1_users_me_avatar_delete",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UserOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Delete Avatar",
-        "tags": [
-          "users"
-        ]
-      },
-      "post": {
-        "operationId": "upload_avatar_api_v1_users_me_avatar_post",
-        "requestBody": {
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "$ref": "#/components/schemas/Body_upload_avatar_api_v1_users_me_avatar_post"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UserOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Upload Avatar",
-        "tags": [
-          "users"
-        ]
-      }
-    },
-    "/api/v1/users/me/cover": {
-      "delete": {
-        "operationId": "delete_cover_api_v1_users_me_cover_delete",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UserOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Delete Cover",
-        "tags": [
-          "users"
-        ]
-      },
-      "post": {
-        "operationId": "upload_cover_api_v1_users_me_cover_post",
-        "requestBody": {
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "$ref": "#/components/schemas/Body_upload_cover_api_v1_users_me_cover_post"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UserOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Upload Cover",
-        "tags": [
-          "users"
-        ]
-      }
-    },
-    "/api/v1/users/me/email": {
-      "post": {
-        "operationId": "change_email_api_v1_users_me_email_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UserEmailChangeIn"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UserOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Change Email",
-        "tags": [
-          "users"
-        ]
-      }
-    },
-    "/api/v1/users/me/email/confirm": {
-      "post": {
-        "operationId": "confirm_email_change_api_v1_users_me_email_confirm_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UserEmailConfirmIn"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UserOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Confirm Email Change",
-        "tags": [
-          "users"
-        ]
-      }
-    },
-    "/api/v1/users/me/password": {
-      "post": {
-        "operationId": "change_password_api_v1_users_me_password_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UserPasswordChangeIn"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PasswordChangeOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Change Password",
-        "tags": [
-          "users"
-        ]
-      }
-    },
-    "/api/v1/users/{user_id}": {
-      "patch": {
-        "operationId": "update_user_admin_api_v1_users__user_id__patch",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "user_id",
-            "required": true,
-            "schema": {
-              "title": "User Id",
-              "type": "integer"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UserAdminUpdate"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UserOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Update User Admin",
-        "tags": [
-          "users"
-        ]
-      }
-    },
-    "/healthz": {
-      "get": {
-        "operationId": "healthz_healthz_get",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "summary": "Healthz"
-      }
-    },
-    "/ready": {
-      "get": {
-        "operationId": "ready_ready_get",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "summary": "Ready"
-      }
-    },
-    "/webpush/admin/disable-user": {
-      "post": {
-        "operationId": "disable_user_push_webpush_admin_disable_user_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/DisableUserPushRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "additionalProperties": {
-                    "anyOf": [
-                      {
-                        "type": "integer"
-                      },
-                      {
-                        "type": "boolean"
-                      }
-                    ]
-                  },
-                  "title": "Response Disable User Push Webpush Admin Disable User Post",
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Disable User Push",
-        "tags": [
-          "webpush"
-        ]
-      }
-    },
-    "/webpush/broadcast": {
-      "post": {
-        "operationId": "broadcast_webpush_broadcast_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/NotifyBody"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SendTestResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Broadcast",
-        "tags": [
-          "webpush"
-        ]
-      }
-    },
-    "/webpush/send-test": {
-      "post": {
-        "operationId": "send_test_webpush_send_test_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/PushTestRequest"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "title": "Payload"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SendTestResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Send Test",
-        "tags": [
-          "webpush"
-        ]
-      }
-    },
-    "/webpush/subscribe": {
-      "post": {
-        "operationId": "subscribe_webpush_subscribe_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PushSubscriptionIn"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PushSubscriptionOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Subscribe",
-        "tags": [
-          "webpush"
-        ]
-      }
-    },
-    "/webpush/subscribe/topics": {
-      "patch": {
-        "operationId": "update_subscription_topics_webpush_subscribe_topics_patch",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PushSubscriptionTopicsUpdate"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PushSubscriptionOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Update Subscription Topics",
-        "tags": [
-          "webpush"
-        ]
-      }
-    },
-    "/webpush/unsubscribe": {
-      "post": {
-        "operationId": "unsubscribe_webpush_unsubscribe_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PushSubscriptionDelete"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "additionalProperties": {
-                    "type": "boolean"
-                  },
-                  "title": "Response Unsubscribe Webpush Unsubscribe Post",
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Unsubscribe",
-        "tags": [
-          "webpush"
-        ]
-      }
-    },
-    "/webpush/vapid-public-key": {
-      "get": {
-        "description": "Return configured VAPID public key.",
-        "operationId": "get_vapid_public_key_webpush_vapid_public_key_get",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "additionalProperties": {
-                    "type": "string"
-                  },
-                  "title": "Response Get Vapid Public Key Webpush Vapid Public Key Get",
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "summary": "Get Vapid Public Key",
-        "tags": [
-          "webpush"
-        ]
-      }
-    },
-    "/api/v1/notifications/admin/dead-letter": {
-      "get": {
-        "summary": "List Dead Letter Queue",
-        "operationId": "list_dead_letter_queue_api_v1_notifications_admin_dead_letter_get",
-        "parameters": [
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "title": "Limit",
-              "type": "integer"
-            }
-          },
-          {
-            "name": "offset",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "title": "Offset",
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotificationDeadLetterListOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/notifications/admin/dead-letter/retry": {
-      "post": {
-        "summary": "Retry Dead Letter Queue",
-        "operationId": "retry_dead_letter_queue_api_v1_notifications_admin_dead_letter_retry_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/NotificationDeadLetterReplayIn"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/notifications/admin/dead-letter/purge": {
-      "post": {
-        "summary": "Purge Dead Letter Queue",
-        "operationId": "purge_dead_letter_queue_api_v1_notifications_admin_dead_letter_purge_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/NotificationDeadLetterPurgeIn"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
           }
         }
       }

--- a/root/tests/test_chat_lifecycle.py
+++ b/root/tests/test_chat_lifecycle.py
@@ -4,7 +4,9 @@ from httpx import AsyncClient
 from app.auth.security import get_password_hash
 
 
-async def _login(async_client: AsyncClient, email: str, password: str) -> dict[str, str]:
+async def _login(
+    async_client: AsyncClient, email: str, password: str
+) -> dict[str, str]:
     response = await async_client.post(
         "/auth/login",
         data={"username": email, "password": password},
@@ -42,9 +44,7 @@ async def test_chat_full_lifecycle(async_client, user_factory):
     assert initial_messages.status_code == 200
     assert initial_messages.json()["items"]
 
-    clear_resp = await async_client.post(
-        f"/chats/{chat_id}/clear", headers=headers
-    )
+    clear_resp = await async_client.post(f"/chats/{chat_id}/clear", headers=headers)
     assert clear_resp.status_code == 200
     assert clear_resp.json()["status"] == "cleared"
     assert clear_resp.json()["deleted_messages"] == 1
@@ -55,13 +55,9 @@ async def test_chat_full_lifecycle(async_client, user_factory):
     assert cleared_messages.status_code == 200
     assert cleared_messages.json()["items"] == []
 
-    delete_resp = await async_client.delete(
-        f"/chats/{chat_id}", headers=headers
-    )
+    delete_resp = await async_client.delete(f"/chats/{chat_id}", headers=headers)
     assert delete_resp.status_code == 200
     assert delete_resp.json()["status"] == "deleted"
 
-    missing_resp = await async_client.get(
-        f"/chats/{chat_id}/messages", headers=headers
-    )
+    missing_resp = await async_client.get(f"/chats/{chat_id}/messages", headers=headers)
     assert missing_resp.status_code == 404

--- a/root/tests/test_chat_lifecycle.py
+++ b/root/tests/test_chat_lifecycle.py
@@ -1,0 +1,67 @@
+import pytest
+from httpx import AsyncClient
+
+from app.auth.security import get_password_hash
+
+
+async def _login(async_client: AsyncClient, email: str, password: str) -> dict[str, str]:
+    response = await async_client.post(
+        "/auth/login",
+        data={"username": email, "password": password},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert response.status_code == 200
+    token = response.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.mark.anyio
+async def test_chat_full_lifecycle(async_client, user_factory):
+    password = "Lifecycle123!"
+    user = await user_factory(hashed_password=get_password_hash(password))
+    other = await user_factory()
+
+    headers = await _login(async_client, user.email, password)
+
+    create_resp = await async_client.post(
+        "/chats", json={"participant_id": other.id}, headers=headers
+    )
+    assert create_resp.status_code == 200
+    chat_id = create_resp.json()["id"]
+
+    send_resp = await async_client.post(
+        f"/chats/{chat_id}/messages",
+        data={"content": "Hello"},
+        headers=headers,
+    )
+    assert send_resp.status_code == 200
+
+    initial_messages = await async_client.get(
+        f"/chats/{chat_id}/messages", headers=headers
+    )
+    assert initial_messages.status_code == 200
+    assert initial_messages.json()["items"]
+
+    clear_resp = await async_client.post(
+        f"/chats/{chat_id}/clear", headers=headers
+    )
+    assert clear_resp.status_code == 200
+    assert clear_resp.json()["status"] == "cleared"
+    assert clear_resp.json()["deleted_messages"] == 1
+
+    cleared_messages = await async_client.get(
+        f"/chats/{chat_id}/messages", headers=headers
+    )
+    assert cleared_messages.status_code == 200
+    assert cleared_messages.json()["items"] == []
+
+    delete_resp = await async_client.delete(
+        f"/chats/{chat_id}", headers=headers
+    )
+    assert delete_resp.status_code == 200
+    assert delete_resp.json()["status"] == "deleted"
+
+    missing_resp = await async_client.get(
+        f"/chats/{chat_id}/messages", headers=headers
+    )
+    assert missing_resp.status_code == 404


### PR DESCRIPTION
## Summary
- add chat maintenance endpoints to clear history or delete chats with permission checks and attachment cleanup
- extend chat schemas/OpenAPI snapshot and regenerate the frontend API client
- wire messenger menu actions to new API calls with optimistic updates, profile preview, and lifecycle test coverage

## Testing
- pytest root/tests/test_chat_lifecycle.py *(fails in this environment: SQLite backend cannot compile JSONB type)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e0e73a4ac8327bb4f328680cecd21)