### PR TITLE
Add chat presence broadcasting and realtime UI updates

### DIFF
--- a/root/app/api/chat.py
+++ b/root/app/api/chat.py
@@ -16,7 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.api.deps import get_current_user
-from app.api.websocket import notify_new_message
+from app.api.websocket import build_presence_map, notify_new_message
 from app.core.config import settings
 from app.core.database import get_db
 from app.localization import translate
@@ -29,6 +29,7 @@ from app.schemas.chat import (
     ChatsListOut,
     MessageResponse,
     MessagesListOut,
+    PresenceStatus,
 )
 from app.utils.files import delete_static_file, save_attachment
 
@@ -120,6 +121,11 @@ async def get_chats(
     query = query.order_by(last_message_subquery.desc().nulls_last()).limit(limit + 1)
     result = await session.execute(query)
     chats = result.scalars().all()
+    participant_ids: set[int] = set()
+
+    for chat in chats:
+        for participant in chat.participants:
+            participant_ids.add(participant.id)
 
     # Check if there are more results
     has_more = len(chats) > limit
@@ -157,8 +163,39 @@ async def get_chats(
         last_chat = chats[-1]
         next_cursor = _encode_cursor(last_chat.updated_at, last_chat.id)
 
+    presence_map = await build_presence_map(participant_ids)
+
+    enriched_chats = []
+    for chat in chat_responses:
+        last_message = chat.last_message
+        if isinstance(last_message, Message):
+            last_message = MessageResponse(
+                id=last_message.id,
+                chat_id=last_message.chat_id,
+                sender_id=last_message.sender_id,
+                content=last_message.content,
+                created_at=last_message.created_at,
+                read_status=last_message.read_status,
+                sender=last_message.sender,
+                attachments=last_message.attachments,
+                sender_presence=presence_map.get(last_message.sender_id),
+            )
+
+        participant_status = {}
+        for participant in chat.participants:
+            participant_status[participant.id] = presence_map.get(
+                participant.id, PresenceStatus()
+            )
+        enriched_chats.append(
+            ChatResponse(
+                **chat.model_dump(),
+                last_message=last_message,
+                presence=participant_status,
+            )
+        )
+
     return ChatsListOut(
-        items=chat_responses,
+        items=enriched_chats,
         has_more=has_more,
         next_cursor=next_cursor,
     )
@@ -219,11 +256,17 @@ async def create_chat(
     await session.commit()
     await session.refresh(new_chat)
 
+    presence_map = await build_presence_map([p.id for p in new_chat.participants])
+
     return ChatResponse(
         id=new_chat.id,
         participants=new_chat.participants,
         created_at=new_chat.created_at,
         updated_at=new_chat.updated_at,
+        presence={
+            participant.id: presence_map.get(participant.id, PresenceStatus())
+            for participant in new_chat.participants
+        },
     )
 
 
@@ -284,8 +327,25 @@ async def get_messages(
         oldest_message = messages[0]  # First in ascending order = oldest
         next_cursor = _encode_cursor(oldest_message.created_at, oldest_message.id)
 
+    presence_map = await build_presence_map({msg.sender_id for msg in messages})
+
+    response_items = [
+        MessageResponse(
+            id=msg.id,
+            chat_id=msg.chat_id,
+            sender_id=msg.sender_id,
+            content=msg.content,
+            created_at=msg.created_at,
+            read_status=msg.read_status,
+            sender=msg.sender,
+            attachments=msg.attachments,
+            sender_presence=presence_map.get(msg.sender_id),
+        )
+        for msg in messages
+    ]
+
     return MessagesListOut(
-        items=messages,
+        items=response_items,
         has_more=has_more,
         next_cursor=next_cursor,
     )
@@ -409,7 +469,19 @@ async def send_message(
     # Notify other participants via WebSocket
     await notify_new_message(message, exclude_user_id=current_user.id)
 
-    return message
+    presence_map = await build_presence_map([message.sender_id])
+
+    return MessageResponse(
+        id=message.id,
+        chat_id=message.chat_id,
+        sender_id=message.sender_id,
+        content=message.content,
+        created_at=message.created_at,
+        read_status=message.read_status,
+        sender=message.sender,
+        attachments=message.attachments,
+        sender_presence=presence_map.get(message.sender_id),
+    )
 
 
 @router.post("/{chat_id}/read")

--- a/root/app/api/websocket.py
+++ b/root/app/api/websocket.py
@@ -12,15 +12,17 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any
+from datetime import UTC, datetime
+from typing import Any, Iterable
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+from sqlalchemy import func, select
 from sqlalchemy.orm import selectinload
 
 from app.core.database import async_session
 from app.models.chat import Chat, Message
-from app.models.models import User
-from app.schemas.chat import ChatParticipant
+from app.models.models import ActiveSession, User
+from app.schemas.chat import ChatParticipant, PresenceStatus
 
 logger = logging.getLogger(__name__)
 
@@ -103,6 +105,23 @@ class ConnectionManager:
                     total_sent += await self.send_to_user(participant.id, message)
         return total_sent
 
+    async def broadcast_presence(
+        self, user_id: int, active: bool, last_seen: datetime | None
+    ) -> int:
+        """Broadcast presence status to all connected users."""
+
+        payload = {
+            "type": "presence",
+            "user_id": user_id,
+            "active": active,
+            "last_seen": last_seen.isoformat() if last_seen else None,
+        }
+
+        total_sent = 0
+        for target_user in list(self.active_connections.keys()):
+            total_sent += await self.send_to_user(target_user, payload)
+        return total_sent
+
     def get_online_users(self) -> list[int]:
         """Get list of all online user IDs."""
         return list(self.active_connections.keys())
@@ -112,28 +131,55 @@ class ConnectionManager:
 manager = ConnectionManager()
 
 
-async def get_user_from_token(token: str) -> User | None:
-    """Validate JWT token and return the user."""
+async def get_user_from_token(token: str) -> tuple[User | None, str | None]:
+    """Validate JWT token and return the user and session identifier."""
     from app.auth.security import decode_token
 
     try:
         payload = decode_token(token)
         if not payload:
-            return None
+            return None, None
 
         user_id = payload.get("sub")
+        session_jti = payload.get("jti")
         if not user_id:
-            return None
+            return None, None
 
         async with async_session() as session:
             user = await session.get(User, int(user_id))
-            return user if user and user.is_active else None
+            if not user or not user.is_active:
+                return None, None
+
+            if not session_jti:
+                return None, None
+
+            result = await session.execute(
+                select(ActiveSession).where(ActiveSession.jti == session_jti)
+            )
+            active_session = result.scalars().first()
+            if not active_session or active_session.user_id != user.id:
+                return None, None
+
+            expires_at = active_session.expires_at
+            if expires_at is None:
+                return None, None
+
+            if expires_at.tzinfo is None:
+                expires_at = expires_at.replace(tzinfo=UTC)
+
+            if expires_at <= datetime.now(UTC):
+                return None, None
+
+            if active_session.revoked_at is not None:
+                return None, None
+
+            return user, session_jti
     except Exception as e:
         logger.warning(f"Token validation failed: {e}")
-        return None
+        return None, None
 
 
-async def get_user_from_cookie(cookie_value: str) -> User | None:
+async def get_user_from_cookie(cookie_value: str) -> tuple[User | None, str | None]:
     """Validate session cookie and return the user."""
 
     try:
@@ -141,14 +187,69 @@ async def get_user_from_cookie(cookie_value: str) -> User | None:
         return await get_user_from_token(cookie_value)
     except Exception as e:
         logger.warning(f"Cookie validation failed: {e}")
-        return None
+        return None, None
 
 
-def serialize_message(message: Message) -> dict[str, Any]:
+async def _update_last_seen(session_jti: str | None) -> datetime:
+    """Persist last_seen_at for a session and return the timestamp used."""
+
+    now = datetime.now(UTC)
+    if not session_jti:
+        return now
+
+    async with async_session() as session:
+        result = await session.execute(
+            select(ActiveSession).where(ActiveSession.jti == session_jti)
+        )
+        active_session = result.scalars().first()
+        if active_session:
+            active_session.last_seen_at = now
+            await session.commit()
+
+    return now
+
+
+async def build_presence_map(user_ids: Iterable[int]) -> dict[int, PresenceStatus]:
+    """Return presence info for a set of users."""
+
+    ids = {uid for uid in user_ids if uid is not None}
+    if not ids:
+        return {}
+
+    async with async_session() as session:
+        result = await session.execute(
+            select(ActiveSession.user_id, func.max(ActiveSession.last_seen_at))
+            .where(ActiveSession.user_id.in_(ids))
+            .group_by(ActiveSession.user_id)
+        )
+        last_seen_map = {row[0]: row[1] for row in result.all()}
+
+    presence: dict[int, PresenceStatus] = {}
+    for uid in ids:
+        presence[uid] = PresenceStatus(
+            active=manager.is_online(uid),
+            last_seen_at=last_seen_map.get(uid),
+        )
+    return presence
+
+
+def serialize_message(
+    message: Message, presence: dict[int, PresenceStatus] | None = None
+) -> dict[str, Any]:
     """Serialize a Message object for WebSocket transmission."""
     sender_data = None
     if message.sender:
         sender_data = ChatParticipant.model_validate(message.sender).model_dump()
+
+    sender_presence = None
+    if presence and message.sender_id in presence:
+        status = presence[message.sender_id]
+        sender_presence = {
+            "active": status.active,
+            "last_seen_at": status.last_seen_at.isoformat()
+            if status.last_seen_at
+            else None,
+        }
 
     return {
         "id": message.id,
@@ -158,6 +259,7 @@ def serialize_message(message: Message) -> dict[str, Any]:
         "created_at": message.created_at.isoformat() if message.created_at else None,
         "read_status": message.read_status,
         "sender": sender_data,
+        "sender_presence": sender_presence,
         "attachments": [
             {
                 "id": att.id,
@@ -191,10 +293,12 @@ async def websocket_chat(websocket: WebSocket):
     - {"type": "typing", "chat_id": "...", "user_id": ...} - Someone is typing
     - {"type": "read", "chat_id": "...", "message_id": "...", "user_id": ...}
       - Message read
-    - {"type": "online", "user_id": ..., "status": true/false} - User online status
+    - {"type": "presence", "user_id": ..., "active": true/false, "last_seen": "..."}
+      - Participant presence updates
     - {"type": "error", "message": "..."} - Error message
     """
     user = None
+    session_jti = None
 
     # Debug: log incoming connection info
     logger.info(
@@ -208,7 +312,7 @@ async def websocket_chat(websocket: WebSocket):
     token = websocket.query_params.get("token")
     if token:
         logger.info("Attempting token auth from query params")
-        user = await get_user_from_token(token)
+        user, session_jti = await get_user_from_token(token)
         if user:
             logger.info(f"Token auth successful: user_id={user.id}")
         else:
@@ -221,7 +325,7 @@ async def websocket_chat(websocket: WebSocket):
             f"Attempting cookie auth, access_token present: {bool(access_token)}"
         )
         if access_token:
-            user = await get_user_from_cookie(access_token)
+            user, session_jti = await get_user_from_cookie(access_token)
             if user:
                 logger.info(f"Cookie auth successful: user_id={user.id}")
             else:
@@ -234,6 +338,8 @@ async def websocket_chat(websocket: WebSocket):
 
     # Connect and register
     await manager.connect(websocket, user.id)
+    last_seen = await _update_last_seen(session_jti)
+    await manager.broadcast_presence(user.id, True, last_seen)
 
     try:
         # Send initial online status to user's contacts
@@ -249,7 +355,9 @@ async def websocket_chat(websocket: WebSocket):
             msg_type = data.get("type")
 
             if msg_type == "ping":
+                last_seen = await _update_last_seen(session_jti)
                 await websocket.send_json({"type": "pong"})
+                await manager.broadcast_presence(user.id, True, last_seen)
 
             elif msg_type == "typing":
                 chat_id = data.get("chat_id")
@@ -300,10 +408,14 @@ async def websocket_chat(websocket: WebSocket):
 
     except WebSocketDisconnect:
         manager.disconnect(websocket)
+        last_seen = await _update_last_seen(session_jti)
+        await manager.broadcast_presence(user.id, False, last_seen)
         logger.info(f"WebSocket disconnected for user {user.id}")
     except Exception as e:
         logger.error(f"WebSocket error for user {user.id}: {e}")
         manager.disconnect(websocket)
+        last_seen = await _update_last_seen(session_jti)
+        await manager.broadcast_presence(user.id, False, last_seen)
 
 
 async def notify_new_message(
@@ -315,12 +427,13 @@ async def notify_new_message(
 
     Returns the number of successful notifications sent.
     """
+    presence = await build_presence_map([message.sender_id])
     return await manager.broadcast_to_chat(
         message.chat_id,
         {
             "type": "new_message",
             "chat_id": message.chat_id,
-            "message": serialize_message(message),
+            "message": serialize_message(message, presence),
         },
         exclude_user_id=exclude_user_id,
     )

--- a/root/app/api/websocket.py
+++ b/root/app/api/websocket.py
@@ -12,8 +12,9 @@ from __future__ import annotations
 
 import json
 import logging
+from collections.abc import Iterable
 from datetime import UTC, datetime
-from typing import Any, Iterable
+from typing import Any
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from sqlalchemy import func, select
@@ -246,9 +247,9 @@ def serialize_message(
         status = presence[message.sender_id]
         sender_presence = {
             "active": status.active,
-            "last_seen_at": status.last_seen_at.isoformat()
-            if status.last_seen_at
-            else None,
+            "last_seen_at": (
+                status.last_seen_at.isoformat() if status.last_seen_at else None
+            ),
         }
 
     return {

--- a/root/app/schemas/chat.py
+++ b/root/app/schemas/chat.py
@@ -14,6 +14,13 @@ class ChatParticipant(BaseModel):
     is_active: bool
 
 
+class PresenceStatus(BaseModel):
+    """Represents a participant's presence state."""
+
+    active: bool = False
+    last_seen_at: datetime | None = None
+
+
 class MessageBase(BaseModel):
     content: str
 
@@ -40,6 +47,7 @@ class MessageResponse(MessageBase):
     created_at: datetime
     read_status: bool
     sender: ChatParticipant | None = None
+    sender_presence: PresenceStatus | None = None
     attachments: list[AttachmentResponse] = []
 
     class Config:
@@ -61,6 +69,7 @@ class ChatResponse(ChatBase):
     unread_count: int = 0
     created_at: datetime
     updated_at: datetime
+    presence: dict[int, PresenceStatus] | None = None
 
     class Config:
         from_attributes = True

--- a/root/frontend/src/api/chat.ts
+++ b/root/frontend/src/api/chat.ts
@@ -9,6 +9,11 @@ export interface Attachment {
   size: number
 }
 
+export interface PresenceStatus {
+  active: boolean
+  last_seen_at: string | null
+}
+
 export interface Message {
   id: string
   chat_id: string
@@ -17,6 +22,7 @@ export interface Message {
   created_at: string
   read_status: boolean
   sender?: User
+  sender_presence?: PresenceStatus
   attachments?: Attachment[]
 }
 
@@ -27,6 +33,7 @@ export interface Chat {
   unread_count: number
   created_at: string
   updated_at: string
+  presence?: Record<number, PresenceStatus>
 }
 
 // Paginated response types

--- a/root/frontend/src/hooks/useChatWebSocket.ts
+++ b/root/frontend/src/hooks/useChatWebSocket.ts
@@ -10,6 +10,7 @@ export type WebSocketMessageType =
   | "read"
   | "new_message"
   | "online"
+  | "presence"
   | "error"
 
 export interface WebSocketMessage {
@@ -21,6 +22,8 @@ export interface WebSocketMessage {
   message?: Message
   status?: boolean
   users?: number[]
+  active?: boolean
+  last_seen?: string | null
 }
 
 export interface UseChatWebSocketOptions {
@@ -29,6 +32,7 @@ export interface UseChatWebSocketOptions {
   onTyping?: (chatId: string, userId: number, userName: string) => void
   onRead?: (chatId: string, messageId: string, userId: number) => void
   onOnlineStatus?: (userId: number, status: boolean) => void
+  onPresenceUpdate?: (userId: number, active: boolean, lastSeen: string | null) => void
 }
 
 interface TypingUser {
@@ -43,6 +47,7 @@ export function useChatWebSocket({
   onTyping,
   onRead,
   onOnlineStatus,
+  onPresenceUpdate,
 }: UseChatWebSocketOptions) {
   const wsRef = useRef<WebSocket | null>(null)
   const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -56,6 +61,7 @@ export function useChatWebSocket({
   const onTypingRef = useRef(onTyping)
   const onReadRef = useRef(onRead)
   const onOnlineStatusRef = useRef(onOnlineStatus)
+  const onPresenceUpdateRef = useRef(onPresenceUpdate)
   const enabledRef = useRef(enabled)
 
   // Keep refs updated
@@ -64,6 +70,7 @@ export function useChatWebSocket({
     onTypingRef.current = onTyping
     onReadRef.current = onRead
     onOnlineStatusRef.current = onOnlineStatus
+    onPresenceUpdateRef.current = onPresenceUpdate
     enabledRef.current = enabled
   })
 
@@ -184,6 +191,15 @@ export function useChatWebSocket({
             case "online":
               if (data.user_id !== undefined && data.status !== undefined) {
                 onOnlineStatusRef.current?.(data.user_id, data.status)
+              }
+              break
+
+            case "presence":
+              if (data.user_id !== undefined && data.active !== undefined) {
+                const lastSeen = data.last_seen ?? null
+                onPresenceUpdateRef.current?.(data.user_id, data.active, lastSeen)
+                // Maintain backward compatibility with online status updates
+                onOnlineStatusRef.current?.(data.user_id, data.active)
               }
               break
 

--- a/root/frontend/src/pages/Messenger.tsx
+++ b/root/frontend/src/pages/Messenger.tsx
@@ -16,6 +16,7 @@ import {
   type ChatsListResponse,
   type Message,
   type MessagesListResponse,
+  type PresenceStatus,
 } from "../api/chat"
 import { useChatWebSocket } from "../hooks/useChatWebSocket"
 import SmartImage from "@/components/SmartImage"
@@ -37,10 +38,31 @@ export default function Messenger() {
   const [profileUser, setProfileUser] = useState<User | null>(null)
   const [isProfileLoading, setIsProfileLoading] = useState(false)
   const [profileError, setProfileError] = useState<string | null>(null)
+  const [presenceMap, setPresenceMap] = useState<Record<number, PresenceStatus>>({})
 
   // WebSocket for real-time updates (uses cookie-based auth)
   const { isConnected, sendTyping, sendRead, getTypingUsersForChat } = useChatWebSocket({
     enabled: !!user,
+    onPresenceUpdate: (userId, active, lastSeen) => {
+      setPresenceMap((prev) => ({
+        ...prev,
+        [userId]: { active, last_seen_at: lastSeen },
+      }))
+
+      queryClient.setQueryData<ChatsListResponse | undefined>(["chats"], (old) => {
+        if (!old) return old
+        const items = old.items.map((chat) => {
+          const participates = chat.participants.some((p) => p.id === userId)
+          if (!participates) return chat
+
+          const nextPresence = { ...(chat.presence || {}) }
+          nextPresence[userId] = { active, last_seen_at: lastSeen }
+          return { ...chat, presence: nextPresence }
+        })
+
+        return { ...old, items }
+      })
+    },
   })
 
   // Fetch Chats with paginated response
@@ -49,6 +71,21 @@ export default function Messenger() {
     queryFn: () => chatApi.getChats(),
   })
   const chats = chatsData?.items ?? []
+
+  useEffect(() => {
+    if (!chatsData?.items) return
+
+    setPresenceMap((prev) => {
+      const next = { ...prev }
+      chatsData.items.forEach((chat) => {
+        Object.entries(chat.presence || {}).forEach(([id, status]) => {
+          const userId = Number(id)
+          next[userId] = status
+        })
+      })
+      return next
+    })
+  }, [chatsData])
 
   // Fetch Messages for selected chat with paginated response
   const { data: messagesData, isLoading: messagesLoading } = useQuery({
@@ -248,6 +285,7 @@ export default function Messenger() {
   // Transform chats for ContactList component
   const contacts = chats.map((chat) => {
     const other = getOtherParticipant(chat)
+    const status = other ? presenceMap[other.id] : undefined
     return {
       id: chat.id,
       name: other?.full_name || "Unknown User",
@@ -260,7 +298,7 @@ export default function Messenger() {
           })
         : "",
       unread: chat.unread_count,
-      online: false, // TODO: Real online status
+      online: status?.active ?? false,
     }
   })
 

--- a/root/frontend/src/tests/hooks/useChatWebSocket.test.tsx
+++ b/root/frontend/src/tests/hooks/useChatWebSocket.test.tsx
@@ -1,0 +1,97 @@
+import { renderHook, act } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+
+import { useChatWebSocket } from "@/hooks/useChatWebSocket"
+
+class MockWebSocket {
+  static OPEN = 1
+  static CONNECTING = 0
+  static CLOSING = 2
+  static CLOSED = 3
+  static instances: MockWebSocket[] = []
+
+  readyState = MockWebSocket.CONNECTING
+  onopen: (() => void) | null = null
+  onmessage: ((event: MessageEvent) => void) | null = null
+  onclose: ((event: CloseEvent) => void) | null = null
+  onerror: ((event: Event) => void) | null = null
+  sentMessages: string[] = []
+
+  constructor(public url: string) {
+    MockWebSocket.instances.push(this)
+  }
+
+  send(data: string) {
+    this.sentMessages.push(data)
+  }
+
+  close(code?: number) {
+    this.readyState = MockWebSocket.CLOSED
+    this.onclose?.({ code } as CloseEvent)
+  }
+
+  open() {
+    this.readyState = MockWebSocket.OPEN
+    this.onopen?.()
+  }
+
+  receive(data: object) {
+    this.onmessage?.({ data: JSON.stringify(data) } as MessageEvent)
+  }
+}
+
+describe("useChatWebSocket", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    MockWebSocket.instances = []
+    vi.stubGlobal("WebSocket", MockWebSocket)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it("emits presence updates with last seen information", () => {
+    const presenceSpy = vi.fn()
+    const onlineSpy = vi.fn()
+    const queryClient = new QueryClient()
+
+    const { unmount } = renderHook(
+      () =>
+        useChatWebSocket({
+          enabled: true,
+          onPresenceUpdate: presenceSpy,
+          onOnlineStatus: onlineSpy,
+        }),
+      {
+        wrapper: ({ children }) => (
+          <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+        ),
+      }
+    )
+
+    const socket = MockWebSocket.instances[0]
+    expect(socket).toBeDefined()
+
+    act(() => {
+      socket.open()
+    })
+
+    act(() => {
+      socket.receive({
+        type: "presence",
+        user_id: 42,
+        active: true,
+        last_seen: "2024-02-01T10:00:00Z",
+      })
+    })
+
+    expect(presenceSpy).toHaveBeenCalledWith(42, true, "2024-02-01T10:00:00Z")
+    expect(onlineSpy).toHaveBeenCalledWith(42, true)
+
+    unmount()
+    queryClient.clear()
+  })
+})


### PR DESCRIPTION
## Summary
- track session presence with last_seen timestamps and broadcast updates over the chat websocket
- surface participant presence in chat and message API responses
- update the messenger UI and websocket client to reflect live presence with a new test for the hook

## Testing
- npm test -- src/tests/hooks/useChatWebSocket.test.tsx

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e176f42488327ba519885e9510ab8)