### PR TITLE
Add property-based coverage for core domains and raise coverage gate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ lint-frontend:
 	npm run format:check --prefix $(FRONTEND_DIR)
 
 backend-test:
-	cd $(ROOT_DIR) && pytest --cov=app --cov-report=xml --cov-report=term-missing --cov-fail-under=72 --junitxml=pytest-report.xml
+cd $(ROOT_DIR) && pytest --cov=app --cov-report=xml --cov-report=term-missing --cov-fail-under=85 --junitxml=pytest-report.xml
 
 backend-typecheck:
 	cd $(ROOT_DIR) && mypy

--- a/root/requirements-dev.in
+++ b/root/requirements-dev.in
@@ -3,6 +3,7 @@
 pytest>=8.3
 pytest-asyncio>=0.23
 pytest-cov>=5
+hypothesis>=6.112
 fakeredis>=2
 brotli-asgi>=1.4
 asgi-lifespan>=2.1.0

--- a/root/requirements-dev.txt
+++ b/root/requirements-dev.txt
@@ -125,6 +125,8 @@ httptools==0.7.1
     # via uvicorn
 httpx==0.28.1
     # via -r root/requirements.in
+hypothesis==6.112.1
+    # via -r root/requirements-dev.in
 identify==2.6.15
     # via pre-commit
 idna==3.11

--- a/root/tests/conftest.py
+++ b/root/tests/conftest.py
@@ -20,8 +20,10 @@ import fakeredis.aioredis
 import httpx
 import pytest
 from asgi_lifespan import LifespanManager
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.compiler import compiles
 
 pytest_plugins = ("pytest_asyncio", "pytest_cov")
 
@@ -97,6 +99,11 @@ from app.services import notification_queue
 from app.utils import ratelimit as ratelimit_module
 
 _ASYNCIO_PLUGIN_ACTIVE = False
+
+
+@compiles(JSONB, "sqlite")
+def _compile_jsonb_sqlite(_element, _compiler, **_kwargs):  # type: ignore[unused-argument]
+    return "JSON"
 
 
 def pytest_configure(config: pytest.Config) -> None:

--- a/root/tests/test_auth_sessions_domain.py
+++ b/root/tests/test_auth_sessions_domain.py
@@ -50,7 +50,9 @@ async def test_resolve_target_user_allows_admin(db_session, user_factory):
 
 def test_extract_jti_prefers_bearer_header(monkeypatch):
     monkeypatch.setattr(
-        sessions, "decode_token", lambda token: {"jti": "header-jti"}  # noqa: ARG005
+        sessions,
+        "decode_token",
+        lambda token: {"jti": "header-jti"},  # noqa: ARG005
     )
 
     request = _make_request(headers=[(b"authorization", b"Bearer token-value")])

--- a/root/tests/test_auth_sessions_domain.py
+++ b/root/tests/test_auth_sessions_domain.py
@@ -1,0 +1,69 @@
+import pytest
+from fastapi import HTTPException, status
+from starlette.requests import Request
+
+from app.api import sessions
+
+
+def _make_request(headers: list[tuple[bytes, bytes]] | None = None) -> Request:
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/",
+        "headers": headers or [],
+        "client": ("127.0.0.1", 1234),
+    }
+    return Request(scope)
+
+
+@pytest.mark.anyio
+async def test_resolve_target_user_rejects_non_admin(db_session, user_factory):
+    current_user = await user_factory(role="student")
+    target_user = await user_factory(role="student")
+
+    with pytest.raises(HTTPException) as exc:
+        await sessions._resolve_target_user(  # noqa: SLF001
+            db=db_session,
+            current_user=current_user,
+            requested_user_id=target_user.id,
+            locale="en",
+        )
+
+    assert exc.value.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.anyio
+async def test_resolve_target_user_allows_admin(db_session, user_factory):
+    admin = await user_factory(role="admin")
+    target_user = await user_factory(role="student")
+
+    resolved_id, resolved_user = await sessions._resolve_target_user(  # noqa: SLF001
+        db=db_session,
+        current_user=admin,
+        requested_user_id=target_user.id,
+        locale="en",
+    )
+
+    assert resolved_id == target_user.id
+    assert resolved_user.id == target_user.id
+
+
+def test_extract_jti_prefers_bearer_header(monkeypatch):
+    monkeypatch.setattr(
+        sessions, "decode_token", lambda token: {"jti": "header-jti"}  # noqa: ARG005
+    )
+
+    request = _make_request(headers=[(b"authorization", b"Bearer token-value")])
+    assert sessions._extract_jti(request) == "header-jti"  # noqa: SLF001
+
+
+def test_extract_jti_uses_cookie_when_header_missing(monkeypatch):
+    def _decode(token: str):  # noqa: ANN001
+        if token == "cookie-token":
+            return {"jti": "cookie-jti"}
+        return None
+
+    monkeypatch.setattr(sessions, "decode_token", _decode)
+
+    request = _make_request(headers=[(b"cookie", b"access_token=cookie-token")])
+    assert sessions._extract_jti(request) == "cookie-jti"  # noqa: SLF001

--- a/root/tests/test_files_mime_edges.py
+++ b/root/tests/test_files_mime_edges.py
@@ -10,9 +10,13 @@ def test_normalize_mime_type_strips_parameters_and_whitespace():
 
 def test_polyglot_detection_flags_script_in_pdf():
     payload = b"%PDF-1.4\n<script>alert(1)</script>"
-    assert files._looks_like_polyglot(payload, "application/pdf") is True  # noqa: SLF001
+    assert (
+        files._looks_like_polyglot(payload, "application/pdf") is True
+    )  # noqa: SLF001
 
 
 def test_polyglot_detection_allows_clean_svg():
-    payload = b"<svg xmlns='http://www.w3.org/2000/svg'><rect width='10' height='10'/></svg>"
+    payload = (
+        b"<svg xmlns='http://www.w3.org/2000/svg'><rect width='10' height='10'/></svg>"
+    )
     assert files._looks_like_polyglot(payload, "image/svg+xml") is False  # noqa: SLF001

--- a/root/tests/test_files_mime_edges.py
+++ b/root/tests/test_files_mime_edges.py
@@ -1,0 +1,18 @@
+from app.utils import files
+
+
+def test_normalize_mime_type_strips_parameters_and_whitespace():
+    assert (
+        files._normalize_mime_type("  TEXT/PLAIN; charset=utf-8  ")  # noqa: SLF001
+        == "text/plain"
+    )
+
+
+def test_polyglot_detection_flags_script_in_pdf():
+    payload = b"%PDF-1.4\n<script>alert(1)</script>"
+    assert files._looks_like_polyglot(payload, "application/pdf") is True  # noqa: SLF001
+
+
+def test_polyglot_detection_allows_clean_svg():
+    payload = b"<svg xmlns='http://www.w3.org/2000/svg'><rect width='10' height='10'/></svg>"
+    assert files._looks_like_polyglot(payload, "image/svg+xml") is False  # noqa: SLF001

--- a/root/tests/test_pagination.py
+++ b/root/tests/test_pagination.py
@@ -3,9 +3,9 @@
 from datetime import UTC, datetime, timedelta
 
 import pytest
+from httpx import AsyncClient
 from hypothesis import given, settings
 from hypothesis import strategies as st
-from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import crud
@@ -35,7 +35,9 @@ def test_chat_cursor_round_trip(timestamp_ms: int, identifier: str) -> None:
 
 @settings(max_examples=25)
 @given(
-    value=st.text(min_size=1).filter(lambda raw: raw.count(":") != 1 or not raw.strip()),
+    value=st.text(min_size=1).filter(
+        lambda raw: raw.count(":") != 1 or not raw.strip()
+    ),
 )
 def test_chat_decode_cursor_rejects_invalid(value: str) -> None:
     assert chat._decode_cursor(value) is None  # noqa: SLF001

--- a/root/tests/test_pagination.py
+++ b/root/tests/test_pagination.py
@@ -3,11 +3,58 @@
 from datetime import UTC, datetime, timedelta
 
 import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import crud
+from app.api import chat
 from app.models import models
+
+
+@settings(max_examples=30)
+@given(
+    timestamp_ms=st.integers(min_value=0, max_value=4_102_444_800_000),
+    identifier=st.text(
+        alphabet=st.characters(blacklist_characters=":", blacklist_categories=["Cs"]),
+        min_size=1,
+        max_size=24,
+    ),
+)
+def test_chat_cursor_round_trip(timestamp_ms: int, identifier: str) -> None:
+    original = datetime.fromtimestamp(timestamp_ms / 1000, tz=UTC)
+    encoded = chat._encode_cursor(original, identifier)  # noqa: SLF001
+    decoded = chat._decode_cursor(encoded)  # noqa: SLF001
+
+    assert decoded is not None
+    decoded_ts, decoded_id = decoded
+    assert decoded_id == identifier
+    assert abs(decoded_ts.timestamp() - original.timestamp()) <= 0.001
+
+
+@settings(max_examples=25)
+@given(
+    value=st.text(min_size=1).filter(lambda raw: raw.count(":") != 1 or not raw.strip()),
+)
+def test_chat_decode_cursor_rejects_invalid(value: str) -> None:
+    assert chat._decode_cursor(value) is None  # noqa: SLF001
+
+
+@settings(max_examples=25)
+@given(
+    timestamp_ms=st.integers(min_value=0, max_value=4_102_444_800_000),
+    news_id=st.integers(min_value=1, max_value=1_000_000),
+)
+def test_news_cursor_round_trip(timestamp_ms: int, news_id: int) -> None:
+    cursor = f"{timestamp_ms}:{news_id}"
+    decoded = crud._decode_news_cursor(cursor)  # noqa: SLF001
+
+    assert decoded is not None
+    decoded_ts, decoded_id = decoded
+    assert decoded_id == news_id
+    decoded_ms = int(decoded_ts.timestamp() * 1000)
+    assert abs(decoded_ms - timestamp_ms) <= 1
 
 
 @pytest.fixture

--- a/root/tests/test_push_topics.py
+++ b/root/tests/test_push_topics.py
@@ -1,0 +1,44 @@
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from app.services import push_topics
+
+
+@settings(max_examples=25)
+@given(
+    raw_topics=st.lists(
+        st.sampled_from(["News", "NEWS", "events", "system", "custom", ""]),
+        min_size=1,
+        max_size=6,
+    )
+)
+def test_normalize_topics_respects_allowed_and_deduplicates(raw_topics: list[str]) -> None:
+    allowed = {"news", "events", "system", "custom"}
+    normalized = push_topics.normalize_topics(raw_topics, allowed_topics=allowed)
+
+    expected: list[str] = []
+    for raw in raw_topics:
+        candidate = raw.strip().lower()
+        if candidate and candidate in allowed and candidate not in expected:
+            expected.append(candidate)
+
+    assert normalized == expected
+
+
+def test_normalize_topic_strict_unknown_topic():
+    with pytest.raises(ValueError):
+        push_topics.normalize_topic(
+            "unsupported", allowed_topics={"news"}, strict=True
+        )
+
+
+def test_sort_topics_uses_allowed_order():
+    allowed = ["system", "events", "news"]
+    topics = ["news", "system", "events"]
+
+    assert push_topics.sort_topics(topics, allowed_topics=allowed) == [
+        "system",
+        "events",
+        "news",
+    ]

--- a/root/tests/test_push_topics.py
+++ b/root/tests/test_push_topics.py
@@ -13,7 +13,9 @@ from app.services import push_topics
         max_size=6,
     )
 )
-def test_normalize_topics_respects_allowed_and_deduplicates(raw_topics: list[str]) -> None:
+def test_normalize_topics_respects_allowed_and_deduplicates(
+    raw_topics: list[str],
+) -> None:
     allowed = {"news", "events", "system", "custom"}
     normalized = push_topics.normalize_topics(raw_topics, allowed_topics=allowed)
 
@@ -28,9 +30,7 @@ def test_normalize_topics_respects_allowed_and_deduplicates(raw_topics: list[str
 
 def test_normalize_topic_strict_unknown_topic():
     with pytest.raises(ValueError):
-        push_topics.normalize_topic(
-            "unsupported", allowed_topics={"news"}, strict=True
-        )
+        push_topics.normalize_topic("unsupported", allowed_topics={"news"}, strict=True)
 
 
 def test_sort_topics_uses_allowed_order():

--- a/root/tests/test_rate_limit.py
+++ b/root/tests/test_rate_limit.py
@@ -436,7 +436,9 @@ def test_parse_rate_limit_accepts_known_units(
     value = f"{leading_ws}{count}{separator}{unit}{trailing_ws}"
     parsed = rate_limit.parse_rate_limit(value, fallback=fallback)
 
-    expected_seconds = rate_limit._TIME_UNITS.get(unit) or rate_limit._TIME_UNITS.get(  # noqa: SLF001
+    expected_seconds = rate_limit._TIME_UNITS.get(
+        unit
+    ) or rate_limit._TIME_UNITS.get(  # noqa: SLF001
         unit.rstrip("s")
     )
     assert parsed == (count, expected_seconds)

--- a/root/tests/test_rate_limit.py
+++ b/root/tests/test_rate_limit.py
@@ -1,6 +1,9 @@
 import httpx
 import pytest
 from fastapi import Depends, FastAPI, Response, status
+from hypothesis import HealthCheck, given
+from hypothesis import settings as hypo_settings
+from hypothesis import strategies as st
 from redis.exceptions import RedisError
 
 from app.auth.security import get_password_hash
@@ -416,3 +419,72 @@ async def test_rate_limit_middleware_allows_when_redis_fails(monkeypatch):
 
     assert response.status_code == status.HTTP_200_OK
     assert "X-RateLimit-Limit" not in response.headers
+
+
+@hypo_settings(max_examples=25)
+@given(
+    count=st.integers(min_value=1, max_value=50),
+    unit=st.sampled_from(list(rate_limit._TIME_UNITS.keys())),
+    separator=st.sampled_from(["/", " per "]),
+    leading_ws=st.text(alphabet=" ", min_size=0, max_size=2),
+    trailing_ws=st.text(alphabet=" ", min_size=0, max_size=2),
+)
+def test_parse_rate_limit_accepts_known_units(
+    count: int, unit: str, separator: str, leading_ws: str, trailing_ws: str
+) -> None:
+    fallback = (99, 99)
+    value = f"{leading_ws}{count}{separator}{unit}{trailing_ws}"
+    parsed = rate_limit.parse_rate_limit(value, fallback=fallback)
+
+    expected_seconds = rate_limit._TIME_UNITS.get(unit) or rate_limit._TIME_UNITS.get(  # noqa: SLF001
+        unit.rstrip("s")
+    )
+    assert parsed == (count, expected_seconds)
+
+
+@hypo_settings(max_examples=25)
+@given(
+    value=st.text().filter(
+        lambda raw: not raw or raw.strip().isdigit() or raw.count("/") > 1
+    )
+)
+def test_parse_rate_limit_invalid_returns_fallback(value: str) -> None:
+    fallback = (3, 7)
+    assert rate_limit.parse_rate_limit(value, fallback=fallback) == fallback
+
+
+@hypo_settings(
+    max_examples=15, suppress_health_check=[HealthCheck.function_scoped_fixture]
+)
+@given(identifier=st.text(min_size=1, max_size=12).filter(lambda s: ":" not in s))
+@pytest.mark.anyio
+async def test_check_rate_limit_blocks_after_limit(
+    identifier: str, _rate_limit_redis_client, monkeypatch
+):
+    monkeypatch.setattr(rate_limit, "_shared_clients", {})
+    monkeypatch.setattr(rate_limit, "_shared_client_locks", {})
+
+    namespace = "prop"
+    limit = 2
+    window = 60
+
+    for _ in range(limit):
+        allowed = await rate_limit.check_rate_limit(
+            identifier=identifier,
+            namespace=namespace,
+            limit=limit,
+            window_seconds=window,
+            redis_url="redis://test",
+        )
+        assert allowed.allowed
+
+    blocked = await rate_limit.check_rate_limit(
+        identifier=identifier,
+        namespace=namespace,
+        limit=limit,
+        window_seconds=window,
+        redis_url="redis://test",
+    )
+
+    assert blocked.allowed is False
+    assert blocked.remaining == 0


### PR DESCRIPTION
## Summary
- add Hypothesis-powered pagination and rate limit regression coverage and bump the backend coverage gate to 85%
- extend SQLite/Redis-backed fixtures to support JSONB models and expand authorization, chat, notifications, and file safety tests
- document the new testing dependency pins for local development

## Testing
- pytest tests/test_auth_sessions_domain.py tests/test_pagination.py tests/test_rate_limit.py tests/test_push_topics.py tests/test_files_mime_edges.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e24f566188327937d7c617db5495b)