### PR TITLE
Add dependency audit allowlists and CI enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,29 +143,15 @@ jobs:
           cache-dependency-path: |
             root/requirements.txt
             root/requirements-dev.txt
-      - name: Install pip-audit
+      - name: Install audit tooling
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pip-audit
-      - name: Run pip-audit (fail only if fixable vulns)
-        shell: bash
+          python -m pip install pip-audit pyyaml
+      - name: Run pip-audit with allowlist enforcement
         run: |
-          audit_file() {
-            f="$1"
-            if [ ! -f "$f" ]; then
-              echo "$f not found, skipping"
-              return 0
-            fi
-            fixable="$(pip-audit -r "$f" --format=json 2>/dev/null | jq '.dependencies[].vulns[].fix_versions[]' || true)"
-            if [ -z "$fixable" ]; then
-              echo "No fixable vulnerabilities in $f"
-              return 0
-            else
-              pip-audit -r "$f"
-            fi
-          }
-          audit_file root/requirements.txt
-          audit_file root/requirements-dev.txt
+          python scripts/audit_dependencies.py \
+            --allowlist security/audit-allowlist.yaml \
+            --pip root/requirements.txt root/requirements-dev.txt
 
   verify-runtime-reqs:
     name: Verify runtime requirements
@@ -340,10 +326,25 @@ jobs:
           node-version: '20'
           cache: npm
           cache-dependency-path: root/frontend/package-lock.json
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: |
+            root/requirements.txt
+            root/requirements-dev.txt
       - name: Install dependencies
         run: npm ci
-      - name: Run npm audit
-        run: npm audit --audit-level=high
+      - name: Install audit tooling
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pyyaml
+      - name: Run npm audit with allowlist enforcement
+        run: |
+          python ../scripts/audit_dependencies.py \
+            --allowlist ../security/audit-allowlist.yaml \
+            --npm .
 
   build:
     name: Frontend build

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,6 +11,19 @@ If you discover a vulnerability, please report it privately so we can address it
 - `npm audit --audit-level=high` (March 2025) currently reports **no outstanding issues** because we force `glob@11.1.0` through `package.json#overrides`. This pulls in the patched release while keeping Tailwind CSS on the stable `3.4.x` train.
 - Keep the override until the Tailwind 4 migration lands so that future installs do not regress to the vulnerable `glob` CLI when `sucrase` updates.
 
+### Automated security pipeline
+
+- CI runs `npm audit --audit-level=high` against `root/frontend/package-lock.json` and `pip-audit` against `root/requirements.txt` + `root/requirements-dev.txt`. The jobs **fail** when a new advisory is detected or when a declared override disappears.
+- Temporary exceptions live in [`security/audit-allowlist.yaml`](security/audit-allowlist.yaml). Every entry must include an owner and an `expires` date; expired entries fail the pipeline so they cannot silently drift.
+- The current allowlist records the `glob@11.1.0` override (owner: `frontend@university.example`, expires: `2025-06-30`) to keep the Tailwind 3.x toolchain on the patched release.
+
+#### Refreshing allowlists and overrides
+
+1. Run `python scripts/audit_dependencies.py --allowlist security/audit-allowlist.yaml --npm root/frontend --pip root/requirements.txt root/requirements-dev.txt` locally. Pip-audit will download advisories; this may take a minute while it builds a virtual environment.
+2. If the command reports new advisories, either patch the dependency or add a **temporary** entry to `security/audit-allowlist.yaml` with `owner`, `expires`, `reason`, and (for npm) the pinned override version. Avoid long expirations.
+3. Commit both the dependency fix/override and the allowlist change together so CI and developers stay in sync.
+4. Remove allowlist entries as soon as upstream releases make the override unnecessary.
+
 ## Private Vulnerability Reporting
 To report a vulnerability, use the **Security** tab on GitHub and open a new **Private vulnerability report**. Issues are disabled for vulnerability discussions; instead, please submit a GitHub Security Advisory so the team can work with you directly on mitigation and disclosure.
 

--- a/scripts/audit_dependencies.py
+++ b/scripts/audit_dependencies.py
@@ -6,7 +6,8 @@ import json
 import pathlib
 import subprocess
 import sys
-from typing import Any, Iterable
+from collections.abc import Iterable
+from typing import Any
 
 import yaml
 
@@ -71,7 +72,9 @@ def collect_npm_advisory_ids(package_dir: pathlib.Path) -> set[str]:
     return advisories
 
 
-def validate_npm_overrides(package_dir: pathlib.Path, allowlist: dict[str, Any]) -> None:
+def validate_npm_overrides(
+    package_dir: pathlib.Path, allowlist: dict[str, Any]
+) -> None:
     overrides = (allowlist.get("npm") or {}).get("overrides") or []
     ensure_not_expired(overrides, label="NPM override")
 
@@ -86,7 +89,9 @@ def validate_npm_overrides(package_dir: pathlib.Path, allowlist: dict[str, Any])
         package = entry.get("package")
         expected_version = entry.get("pinned_version")
         if not package or not expected_version:
-            raise AuditFailure(f"Override entry must include package and pinned_version: {entry}")
+            raise AuditFailure(
+                f"Override entry must include package and pinned_version: {entry}"
+            )
 
         configured_version = configured_overrides.get(package)
         if configured_version != expected_version:
@@ -95,7 +100,9 @@ def validate_npm_overrides(package_dir: pathlib.Path, allowlist: dict[str, Any])
             )
 
 
-def check_allowances(found_ids: set[str], allowed_entries: list[dict[str, Any]], *, ecosystem: str) -> None:
+def check_allowances(
+    found_ids: set[str], allowed_entries: list[dict[str, Any]], *, ecosystem: str
+) -> None:
     ensure_not_expired(allowed_entries, label=f"{ecosystem} advisory allowlist")
 
     allowed_ids = {entry.get("id") for entry in allowed_entries if entry.get("id")}
@@ -155,9 +162,13 @@ def audit_pip(args: argparse.Namespace, allowlist: dict[str, Any]) -> None:
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Enforce dependency audit allowlists.")
-    parser.add_argument("--allowlist", required=True, help="Path to the audit allowlist YAML file.")
+    parser.add_argument(
+        "--allowlist", required=True, help="Path to the audit allowlist YAML file."
+    )
     parser.add_argument("--npm", help="Path to the npm project directory to audit.")
-    parser.add_argument("--pip", nargs="*", help="Requirements files to audit with pip-audit.")
+    parser.add_argument(
+        "--pip", nargs="*", help="Requirements files to audit with pip-audit."
+    )
     return parser
 
 
@@ -172,7 +183,9 @@ def main(argv: list[str] | None = None) -> int:
         print(f"::error::{exc}", file=sys.stderr)
         return 1
 
-    print("Dependency audits passed with no unapproved advisories or missing overrides.")
+    print(
+        "Dependency audits passed with no unapproved advisories or missing overrides."
+    )
     return 0
 
 

--- a/scripts/audit_dependencies.py
+++ b/scripts/audit_dependencies.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import pathlib
+import subprocess
+import sys
+from typing import Any, Iterable
+
+import yaml
+
+
+class AuditFailure(Exception):
+    """Raised when an audit check fails."""
+
+
+def parse_date(raw: str) -> dt.date:
+    try:
+        return dt.date.fromisoformat(raw)
+    except ValueError as exc:
+        raise AuditFailure(f"Invalid date '{raw}', expected YYYY-MM-DD") from exc
+
+
+def load_allowlist(path: pathlib.Path) -> dict[str, Any]:
+    if not path.exists():
+        raise AuditFailure(f"Allowlist file not found: {path}")
+
+    data = yaml.safe_load(path.read_text()) or {}
+    return data
+
+
+def ensure_not_expired(entries: Iterable[dict[str, Any]], *, label: str) -> None:
+    today = dt.date.today()
+    for entry in entries:
+        expires_raw = entry.get("expires")
+        if not expires_raw:
+            raise AuditFailure(f"{label} entry missing expiry date: {entry}")
+
+        expires = parse_date(str(expires_raw))
+        if expires < today:
+            owner = entry.get("owner", "(unknown owner)")
+            raise AuditFailure(
+                f"{label} entry for '{entry.get('id') or entry.get('package')}' expired on {expires} (owner: {owner})"
+            )
+
+
+def collect_npm_advisory_ids(package_dir: pathlib.Path) -> set[str]:
+    cmd = ["npm", "audit", "--audit-level=high", "--json"]
+    result = subprocess.run(cmd, cwd=package_dir, capture_output=True, text=True)
+
+    if result.returncode not in (0, 1):
+        raise AuditFailure(f"npm audit failed: {result.stderr or result.stdout}")
+
+    try:
+        payload = json.loads(result.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        raise AuditFailure(f"npm audit produced invalid JSON: {exc}") from exc
+
+    advisories: set[str] = set()
+    for vulnerability in (payload.get("vulnerabilities") or {}).values():
+        if vulnerability.get("severity") not in {"high", "critical"}:
+            continue
+        for via in vulnerability.get("via", []):
+            if isinstance(via, str):
+                advisories.add(via)
+            elif isinstance(via, dict):
+                source = via.get("source") or via.get("url") or via.get("name")
+                if source:
+                    advisories.add(str(source))
+    return advisories
+
+
+def validate_npm_overrides(package_dir: pathlib.Path, allowlist: dict[str, Any]) -> None:
+    overrides = (allowlist.get("npm") or {}).get("overrides") or []
+    ensure_not_expired(overrides, label="NPM override")
+
+    package_json = package_dir / "package.json"
+    if not package_json.exists():
+        raise AuditFailure(f"package.json not found at {package_json}")
+
+    package_data = json.loads(package_json.read_text())
+    configured_overrides = package_data.get("overrides") or {}
+
+    for entry in overrides:
+        package = entry.get("package")
+        expected_version = entry.get("pinned_version")
+        if not package or not expected_version:
+            raise AuditFailure(f"Override entry must include package and pinned_version: {entry}")
+
+        configured_version = configured_overrides.get(package)
+        if configured_version != expected_version:
+            raise AuditFailure(
+                f"Expected override for {package!r} to pin version {expected_version}, got {configured_version!r}."
+            )
+
+
+def check_allowances(found_ids: set[str], allowed_entries: list[dict[str, Any]], *, ecosystem: str) -> None:
+    ensure_not_expired(allowed_entries, label=f"{ecosystem} advisory allowlist")
+
+    allowed_ids = {entry.get("id") for entry in allowed_entries if entry.get("id")}
+    missing = sorted(found_ids - allowed_ids)
+    if missing:
+        formatted = "\n".join(f"- {value}" for value in missing)
+        raise AuditFailure(
+            f"{ecosystem} audit found advisories that are not in the allowlist:\n{formatted}\n"
+            "Add a temporary allowlist entry with an owner and expiry if this cannot be fixed immediately."
+        )
+
+
+def audit_npm(args: argparse.Namespace, allowlist: dict[str, Any]) -> None:
+    if not args.npm:
+        return
+
+    package_dir = pathlib.Path(args.npm)
+    validate_npm_overrides(package_dir, allowlist)
+
+    advisories = collect_npm_advisory_ids(package_dir)
+    allowed = (allowlist.get("npm") or {}).get("advisories") or []
+    check_allowances(advisories, allowed, ecosystem="npm")
+
+
+def collect_pip_advisories(requirements: list[str]) -> set[str]:
+    cmd = ["pip-audit", "--format=json"]
+    for req_file in requirements:
+        cmd.extend(["-r", req_file])
+
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode not in (0, 1):
+        raise AuditFailure(f"pip-audit failed: {result.stderr or result.stdout}")
+
+    try:
+        payload = json.loads(result.stdout or "[]")
+    except json.JSONDecodeError as exc:
+        raise AuditFailure(f"pip-audit produced invalid JSON: {exc}") from exc
+
+    dependencies = payload.get("dependencies") if isinstance(payload, dict) else payload
+    advisories: set[str] = set()
+    for dependency in dependencies or []:
+        for vuln in dependency.get("vulns", []):
+            vuln_id = vuln.get("id")
+            if vuln_id:
+                advisories.add(str(vuln_id))
+    return advisories
+
+
+def audit_pip(args: argparse.Namespace, allowlist: dict[str, Any]) -> None:
+    if not args.pip:
+        return
+
+    advisories = collect_pip_advisories(args.pip)
+    allowed = (allowlist.get("pip") or {}).get("advisories") or []
+    check_allowances(advisories, allowed, ecosystem="pip")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Enforce dependency audit allowlists.")
+    parser.add_argument("--allowlist", required=True, help="Path to the audit allowlist YAML file.")
+    parser.add_argument("--npm", help="Path to the npm project directory to audit.")
+    parser.add_argument("--pip", nargs="*", help="Requirements files to audit with pip-audit.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    allowlist = load_allowlist(pathlib.Path(args.allowlist))
+
+    try:
+        audit_npm(args, allowlist)
+        audit_pip(args, allowlist)
+    except AuditFailure as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        return 1
+
+    print("Dependency audits passed with no unapproved advisories or missing overrides.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/security/audit-allowlist.yaml
+++ b/security/audit-allowlist.yaml
@@ -1,0 +1,20 @@
+# Track temporary dependency audit exceptions.
+# All entries must include an owner and expiry date to avoid silent drift.
+npm:
+  overrides:
+    - package: glob
+      pinned_version: "11.1.0"
+      owner: frontend@university.example
+      expires: 2025-12-31
+      reason: |
+        Tailwind CSS 3.x pulls in sucrase's glob CLI; pinning ensures we stay on the patched release until the Tailwind 4 upgrade.
+  advisories: []
+
+pip:
+  advisories:
+    - id: CVE-2024-23342
+      package: ecdsa
+      owner: backend@university.example
+      expires: 2025-12-31
+      reason: |
+        python-ecdsa has no upstream fix for CVE-2024-23342 (GHSA-wj6h-64fc-37mp). Monitor upstream and replace or upgrade when a patch lands.


### PR DESCRIPTION
## Summary
- add a shared audit script that enforces allowlisted npm overrides and pip advisories with expiry metadata
- track the glob override and current pip exception in a versioned allowlist
- wire CI npm/pip audit jobs to the allowlist and document the refresh process in SECURITY.md

## Testing
- python scripts/audit_dependencies.py --allowlist security/audit-allowlist.yaml --npm root/frontend --pip root/requirements.txt root/requirements-dev.txt

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f122a65048327a2e0b809ada9f7c2)