### PR TITLE
WebSocket auth: accept Sec-WebSocket-Protocol / Authorization headers, add compat flag and frontend token handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Set `NOTIFICATIONS_SCHEDULER_INLINE_ENABLED=false` when the API and worker run s
 ## Platform capabilities
 
 - REST APIs for chat, events, news, schedules, sessions, Spotify, stats, stories, users, and push notifications
+- WebSocket chat updates at `/ws/chat` with cookie auth or `Sec-WebSocket-Protocol`/`Authorization` tokens (query-param tokens only when `websocket_query_param_compat` is enabled)
 - Push notifications with VAPID keys and a dedicated delivery worker; dead-letter queues and retention cleanup are built in
 - Optional Redis cache and rate limiting middleware; `/stats/*` responses and schedule payloads use Redis-backed caching when enabled
 - Configurable CORS, security headers (including COOP/COEP/CORP toggles), gzip compression, and proxy header support

--- a/app/api/websocket.py
+++ b/app/api/websocket.py
@@ -22,6 +22,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.core.database import async_session
+from app.core.feature_flags import feature_flags
 from app.models.chat import Chat, Message
 from app.models.models import ActiveSession, User
 from app.schemas.chat import ChatParticipant, PresenceStatus
@@ -41,9 +42,14 @@ class ConnectionManager:
         # websocket -> user_id (for reverse lookup on disconnect)
         self.connection_users: dict[WebSocket, int] = {}
 
-    async def connect(self, websocket: WebSocket, user_id: int) -> None:
+    async def connect(
+        self, websocket: WebSocket, user_id: int, *, subprotocol: str | None = None
+    ) -> None:
         """Accept a WebSocket connection and register it for the user."""
-        await websocket.accept()
+        if subprotocol:
+            await websocket.accept(subprotocol=subprotocol)
+        else:
+            await websocket.accept()
         if user_id not in self.active_connections:
             self.active_connections[user_id] = set()
         self.active_connections[user_id].add(websocket)
@@ -193,6 +199,38 @@ async def get_user_from_cookie(cookie_value: str) -> tuple[User | None, str | No
         return None, None
 
 
+def _extract_bearer_token(header_value: str | None) -> str | None:
+    if not header_value:
+        return None
+    parts = header_value.strip().split()
+    if len(parts) == 2 and parts[0].lower() == "bearer":
+        return parts[1]
+    if len(parts) == 1:
+        return parts[0]
+    return None
+
+
+def _extract_token_from_subprotocol(header_value: str | None) -> str | None:
+    if not header_value:
+        return None
+    protocols = [protocol.strip() for protocol in header_value.split(",") if protocol.strip()]
+    for index, protocol in enumerate(protocols):
+        if protocol.lower() in {"access_token", "bearer", "authorization"}:
+            if index + 1 < len(protocols):
+                return protocols[index + 1]
+    return None
+
+
+def _select_subprotocol(header_value: str | None) -> str | None:
+    if not header_value:
+        return None
+    protocols = [protocol.strip() for protocol in header_value.split(",") if protocol.strip()]
+    for candidate in protocols:
+        if candidate.lower() in {"access_token", "bearer"}:
+            return candidate
+    return None
+
+
 async def _update_last_seen(session_jti: str | None) -> datetime:
     """Persist last_seen_at for a session and return the timestamp used."""
 
@@ -294,8 +332,11 @@ async def websocket_chat(websocket: WebSocket):
     WebSocket endpoint for real-time chat.
 
     Authentication:
-    - Pass JWT token as query parameter `token`, OR
+    - Send JWT in `Sec-WebSocket-Protocol` (e.g. `access_token, <JWT>`), OR
+    - Send `Authorization: Bearer <JWT>` header, OR
     - Use cookie-based auth (access_token cookie)
+    - Query param `token` can be enabled temporarily via
+      feature flag `websocket_query_param_compat`
 
     Message types (from client):
     - {"type": "ping"} - Keep-alive ping
@@ -327,10 +368,19 @@ async def websocket_chat(websocket: WebSocket):
         ),
     )
 
-    # Try token from query params first
-    token = websocket.query_params.get("token")
-    if token:
-        logger.info("Attempting token auth from query params")
+    auth_header = websocket.headers.get("authorization")
+    protocol_header = websocket.headers.get("sec-websocket-protocol")
+    header_token = _extract_bearer_token(auth_header)
+    protocol_token = _extract_token_from_subprotocol(protocol_header)
+    selected_subprotocol = _select_subprotocol(protocol_header)
+
+    if header_token or protocol_token:
+        logger.info(
+            "Attempting WebSocket token auth from headers (auth=%s, protocol=%s)",
+            bool(header_token),
+            bool(protocol_token),
+        )
+        token = header_token or protocol_token
         user, session_jti = await get_user_from_token(token)
         if user:
             logger.info(f"Token auth successful: user_id={user.id}")
@@ -338,6 +388,16 @@ async def websocket_chat(websocket: WebSocket):
             logger.warning("Token auth failed: invalid token")
 
     # Fallback to cookie-based auth
+    if not user and feature_flags.is_enabled("websocket_query_param_compat"):
+        token = websocket.query_params.get("token")
+        if token:
+            logger.info("Attempting token auth from query params (compat mode)")
+            user, session_jti = await get_user_from_token(token)
+            if user:
+                logger.info(f"Token auth successful: user_id={user.id}")
+            else:
+                logger.warning("Token auth failed: invalid token")
+
     if not user:
         access_token = websocket.cookies.get("access_token_v2")
         logger.info(
@@ -356,7 +416,7 @@ async def websocket_chat(websocket: WebSocket):
         return
 
     # Connect and register
-    await manager.connect(websocket, user.id)
+    await manager.connect(websocket, user.id, subprotocol=selected_subprotocol)
     last_seen = await _update_last_seen(session_jti)
     await manager.broadcast_presence(user.id, True, last_seen)
 

--- a/app/api/websocket.py
+++ b/app/api/websocket.py
@@ -213,7 +213,9 @@ def _extract_bearer_token(header_value: str | None) -> str | None:
 def _extract_token_from_subprotocol(header_value: str | None) -> str | None:
     if not header_value:
         return None
-    protocols = [protocol.strip() for protocol in header_value.split(",") if protocol.strip()]
+    protocols = [
+        protocol.strip() for protocol in header_value.split(",") if protocol.strip()
+    ]
     for index, protocol in enumerate(protocols):
         if protocol.lower() in {"access_token", "bearer", "authorization"}:
             if index + 1 < len(protocols):
@@ -224,7 +226,9 @@ def _extract_token_from_subprotocol(header_value: str | None) -> str | None:
 def _select_subprotocol(header_value: str | None) -> str | None:
     if not header_value:
         return None
-    protocols = [protocol.strip() for protocol in header_value.split(",") if protocol.strip()]
+    protocols = [
+        protocol.strip() for protocol in header_value.split(",") if protocol.strip()
+    ]
     for candidate in protocols:
         if candidate.lower() in {"access_token", "bearer"}:
             return candidate

--- a/app/core/feature_flags.py
+++ b/app/core/feature_flags.py
@@ -300,6 +300,14 @@ feature_flags.register(
 
 feature_flags.register(
     FeatureFlag(
+        name="websocket_query_param_compat",
+        status=FlagStatus.DISABLED,
+        description="Temporary support for WebSocket token in query param",
+    )
+)
+
+feature_flags.register(
+    FeatureFlag(
         name="push_batching",
         status=FlagStatus.ENABLED,
         description="Batch push notification delivery",

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -178,7 +178,15 @@ Rate limit headers are included in responses:
 
 Real-time updates are available via WebSocket:
 
-**Endpoint**: `wss://{host}/ws`
+**Endpoint**: `wss://{host}/ws/chat`
+
+**Authentication**:
+- `Sec-WebSocket-Protocol: access_token, <JWT>`
+- `Authorization: Bearer <JWT>`
+- Cookie-based auth (`access_token_v2`)
+
+Query-param tokens are supported only when the `websocket_query_param_compat`
+feature flag is enabled.
 
 **Events**:
 - `chat.message` - New message in chat

--- a/frontend/src/hooks/auth/tokenStorage.ts
+++ b/frontend/src/hooks/auth/tokenStorage.ts
@@ -1,0 +1,27 @@
+export const ACCESS_TOKEN_STORAGE_KEY = "ecosystem.access.token"
+
+export const readAccessToken = (): string | null => {
+  if (typeof sessionStorage === "undefined") return null
+  try {
+    return sessionStorage.getItem(ACCESS_TOKEN_STORAGE_KEY)
+  } catch {
+    return null
+  }
+}
+
+export const persistAccessToken = (token: string | null | undefined) => {
+  if (typeof sessionStorage === "undefined") return
+  try {
+    if (token) {
+      sessionStorage.setItem(ACCESS_TOKEN_STORAGE_KEY, token)
+    } else {
+      sessionStorage.removeItem(ACCESS_TOKEN_STORAGE_KEY)
+    }
+  } catch {
+    /* ignore */
+  }
+}
+
+export const clearAccessToken = () => {
+  persistAccessToken(null)
+}

--- a/frontend/src/hooks/auth/useAuthApi.ts
+++ b/frontend/src/hooks/auth/useAuthApi.ts
@@ -16,6 +16,7 @@ import {
 import { fetchCurrentUser } from "./useProfileSync"
 import i18n from "@/i18n/config"
 import type { WebAuthnAuthenticationOptionsOut } from "@/types/Auth"
+import { clearAccessToken, persistAccessToken } from "./tokenStorage"
 
 type TokenWithProfileResponse = {
   access_token: string
@@ -162,6 +163,7 @@ export const useAuthApi = (
           updateSessionSigningKey(extractSigningKey(data))
           setUser(data.user)
           updatePendingMfa(null)
+          persistAccessToken(data.access_token)
           if (data.user.spotify_connected) {
             window.dispatchEvent(new Event(SPOTIFY_REAUTH_EVENT))
           }
@@ -225,6 +227,7 @@ export const useAuthApi = (
     } catch (error) {
       console.error("Logout failed", error)
     } finally {
+      clearAccessToken()
       handleUnauthorized()
     }
   }, [handleUnauthorized, user])
@@ -261,6 +264,7 @@ export const useAuthApi = (
           updateSessionSigningKey(extractSigningKey(data))
           setUser(data.user)
           updatePendingMfa(null)
+          persistAccessToken(data.access_token)
           if (data.user.spotify_connected) {
             window.dispatchEvent(new Event(SPOTIFY_REAUTH_EVENT))
           }
@@ -394,6 +398,7 @@ export const useAuthApi = (
           updateSessionSigningKey(extractSigningKey(data))
           setUser(data.user)
           updatePendingMfa(null)
+          persistAccessToken(data.access_token)
           if (data.user.spotify_connected) {
             window.dispatchEvent(new Event(SPOTIFY_REAUTH_EVENT))
           }

--- a/frontend/src/hooks/auth/useProfileSync.ts
+++ b/frontend/src/hooks/auth/useProfileSync.ts
@@ -8,6 +8,7 @@ import api, { resetEtagCache } from "@/api/client"
 import type { User } from "@/types/User"
 import { signSnapshot } from "./useSessionCrypto"
 import type { PendingMfaState, SetUserArg, UserState } from "@/types/Auth"
+import { clearAccessToken } from "./tokenStorage"
 
 const PROFILE_CACHE_BASE_KEY = "ecosystem.profile.cache"
 const PROFILE_CACHE_SCHEMA_VERSION = 6
@@ -653,6 +654,7 @@ export const useProfileSync = (
   const handleUnauthorized = useCallback(
     ({ broadcast = true, persist = true }: HandleUnauthorizedOptions = {}) => {
       resetEtagCache()
+      clearAccessToken()
       // We need to clear session signing key too.
       // We need to call updateSessionSigningKey(null)
       // But we also need to clear the promise ref.

--- a/frontend/src/hooks/useChatWebSocket.ts
+++ b/frontend/src/hooks/useChatWebSocket.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useCallback, useState } from "react"
 import { useQueryClient } from "@tanstack/react-query"
 import type { Message, MessagesListResponse } from "../api/chat"
+import { readAccessToken } from "./auth/tokenStorage"
 
 // Reconnection configuration
 const RECONNECT_BASE_DELAY_MS = 1000 // 1 second
@@ -119,7 +120,8 @@ export function useChatWebSocket({
     const wsUrl = `${wsProtocol}//${window.location.host}/ws/chat`
 
     try {
-      const ws = new WebSocket(wsUrl)
+      const token = readAccessToken()
+      const ws = token ? new WebSocket(wsUrl, ["access_token", token]) : new WebSocket(wsUrl)
       wsRef.current = ws
 
       ws.onopen = () => {


### PR DESCRIPTION
### Motivation
- Replace brittle query-param token handling for WebSocket auth with more secure transports: `Sec-WebSocket-Protocol`, `Authorization` header, or cookie-based auth.
- Provide a temporary compatibility mode to continue supporting legacy query-param tokens during rollout.
- Update the frontend client to send tokens using the negotiated WebSocket subprotocol and persist tokens per-session for reconnects.
- Update API docs and README to describe the new connection/auth options.

### Description
- Backend: updated `app/api/websocket.py` to extract tokens from `Authorization` header and `Sec-WebSocket-Protocol`, negotiate/accept subprotocols on `WebSocket.accept`, and added a compatibility check gated by the `websocket_query_param_compat` feature flag; feature flag registered in `app/core/feature_flags.py`.
- Frontend: added `frontend/src/hooks/auth/tokenStorage.ts` for sessionStorage token persistence, updated `useAuthApi` and `useProfileSync` to persist/clear the access token on login/logout/unauthorized, and changed `useChatWebSocket` to open `new WebSocket(wsUrl, ["access_token", token])` when a token is present.
- Docs: updated `docs/api/README.md` and top-level `README.md` to point websocket clients to `wss://{host}/ws/chat` and document auth options and the query-param compat flag.

### Testing
- No automated tests were executed as part of this change.
- Manual static checks or runtime validation were not run (not requested).
- Ensure CI runs the usual `make backend-test` and `make frontend-test` to validate integration with auth flows after merge.
- Recommend enabling the `websocket_query_param_compat` feature flag in staging to migrate clients gradually.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962d278c9a8832784cef799e80a8fb0)