### PR TITLE
Limit presence broadcasts to chat participants, add throttling and optional Redis pub/sub

### DIFF
--- a/app/api/websocket.py
+++ b/app/api/websocket.py
@@ -75,7 +75,9 @@ class PresencePubSub:
         if redis is not None:
             self._redis = redis
         elif settings.cache_redis_url:
-            self._redis = Redis.from_url(settings.cache_redis_url, decode_responses=True)
+            self._redis = Redis.from_url(
+                settings.cache_redis_url, decode_responses=True
+            )
         if self._redis:
             self._pubsub_task = asyncio.create_task(self._listen_for_updates())
 
@@ -93,7 +95,9 @@ class PresencePubSub:
             return
         envelope = dict(payload)
         envelope["instance_id"] = _PRESENCE_INSTANCE_ID
-        await self._redis.publish(settings.presence_pubsub_channel, json.dumps(envelope))
+        await self._redis.publish(
+            settings.presence_pubsub_channel, json.dumps(envelope)
+        )
 
     async def _listen_for_updates(self) -> None:
         if not self._redis:

--- a/app/api/websocket.py
+++ b/app/api/websocket.py
@@ -10,20 +10,25 @@ This module provides WebSocket connections for:
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
+import uuid
 from collections.abc import Iterable
 from datetime import UTC, datetime
 from typing import Any
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+from redis.asyncio import Redis
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from app.core.config import settings
 from app.core.database import async_session
 from app.core.feature_flags import feature_flags
-from app.models.chat import Chat, Message
+from app.core.metrics import record_presence_event, record_presence_throttled
+from app.models.chat import Chat, Message, chat_participants
 from app.models.models import ActiveSession, User
 from app.schemas.chat import ChatParticipant, PresenceStatus
 from app.utils.logging import redact_sensitive_mapping
@@ -31,6 +36,91 @@ from app.utils.logging import redact_sensitive_mapping
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/ws", tags=["websocket"])
+
+
+PRESENCE_SOURCE_CONNECT = "connect"
+PRESENCE_SOURCE_DISCONNECT = "disconnect"
+PRESENCE_SOURCE_PING = "ping"
+PRESENCE_SOURCE_PUBSUB = "pubsub"
+
+_PRESENCE_INSTANCE_ID = uuid.uuid4().hex
+
+
+async def _get_presence_audience(user_id: int) -> set[int]:
+    """Resolve user IDs that should receive presence updates for user_id."""
+    async with async_session() as session:
+        chat_ids = select(chat_participants.c.chat_id).where(
+            chat_participants.c.user_id == user_id
+        )
+        result = await session.execute(
+            select(chat_participants.c.user_id)
+            .distinct()
+            .where(chat_participants.c.chat_id.in_(chat_ids))
+        )
+        audience = {row[0] for row in result.all()}
+    audience.discard(user_id)
+    return audience
+
+
+class PresencePubSub:
+    """Optional Redis pub/sub bridge for presence events."""
+
+    def __init__(self) -> None:
+        self._redis: Redis | None = None
+        self._pubsub_task: asyncio.Task | None = None
+
+    async def initialize(self, redis: Redis | None = None) -> None:
+        if self._redis or not settings.presence_pubsub_enabled:
+            return
+        if redis is not None:
+            self._redis = redis
+        elif settings.cache_redis_url:
+            self._redis = Redis.from_url(settings.cache_redis_url, decode_responses=True)
+        if self._redis:
+            self._pubsub_task = asyncio.create_task(self._listen_for_updates())
+
+    async def shutdown(self) -> None:
+        if self._pubsub_task:
+            self._pubsub_task.cancel()
+            try:
+                await self._pubsub_task
+            except asyncio.CancelledError:
+                pass
+        self._pubsub_task = None
+
+    async def publish(self, payload: dict[str, Any]) -> None:
+        if not self._redis or not settings.presence_pubsub_enabled:
+            return
+        envelope = dict(payload)
+        envelope["instance_id"] = _PRESENCE_INSTANCE_ID
+        await self._redis.publish(settings.presence_pubsub_channel, json.dumps(envelope))
+
+    async def _listen_for_updates(self) -> None:
+        if not self._redis:
+            return
+        ps = self._redis.pubsub()
+        await ps.subscribe(settings.presence_pubsub_channel)
+        try:
+            async for message in ps.listen():
+                if message.get("type") != "message":
+                    continue
+                raw = message.get("data")
+                try:
+                    payload = json.loads(raw) if raw else {}
+                except json.JSONDecodeError:
+                    logger.warning("Invalid presence payload received from pubsub")
+                    continue
+                if payload.get("instance_id") == _PRESENCE_INSTANCE_ID:
+                    continue
+                await _handle_presence_pubsub(payload)
+        except asyncio.CancelledError:
+            await ps.unsubscribe(settings.presence_pubsub_channel)
+            await ps.close()
+        except Exception as exc:
+            logger.error("Presence Pub/Sub listener error: %s", exc)
+
+
+presence_pubsub = PresencePubSub()
 
 
 class ConnectionManager:
@@ -41,6 +131,7 @@ class ConnectionManager:
         self.active_connections: dict[int, set[WebSocket]] = {}
         # websocket -> user_id (for reverse lookup on disconnect)
         self.connection_users: dict[WebSocket, int] = {}
+        self._last_presence_sent_at: dict[int, datetime] = {}
 
     async def connect(
         self, websocket: WebSocket, user_id: int, *, subprotocol: str | None = None
@@ -114,10 +205,36 @@ class ConnectionManager:
                     total_sent += await self.send_to_user(participant.id, message)
         return total_sent
 
+    def _should_broadcast_presence(
+        self, user_id: int, now: datetime, *, force: bool
+    ) -> bool:
+        min_interval = max(settings.presence_ping_min_interval_seconds, 0)
+        if force or min_interval <= 0:
+            return True
+        last_sent = self._last_presence_sent_at.get(user_id)
+        if last_sent is None:
+            return True
+        elapsed = (now - last_sent).total_seconds()
+        return elapsed >= min_interval
+
     async def broadcast_presence(
-        self, user_id: int, active: bool, last_seen: datetime | None
+        self,
+        user_id: int,
+        active: bool,
+        last_seen: datetime | None,
+        *,
+        source: str,
+        force: bool = False,
+        publish: bool = True,
     ) -> int:
-        """Broadcast presence status to all connected users."""
+        """Broadcast presence status to relevant chat participants."""
+        now = datetime.now(UTC)
+        state = "active" if active else "inactive"
+        if not self._should_broadcast_presence(user_id, now, force=force):
+            record_presence_throttled(state, source)
+            return 0
+        self._last_presence_sent_at[user_id] = now
+        record_presence_event(state, source)
 
         payload = {
             "type": "presence",
@@ -126,8 +243,12 @@ class ConnectionManager:
             "last_seen": last_seen.isoformat() if last_seen else None,
         }
 
+        if publish:
+            await presence_pubsub.publish(payload)
+
+        audience = await _get_presence_audience(user_id)
         total_sent = 0
-        for target_user in list(self.active_connections.keys()):
+        for target_user in audience:
             total_sent += await self.send_to_user(target_user, payload)
         return total_sent
 
@@ -138,6 +259,36 @@ class ConnectionManager:
 
 # Global connection manager instance
 manager = ConnectionManager()
+
+
+async def _handle_presence_pubsub(payload: dict[str, Any]) -> None:
+    user_id = payload.get("user_id")
+    if user_id is None:
+        return
+    active = bool(payload.get("active"))
+    last_seen_raw = payload.get("last_seen")
+    last_seen = None
+    if last_seen_raw:
+        try:
+            last_seen = datetime.fromisoformat(str(last_seen_raw))
+        except ValueError:
+            logger.warning("Invalid last_seen value in presence payload")
+    await manager.broadcast_presence(
+        int(user_id),
+        active,
+        last_seen,
+        source=PRESENCE_SOURCE_PUBSUB,
+        force=True,
+        publish=False,
+    )
+
+
+async def start_presence_pubsub() -> None:
+    await presence_pubsub.initialize()
+
+
+async def stop_presence_pubsub() -> None:
+    await presence_pubsub.shutdown()
 
 
 async def get_user_from_token(token: str) -> tuple[User | None, str | None]:
@@ -422,7 +573,13 @@ async def websocket_chat(websocket: WebSocket):
     # Connect and register
     await manager.connect(websocket, user.id, subprotocol=selected_subprotocol)
     last_seen = await _update_last_seen(session_jti)
-    await manager.broadcast_presence(user.id, True, last_seen)
+    await manager.broadcast_presence(
+        user.id,
+        True,
+        last_seen,
+        source=PRESENCE_SOURCE_CONNECT,
+        force=True,
+    )
 
     try:
         # Send initial online status to user's contacts
@@ -440,7 +597,12 @@ async def websocket_chat(websocket: WebSocket):
             if msg_type == "ping":
                 last_seen = await _update_last_seen(session_jti)
                 await websocket.send_json({"type": "pong"})
-                await manager.broadcast_presence(user.id, True, last_seen)
+                await manager.broadcast_presence(
+                    user.id,
+                    True,
+                    last_seen,
+                    source=PRESENCE_SOURCE_PING,
+                )
 
             elif msg_type == "typing":
                 chat_id = data.get("chat_id")
@@ -492,13 +654,25 @@ async def websocket_chat(websocket: WebSocket):
     except WebSocketDisconnect:
         manager.disconnect(websocket)
         last_seen = await _update_last_seen(session_jti)
-        await manager.broadcast_presence(user.id, False, last_seen)
+        await manager.broadcast_presence(
+            user.id,
+            False,
+            last_seen,
+            source=PRESENCE_SOURCE_DISCONNECT,
+            force=True,
+        )
         logger.info(f"WebSocket disconnected for user {user.id}")
     except Exception as e:
         logger.error(f"WebSocket error for user {user.id}: {e}")
         manager.disconnect(websocket)
         last_seen = await _update_last_seen(session_jti)
-        await manager.broadcast_presence(user.id, False, last_seen)
+        await manager.broadcast_presence(
+            user.id,
+            False,
+            last_seen,
+            source=PRESENCE_SOURCE_DISCONNECT,
+            force=True,
+        )
 
 
 async def notify_new_message(

--- a/app/core/config/app_gen.py
+++ b/app/core/config/app_gen.py
@@ -35,6 +35,9 @@ class AppGeneralSettings(BaseAppSettings):
     metrics_allowlist: str | list[str] = ""
     monitoring_heavy_probe_enabled: bool = False
     health_storage_probe_enabled: bool = True
+    presence_ping_min_interval_seconds: int = 5
+    presence_pubsub_enabled: bool = False
+    presence_pubsub_channel: str = "presence_updates"
 
     api_v2_prefix: str = "/api/v2"
     audit_log_secret: str = "development-audit-secret"

--- a/app/core/lifespan.py
+++ b/app/core/lifespan.py
@@ -59,8 +59,8 @@ from app.services.story_cleanup import (
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    from app.core.feature_flags import feature_flags
     from app.api.websocket import start_presence_pubsub, stop_presence_pubsub
+    from app.core.feature_flags import feature_flags
 
     await broker.startup()
     await feature_flags.initialize()

--- a/app/core/lifespan.py
+++ b/app/core/lifespan.py
@@ -60,9 +60,11 @@ from app.services.story_cleanup import (
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     from app.core.feature_flags import feature_flags
+    from app.api.websocket import start_presence_pubsub, stop_presence_pubsub
 
     await broker.startup()
     await feature_flags.initialize()
+    await start_presence_pubsub()
     await wait_db(max_attempts=10, delay=0.5)
 
     # Configure domain event handlers
@@ -189,6 +191,7 @@ async def lifespan(app: FastAPI):
     try:
         yield
     finally:
+        await stop_presence_pubsub()
         if stop_scheduler is not None:
             await stop_scheduler()
         if stop_notifications_retention is not None:

--- a/app/core/metrics.py
+++ b/app/core/metrics.py
@@ -302,6 +302,28 @@ _MFA_ADOPTION = (
     else None
 )
 
+_PRESENCE_EVENTS = (
+    Counter(
+        "websocket_presence_events_total",
+        "Total presence events broadcast over websockets",
+        ("state", "source"),
+        registry=REGISTRY,
+    )
+    if Counter is not None
+    else None
+)
+
+_PRESENCE_THROTTLED = (
+    Counter(
+        "websocket_presence_throttled_total",
+        "Total presence events throttled before broadcast",
+        ("state", "source"),
+        registry=REGISTRY,
+    )
+    if Counter is not None
+    else None
+)
+
 
 def record_login_success() -> None:
     """Record a successful login."""
@@ -343,6 +365,18 @@ def set_mfa_adoption(count: int) -> None:
     """Set the MFA adoption count."""
     if _MFA_ADOPTION is not None:
         _MFA_ADOPTION.set(float(count))
+
+
+def record_presence_event(state: str, source: str) -> None:
+    """Record a presence broadcast event."""
+    if _PRESENCE_EVENTS is not None:
+        _PRESENCE_EVENTS.labels(state=state, source=source).inc()
+
+
+def record_presence_throttled(state: str, source: str) -> None:
+    """Record a throttled presence event."""
+    if _PRESENCE_THROTTLED is not None:
+        _PRESENCE_THROTTLED.labels(state=state, source=source).inc()
 
 
 _CONFIGURED_ATTR = "_metrics_configured"

--- a/tests/test_websocket_chat.py
+++ b/tests/test_websocket_chat.py
@@ -9,6 +9,7 @@ from starlette.websockets import WebSocket, WebSocketDisconnect
 
 from app.api.websocket import ConnectionManager
 from app.auth.security import create_access_token
+from app.core.config import settings
 from app.models.chat import Chat, Message
 
 
@@ -152,6 +153,74 @@ class TestConnectionManager:
         online = connection_manager.get_online_users()
 
         assert set(online) == {1, 2}
+
+    @pytest.mark.asyncio
+    async def test_broadcast_presence_targets_chat_participants_only(
+        self, connection_manager: ConnectionManager, db_session, user_factory
+    ):
+        """Presence updates should only go to users sharing a chat."""
+        user_a = await user_factory()
+        user_b = await user_factory()
+        user_c = await user_factory()
+
+        chat = Chat()
+        chat.participants = [user_a, user_b]
+        db_session.add(chat)
+        await db_session.commit()
+
+        ws_b = AsyncMock(spec=WebSocket)
+        ws_c = AsyncMock(spec=WebSocket)
+        connection_manager.active_connections[user_b.id] = {ws_b}
+        connection_manager.connection_users[ws_b] = user_b.id
+        connection_manager.active_connections[user_c.id] = {ws_c}
+        connection_manager.connection_users[ws_c] = user_c.id
+
+        last_seen = datetime.now(UTC)
+        await connection_manager.broadcast_presence(
+            user_a.id,
+            True,
+            last_seen,
+            source="ping",
+            force=True,
+            publish=False,
+        )
+
+        ws_b.send_json.assert_called_once()
+        ws_c.send_json.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_broadcast_presence_throttles_pings(
+        self, connection_manager: ConnectionManager, monkeypatch
+    ):
+        """Presence broadcasts should be throttled when configured."""
+        send_mock = AsyncMock(return_value=1)
+        connection_manager.send_to_user = send_mock
+
+        async def _audience(_user_id: int) -> set[int]:
+            return {2}
+
+        monkeypatch.setattr("app.api.websocket._get_presence_audience", _audience)
+        monkeypatch.setattr(
+            settings, "presence_ping_min_interval_seconds", 60, raising=False
+        )
+
+        last_seen = datetime.now(UTC)
+        await connection_manager.broadcast_presence(
+            1,
+            True,
+            last_seen,
+            source="ping",
+            publish=False,
+        )
+        await connection_manager.broadcast_presence(
+            1,
+            True,
+            last_seen,
+            source="ping",
+            publish=False,
+        )
+
+        assert send_mock.call_count == 1
 
 
 class TestWebSocketAuth:


### PR DESCRIPTION
### Motivation

- Avoid noisy/unnecessary presence notifications by sending presence only to users who share chats with the actor instead of broadcasting to everyone.  
- Throttle frequent presence pings to reduce DB/WS load and network churn.  
- Enable horizontal scaling of presence fan-out via an optional Redis pub/sub bridge.  
- Add observability to measure presence broadcasts and throttled events.

### Description

- Restrict presence delivery by resolving the audience via `chat_participants` and sending presence only to that audience in `ConnectionManager.broadcast_presence` instead of iterating over all `active_connections`.  
- Add ping throttling using a configurable `presence_ping_min_interval_seconds` setting and track last-sent timestamps to avoid sending presence more often than configured.  
- Introduce a `PresencePubSub` helper to optionally publish/subscribe presence events to Redis and wire lifecycle calls `start_presence_pubsub` / `stop_presence_pubsub` into the app lifespan.  
- Add metrics counters `websocket_presence_events_total` and `websocket_presence_throttled_total` with helper functions `record_presence_event` and `record_presence_throttled`, add config flags `presence_pubsub_enabled` and `presence_pubsub_channel`, and include tests exercising audience targeting and throttling in `tests/test_websocket_chat.py`.

### Testing

- Added unit tests `test_broadcast_presence_targets_chat_participants_only` and `test_broadcast_presence_throttles_pings` in `tests/test_websocket_chat.py` to verify audience scoping and throttling.  
- Ran the websocket tests with `pytest -q tests/test_websocket_chat.py`, which failed to execute due to a missing test plugin (`pytest_asyncio`) in the environment.  
- No other automated test runs were executed in this rollout due to the local test environment limitation.  
- The changes are covered by the added unit tests and metrics to observe presence event frequency once CI/test environment has `pytest_asyncio` available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962d7b908248327bcdf535d52bfbaaa)