### PR TITLE
Respect trusted proxies for rate limit IP resolution

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -66,6 +66,11 @@ This document describes all environment variables used by the University Ecosyst
 | `RATE_LIMIT_DEFAULT` | Default rate | `100/minute` |
 | `RATE_LIMIT_SENSITIVE` | Sensitive endpoints rate | `5/minute` |
 | `RATE_LIMIT_STORAGE_BACKEND` | `memory` or `redis` | `memory` |
+| `TRUSTED_PROXIES` | Comma-separated proxy IPs allowed to supply `X-Forwarded-For` | Empty |
+
+When `TRUSTED_PROXIES` is empty (default), rate limiting uses the direct client IP.
+If the request originates from a trusted proxy, rate limiting uses the first IP from
+`X-Forwarded-For` (or the `Forwarded` header as a fallback).
 
 ---
 

--- a/app/core/config/security.py
+++ b/app/core/config/security.py
@@ -61,6 +61,7 @@ class SecuritySettings(BaseAppSettings):
     rate_limit_storage_backend: str = "memory"
     rate_limit_storage_uri: str = "memory://"
     rate_limit_headers_enabled: bool = True
+    trusted_proxies: str | list[str] = ""
 
     auth_lockout_thresholds: str | list[str] = "5:30,8:300,10:3600"
     auth_lockout_history_minutes: int = 1_440
@@ -351,6 +352,10 @@ class SecuritySettings(BaseAppSettings):
     def rate_limit_sensitive_value(self) -> str | None:
         value = str(self.rate_limit_sensitive).strip()
         return value or None
+
+    @cached_property
+    def trusted_proxies_list(self) -> list[str]:
+        return [proxy for proxy in _coerce_str_list(self.trusted_proxies) if proxy]
 
     @cached_property
     def strict_security_headers_enabled(self) -> bool:

--- a/app/utils/ratelimit.py
+++ b/app/utils/ratelimit.py
@@ -106,32 +106,42 @@ def _extract_ip_from_forwarded(forwarded_header: str) -> str | None:
     return None
 
 
+def _normalize_ip(value: str | None) -> str | None:
+    if not value:
+        return None
+    normalized = value.strip().lower()
+    if not normalized:
+        return None
+    if normalized.startswith("[") and "]" in normalized:
+        normalized = normalized[1 : normalized.index("]")]
+    elif normalized.count(":") == 1 and "]" not in normalized:
+        normalized = normalized.split(":", 1)[0]
+    return normalized or None
+
+
 def _resolve_client_ip(request: Request) -> str:
-    x_forwarded_for = request.headers.get("X-Forwarded-For")
-    if x_forwarded_for:
-        for part in x_forwarded_for.split(","):
-            candidate = part.strip()
-            if candidate:
-                ip = candidate
-                break
-        else:
-            ip = None
-    else:
-        ip = None
+    client_host = request.client.host if request.client else "unknown"
+    normalized_client = _normalize_ip(client_host) or "unknown"
+    trusted = {_normalize_ip(proxy) for proxy in settings.trusted_proxies_list}
+    trusted.discard(None)
+
+    ip: str | None = None
+    if normalized_client in trusted:
+        x_forwarded_for = request.headers.get("X-Forwarded-For")
+        if x_forwarded_for:
+            for part in x_forwarded_for.split(","):
+                candidate = _normalize_ip(part)
+                if candidate:
+                    ip = candidate
+                    break
+
+        if not ip:
+            forwarded_header = request.headers.get("Forwarded")
+            if forwarded_header:
+                ip = _normalize_ip(_extract_ip_from_forwarded(forwarded_header))
 
     if not ip:
-        forwarded_header = request.headers.get("Forwarded")
-        if forwarded_header:
-            ip = _extract_ip_from_forwarded(forwarded_header)
-
-    if not ip:
-        ip = request.client.host if request.client else "unknown"
-
-    ip = ip.strip().lower()
-    if ip.startswith("[") and "]" in ip:
-        ip = ip[1 : ip.index("]")]
-    elif ip.count(":") == 1 and "]" not in ip:
-        ip = ip.split(":", 1)[0]
+        ip = normalized_client
 
     return ip or "unknown"
 

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -217,8 +217,10 @@ async def test_sensitive_dependency_memory_backend():
 async def test_sensitive_dependency_memory_backend_resolves_proxy_headers():
     original_backend = settings.rate_limit_storage_backend
     original_uri = settings.rate_limit_storage_uri
+    original_trusted = settings.trusted_proxies
     settings.rate_limit_storage_backend = "memory"
     settings.rate_limit_storage_uri = "memory://"
+    settings.trusted_proxies = "127.0.0.1"
     ratelimit_module.limiter.reset()
 
     dependency = ratelimit_module.sensitive_route_limit(
@@ -252,6 +254,55 @@ async def test_sensitive_dependency_memory_backend_resolves_proxy_headers():
     finally:
         settings.rate_limit_storage_backend = original_backend
         settings.rate_limit_storage_uri = original_uri
+        settings.trusted_proxies = original_trusted
+
+    assert first.status_code == status.HTTP_200_OK
+    assert second.status_code == status.HTTP_200_OK
+    assert third.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+
+
+@pytest.mark.anyio
+async def test_sensitive_dependency_memory_backend_ignores_untrusted_proxy_headers():
+    original_backend = settings.rate_limit_storage_backend
+    original_uri = settings.rate_limit_storage_uri
+    original_trusted = settings.trusted_proxies
+    settings.rate_limit_storage_backend = "memory"
+    settings.rate_limit_storage_uri = "memory://"
+    settings.trusted_proxies = ""
+    ratelimit_module.limiter.reset()
+
+    dependency = ratelimit_module.sensitive_route_limit(
+        limit=2, window_sec=60, key_prefix="memory-untrusted-proxy"
+    )
+
+    app = FastAPI()
+
+    @app.get("/limited", dependencies=[Depends(dependency)])
+    async def _limited():  # pragma: no cover - minimal endpoint
+        return {"ok": True}
+
+    transport = httpx.ASGITransport(app=app)
+
+    try:
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://testserver"
+        ) as client:
+            first = await client.get(
+                "/limited",
+                headers={"X-Forwarded-For": "203.0.113.10"},
+            )
+            second = await client.get(
+                "/limited",
+                headers={"X-Forwarded-For": "198.51.100.12"},
+            )
+            third = await client.get(
+                "/limited",
+                headers={"X-Forwarded-For": "198.51.100.13"},
+            )
+    finally:
+        settings.rate_limit_storage_backend = original_backend
+        settings.rate_limit_storage_uri = original_uri
+        settings.trusted_proxies = original_trusted
 
     assert first.status_code == status.HTTP_200_OK
     assert second.status_code == status.HTTP_200_OK
@@ -309,8 +360,10 @@ async def test_sensitive_dependency_redis_backend_forwarded_header(
 ):
     original_backend = settings.rate_limit_storage_backend
     original_uri = settings.rate_limit_storage_uri
+    original_trusted = settings.trusted_proxies
     settings.rate_limit_storage_backend = "redis"
     settings.rate_limit_storage_uri = "redis://test"
+    settings.trusted_proxies = "127.0.0.1"
 
     dependency = ratelimit_module.sensitive_route_limit(
         limit=2, window_sec=60, key_prefix="redis-proxy"
@@ -356,6 +409,7 @@ async def test_sensitive_dependency_redis_backend_forwarded_header(
     finally:
         settings.rate_limit_storage_backend = original_backend
         settings.rate_limit_storage_uri = original_uri
+        settings.trusted_proxies = original_trusted
 
     assert first.status_code == status.HTTP_200_OK
     assert second.status_code == status.HTTP_200_OK


### PR DESCRIPTION
### Motivation
- Prevent untrusted clients from influencing rate-limiting by only parsing `X-Forwarded-For`/`Forwarded` when the immediate peer is a configured trusted proxy.

### Description
- Add a `trusted_proxies` setting and `trusted_proxies_list` property in `app/core/config/security.py` to configure allowed proxy IPs.
- Implement `_normalize_ip` and update `_resolve_client_ip` in `app/utils/ratelimit.py` to normalize addresses and only use `X-Forwarded-For`/`Forwarded` if `request.client.host` is in `trusted_proxies_list`.
- Document the new `TRUSTED_PROXIES` variable in `CONFIGURATION.md` and update `tests/test_rate_limit.py` to cover trusted vs untrusted proxy header scenarios.

### Testing
- Ran `pytest tests/test_rate_limit.py` to exercise the updated rate-limit tests.
- The test run failed due to the environment missing the `pytest_asyncio` plugin, so full automated verification could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962db80fa00832791d11a8639c5ba87)