### PR TITLE
Split CSP templates for dev/prod and enforce strict CSP in production

### DIFF
--- a/app/core/config/security.py
+++ b/app/core/config/security.py
@@ -78,17 +78,34 @@ class SecuritySettings(BaseAppSettings):
     trusted_device_expire_days: int = 30
     trusted_device_cookie_name: str = "trusted_device"
 
-    security_csp: str = (
-        "default-src 'self'; "
-        "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://accounts.google.com; "
+    security_csp: str = ""
+    security_csp_dev: str = (
+        "default-src 'self' http://localhost:5173; "
+        "script-src 'self' 'unsafe-inline' 'unsafe-eval' "
+        "http://localhost:5173 https://accounts.google.com 'report-sample'; "
         "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
         "img-src 'self' data: https: blob:; "
-        "connect-src 'self' https://api.spotify.com https://fcm.googleapis.com "
-        "https://fcmregistrations.googleapis.com "
-        "https://*.push.services.mozilla.com https://*.push.apple.com; "
+        "connect-src {connect_src}; "
         "font-src 'self' data: https://fonts.gstatic.com; "
         "object-src 'none'; "
-        "base-uri 'self';"
+        "base-uri 'self'; "
+        "frame-ancestors 'self'; "
+        "trusted-types app dompurify-news goog#html 'allow-duplicates'; "
+        "{require_trusted_types}"
+    )
+    security_csp_prod: str = (
+        "default-src 'self'; "
+        "script-src 'self' 'nonce-{nonce}' 'strict-dynamic' "
+        "https://accounts.google.com 'report-sample'; "
+        "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
+        "img-src 'self' data: https: blob:; "
+        "connect-src {connect_src}; "
+        "font-src 'self' data: https://fonts.gstatic.com; "
+        "object-src 'none'; "
+        "base-uri 'self'; "
+        "frame-ancestors 'self'; "
+        "trusted-types app dompurify-news goog#html 'allow-duplicates'; "
+        "{require_trusted_types}"
     )
     security_connect_src_extra: str | list[str] = (
         "https://api.spotify.com,"
@@ -475,72 +492,37 @@ class SecuritySettings(BaseAppSettings):
     def build_csp_policy(self, *, nonce: str | None, report_only: bool) -> str:
         if "security_csp" in self.model_fields_set and self.security_csp.strip():
             template = self.security_csp.strip()
-            require_trusted_types = (
-                "require-trusted-types-for 'script'"
-                if self.strict_security_headers_enabled and not report_only
-                else ""
-            )
-            policy = template.replace("{require_trusted_types}", require_trusted_types)
-            connect_sources = (
-                self.security_connect_src_values + self._development_connect_overrides()
-            )
-            connect_value = " ".join(connect_sources).strip()
-            policy = policy.replace("{connect_src}", connect_value or "'self'")
-            if nonce:
-                policy = policy.replace("{nonce}", nonce)
-            else:
-                policy = (
-                    policy.replace("'nonce-{nonce}'", "")
-                    .replace("{nonce}", "")
-                    .replace("  ", " ")
-                )
-            directives = [part.strip() for part in policy.split(";") if part.strip()]
-            policy = "; ".join(directives)
         else:
-            connect_sources = (
-                self.security_connect_src_values + self._development_connect_overrides()
+            template = (
+                self.security_csp_dev
+                if getattr(self, "is_development", False)
+                else self.security_csp_prod
             )
-            connect_value = " ".join(
-                dict.fromkeys([value for value in connect_sources if value])
+        require_trusted_types = (
+            "require-trusted-types-for 'script'"
+            if self.strict_security_headers_enabled and not report_only
+            else ""
+        )
+        policy = template.replace("{require_trusted_types}", require_trusted_types)
+        connect_sources = self.security_connect_src_values + (
+            self._development_connect_overrides()
+            if getattr(self, "is_development", False)
+            else []
+        )
+        connect_value = " ".join(
+            dict.fromkeys([value for value in connect_sources if value])
+        ).strip()
+        policy = policy.replace("{connect_src}", connect_value or "'self'")
+        if nonce:
+            policy = policy.replace("{nonce}", nonce)
+        else:
+            policy = (
+                policy.replace("'nonce-{nonce}'", "")
+                .replace("{nonce}", "")
+                .replace("  ", " ")
             )
-            if not connect_value:
-                connect_value = "'self'"
-            if self.strict_security_headers_enabled and not report_only:
-                directives = [
-                    "default-src 'self'",
-                    (
-                        "script-src 'self' 'nonce-{nonce}' "
-                        "'strict-dynamic' 'report-sample'"
-                    ),
-                    "style-src 'self' 'unsafe-inline'",
-                    "img-src 'self' data: blob:",
-                    f"connect-src {connect_value}",
-                    "object-src 'none'",
-                    "base-uri 'self'",
-                    "frame-ancestors 'self'",
-                    "trusted-types app dompurify-news goog#html 'allow-duplicates'",
-                    "require-trusted-types-for 'script'",
-                ]
-            else:
-                directives = [
-                    "default-src 'self' http://localhost:5173",
-                    (
-                        "script-src 'self' 'unsafe-inline' 'unsafe-eval' "
-                        "http://localhost:5173 'report-sample'"
-                    ),
-                    "style-src 'self' 'unsafe-inline'",
-                    "img-src 'self' data: blob:",
-                    f"connect-src {connect_value}",
-                    "object-src 'none'",
-                    "base-uri 'self'",
-                    "frame-ancestors 'self'",
-                    "trusted-types app dompurify-news goog#html 'allow-duplicates'",
-                ]
-            policy = "; ".join(directives)
-            if nonce:
-                policy = policy.replace("{nonce}", nonce)
-            else:
-                policy = policy.replace("'nonce-{nonce}'", "").replace("{nonce}", "")
+        directives = [part.strip() for part in policy.split(";") if part.strip()]
+        policy = "; ".join(directives)
         policy = "; ".join(
             part.strip() for part in policy.split(";") if part and part.strip()
         )

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -78,6 +78,8 @@ async def test_security_headers_production_mode(monkeypatch):
     assert "'report-sample'" in script_src
     # Check for nonce
     assert any(token.startswith("'nonce-") for token in script_src)
+    assert "'unsafe-inline'" not in script_src
+    assert "'unsafe-eval'" not in script_src
 
     style_src = directives.get("style-src", [])
     assert "'self'" in style_src


### PR DESCRIPTION
### Motivation

- Provide separate Content-Security-Policy templates for development and production so the policy can be permissive during development and strict in production.
- In production, prefer `nonce` + `strict-dynamic` and remove `unsafe-inline`/`unsafe-eval` for stronger script security.
- Make `build_csp_policy` pick the right template based on environment and preserve existing connect-src overrides and nonce replacement.
- Add an assertion in tests to ensure the strict production CSP excludes `unsafe-inline`/`unsafe-eval`.

### Description

- Added `security_csp_dev` and `security_csp_prod` templates and set `security_csp` default to an empty string in `app/core/config/security.py`.
- Updated `build_csp_policy` to select the template from `security_csp` (if provided) or pick `security_csp_dev` when `is_development` is true, otherwise `security_csp_prod`, while still injecting `{connect_src}`, `{nonce}` and `{require_trusted_types}` appropriately.
- Production template uses `script-src 'self' 'nonce-{nonce}' 'strict-dynamic'` and omits `unsafe-inline`/`unsafe-eval`, while the dev template keeps inline/eval allowances and local origins for developer convenience.
- Tightened `tests/test_security_headers.py` to assert that `script-src` in production mode does not contain `unsafe-inline` or `unsafe-eval`.

### Testing

- Ran `pytest tests/test_security_headers.py` locally to validate the header behavior, but the run failed due to a missing `pytest_asyncio` plugin in the environment.
- The updated test file `tests/test_security_headers.py` now includes assertions checking for presence of nonce/`strict-dynamic` and absence of `unsafe-inline`/`unsafe-eval` in production mode.
- No other automated test suites were executed in this rollout due to the plugin failure.
- Manual inspection and local execution verified the `build_csp_policy` changes and template selection logic in `app/core/config/security.py`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962db81a1c083278b0ee87cf466bb61)