### PR TITLE
Harden CSP report handling

### DIFF
--- a/app/api/internal/csp_report.py
+++ b/app/api/internal/csp_report.py
@@ -10,13 +10,49 @@ import logging
 from typing import Any
 
 from fastapi import APIRouter, Request, Response, status
+from fastapi.params import Depends
+
+from app.core.metrics import record_csp_report
+from app.utils.ratelimit import sensitive_route_limit
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/csp-report", tags=["security"])
 
+MAX_CSP_REPORT_BYTES = 16 * 1024
+MAX_LOG_VALUE_LENGTH = 200
+MAX_SCRIPT_SAMPLE_LENGTH = 100
 
-@router.post("", status_code=status.HTTP_204_NO_CONTENT)
+
+def _truncate(value: Any, limit: int = MAX_LOG_VALUE_LENGTH) -> str | None:
+    if value is None:
+        return None
+    return str(value)[:limit]
+
+
+async def _read_body_with_limit(request: Request, limit: int) -> bytes | None:
+    content_length = request.headers.get("content-length")
+    if content_length:
+        try:
+            if int(content_length) > limit:
+                return None
+        except ValueError:
+            logger.debug("Invalid content-length header for CSP report")
+    body = bytearray()
+    async for chunk in request.stream():
+        if not chunk:
+            continue
+        body.extend(chunk)
+        if len(body) > limit:
+            return None
+    return bytes(body)
+
+
+@router.post(
+    "",
+    status_code=status.HTTP_204_NO_CONTENT,
+    dependencies=[Depends(sensitive_route_limit(limit=30, window_sec=60))],
+)
 async def receive_csp_report(request: Request) -> Response:
     """
     Receive CSP violation reports from browsers.
@@ -25,8 +61,16 @@ async def receive_csp_report(request: Request) -> Response:
     when a CSP policy is violated.
     """
     try:
-        body = await request.body()
+        body = await _read_body_with_limit(request, MAX_CSP_REPORT_BYTES)
+        if body is None:
+            record_csp_report("too_large")
+            logger.warning(
+                "CSP report payload too large",
+                extra={"event": "csp_report", "status": "payload_too_large"},
+            )
+            return Response(status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE)
         if not body:
+            record_csp_report("empty")
             return Response(status_code=status.HTTP_204_NO_CONTENT)
 
         # Parse the violation report
@@ -35,6 +79,7 @@ async def receive_csp_report(request: Request) -> Response:
         try:
             report_data: dict[str, Any] = json.loads(body)
         except json.JSONDecodeError:
+            record_csp_report("invalid_json")
             logger.warning(
                 "Invalid CSP report format",
                 extra={"event": "csp_report", "status": "invalid_json"},
@@ -45,24 +90,34 @@ async def receive_csp_report(request: Request) -> Response:
         csp_report = report_data.get("csp-report", report_data)
 
         # Log the violation in structured format
+        record_csp_report("accepted")
         logger.warning(
             "CSP violation detected",
             extra={
                 "event": "csp_violation",
-                "document_uri": csp_report.get("document-uri"),
-                "violated_directive": csp_report.get("violated-directive"),
-                "effective_directive": csp_report.get("effective-directive"),
-                "blocked_uri": csp_report.get("blocked-uri"),
-                "source_file": csp_report.get("source-file"),
+                "document_uri": _truncate(csp_report.get("document-uri")),
+                "violated_directive": _truncate(csp_report.get("violated-directive")),
+                "effective_directive": _truncate(
+                    csp_report.get("effective-directive")
+                ),
+                "blocked_uri": _truncate(csp_report.get("blocked-uri")),
+                "source_file": _truncate(csp_report.get("source-file")),
                 "line_number": csp_report.get("line-number"),
                 "column_number": csp_report.get("column-number"),
                 "status_code": csp_report.get("status-code"),
-                "script_sample": csp_report.get("script-sample", "")[:100],  # Truncate
-                "user_agent": request.headers.get("user-agent", "")[:200],
+                "script_sample": _truncate(
+                    csp_report.get("script-sample", ""),
+                    limit=MAX_SCRIPT_SAMPLE_LENGTH,
+                ),
+                "user_agent": _truncate(
+                    request.headers.get("user-agent", ""),
+                    limit=MAX_LOG_VALUE_LENGTH,
+                ),
             },
         )
 
     except Exception:
+        record_csp_report("error")
         # Silently ignore errors - don't disrupt user experience
         logger.debug("Failed to process CSP report", exc_info=True)
 

--- a/app/core/metrics.py
+++ b/app/core/metrics.py
@@ -324,6 +324,17 @@ _PRESENCE_THROTTLED = (
     else None
 )
 
+_CSP_REPORTS = (
+    Counter(
+        "csp_reports_total",
+        "Total CSP violation reports received",
+        ("outcome",),
+        registry=REGISTRY,
+    )
+    if Counter is not None
+    else None
+)
+
 
 def record_login_success() -> None:
     """Record a successful login."""
@@ -377,6 +388,12 @@ def record_presence_throttled(state: str, source: str) -> None:
     """Record a throttled presence event."""
     if _PRESENCE_THROTTLED is not None:
         _PRESENCE_THROTTLED.labels(state=state, source=source).inc()
+
+
+def record_csp_report(outcome: str) -> None:
+    """Record a CSP report processing outcome."""
+    if _CSP_REPORTS is not None:
+        _CSP_REPORTS.labels(outcome=outcome).inc()
 
 
 _CONFIGURED_ATTR = "_metrics_configured"

--- a/docs/observability/prometheus-alerts.json
+++ b/docs/observability/prometheus-alerts.json
@@ -40,6 +40,16 @@
             "summary": "Spike in 5xx responses",
             "description": "Router {{ $labels.router }} reported more than 5 errors in 5 minutes"
           }
+        },
+        {
+          "alert": "CSPReportSpike",
+          "expr": "sum(rate(csp_reports_total{outcome=\"accepted\"}[5m])) > 20",
+          "for": "5m",
+          "labels": {"severity": "warning"},
+          "annotations": {
+            "summary": "Spike in CSP violation reports",
+            "description": "CSP reports exceeded 20 per minute over 5 minutes"
+          }
         }
       ]
     }


### PR DESCRIPTION
### Motivation
- Limit and validate incoming CSP report payloads to prevent large or malformed requests from consuming resources.
- Rate-limit the endpoint to reduce abuse and noisy spikes from clients.
- Avoid logging raw/large payloads to improve privacy and prevent log injection.
- Add observability so spikes in CSP reports can be detected and alerted on.

### Description
- Add a bounded body reader ` _read_body_with_limit` and respond `413` if the request exceeds `MAX_CSP_REPORT_BYTES`, and return early for empty payloads in `app/api/internal/csp_report.py`.
- Apply an endpoint rate limit via the `sensitive_route_limit(limit=30, window_sec=60)` dependency on the `/csp-report` route to throttle requests.
- Replace raw payload logging with truncated fields via `_truncate` and limit `script_sample` and `user_agent` lengths to avoid writing full payloads to logs.
- Introduce a Prometheus counter `csp_reports_total` and helper `record_csp_report(outcome)` in `app/core/metrics.py`, and emit outcomes (`too_large`, `empty`, `invalid_json`, `accepted`, `error`) from the handler, plus add a `CSPReportSpike` alert rule in `docs/observability/prometheus-alerts.json`.

### Testing
- No automated tests were run as part of this change.
- Static checks and runtime behavior should be validated during integration and staging deployments before production rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962db846c4883279bb4cda8ec8aef11)