### PR TITLE
Remove SVG from allowed image uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Set `NOTIFICATIONS_SCHEDULER_INLINE_ENABLED=false` when the API and worker run s
 
 ## Image uploads
 
-Uploaded profile photos and news images are limited to **5 MB**. The backend automatically resizes images within the `IMAGE_MAX_WIDTH` × `IMAGE_MAX_HEIGHT` bounds (default 1920×1920), strips EXIF metadata, and stores them as WebP (PNG when transparency is required).
+Uploaded profile photos and news images are limited to **5 MB**. Supported formats are JPEG, PNG, and WebP (SVG is not accepted). The backend automatically resizes images within the `IMAGE_MAX_WIDTH` × `IMAGE_MAX_HEIGHT` bounds (default 1920×1920), strips EXIF metadata, and stores them as WebP (PNG when transparency is required).
 
 ## Running tests and linters
 

--- a/app/utils/files.py
+++ b/app/utils/files.py
@@ -73,7 +73,6 @@ ALLOWED_IMAGE_TYPES: Final[set[str]] = {
     "image/jpeg",
     "image/png",
     "image/webp",
-    "image/svg+xml",
 }
 MAX_IMAGE_SIZE: Final[int] = 5 * 1024 * 1024
 
@@ -82,7 +81,6 @@ _PREFERRED_EXTENSIONS: Final[dict[str, str]] = {
     "image/jpeg": ".jpg",
     "image/png": ".png",
     "image/webp": ".webp",
-    "image/svg+xml": ".svg",
 }
 
 try:  # pragma: no cover - exercised indirectly via detect_mime_type


### PR DESCRIPTION
### Motivation

- Decide a single safe strategy for SVG handling; disallowing SVG avoids server-side XML sanitization complexity and reduces XSS/polyglot risks.
- Keep image processing predictable by restricting uploads to raster formats that the optimizer expects.
- Make accepted upload formats explicit in user-facing docs so integrators won't rely on SVG support.

### Description

- Removed `"image/svg+xml"` from `ALLOWED_IMAGE_TYPES` in `app/utils/files.py` so `save_image` will reject SVG uploads.
- Removed the SVG mapping from `_PREFERRED_EXTENSIONS` in `app/utils/files.py` to reflect the supported set.
- Updated `README.md` image upload section to list supported formats as JPEG, PNG, and WebP and to explicitly state that SVG is not accepted.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962db86b2f8832795bd176fe9f66d53)