### PR TITLE
test: mock schedule data in translation tests

### DIFF
--- a/frontend/src/pages/__tests__/Schedule.translations.test.tsx
+++ b/frontend/src/pages/__tests__/Schedule.translations.test.tsx
@@ -72,9 +72,66 @@ const authState: AuthState = {
   setUser: vi.fn(),
 }
 
+const { scheduleDataMock } = vi.hoisted(() => {
+  const lesson = {
+    id: 42,
+    weekday: "Monday",
+    parity: "odd",
+    start_time: "08:00",
+    end_time: "09:30",
+    subject: "Linear Algebra",
+    teacher: "Ada Lovelace",
+    room: "101",
+    lesson_type: "lecture",
+    group_id: 1,
+  }
+
+  const scheduleDataMock = {
+    user: { role: "student" },
+    groups: [{ id: 1, name: "CS-101" }],
+    selectedGroup: 1,
+    setSelectedGroup: () => {},
+    currentParity: "odd",
+    setCurrentParity: () => {},
+    schedule: [lesson],
+    rawSchedule: [lesson],
+    isLoading: false,
+    refresh: () => {},
+    applyScheduleUpdate: () => {},
+    weekdayConfigs: [{ id: "mon", backend: ["Monday"], long: "Monday", short: "Mon" }],
+    weekdayBackend: ["Monday"],
+    weekdayLabels: ["Monday"],
+    weekdayShort: ["Mon"],
+    getDayLabel: (value: string) => value,
+    lessonTypeConfigs: [
+      { id: "lecture", backend: ["lecture"], label: "Lecture", color: "#3366ff" },
+    ],
+    lessonTypeOptions: [{ value: "lecture", label: "Lecture" }],
+    lessonTypeLabels: new Map([["lecture", "Lecture"]]),
+    defaultLessonType: "lecture",
+    getLessonTypeColor: () => "#3366ff",
+    toBackendLessonType: (value?: string | null) => value ?? "lecture",
+    todayIdx: 0,
+    hasToday: false,
+    nowTick: new Date(),
+    todayLessons: [],
+    currentLesson: null,
+    nextLesson: null,
+    conflictedIds: new Set<number>(),
+    timeLeftText: "",
+    currentProgress: 0,
+  }
+
+  return { scheduleDataMock }
+})
+
 vi.mock("@/contexts/AuthContext", () => ({
   useAuth: () => authState,
   currentUserQueryKey: ["users", "me"] as const,
+}))
+
+vi.mock("@/hooks/useScheduleData", () => ({
+  useScheduleData: () => scheduleDataMock,
 }))
 
 vi.mock("@/api/client", () => ({
@@ -137,8 +194,7 @@ describe("Schedule translations", () => {
     cleanup()
   })
 
-  // TODO: Requires mocking useScheduleData return values; skip for now to unblock CI.
-  it.skip("renders English weekday headers and lesson labels", async () => {
+  it("renders English weekday headers and lesson labels", async () => {
     apiGetMock.mockImplementation(async (url: string) => {
       if (url === "/groups") {
         return { data: [{ id: 1, name: "CS-101" }] }

--- a/frontend/src/tests/pageTranslations.test.tsx
+++ b/frontend/src/tests/pageTranslations.test.tsx
@@ -293,10 +293,67 @@ const authState = {
   setUser: vi.fn(),
 }
 
+const { scheduleDataMock } = vi.hoisted(() => {
+  const lesson = {
+    id: 42,
+    weekday: "Monday",
+    parity: "odd",
+    start_time: "08:00",
+    end_time: "09:30",
+    subject: "Linear Algebra",
+    teacher: "Ada Lovelace",
+    room: "101",
+    lesson_type: "lecture",
+    group_id: 1,
+  }
+
+  const scheduleDataMock = {
+    user: { role: "student" },
+    groups: [{ id: 1, name: "CS-101" }],
+    selectedGroup: 1,
+    setSelectedGroup: () => {},
+    currentParity: "odd",
+    setCurrentParity: () => {},
+    schedule: [lesson],
+    rawSchedule: [lesson],
+    isLoading: false,
+    refresh: () => {},
+    applyScheduleUpdate: () => {},
+    weekdayConfigs: [{ id: "mon", backend: ["Monday"], long: "Monday", short: "Mon" }],
+    weekdayBackend: ["Monday"],
+    weekdayLabels: ["Monday"],
+    weekdayShort: ["Mon"],
+    getDayLabel: (value: string) => value,
+    lessonTypeConfigs: [
+      { id: "lecture", backend: ["lecture"], label: "Lecture", color: "#3366ff" },
+    ],
+    lessonTypeOptions: [{ value: "lecture", label: "Lecture" }],
+    lessonTypeLabels: new Map([["lecture", "Lecture"]]),
+    defaultLessonType: "lecture",
+    getLessonTypeColor: () => "#3366ff",
+    toBackendLessonType: (value?: string | null) => value ?? "lecture",
+    todayIdx: 0,
+    hasToday: false,
+    nowTick: new Date(),
+    todayLessons: [],
+    currentLesson: null,
+    nextLesson: null,
+    conflictedIds: new Set<number>(),
+    timeLeftText: "",
+    currentProgress: 0,
+  }
+
+  return { scheduleDataMock }
+})
+
 vi.mock("@/contexts/AuthContext", () => ({
   useAuth: () => authState,
   currentUserQueryKey: ["users", "me"] as const,
   fetchCurrentUser: fetchCurrentUserMock,
+}))
+
+vi.mock("@/hooks/useScheduleData", () => ({
+  useScheduleData: () => scheduleDataMock,
 }))
 
 vi.mock("@/hooks/useNowPlaying", () => ({
@@ -477,8 +534,7 @@ describe("page translations", () => {
     expect(await screen.findByText("Активность")).toBeInTheDocument()
   })
 
-  // TODO: Requires mocking useScheduleData to avoid perpetual isLoading; skip for now.
-  it.skip("switches schedule page translations", async () => {
+  it("switches schedule page translations", async () => {
     const { user } = renderWithProviders(<Schedule />, { initialPath: "/schedule" })
 
     expect(await screen.findByText("My schedule")).toBeInTheDocument()


### PR DESCRIPTION
### Motivation
- The Schedule translation specs were previously skipped because `useScheduleData` left the page in a perpetual loading state and made assertions flaky. 
- Re-enable and stabilize those translation assertions so the Schedule page i18n is covered by tests. 
- Provide a minimal, deterministic schedule fixture so tests can reliably assert weekday headers and lesson labels.

### Description
- Added a hoisted `scheduleDataMock` fixture and mocked `useScheduleData` in `frontend/src/pages/__tests__/Schedule.translations.test.tsx` and `frontend/src/tests/pageTranslations.test.tsx` so tests receive a stable schedule dataset. 
- The mock sets `isLoading: false`, provides a sample lesson, exposes `conflictedIds` as a `Set<number>`, and uses `nowTick: new Date()` to avoid hoisting/import timing issues. 
- Re-enabled the previously skipped schedule translation tests and restored the assertions for weekday headers and lesson type labels. 
- Only test code and fixtures were changed; no production code was modified.

### Testing
- Ran `npm run test -- src/pages/__tests__/Schedule.translations.test.tsx src/tests/pageTranslations.test.tsx` to validate the changes. 
- Final test run: both test files passed (all assertions in the two files succeeded). 
- A non-blocking console warning about `HTMLCanvasElement.getContext` was observed earlier but it did not affect the test results.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962db894b7c8327af300745a01b77fb)