### PR TITLE
fix(wave34): bump Go 1.26.0→1.26.1 and x/image v0.37.0→v0.38.0

### DIFF
--- a/gen/go/go.mod
+++ b/gen/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/university-ecosystem/core/gen/go
 
-go 1.26.0
+go 1.26.1
 
 require (
 	google.golang.org/grpc v1.79.3

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module university-ecosystem
 
-go 1.26.0
+go 1.26.1

--- a/go.work
+++ b/go.work
@@ -8,7 +8,7 @@
 // To add a new module: `go work use ./path/to/module`
 // To regenerate: `go work sync`
 
-go 1.26.0
+go 1.26.1
 
 use (
 	.

--- a/services/cmd/uni-cli/go.mod
+++ b/services/cmd/uni-cli/go.mod
@@ -1,6 +1,6 @@
 module github.com/university-ecosystem/uni-cli
 
-go 1.26.0
+go 1.26.1
 
 require (
 	github.com/redis/go-redis/v9 v9.18.0

--- a/services/file-processor/go.mod
+++ b/services/file-processor/go.mod
@@ -1,6 +1,6 @@
 module github.com/university-ecosystem/file-processor
 
-go 1.26.0
+go 1.26.1
 
 require (
 	github.com/getsentry/sentry-go v0.43.0
@@ -22,7 +22,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.42.0
 	go.temporal.io/api v1.62.5
 	go.temporal.io/sdk v1.41.1
-	golang.org/x/image v0.37.0
+	golang.org/x/image v0.38.0
 	google.golang.org/grpc v1.79.3
 )
 

--- a/services/file-processor/go.sum
+++ b/services/file-processor/go.sum
@@ -164,8 +164,8 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.48.0 h1:/VRzVqiRSggnhY7gNRxPauEQ5Drw9haKdM0jqfcCFts=
 golang.org/x/crypto v0.48.0/go.mod h1:r0kV5h3qnFPlQnBSrULhlsRfryS2pmewsg+XfMgkVos=
-golang.org/x/image v0.37.0 h1:ZiRjArKI8GwxZOoEtUfhrBtaCN+4b/7709dlT6SSnQA=
-golang.org/x/image v0.37.0/go.mod h1:/3f6vaXC+6CEanU4KJxbcUZyEePbyKbaLoDOe4ehFYY=
+golang.org/x/image v0.38.0 h1:5l+q+Y9JDC7mBOMjo4/aPhMDcxEptsX+Tt3GgRQRPuE=
+golang.org/x/image v0.38.0/go.mod h1:/3f6vaXC+6CEanU4KJxbcUZyEePbyKbaLoDOe4ehFYY=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=

--- a/services/gateway/go.mod
+++ b/services/gateway/go.mod
@@ -1,6 +1,6 @@
 module github.com/university-ecosystem/gateway
 
-go 1.26.0
+go 1.26.1
 
 require (
 	github.com/getsentry/sentry-go v0.43.0

--- a/services/ws-hub/go.mod
+++ b/services/ws-hub/go.mod
@@ -1,6 +1,6 @@
 module github.com/university-ecosystem/ws-hub
 
-go 1.26.0
+go 1.26.1
 
 require (
 	github.com/getsentry/sentry-go v0.43.0


### PR DESCRIPTION
Patches 21 HIGH/CRITICAL vulnerabilities detected by osv-scanner:
- GO-2026-4599: crypto/x509 email address constraint bypass
- GO-2026-4600: crypto/x509 panic on empty DNS name
- GO-2026-4601: net/url insufficient host validation
- GO-2026-4602: os.ReadDir directory traversal on Unix
- GO-2026-4603: html/template XSS via unescaped meta content URLs
- GO-2026-4815: golang.org/x/image/tiff 4 GiB allocation DoS

Updated: go.work, go.mod, gen/go/go.mod, all 4 service go.mod files.