### PR TITLE
test(session-9): 4-front coverage climb — backend 86, frontend fns 68, first Go ratchet (ws-hub 62/fp 49/gw 61), first Rust cargo-test CI

### DIFF
--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -62,6 +62,13 @@ allow-dependencies-licenses:
   - "pkg:pypi/mutmut"
   - "pkg:pypi/textual"
   - "pkg:pypi/uc-micro-py"
+  # Session 9 Stream D — wasm-bindgen-test (=0.3.64, rust-crypto dev-dep for the
+  # browser-parity KATs) pulls minicov 0.3.8 transitively. minicov is dual
+  # Apache-2.0/MIT (permissive, compatible) but its crate metadata emits the
+  # malformed string "LicenseRef-bad-apache-2.0mit", which the Advisory DB
+  # cannot map to an SPDX id — same metadata-parsing artifact class as the
+  # pact-python PEP-639 case above. Test/coverage-only transitive dep.
+  - "pkg:cargo/minicov"
 
 vulnerability-check: true
 license-check: true

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -77,8 +77,27 @@ jobs:
     name: Chromatic Visual Regression
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    # Skip cleanly when the secret is not configured (forks, fresh checkouts).
-    if: ${{ vars.CHROMATIC_ENABLED == 'true' }}
+    # DISABLED 2026-06-13 (user request) — the Chromatic billing quota for this
+    # cycle is exhausted, so `chromaui/action` posts a "UI Tests" GitHub commit
+    # status that HANGS on "Update your plan to resume testing" indefinitely
+    # (the PR stays MERGEABLE but perpetually shows a pending check). The job is
+    # gated behind a SECOND, never-set repo variable `CHROMATIC_BILLING_ACTIVE`
+    # so it never runs regardless of `CHROMATIC_ENABLED` — the action never runs
+    # → no build → no stuck "UI Tests"/"UI Review" status on new commit SHAs. The
+    # job shows as "skipping" (neutral, never a fail/pending). (A literal
+    # `if: false` is rejected by the actionlint pre-commit hook as a constant
+    # expression, hence the sentinel-var form.) chromatic.yml is a STANDALONE
+    # workflow (NOT part of ci.yml's `ci-success` aggregate) → fully isolated.
+    #
+    # TO RE-ENABLE once the Chromatic plan/quota is restored:
+    #   1. Drop the `&& vars.CHROMATIC_BILLING_ACTIVE == 'true'` clause below (back
+    #      to just `if: ${{ vars.CHROMATIC_ENABLED == 'true' }}`) — OR set the
+    #      `CHROMATIC_BILLING_ACTIVE=true` repo variable.
+    #   2. Remove the `skip: true` line added to the Publish step below (it green-
+    #      stubs — posts passing statuses WITHOUT consuming snapshots — so even a
+    #      premature re-enable can't hang the PR again; remove it to resume real
+    #      visual diffs).
+    if: ${{ vars.CHROMATIC_ENABLED == 'true' && vars.CHROMATIC_BILLING_ACTIVE == 'true' }}
     defaults:
       run:
         working-directory: frontend
@@ -134,19 +153,19 @@ jobs:
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           workingDir: frontend
-          # NOTE (2026-06-05): the Chromatic snapshot quota for this billing
-          # cycle is exhausted, so the "UI Tests" commit status hangs on
-          # "Update your plan to resume testing" until the plan is restored or
-          # the monthly quota resets. It is NON-BLOCKING (PR stays MERGEABLE).
-          # We intentionally keep publishing here so "Storybook Publish —
-          # N stories published" still confirms the build compiles + uploads.
-          # To also suppress the stuck "UI Tests" check while keeping the
-          # publish, disable it in the Chromatic dashboard (Manage → Checks),
-          # OR restore/upgrade the plan. (`skip: true` is the code lever that
-          # clears BOTH statuses — but it stops publishing too, so it's not used.)
+          # 2026-06-13: the job above is hard-disabled (`if: false`) because the
+          # Chromatic billing quota is exhausted and the "UI Tests" status hangs.
+          # `skip: true` is retained here as the green-stub guard: if the job is
+          # ever re-enabled while the quota is still gone, the action posts a
+          # PASSING build status WITHOUT consuming snapshots (clears BOTH the
+          # "UI Tests" and "UI Review" statuses) instead of hanging the PR.
+          # Remove this line (and restore the `if:` gate) to resume real visual
+          # diffs once the plan/quota is restored. (Per Chromatic docs `skip`
+          # marks the build passed without snapshotting → no "Storybook Publish"
+          # confirmation either, which is acceptable while disabled.)
+          skip: true
           # Collect-only / REPORT mode (W201): diffs are visible but don't block PRs.
-          # Enforce by flipping this to `false` once the baseline is trusted
-          # (W201 documented this as a deliberate post-baseline follow-up).
+          # Enforce by flipping this to `false` once the baseline is trusted.
           exitZeroOnChanges: true
           onlyChanged: true
           autoAcceptChanges: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,7 +294,7 @@ jobs:
       # service/repository-coverage climb; CI Linux+integration measures higher).
       # Raise incrementally as the backend coverage campaign lands. Unified with
       # pyproject/Makefile.
-      coverage-threshold: ${{ matrix.coverage-check && 85 || 0 }}
+      coverage-threshold: ${{ matrix.coverage-check && 86 || 0 }}
       run-integration-tests: ${{ matrix.run-integration }}
       parallel-workers: 0 # LOW-W19: 0 = auto-detect workers via pytest-xdist (-n auto)
       python-gil: ${{ matrix.free-threading && '0' || '1' }}  # MOD-24-03

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -355,15 +355,22 @@ jobs:
         # unit-coverage run excludes — see the go-integration-* jobs + ADR-022.
         # These are no-regression floors to raise incrementally as unit tests
         # are added (target 80 across the board).
+        # Session 9 climb (first Go ratchet): new dependency-free unit tests
+        # (mock RESP servers, httptest JWKS, Temporal testsuite, gRPC metadata
+        # auth) lifted every service. Floor = floor(measured ×2) − 2 buffer.
         include:
           - service: services/gateway
-            coverage-threshold: 45
+            # Measured 63.0% unit-only ×2 (setupRouter smoke + Redis-revocation
+            # RESP mock + JWKS error paths + RequireRole). Floor 61.
+            coverage-threshold: 61
           - service: services/file-processor
-            # Measured 29.0% unit-only on CI (heavy generated gRPC/GraphQL +
-            # Temporal-integration paths excluded). Floor 28 = reality − buffer.
-            coverage-threshold: 28
+            # Measured 51.4% unit-only ×2 (cmd/* auth helpers + resolver/sanitizeKey
+            # + Temporal testsuite workflow + depth middleware). Floor 49.
+            coverage-threshold: 49
           - service: services/ws-hub
-            coverage-threshold: 35
+            # Measured 64.9% unit-only ×2 (NATS handler closures + Run/broadcast
+            # loop + RS256/JWKS + ticket-RESP mock + WS upgrade E2E). Floor 62.
+            coverage-threshold: 62
           - service: services/cmd/uni-cli
             coverage-threshold: 80
     needs: pre-commit-check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1107,6 +1107,88 @@ jobs:
           path: "asan-report.*"
           if-no-files-found: ignore
 
+  rust-tests:
+    # Testing session 9, Stream D — the first `cargo test` job in CI (the prior
+    # Rust coverage came only from the ASan job + the weekly fuzz run).
+    # Runs the native unit/KAT suites for all three Rust crates plus the
+    # browser-parity wasm-bindgen tests for rust-crypto. Deterministic, so it is
+    # BLOCKING (in the ci-success results array), unlike the advisory mutation /
+    # load-and-chaos jobs.
+    name: "Rust — cargo test (×3 crates) + wasm-pack"
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    if: |
+      github.event_name == 'push' ||
+      github.event_name == 'pull_request' ||
+      github.event_name == 'workflow_dispatch'
+    env:
+      RUST_BACKTRACE: "1"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Python
+        # rust_ext is a PyO3 crate: even with --no-default-features (extension-module
+        # dropped) the build links libpython, so a Python install must be present.
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.13"
+
+      - name: Set up Rust (stable + wasm32 target)
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache Cargo registry + target dirs
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            native/rust_ext/target/
+            frontend/wasm-sanitizer/target/
+            frontend/rust-crypto/target/
+          key: ${{ runner.os }}-cargo-rust-tests-${{ hashFiles('native/rust_ext/Cargo.toml', 'frontend/wasm-sanitizer/Cargo.toml', 'frontend/rust-crypto/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-rust-tests-
+
+      - name: rust_ext — native unit tests (--no-default-features)
+        # extension-module produces undefined Python symbols in a standalone test
+        # binary on Linux; drop it and point the linker/loader at setup-python's
+        # libpython via sysconfig LIBDIR.
+        working-directory: native/rust_ext
+        run: |
+          LIBDIR="$(python -c 'import sysconfig; print(sysconfig.get_config_var("LIBDIR"))')"
+          export LD_LIBRARY_PATH="${LIBDIR}:${LD_LIBRARY_PATH}"
+          cargo test --no-default-features --lib
+
+      - name: wasm-sanitizer — native unit tests
+        working-directory: frontend/wasm-sanitizer
+        run: cargo test --lib
+
+      - name: rust-crypto — native KAT tests
+        working-directory: frontend/rust-crypto
+        run: cargo test --lib
+
+      - name: Install wasm-pack
+        # rustwasm canonical curl installer (W141 polish-v2 / W142 polish-v3:
+        # taiki-e/install-action hardcodes the old drager/wasm-pack repo → 404).
+        run: |
+          curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+          wasm-pack --version
+
+      - name: rust-crypto — browser-parity KATs (wasm-pack, headless Chrome)
+        # ubuntu-latest preinstalls Chrome + sets CHROMEWEBDRIVER; fall back to
+        # wasm-pack's auto-download if the env var is unset.
+        run: |
+          if [ -n "${CHROMEWEBDRIVER:-}" ] && [ -x "${CHROMEWEBDRIVER}/chromedriver" ]; then
+            export CHROMEDRIVER="${CHROMEWEBDRIVER}/chromedriver"
+          fi
+          wasm-pack test --headless --chrome frontend/rust-crypto
+
   mutation-tests:
     name: Incremental Mutation Tests (mutmut)
     runs-on: ubuntu-latest
@@ -1437,6 +1519,7 @@ jobs:
       - provenance-check
       - e2e-tests
       - rust-ffi-asan
+      - rust-tests
       - mutation-tests
       - load-and-chaos-tests
     steps:
@@ -1484,6 +1567,7 @@ jobs:
             "${{ needs.provenance-check.result }}"
             "${{ needs.e2e-tests.result }}"
             "${{ needs.rust-ffi-asan.result }}"
+            "${{ needs.rust-tests.result }}"
           )
 
           failed=false

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -152,14 +152,14 @@
         "filename": ".github\\workflows\\ci.yml",
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
-        "line_number": 549
+        "line_number": 556
       },
       {
         "type": "Basic Auth Credentials",
         "filename": ".github\\workflows\\ci.yml",
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
-        "line_number": 559
+        "line_number": 566
       }
     ],
     ".github\\workflows\\reusable-backend-tests.yml": [
@@ -2260,5 +2260,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-07T12:38:53Z"
+  "generated_at": "2026-06-12T23:08:11Z"
 }

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ lint-frontend:
 	npm run format:check --prefix $(FRONTEND_DIR)
 
 backend-test:
-	pytest --cov=app --cov-report=xml --cov-report=term-missing --cov-fail-under=85 --junitxml=pytest-report.xml
+	pytest --cov=app --cov-report=xml --cov-report=term-missing --cov-fail-under=86 --junitxml=pytest-report.xml
 
 backend-typecheck:
 	mypy

--- a/frontend/rust-crypto/Cargo.lock
+++ b/frontend/rust-crypto/Cargo.lock
@@ -3,6 +3,23 @@
 version = 4
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22,6 +39,22 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "cc"
+version = "1.2.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -67,6 +100,36 @@ dependencies = [
  "block-buffer",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
 ]
 
 [[package]]
@@ -117,6 +180,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
 name = "js-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -133,10 +202,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "memchr"
+version = "2.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+
+[[package]]
+name = "minicov"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
+dependencies = [
+ "cc",
+ "walkdir",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+ "libm",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "password-hash"
@@ -158,6 +274,12 @@ dependencies = [
  "digest",
  "hmac",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "proc-macro2"
@@ -202,6 +324,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scrypt"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -214,6 +345,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -223,6 +397,18 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "subtle"
@@ -258,6 +444,7 @@ dependencies = [
  "scrypt",
  "sha2",
  "wasm-bindgen",
+ "wasm-bindgen-test",
 ]
 
 [[package]]
@@ -271,6 +458,16 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasi"
@@ -289,6 +486,20 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -322,3 +533,82 @@ checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6311c867385cc7d5602463b31825d454d0837a3aba7cdb5e56d5201792a3f7fe"
+dependencies = [
+ "async-trait",
+ "cast",
+ "js-sys",
+ "libm",
+ "minicov",
+ "nu-ansi-term",
+ "num-traits",
+ "oorandom",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+ "wasm-bindgen-test-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67008cdde4769831958536b0f11b3bdd0380bde882be17fff9c2f34bb4549abd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "wasm-bindgen-test-shared"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe29135b180b72b04c74aa97b2b4a2ef275161eff9a6c7955ea9eaedc7e1d4e"
+
+[[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/frontend/rust-crypto/Cargo.toml
+++ b/frontend/rust-crypto/Cargo.toml
@@ -4,7 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
-crate-type = ["cdylib"]
+# rlib added (testing session 9) so the crate can be linked into native
+# `cargo test` binaries for the RFC KAT tests; cdylib still drives wasm-pack.
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 wasm-bindgen = "0.2"
@@ -14,3 +16,8 @@ pbkdf2 = "0.12"
 scrypt = "0.11"
 hex = "0.4"
 getrandom = { version = "0.2", features = ["js"] }
+
+[dev-dependencies]
+# Exact pair for the locked wasm-bindgen 0.2.114 (TD-22-02 pin style). Drives
+# the browser-parity KATs in tests/wasm.rs under `wasm-pack test`.
+wasm-bindgen-test = "=0.3.64"

--- a/frontend/rust-crypto/src/lib.rs
+++ b/frontend/rust-crypto/src/lib.rs
@@ -30,3 +30,88 @@ pub fn scrypt_derive(password: &[u8], salt: &[u8], n: u32, r: u32, p: u32, dk_le
         .map_err(|e| JsValue::from_str(&format!("Scrypt failed: {:?}", e)))?;
     Ok(res)
 }
+
+// Native Known-Answer-Test (KAT) suite (testing session 9). The #[wasm_bindgen]
+// functions are callable as plain Rust on a non-wasm target; PBKDF2/HMAC return
+// hex Strings and scrypt returns Ok(Vec<u8>) on valid params (the JsValue error
+// branch is never hit here — it lives only in the wasm-target error test in
+// tests/wasm.rs, where JsValue is real). All vectors are canonical RFC values;
+// running them against the RustCrypto reference impls (pbkdf2 0.12 / scrypt 0.11
+// / hmac 0.12) is mutual confirmation: a PASS proves both the vector and the
+// wiring. ⛔ No n=0 scrypt vector — n.ilog2() panics on zero.
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use super::*;
+
+    // RFC 7914 §11: PBKDF2-HMAC-SHA-256, P="passwd", S="salt", c=1, dkLen=64.
+    const PBKDF2_PASSWD_SALT_C1: &str = "55ac046e56e3089fec1691c22544b605f94185216dde0465e68b9d57c20dacbc49ca9cccf179b645991664b39d77ef317c71b845b1e30bd509112041d3a19783"; // pragma: allowlist secret
+
+    // RFC 4231 §4.2 (TC1): key = 0x0b x20 (valid UTF-8: 0x0b is a control char),
+    // data = "Hi There".
+    const HMAC_TC1: &str = "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7"; // pragma: allowlist secret
+    // RFC 4231 §4.3 (TC2): key = "Jefe", data = "what do ya want for nothing?".
+    const HMAC_TC2: &str = "5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843"; // pragma: allowlist secret
+
+    // RFC 7914 §12: scrypt vectors (pass the actual N; scrypt_derive takes ilog2).
+    const SCRYPT_V1: &str = "77d6576238657b203b19ca42c18a0497f16b4844e3074ae8dfdffa3fede21442fcd0069ded0948f8326a753a0fc81f17e8d3e0fb2e0d3628cf35e20c38d18906"; // pragma: allowlist secret
+    const SCRYPT_V2: &str = "fdbabe1c9d3472007856e7190d01e9fe7c6ad7cbc8237830e77376634b3731622eaf30d92e22a3886ff109279d9830dac727afb94a83ee6d8360cbdfa2cc0640"; // pragma: allowlist secret
+    const SCRYPT_V3: &str = "7023bdcb3afd7348461c06cd81fd38ebfda8fbba904f8e3ea9b543f6545da1f2d5432955613f0fcf62d49705242a9af9e61e85dc0d651e40dfcf017b45575887"; // pragma: allowlist secret
+
+    #[test]
+    fn pbkdf2_hmac_sha256_rfc7914_vector() {
+        assert_eq!(pbkdf2_derive("passwd", "salt", 1, 64), PBKDF2_PASSWD_SALT_C1);
+    }
+
+    #[test]
+    fn pbkdf2_length_tracks_key_size() {
+        // dkLen=20 → 40 hex chars; sanity that key_size threads through.
+        assert_eq!(pbkdf2_derive("pw", "salt", 2, 20).len(), 40);
+    }
+
+    #[test]
+    fn hmac_sha256_rfc4231_tc1() {
+        let key = "\u{0b}".repeat(20); // 0x0b x20 — a valid UTF-8 &str
+        assert_eq!(hmac_sha256_sign(&key, "Hi There"), HMAC_TC1);
+    }
+
+    #[test]
+    fn hmac_sha256_rfc4231_tc2() {
+        assert_eq!(
+            hmac_sha256_sign("Jefe", "what do ya want for nothing?"),
+            HMAC_TC2
+        );
+    }
+
+    #[test]
+    fn hmac_sha256_is_deterministic() {
+        let a = hmac_sha256_sign("k", "m");
+        let b = hmac_sha256_sign("k", "m");
+        assert_eq!(a, b);
+        assert_eq!(a.len(), 64, "SHA-256 HMAC is 32 bytes = 64 hex chars");
+    }
+
+    #[test]
+    fn scrypt_rfc7914_vector1() {
+        let out = scrypt_derive(b"", b"", 16, 1, 1, 64).expect("valid params");
+        assert_eq!(hex::encode(out), SCRYPT_V1);
+    }
+
+    #[test]
+    fn scrypt_rfc7914_vector2() {
+        let out = scrypt_derive(b"password", b"NaCl", 1024, 8, 16, 64).expect("valid params");
+        assert_eq!(hex::encode(out), SCRYPT_V2);
+    }
+
+    #[test]
+    fn scrypt_rfc7914_vector3() {
+        let out = scrypt_derive(b"pleaseletmein", b"SodiumChloride", 16384, 8, 1, 64)
+            .expect("valid params");
+        assert_eq!(hex::encode(out), SCRYPT_V3);
+    }
+
+    #[test]
+    fn scrypt_dk_len_is_honored() {
+        let out = scrypt_derive(b"pw", b"salt", 16, 1, 1, 32).expect("valid params");
+        assert_eq!(out.len(), 32);
+    }
+}

--- a/frontend/rust-crypto/tests/wasm.rs
+++ b/frontend/rust-crypto/tests/wasm.rs
@@ -1,0 +1,51 @@
+// Browser-parity KATs (testing session 9), run via `wasm-pack test --headless
+// --chrome`. These prove the wasm build produces identical output to the native
+// KAT suite in src/lib.rs (same RFC 7914 / RFC 4231 vectors) AND exercise the
+// wasm-only error path where JsValue is real (scrypt_derive with r=0 → Err).
+//
+// Kept to the cheap vectors (c=1 PBKDF2, N=16 scrypt) so the headless run stays
+// fast; the native suite already covers the heavier N=1024/16384 vectors.
+
+#![cfg(target_arch = "wasm32")]
+
+use uni_wasm_crypto::{hmac_sha256_sign, pbkdf2_derive, scrypt_derive};
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[wasm_bindgen_test]
+fn pbkdf2_parity_rfc7914() {
+    // RFC 7914 §11: P="passwd", S="salt", c=1, dkLen=64.
+    assert_eq!(
+        pbkdf2_derive("passwd", "salt", 1, 64),
+        "55ac046e56e3089fec1691c22544b605f94185216dde0465e68b9d57c20dacbc49ca9cccf179b645991664b39d77ef317c71b845b1e30bd509112041d3a19783" // pragma: allowlist secret
+    );
+}
+
+#[wasm_bindgen_test]
+fn hmac_parity_rfc4231_tc2() {
+    // RFC 4231 §4.3 (TC2): key="Jefe", data="what do ya want for nothing?".
+    assert_eq!(
+        hmac_sha256_sign("Jefe", "what do ya want for nothing?"),
+        "5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843" // pragma: allowlist secret
+    );
+}
+
+#[wasm_bindgen_test]
+fn scrypt_parity_rfc7914_vector1() {
+    // RFC 7914 §12 vector 1: P="" S="" N=16 r=1 p=1 dkLen=64.
+    let out = scrypt_derive(b"", b"", 16, 1, 1, 64).expect("valid params");
+    assert_eq!(
+        hex::encode(out),
+        "77d6576238657b203b19ca42c18a0497f16b4844e3074ae8dfdffa3fede21442fcd0069ded0948f8326a753a0fc81f17e8d3e0fb2e0d3628cf35e20c38d18906" // pragma: allowlist secret
+    );
+}
+
+#[wasm_bindgen_test]
+fn scrypt_invalid_r_returns_err() {
+    // r=0 is rejected by ScryptParams::new → scrypt_derive maps to Err(JsValue).
+    // This is the wasm-only path: JsValue construction would panic on native, so
+    // it is exercised here in the browser where JsValue is real. (n=0 is NOT
+    // tested — n.ilog2() panics before any param check.)
+    assert!(scrypt_derive(b"pw", b"salt", 16, 0, 1, 64).is_err());
+}

--- a/frontend/src/components/navbar/__tests__/NavbarOverflowMenu.test.tsx
+++ b/frontend/src/components/navbar/__tests__/NavbarOverflowMenu.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * Coverage tests for NavbarOverflowMenu (testing session 9).
+ *
+ * Previously ~9% covered (only the module import). Exercises: empty-items
+ * null render, open/close toggle, Escape + outside-pointerdown close,
+ * item click → go() + close, active styling.
+ */
+import { fireEvent, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+import { Home } from "lucide-react"
+
+import { NavbarOverflowMenu } from "@/components/navbar/NavbarOverflowMenu"
+import { renderWithRouter } from "@/tests/helpers/renderWithRouter"
+import type { NavigationItem } from "@/config/navigation"
+
+const items: NavigationItem[] = [
+  { to: "/news", label: "News", icon: Home },
+  { to: "/events", label: "Events", icon: Home },
+]
+
+const extraRoutes = [
+  { path: "/news", Component: () => <div>News page</div> },
+  { path: "/events", Component: () => <div>Events page</div> },
+]
+
+const renderMenu = async (overrides: Partial<Parameters<typeof NavbarOverflowMenu>[0]> = {}) => {
+  const props = {
+    items,
+    isActive: () => false,
+    go: vi.fn(),
+    prefersReducedMotion: true,
+    isCompact: false,
+    ...overrides,
+  }
+  await renderWithRouter({
+    ui: () => <NavbarOverflowMenu {...props} />,
+    extraRoutes,
+    authProvider: false,
+  })
+  return props
+}
+
+describe("NavbarOverflowMenu", () => {
+  it("renders nothing when items list is empty", async () => {
+    await renderMenu({ items: [] })
+    expect(screen.queryByRole("button")).not.toBeInTheDocument()
+  })
+
+  it("opens the menu on trigger click and lists items", async () => {
+    await renderMenu()
+    const trigger = screen.getByRole("button")
+    expect(trigger).toHaveAttribute("aria-expanded", "false")
+
+    await userEvent.click(trigger)
+
+    expect(trigger).toHaveAttribute("aria-expanded", "true")
+    expect(screen.getByRole("menu")).toBeInTheDocument()
+    expect(screen.getByText("News")).toBeInTheDocument()
+    expect(screen.getByText("Events")).toBeInTheDocument()
+  })
+
+  it("closes the menu on second trigger click", async () => {
+    await renderMenu()
+    const trigger = screen.getByRole("button")
+    await userEvent.click(trigger)
+    expect(screen.getByRole("menu")).toBeInTheDocument()
+
+    await userEvent.click(trigger)
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument()
+  })
+
+  it("invokes go() and closes when an item is clicked", async () => {
+    const props = await renderMenu()
+    await userEvent.click(screen.getByRole("button"))
+    await userEvent.click(screen.getByText("News"))
+
+    expect(props.go).toHaveBeenCalledWith("/news")
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument()
+  })
+
+  it("closes on Escape", async () => {
+    await renderMenu()
+    await userEvent.click(screen.getByRole("button"))
+    expect(screen.getByRole("menu")).toBeInTheDocument()
+
+    fireEvent.keyDown(document, { key: "Escape" })
+    await waitFor(() => expect(screen.queryByRole("menu")).not.toBeInTheDocument())
+  })
+
+  it("closes on outside pointerdown but stays open on inside pointerdown", async () => {
+    await renderMenu()
+    await userEvent.click(screen.getByRole("button"))
+    const menu = screen.getByRole("menu")
+
+    fireEvent.pointerDown(menu)
+    expect(screen.getByRole("menu")).toBeInTheDocument()
+
+    fireEvent.pointerDown(document.body)
+    await waitFor(() => expect(screen.queryByRole("menu")).not.toBeInTheDocument())
+  })
+
+  it("marks active items via data-active and highlights the trigger", async () => {
+    await renderMenu({ isActive: (to: string) => to === "/news" })
+    const trigger = screen.getByRole("button")
+    expect(trigger.className).toContain("nav-active")
+
+    await userEvent.click(trigger)
+    const newsLink = screen.getByText("News").closest("a")
+    const eventsLink = screen.getByText("Events").closest("a")
+    expect(newsLink).toHaveAttribute("data-active", "true")
+    expect(eventsLink).not.toHaveAttribute("data-active")
+  })
+
+  it("respects compact sizing and non-reduced motion props", async () => {
+    await renderMenu({ isCompact: true, prefersReducedMotion: false })
+    const trigger = screen.getByRole("button")
+    expect(trigger.className).toContain("size-8")
+    await userEvent.click(trigger)
+    expect(screen.getByRole("menu")).toBeInTheDocument()
+  })
+})

--- a/frontend/src/features/admin/components/__tests__/AdminBackdrop.test.tsx
+++ b/frontend/src/features/admin/components/__tests__/AdminBackdrop.test.tsx
@@ -1,0 +1,36 @@
+/**
+ * Coverage tests for AdminBackdrop (testing session 9).
+ *
+ * Pure presentational orb layer (previously ~3% covered). Verifies the
+ * aria-hidden decorative discipline + the isNarrow / prefersReducedMotion
+ * conditional orb matrix (W118 SW3 pixel-anchored pattern).
+ */
+import { render } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { AdminBackdrop } from "@/features/admin/components/AdminBackdrop"
+
+const orbCount = (container: HTMLElement): number =>
+  container.querySelectorAll("[aria-hidden='true'] > div").length
+
+describe("AdminBackdrop", () => {
+  it("renders all four orbs on wide viewports with motion enabled", () => {
+    const { container } = render(<AdminBackdrop isNarrow={false} prefersReducedMotion={false} />)
+    const wrapper = container.querySelector("[aria-hidden='true']")
+    expect(wrapper).not.toBeNull()
+    expect(wrapper?.className).toContain("pointer-events-none")
+    expect(orbCount(container)).toBe(4)
+  })
+
+  it("drops the highlight and conic orbs on narrow viewports", () => {
+    const { container } = render(<AdminBackdrop isNarrow={true} prefersReducedMotion={false} />)
+    expect(orbCount(container)).toBe(2)
+  })
+
+  it("suppresses the drifting conic orb under reduced motion", () => {
+    const { container } = render(<AdminBackdrop isNarrow={false} prefersReducedMotion={true} />)
+    expect(orbCount(container)).toBe(3)
+    const html = container.innerHTML
+    expect(html).not.toContain("orb-drift")
+  })
+})

--- a/frontend/src/features/news/components/__tests__/NewsHeader.test.tsx
+++ b/frontend/src/features/news/components/__tests__/NewsHeader.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * Coverage tests for NewsHeader (testing session 9).
+ *
+ * Functions coverage was 1/8 — the inline JSX handlers (search change/clear,
+ * category pills, saved filter, sort toggle, admin add) were unexercised.
+ */
+import { screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { NewsHeader } from "@/features/news/components/NewsHeader"
+import { renderWithRouter } from "@/tests/helpers/renderWithRouter"
+
+type Props = Parameters<typeof NewsHeader>[0]
+
+const renderHeader = async (overrides: Partial<Props> = {}) => {
+  const props: Props = {
+    onAddClick: vi.fn(),
+    isAdmin: false,
+    newsCount: 7,
+    searchQuery: "",
+    onSearchChange: vi.fn(),
+    activeCategory: "all",
+    onCategoryChange: vi.fn(),
+    sortMode: "newest",
+    onSortChange: vi.fn(),
+    bookmarkCount: 0,
+    ...overrides,
+  }
+  await renderWithRouter({
+    ui: () => <NewsHeader {...props} />,
+    authProvider: false,
+  })
+  return props
+}
+
+describe("NewsHeader", () => {
+  it("renders the news count badge and search input", async () => {
+    await renderHeader()
+    expect(screen.getByText("7")).toBeInTheDocument()
+    expect(screen.getByRole("textbox")).toBeInTheDocument()
+  })
+
+  it("fires onSearchChange when typing in the search field", async () => {
+    const props = await renderHeader()
+    await userEvent.type(screen.getByRole("textbox"), "a")
+    expect(props.onSearchChange).toHaveBeenCalledWith("a")
+  })
+
+  it("clears the search via the clear button", async () => {
+    const props = await renderHeader({ searchQuery: "rust" })
+    const clearButton = screen.getByRole("button", { name: /clear/i })
+    await userEvent.click(clearButton)
+    expect(props.onSearchChange).toHaveBeenCalledWith("")
+  })
+
+  it("changes category via the All pill and category pills", async () => {
+    const props = await renderHeader({ activeCategory: "all" })
+    const allPill = screen.getByRole("button", { current: "page" })
+    expect(allPill).toBeInTheDocument()
+
+    // Click a non-active category pill (any pill that is not aria-current).
+    const pills = screen
+      .getAllByRole("button")
+      .filter((b) => b.getAttribute("aria-current") !== "page")
+    expect(pills.length).toBeGreaterThan(0)
+    await userEvent.click(pills[0]!)
+    expect(props.onCategoryChange).toHaveBeenCalled()
+
+    await userEvent.click(allPill)
+    expect(props.onCategoryChange).toHaveBeenCalledWith("all")
+  })
+
+  it("shows the saved filter only when bookmarks exist and selects it", async () => {
+    const props = await renderHeader({ bookmarkCount: 3 })
+    const savedPill = screen.getByText("(3)").closest("button")
+    expect(savedPill).not.toBeNull()
+    await userEvent.click(savedPill!)
+    expect(props.onCategoryChange).toHaveBeenCalledWith("saved")
+  })
+
+  it("hides the saved filter when there are no bookmarks", async () => {
+    await renderHeader({ bookmarkCount: 0 })
+    expect(screen.queryByText(/\(0\)/)).not.toBeInTheDocument()
+  })
+
+  it("toggles sort mode newest -> popular and back", async () => {
+    const props = await renderHeader({ sortMode: "newest" })
+    const sortButton = screen.getByRole("button", { name: /sort/i })
+    await userEvent.click(sortButton)
+    expect(props.onSortChange).toHaveBeenCalledWith("popular")
+  })
+
+  it("toggles sort mode popular -> newest", async () => {
+    const props = await renderHeader({ sortMode: "popular" })
+    const sortButton = screen.getByRole("button", { name: /sort/i })
+    await userEvent.click(sortButton)
+    expect(props.onSortChange).toHaveBeenCalledWith("newest")
+  })
+
+  it("shows the add button for admins and fires onAddClick", async () => {
+    const props = await renderHeader({ isAdmin: true })
+    const addButton = document.getElementById("news-header-add-btn")
+    expect(addButton).not.toBeNull()
+    await userEvent.click(addButton!)
+    expect(props.onAddClick).toHaveBeenCalled()
+  })
+
+  it("hides the add button for non-admins", async () => {
+    await renderHeader({ isAdmin: false })
+    expect(document.getElementById("news-header-add-btn")).toBeNull()
+  })
+})

--- a/frontend/src/pages/__tests__/AdminNotifications.test.tsx
+++ b/frontend/src/pages/__tests__/AdminNotifications.test.tsx
@@ -137,4 +137,145 @@ describe("AdminNotifications page", () => {
 
     queryClient.clear()
   })
+
+  // ── Testing session 9 — coverage extension ──────────────────────────────
+  // Select-all toggle, per-row actions, action-error surface and the entire
+  // user-topics management section (load / toggle / save + error paths).
+
+  it("select-all toggles every row and back", async () => {
+    const { queryClient } = await renderPage()
+
+    const selectAll = await screen.findByRole("checkbox", { name: /Select all/i })
+    const rowCheckbox = await screen.findByRole("checkbox", {
+      name: /Select job 550e8400-e29b-41d4-a716-446655440000/i,
+    })
+
+    await userEvent.click(selectAll)
+    expect(rowCheckbox).toBeChecked()
+
+    await userEvent.click(selectAll)
+    expect(rowCheckbox).not.toBeChecked()
+
+    queryClient.clear()
+  })
+
+  it("retries a single job via the row action button", async () => {
+    const { queryClient } = await renderPage()
+
+    expect(await screen.findByText("Timeout")).toBeInTheDocument()
+    const retryButtons = await screen.findAllByRole("button", { name: "Retry" })
+    await userEvent.click(retryButtons[0]!)
+
+    await waitFor(() => expect(screen.queryByText("Timeout")).not.toBeInTheDocument())
+    expect(screen.getByText("Total jobs: 1")).toBeInTheDocument()
+
+    queryClient.clear()
+  })
+
+  it("surfaces an action error when retry fails", async () => {
+    server.use(
+      http.post("*/notifications/admin/dead-letter/retry", () =>
+        HttpResponse.json({ detail: "retry exploded" }, { status: 500 })
+      )
+    )
+    const { queryClient } = await renderPage()
+
+    const firstJobCheckbox = await screen.findByRole("checkbox", {
+      name: /Select job 550e8400-e29b-41d4-a716-446655440000/i,
+    })
+    await userEvent.click(firstJobCheckbox)
+    await userEvent.click(screen.getByRole("button", { name: /Retry selected/i }))
+
+    expect(await screen.findByText("retry exploded")).toBeInTheDocument()
+
+    queryClient.clear()
+  })
+
+  it("rejects an empty user id in the topics loader", async () => {
+    const { queryClient } = await renderPage()
+
+    await userEvent.click(await screen.findByRole("button", { name: /Load topics/i }))
+    expect(await screen.findByText(/Please enter a valid user ID/i)).toBeInTheDocument()
+
+    queryClient.clear()
+  })
+
+  it("loads, toggles and saves user topics", async () => {
+    const topicsResponse = {
+      user_id: "11111111-1111-1111-1111-111111111111",
+      email: "student@example.com",
+      allowed_topics: ["news", "events"],
+      topics: ["news"],
+    }
+    let savedTopics: string[] | null = null
+    server.use(
+      http.get("*/push/admin/topics/:userId", () => HttpResponse.json(topicsResponse)),
+      http.put("*/push/admin/topics/:userId", async ({ request }) => {
+        const body = (await request.json()) as { topics: string[] }
+        savedTopics = body.topics
+        return HttpResponse.json({ ...topicsResponse, topics: body.topics })
+      })
+    )
+
+    const { queryClient } = await renderPage()
+
+    await userEvent.type(await screen.findByRole("textbox"), topicsResponse.user_id)
+    await userEvent.click(screen.getByRole("button", { name: /Load topics/i }))
+
+    expect(await screen.findByText(/Topics loaded for student@example.com/i)).toBeInTheDocument()
+
+    const newsTopic = screen.getByRole("checkbox", { name: /news/i })
+    const eventsTopic = screen.getByRole("checkbox", { name: /events/i })
+    expect(newsTopic).toBeChecked()
+    expect(eventsTopic).not.toBeChecked()
+
+    await userEvent.click(eventsTopic)
+    await userEvent.click(screen.getByRole("button", { name: /Save topics/i }))
+
+    expect(await screen.findByText(/Topics updated successfully/i)).toBeInTheDocument()
+    expect(savedTopics).toEqual(["news", "events"])
+
+    queryClient.clear()
+  })
+
+  it("surfaces topics load and save errors", async () => {
+    const topicsResponse = {
+      user_id: "22222222-2222-2222-2222-222222222222",
+      email: "broken@example.com",
+      allowed_topics: ["news"],
+      topics: [],
+    }
+    // NOTE: topics API calls flow through the generated client +
+    // ensureValidResponse — a 500 surfaces as ApiResponseValidationError
+    // (NOT the axios detail), so assert the error alert rather than the
+    // backend detail text.
+    server.use(
+      http.get("*/push/admin/topics/:userId", () =>
+        HttpResponse.json({ detail: "load boom" }, { status: 500 })
+      )
+    )
+
+    const { queryClient } = await renderPage()
+
+    await userEvent.type(await screen.findByRole("textbox"), "some-user-id")
+    await userEvent.click(screen.getByRole("button", { name: /Load topics/i }))
+    await waitFor(() => expect(screen.getAllByRole("alert").length).toBeGreaterThan(0))
+    expect(screen.queryByText(/Topics loaded for/i)).not.toBeInTheDocument()
+
+    // Now make load succeed but save fail.
+    server.use(
+      http.get("*/push/admin/topics/:userId", () => HttpResponse.json(topicsResponse)),
+      http.put("*/push/admin/topics/:userId", () =>
+        HttpResponse.json({ detail: "save boom" }, { status: 500 })
+      )
+    )
+    await userEvent.click(screen.getByRole("button", { name: /Load topics/i }))
+    expect(await screen.findByText(/Managing topics for broken@example.com/i)).toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole("button", { name: /Save topics/i }))
+    await waitFor(() => expect(screen.getAllByRole("alert").length).toBeGreaterThan(0))
+    expect(screen.queryByText(/Topics updated successfully/i)).not.toBeInTheDocument()
+
+    queryClient.clear()
+  })
 })

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -57,19 +57,19 @@ export default defineConfig({
         "src/utils/spotify.ts",
         "src/utils/workerChrome.ts",
       ],
-      // Ratchet floors at measured reality. After the uiFormPrimitives render
-      // slice (Button, Input, Textarea, Card, TextField, RadioGroup, Select — on
-      // top of the prior uiPrimitives Badge/EmptyState/ProgressBar/... slice):
-      // statements 67.45 / branches 72.66 / functions 67.97 / lines 67.45.
-      // branches RAISED 71→72 (72.66 → 0.66 buffer, ≥ the ~0.5 no-cushion margin).
-      // statements/lines HELD at 67 (67.45 → a 68 floor is 1.55 short) and
-      // functions HELD at 67 (67.97 → a 68 floor is 0.53 short). NO-REGRESSION
-      // floors, NOT the target — raise incrementally (target 90; local == CI, so
-      // there is no integration cushion: keep ≥~0.5pp headroom before any raise).
+      // Ratchet floors at measured reality. After the session-9 slice
+      // (NavbarOverflowMenu + AdminBackdrop + AdminNotifications topics flows +
+      // NewsHeader handlers): statements 68.17 / branches 73.08 / functions
+      // 69.09 / lines 68.17. functions RAISED 67→68 (69.09 → 1.09 buffer,
+      // ≥ the ~0.5 no-cushion margin). statements/lines HELD at 67 (68.17 → a
+      // 68 floor is only 0.17 over) and branches HELD at 72 (73.08 → a 73
+      // floor is only 0.08 over). NO-REGRESSION floors, NOT the target — raise
+      // incrementally (target 90; local == CI, so there is no integration
+      // cushion: keep ≥~0.5pp headroom before any raise).
       thresholds: {
         statements: 67,
         branches: 72,
-        functions: 67,
+        functions: 68,
         lines: 67,
       },
     },

--- a/frontend/wasm-sanitizer/src/lib.rs
+++ b/frontend/wasm-sanitizer/src/lib.rs
@@ -56,3 +56,105 @@ pub fn strip_html(html: &str) -> String {
         .clean(html)
         .to_string()
 }
+
+// Native unit tests (testing session 9). #[wasm_bindgen] leaves the functions
+// callable as plain Rust on a non-wasm target, and ammonia is a native crate,
+// so these exercise the exact sanitization code paths the browser runs. The
+// crate-type already includes "rlib", so no Cargo.toml change is needed. The
+// browser parity is deliberately NOT re-run via wasm-pack here: pure Rust ->
+// identical code paths (wasm-sanitizer has no JS-only branches). Assertions are
+// presence/absence based to stay robust across ammonia minor versions.
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rich_text_strips_script_element_and_content() {
+        let out = sanitize_rich_text("<p>safe</p><script>alert('xss')</script>");
+        assert!(out.contains("safe"), "allowed text must survive: {out}");
+        assert!(!out.contains("<script"), "script tag must be removed: {out}");
+        assert!(!out.contains("alert"), "script content must be removed: {out}");
+    }
+
+    #[test]
+    fn rich_text_strips_onerror_handler_and_img() {
+        let out = sanitize_rich_text("<img src=x onerror=alert(1)>");
+        assert!(!out.contains("onerror"), "event handler must be stripped: {out}");
+        assert!(!out.contains("<img"), "img is not in the allowed tag set: {out}");
+    }
+
+    #[test]
+    fn rich_text_drops_javascript_scheme_href() {
+        let out = sanitize_rich_text(r#"<a href="javascript:alert(1)">click</a>"#);
+        assert!(out.contains("click"), "link text must survive: {out}");
+        assert!(!out.contains("javascript:"), "javascript: scheme must be dropped: {out}");
+    }
+
+    #[test]
+    fn rich_text_drops_data_scheme_href() {
+        let out = sanitize_rich_text(r#"<a href="data:text/html,<script>1</script>">x</a>"#);
+        assert!(!out.contains("data:"), "data: scheme must be dropped: {out}");
+        assert!(!out.contains("<script"), "embedded script must be gone: {out}");
+    }
+
+    #[test]
+    fn rich_text_keeps_https_link_with_noopener_rel() {
+        let out = sanitize_rich_text(r#"<a href="https://example.com" target="_blank">go</a>"#);
+        assert!(out.contains(r#"href="https://example.com""#), "https href must survive: {out}");
+        assert!(out.contains("noopener"), "rel must include noopener: {out}");
+        assert!(out.contains("noreferrer"), "rel must include noreferrer: {out}");
+    }
+
+    #[test]
+    fn rich_text_keeps_allowed_formatting_tags() {
+        let out = sanitize_rich_text("<p><strong>bold</strong> and <em>em</em></p>");
+        assert!(out.contains("<strong>bold</strong>"), "strong must survive: {out}");
+        assert!(out.contains("<em>em</em>"), "em must survive: {out}");
+    }
+
+    #[test]
+    fn rich_text_strips_unknown_tag_but_keeps_text() {
+        let out = sanitize_rich_text("<div class=evil>content</div>");
+        assert!(out.contains("content"), "text must survive: {out}");
+        assert!(!out.contains("<div"), "div is not in the rich-text allow list: {out}");
+    }
+
+    #[test]
+    fn basic_keeps_only_inline_emphasis_tags() {
+        let out = sanitize_html_basic("<p>para</p><b>bold</b><script>x</script>");
+        assert!(out.contains("<b>bold</b>"), "b must survive: {out}");
+        assert!(out.contains("para"), "stripped-tag text must survive: {out}");
+        assert!(!out.contains("<p>"), "p is not in the basic allow list: {out}");
+        assert!(!out.contains("<script"), "script must be removed: {out}");
+    }
+
+    #[test]
+    fn basic_removes_anchor_tags() {
+        let out = sanitize_html_basic(r#"<a href="https://x.com">link</a>"#);
+        assert!(out.contains("link"), "anchor text must survive: {out}");
+        assert!(!out.contains("<a"), "anchors are not allowed in basic mode: {out}");
+    }
+
+    #[test]
+    fn strip_html_removes_all_tags_keeps_text() {
+        let out = strip_html("<b>hi</b> <i>there</i><script>nope</script>");
+        assert!(out.contains("hi"), "text must survive: {out}");
+        assert!(out.contains("there"), "text must survive: {out}");
+        assert!(!out.contains('<'), "no tags may remain: {out}");
+        assert!(!out.contains("nope"), "script content must be removed: {out}");
+    }
+
+    #[test]
+    fn strip_html_is_idempotent_on_plain_text() {
+        let plain = "just plain text, no markup";
+        assert_eq!(strip_html(plain), plain);
+        assert_eq!(strip_html(&strip_html("<b>x</b>")), strip_html("<b>x</b>"));
+    }
+
+    #[test]
+    fn sanitizers_handle_empty_input() {
+        assert_eq!(sanitize_rich_text(""), "");
+        assert_eq!(sanitize_html_basic(""), "");
+        assert_eq!(strip_html(""), "");
+    }
+}

--- a/go.work.sum
+++ b/go.work.sum
@@ -56,6 +56,7 @@ github.com/moby/sys/mountinfo v0.7.2/go.mod h1:1YOa8w8Ih7uW0wALDUgT1dTTSBrZ+HiBL
 github.com/moby/sys/reexec v0.1.0/go.mod h1:EqjBg8F3X7iZe5pU6nRZnYCMUTXoxsjiIfHup5wYIN8=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
+github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10/go.mod h1:t/avpk3KcrXxUnYOhZhMXJlSEyie6gQbtLq5NM3loB8=
 github.com/prometheus/client_golang v1.20.4/go.mod h1:PIEt8X02hGcP8JWbeHyeZ53Y/jReSnHgO035n//V5WE=
@@ -96,6 +97,7 @@ golang.org/x/mod v0.32.0/go.mod h1:SgipZ/3h2Ci89DlEtEXWUk/HteuRin+HHhN+WbNhguU=
 golang.org/x/mod v0.33.0/go.mod h1:swjeQEj+6r7fODbD2cqrnje9PnziFuw4bmLbBZFrQ5w=
 golang.org/x/mod v0.34.0/go.mod h1:ykgH52iCZe79kzLLMhyCUzhMci+nQj+0XkbXpNYtVjY=
 golang.org/x/mod v0.35.0/go.mod h1:+GwiRhIInF8wPm+4AoT6L0FA1QWAad3OMdTRx4tFYlU=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/net v0.43.0/go.mod h1:vhO1fvI4dGsIjh73sWfUVjj3N7CA9WkKJNQm2svM6Jg=
 golang.org/x/net v0.48.0/go.mod h1:+ndRgGjkh8FGtu1w1FGbEC31if4VrNVMuKTgcAAnQRY=
 golang.org/x/net v0.49.0/go.mod h1:/ysNB2EvaqvesRkuLAyjI1ycPZlQHM3q01F02UY/MV8=
@@ -118,7 +120,6 @@ golang.org/x/telemetry v0.0.0-20260311193753-579e4da9a98c/go.mod h1:TpUTTEp9frx7
 golang.org/x/telemetry v0.0.0-20260409153401-be6f6cb8b1fa/go.mod h1:kHjTxDEnAu6/Nl9lDkzjWpR+bmKfxeiRuSDlsMb70gE=
 golang.org/x/term v0.40.0/go.mod h1:w2P8uVp06p2iyKKuvXIm7N/y0UCRt3UfJTfZ7oOpglM=
 golang.org/x/term v0.42.0/go.mod h1:Dq/D+snpsbazcBG5+F9Q1n2rXV8Ma+71xEjTRufARgY=
-golang.org/x/term v0.43.0/go.mod h1:lrhlHNdQJHO+1qVYiHfFKVuVioJIheAc3fBSMFYEIsk=
 golang.org/x/text v0.28.0/go.mod h1:U8nCwOR8jO/marOQ0QbDiOngZVEBB7MAiitBuMjXiNU=
 golang.org/x/text v0.32.0/go.mod h1:o/rUWzghvpD5TXrTIBuJU77MTaN0ljMWE47kxGJQ7jY=
 golang.org/x/text v0.33.0/go.mod h1:LuMebE6+rBincTi9+xWTY8TztLzKHc/9C1uBCG27+q8=
@@ -132,6 +133,7 @@ golang.org/x/tools v0.41.0/go.mod h1:XSY6eDqxVNiYgezAVqqCeihT4j1U2CCsqvH3WhQpnlg
 golang.org/x/tools v0.42.0/go.mod h1:Ma6lCIwGZvHK6XtgbswSoWroEkhugApmsXyrUmBhfr0=
 golang.org/x/tools v0.43.0/go.mod h1:uHkMso649BX2cZK6+RpuIPXS3ho2hZo4FVwfoy1vIk0=
 golang.org/x/tools v0.44.0/go.mod h1:KA0AfVErSdxRZIsOVipbv3rQhVXTnlU6UhKxHd1seDI=
+golang.org/x/tools v0.45.0/go.mod h1:LuUGqqaXcXMEFEruIVJVm5mgDD8vww/z/SR1gQ4uE/0=
 gonum.org/v1/plot v0.15.2/go.mod h1:DX+x+DWso3LTha+AdkJEv5Txvi+Tql3KAGkehP0/Ubg=
 gonum.org/v1/tools v0.0.0-20200318103217-c168b003ce8c/go.mod h1:fy6Otjqbk477ELp8IXTpw1cObQtLbRCBVonY+bTTfcM=
 google.golang.org/genproto/googleapis/api v0.0.0-20260120221211-b8f7ae30c516/go.mod h1:p3MLuOwURrGBRoEyFHBT3GjUwaCQVKeNqqWxlcISGdw=
@@ -140,6 +142,7 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20260120221211-b8f7ae30c516/go.
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260226221140-a57be14db171/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260401001100-f93e5f3e9f0f/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20260406210006-6f92a3bedf2d/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
 google.golang.org/grpc v1.79.3/go.mod h1:KmT0Kjez+0dde/v2j9vzwoAScgEPx/Bw1CYChhHLrHQ=
 google.golang.org/grpc v1.80.0/go.mod h1:ho/dLnxwi3EDJA4Zghp7k2Ec1+c2jqup0bFkw07bwF4=
 google.golang.org/grpc/examples v0.0.0-20250407062114-b368379ef8f6/go.mod h1:6ytKWczdvnpnO+m+JiG9NjEDzR1FJfsnmJdG7B8QVZ8=

--- a/native/rust_ext/Cargo.toml
+++ b/native/rust_ext/Cargo.toml
@@ -9,7 +9,7 @@ name = "rust_ext"
 crate-type = ["cdylib", "rlib"]  # rlib needed for cargo-fuzz and #[cfg(test)]
 
 [dependencies]
-pyo3 = { version = "0.27", features = ["extension-module", "chrono"] }
+pyo3 = { version = "0.27", features = ["chrono"] }
 # TD-22-02 (Wave 22): Pin exact versions for reproducible builds of
 # security-critical FFI code. Renovate will propose updates via Cargo rule.
 rayon = "=1.11.0"
@@ -17,3 +17,16 @@ chrono = { version = "0.4", features = ["serde"] }
 hmac = "=0.12.1"
 sha2 = "=0.10.9"
 hex = "=0.4.3"
+
+# Variant B feature-gate (testing session 9). extension-module stays the DEFAULT,
+# so every existing build site is unchanged: maturin/uv (the abi3 wheel),
+# cargo-fuzz, and the rust-ffi-asan CI job all build with default features and
+# keep `pyo3/extension-module`. The new rust-tests CI job runs the 19 unit tests
+# with `cargo test --no-default-features --lib`: extension-module produces
+# undefined Python symbols in a standalone test binary on Linux, so dropping it
+# lets the binary link libpython directly (CI exports LD_LIBRARY_PATH from
+# sysconfig LIBDIR). On Windows the python import lib is always linked, so a
+# default-features `cargo test` also works locally.
+[features]
+default = ["extension-module"]
+extension-module = ["pyo3/extension-module"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -362,12 +362,12 @@ omit = [
 [tool.coverage.report]
 show_missing = true
 # Ratchet floor at measured reality. Local hermetic (Windows, pyvips skipped)
-# = 85.33% local hermetic after the service/repository-coverage climb
-# (chat_repository / audit_service / news_service / event_service); CI
-# (Linux + integration tier) measures ~0.7pp higher. No-regression floor, NOT
-# the aspirational target — raise incrementally as the campaign adds tests
-# (target 95%). Unified across pyproject / Makefile / ci.yml.
-fail_under = 85
+# = 86.53% after the session-9 service-layer climb (session_service /
+# analytics_service / notifications delivery+core+news_events /
+# compliance_service); CI (Linux + integration tier) measures ~0.7pp higher.
+# No-regression floor, NOT the aspirational target — raise incrementally as
+# the campaign adds tests (target 95%). Unified across pyproject / Makefile / ci.yml.
+fail_under = 86
 exclude_lines = [
   "pragma: no cover",
   "def __repr__",

--- a/security/audit-allowlist.yaml
+++ b/security/audit-allowlist.yaml
@@ -406,6 +406,63 @@ npm:
       expires: 2026-08-31
       reason: |
         Transitive via reference cascade from lodash advisories.
+    # Session 9 — fresh upstream disclosures since main's last green run (the
+    # frontend lockfile is UNCHANGED by this PR; npm audit --omit=dev still
+    # returns 0, so all of these are dev/build-tooling only). npm rotated the
+    # source ids of advisories already allowlisted at 1119610 (tmp) / 1120011
+    # (vitest); the new ids + the package-name "via" rollups need explicit
+    # entries. Revisit when esbuild/vite/vitest ship patched dev tooling.
+    - id: "1120126"
+      package: "vitest"
+      owner: frontend@university.example
+      expires: 2026-08-31
+      reason: |
+        Vitest UI server arbitrary file read/execute (GHSA-5xrq-8626-4rwp) —
+        rotated source id of the already-allowlisted 1120011. The UI server is a
+        dev-only tool; npm audit --omit=dev returns 0.
+    - id: "1120654"
+      package: "tmp"
+      owner: frontend@university.example
+      expires: 2026-08-31
+      reason: |
+        tmp path traversal via unsanitized prefix/postfix (GHSA-ph9p-34f9-6g65) —
+        rotated source id of the already-allowlisted 1119610. Dev/test transitive.
+    - id: "1120679"
+      package: "esbuild"
+      owner: frontend@university.example
+      expires: 2026-08-31
+      reason: |
+        esbuild missing binary integrity verification in the Deno module enables
+        RCE via NPM_CONFIG_REGISTRY (GHSA-gv7w-rqvm-qjhr). The Deno vector does not
+        apply to our npm/Vite build; esbuild is build-time tooling only.
+    - id: "1120680"
+      package: "esbuild"
+      owner: frontend@university.example
+      expires: 2026-08-31
+      reason: |
+        esbuild arbitrary file read when running the dev server on Windows
+        (GHSA-g7r4-m6w7-qqqr, low). Affects `esbuild serve` only, not prod builds.
+    - id: "esbuild"
+      package: "esbuild"
+      owner: frontend@university.example
+      expires: 2026-08-31
+      reason: |
+        Package-name rollup for the esbuild advisories above (the dev-server /
+        Deno-module vectors); build-time tooling only.
+    - id: "vite"
+      package: "vite"
+      owner: frontend@university.example
+      expires: 2026-08-31
+      reason: |
+        Transitive via reference cascade — vite is flagged solely because it
+        depends on the esbuild advisories above. Build-time tooling only.
+    - id: "vite-node"
+      package: "vite-node"
+      owner: frontend@university.example
+      expires: 2026-08-31
+      reason: |
+        Transitive via reference cascade — vite-node is flagged solely via its
+        esbuild/vite dependency. Test-time tooling only.
 
 pip:
   advisories:

--- a/services/file-processor/cmd/file-processor/main_auth_test.go
+++ b/services/file-processor/cmd/file-processor/main_auth_test.go
@@ -1,0 +1,261 @@
+package main
+
+// Coverage tests (testing session 9) for the pure auth helpers in main.go:
+// parseRSAPublicKey, jwtKeyFunc (FIX-ALG-01 algorithm-confusion guards),
+// httpJWTMiddleware (incl. the FIX-ALG-02 downgrade pre-check), authFunc
+// (gRPC metadata path) and the setupGRPCServer smoke.
+//
+// ⛔ setupGraphQLServer is deliberately NOT called (os.ReadFile of
+// schema.graphql relative to cwd + os.Exit(1) on failure); connectTemporal /
+// startNatsSubscriber / runServers need live infrastructure.
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/university-ecosystem/file-processor/internal/config"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+func generateRSAKey(t *testing.T) *rsa.PrivateKey {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	return key
+}
+
+func rsaPublicPEM(t *testing.T, pub *rsa.PublicKey) string {
+	t.Helper()
+	der, err := x509.MarshalPKIXPublicKey(pub)
+	require.NoError(t, err)
+	return string(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der}))
+}
+
+func signedToken(t *testing.T, method jwt.SigningMethod, key any, claims jwt.MapClaims) string {
+	t.Helper()
+	token := jwt.NewWithClaims(method, claims)
+	signed, err := token.SignedString(key)
+	require.NoError(t, err)
+	return signed
+}
+
+// ---------------------------------------------------------------------------
+// parseRSAPublicKey
+// ---------------------------------------------------------------------------
+
+func TestParseRSAPublicKey_Valid(t *testing.T) {
+	key := generateRSAKey(t)
+	pub, err := parseRSAPublicKey(rsaPublicPEM(t, &key.PublicKey))
+	require.NoError(t, err)
+	assert.Equal(t, key.N, pub.N)
+}
+
+func TestParseRSAPublicKey_Errors(t *testing.T) {
+	t.Run("no PEM block", func(t *testing.T) {
+		_, err := parseRSAPublicKey("not a pem at all")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no PEM block")
+	})
+
+	t.Run("garbage DER", func(t *testing.T) {
+		garbage := string(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: []byte("junk")}))
+		_, err := parseRSAPublicKey(garbage)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse")
+	})
+
+	t.Run("non-RSA key", func(t *testing.T) {
+		ecKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err)
+		der, err := x509.MarshalPKIXPublicKey(&ecKey.PublicKey)
+		require.NoError(t, err)
+		ecPEM := string(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der}))
+		_, err = parseRSAPublicKey(ecPEM)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not an RSA key")
+	})
+}
+
+// ---------------------------------------------------------------------------
+// jwtKeyFunc — FIX-ALG-01 algorithm matrix
+// ---------------------------------------------------------------------------
+
+func TestJWTKeyFunc_AlgorithmMatrix(t *testing.T) {
+	rsaKey := generateRSAKey(t)
+
+	t.Run("RS256 with key configured returns key", func(t *testing.T) {
+		fn := jwtKeyFunc("", &rsaKey.PublicKey)
+		got, err := fn(jwt.New(jwt.SigningMethodRS256))
+		require.NoError(t, err)
+		assert.Equal(t, &rsaKey.PublicKey, got)
+	})
+
+	t.Run("RS256 without key errors", func(t *testing.T) {
+		fn := jwtKeyFunc("secret", nil) // pragma: allowlist secret
+		_, err := fn(jwt.New(jwt.SigningMethodRS256))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no RSA public key configured")
+	})
+
+	t.Run("HS256 rejected when RS256 configured (FIX-ALG-01)", func(t *testing.T) {
+		fn := jwtKeyFunc("secret", &rsaKey.PublicKey) // pragma: allowlist secret
+		_, err := fn(jwt.New(jwt.SigningMethodHS256))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "HS256 token rejected")
+	})
+
+	t.Run("HS256 without secret errors", func(t *testing.T) {
+		fn := jwtKeyFunc("", nil)
+		_, err := fn(jwt.New(jwt.SigningMethodHS256))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no JWT secret configured")
+	})
+
+	t.Run("HS256 with secret returns secret bytes", func(t *testing.T) {
+		fn := jwtKeyFunc("hmac-secret", nil) // pragma: allowlist secret
+		got, err := fn(jwt.New(jwt.SigningMethodHS256))
+		require.NoError(t, err)
+		assert.Equal(t, []byte("hmac-secret"), got)
+	})
+
+	t.Run("unexpected method rejected", func(t *testing.T) {
+		fn := jwtKeyFunc("secret", nil) // pragma: allowlist secret
+		_, err := fn(jwt.New(jwt.SigningMethodES256))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unexpected signing method")
+	})
+}
+
+// ---------------------------------------------------------------------------
+// httpJWTMiddleware
+// ---------------------------------------------------------------------------
+
+func runMiddleware(t *testing.T, secret string, rsaPub *rsa.PublicKey, authHeader string) (*httptest.ResponseRecorder, *string) {
+	t.Helper()
+	var capturedSub *string
+	next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		if sub, ok := r.Context().Value(userIDKey).(string); ok {
+			capturedSub = &sub
+		}
+	})
+	handler := httpJWTMiddleware(secret, rsaPub, testLogger(), next)
+	req := httptest.NewRequest(http.MethodPost, "/graphql", nil)
+	if authHeader != "" {
+		req.Header.Set("Authorization", authHeader)
+	}
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	return rec, capturedSub
+}
+
+func TestHTTPJWTMiddleware_MissingOrMalformedHeader(t *testing.T) {
+	rec, _ := runMiddleware(t, "secret", nil, "")
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+
+	rec, _ = runMiddleware(t, "secret", nil, "Token abc")
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestHTTPJWTMiddleware_DowngradeRejectedWhenRS256Configured(t *testing.T) {
+	rsaKey := generateRSAKey(t)
+	hs := signedToken(t, jwt.SigningMethodHS256, []byte("secret"), jwt.MapClaims{"sub": "u"})
+	rec, _ := runMiddleware(t, "secret", &rsaKey.PublicKey, "Bearer "+hs)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestHTTPJWTMiddleware_ValidRS256SetsUserContext(t *testing.T) {
+	rsaKey := generateRSAKey(t)
+	rs := signedToken(t, jwt.SigningMethodRS256, rsaKey, jwt.MapClaims{"sub": "user-42"})
+	rec, sub := runMiddleware(t, "", &rsaKey.PublicKey, "Bearer "+rs)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	require.NotNil(t, sub)
+	assert.Equal(t, "user-42", *sub)
+}
+
+func TestHTTPJWTMiddleware_ValidHS256WhenNoRSA(t *testing.T) {
+	hs := signedToken(t, jwt.SigningMethodHS256, []byte("hmac-secret"), jwt.MapClaims{"sub": "user-h"})
+	rec, sub := runMiddleware(t, "hmac-secret", nil, "Bearer "+hs)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	require.NotNil(t, sub)
+	assert.Equal(t, "user-h", *sub)
+}
+
+func TestHTTPJWTMiddleware_InvalidSignatureRejected(t *testing.T) {
+	hs := signedToken(t, jwt.SigningMethodHS256, []byte("wrong-secret"), jwt.MapClaims{"sub": "u"})
+	rec, _ := runMiddleware(t, "right-secret", nil, "Bearer "+hs)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+// ---------------------------------------------------------------------------
+// authFunc — gRPC metadata path
+// ---------------------------------------------------------------------------
+
+func metadataCtx(token string) context.Context {
+	md := metadata.Pairs("authorization", "Bearer "+token)
+	return metadata.NewIncomingContext(context.Background(), md)
+}
+
+func TestAuthFunc_ValidTokenPutsSubInContext(t *testing.T) {
+	fn := authFunc("grpc-secret", nil, testLogger()) // pragma: allowlist secret
+	token := signedToken(t, jwt.SigningMethodHS256, []byte("grpc-secret"), jwt.MapClaims{"sub": "grpc-user"})
+
+	ctx, err := fn(metadataCtx(token))
+	require.NoError(t, err)
+	assert.Equal(t, "grpc-user", ctx.Value(userIDKey))
+}
+
+func TestAuthFunc_InvalidTokenUnauthenticated(t *testing.T) {
+	fn := authFunc("grpc-secret", nil, testLogger()) // pragma: allowlist secret
+	token := signedToken(t, jwt.SigningMethodHS256, []byte("other-secret"), jwt.MapClaims{"sub": "x"})
+
+	_, err := fn(metadataCtx(token))
+	require.Error(t, err)
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+}
+
+func TestAuthFunc_MissingSubRejected(t *testing.T) {
+	fn := authFunc("grpc-secret", nil, testLogger()) // pragma: allowlist secret
+	token := signedToken(t, jwt.SigningMethodHS256, []byte("grpc-secret"), jwt.MapClaims{"role": "nobody"})
+
+	_, err := fn(metadataCtx(token))
+	require.Error(t, err)
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+}
+
+func TestAuthFunc_MissingMetadataErrors(t *testing.T) {
+	fn := authFunc("grpc-secret", nil, testLogger()) // pragma: allowlist secret
+	_, err := fn(context.Background())
+	require.Error(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// setupGRPCServer smoke — registers services without binding a listener
+// ---------------------------------------------------------------------------
+
+func TestSetupGRPCServer_BuildsServer(t *testing.T) {
+	cfg := &config.Config{JWTSecret: "smoke-secret"} // pragma: allowlist secret
+	srv := setupGRPCServer(context.Background(), cfg, nil, nil, testLogger())
+	require.NotNil(t, srv)
+	info := srv.GetServiceInfo()
+	assert.Contains(t, info, "grpc.health.v1.Health")
+	srv.Stop()
+}

--- a/services/file-processor/internal/graphql/resolver_coverage_test.go
+++ b/services/file-processor/internal/graphql/resolver_coverage_test.go
@@ -1,0 +1,165 @@
+package graphql
+
+// Coverage tests (testing session 9) for the GraphQL resolver: ProcessFile
+// happy/error paths, sanitizeKey traversal guards and the sub-resolver
+// accessors. Mirrors the manual fakeTemporalClient idiom from
+// internal/service/server_test.go (it is unexported there, so duplicated).
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	gql "github.com/graph-gophers/graphql-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/university-ecosystem/file-processor/internal/workflow"
+	"go.temporal.io/sdk/client"
+)
+
+type fakeWorkflowRun struct {
+	client.WorkflowRun
+	id string
+}
+
+func (f *fakeWorkflowRun) GetID() string { return f.id }
+
+type fakeTemporalClient struct {
+	client.Client
+	executeFunc func(ctx context.Context, options client.StartWorkflowOptions, wf interface{}, args ...interface{}) (client.WorkflowRun, error)
+}
+
+func (f *fakeTemporalClient) ExecuteWorkflow(ctx context.Context, options client.StartWorkflowOptions, wf interface{}, args ...interface{}) (client.WorkflowRun, error) {
+	if f.executeFunc != nil {
+		return f.executeFunc(ctx, options, wf, args...)
+	}
+	return &fakeWorkflowRun{id: "noop"}, nil
+}
+
+func int32Ptr(v int32) *int32 { return &v }
+
+// ---------------------------------------------------------------------------
+// sanitizeKey
+// ---------------------------------------------------------------------------
+
+func TestSanitizeKey(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{"clean path", "uploads/file.png", "uploads/file.png", false},
+		{"leading slash collapsed", "/uploads/a.png", "uploads/a.png", false},
+		{"traversal rejected", "../etc/passwd", "", true},
+		{"embedded traversal rejected", "uploads/../../etc/passwd", "", true},
+		{"empty rejected", "", "", true},
+		{"root rejected", "/", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := sanitizeKey(tc.input)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Resolver.File
+// ---------------------------------------------------------------------------
+
+func TestFile_ResolvesSanitizedURL(t *testing.T) {
+	r := &Resolver{MinioBucket: "files"}
+	fr := r.File(struct{ ID gql.ID }{ID: gql.ID("uploads/photo.png")})
+	require.NotNil(t, fr)
+	assert.Equal(t, gql.ID("uploads/photo.png"), fr.ID())
+	assert.Contains(t, fr.URL(), "/files/")
+	assert.NotNil(t, fr.Size())
+	assert.NotNil(t, fr.Type())
+}
+
+func TestFile_TraversalFallsBackToInvalidPath(t *testing.T) {
+	r := &Resolver{MinioBucket: "files"}
+	fr := r.File(struct{ ID gql.ID }{ID: gql.ID("../../etc/passwd")})
+	require.NotNil(t, fr)
+	assert.Equal(t, gql.ID("invalid-path"), fr.ID())
+}
+
+func TestHealth_ReturnsOK(t *testing.T) {
+	r := &Resolver{}
+	assert.Equal(t, "OK", r.Health())
+}
+
+// ---------------------------------------------------------------------------
+// Resolver.ProcessFile
+// ---------------------------------------------------------------------------
+
+func TestProcessFile_SuccessThreadsOptionsAndPrefix(t *testing.T) {
+	var capturedOptions client.StartWorkflowOptions
+	var capturedJob workflow.ProcessJob
+	fake := &fakeTemporalClient{
+		executeFunc: func(_ context.Context, options client.StartWorkflowOptions, _ interface{}, args ...interface{}) (client.WorkflowRun, error) {
+			capturedOptions = options
+			require.Len(t, args, 1)
+			capturedJob = args[0].(workflow.ProcessJob)
+			return &fakeWorkflowRun{id: "wf-run-1"}, nil
+		},
+	}
+	r := &Resolver{TemporalClient: fake, MinioBucket: "files"}
+
+	input := ProcessFileInput{
+		Type:      "image",
+		SourceKey: "src/a.png",
+		DestKey:   "dst/a.png",
+		Width:     int32Ptr(640),
+		Height:    int32Ptr(480),
+	}
+	jobRes, err := r.ProcessFile(context.Background(), struct{ Input ProcessFileInput }{Input: input})
+	require.NoError(t, err)
+	require.NotNil(t, jobRes)
+
+	assert.Equal(t, gql.ID("wf-run-1"), jobRes.JobID())
+	assert.Equal(t, "STARTED", jobRes.Status())
+	assert.True(t, strings.HasPrefix(capturedOptions.ID, "graphql-"))
+	assert.Equal(t, "FILE_PROCESSING_TASK_QUEUE", capturedOptions.TaskQueue)
+	assert.Equal(t, 640, capturedJob.Options["width"])
+	assert.Equal(t, 480, capturedJob.Options["height"])
+	assert.Equal(t, "src/a.png", capturedJob.SourceKey)
+	assert.Equal(t, "dst/a.png", capturedJob.DestKey)
+}
+
+func TestProcessFile_InvalidSourceKeyRejected(t *testing.T) {
+	r := &Resolver{TemporalClient: &fakeTemporalClient{}, MinioBucket: "files"}
+	_, err := r.ProcessFile(context.Background(), struct{ Input ProcessFileInput }{
+		Input: ProcessFileInput{Type: "image", SourceKey: "../etc/passwd", DestKey: "dst/ok.png"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid source key")
+}
+
+func TestProcessFile_InvalidDestKeyRejected(t *testing.T) {
+	r := &Resolver{TemporalClient: &fakeTemporalClient{}, MinioBucket: "files"}
+	_, err := r.ProcessFile(context.Background(), struct{ Input ProcessFileInput }{
+		Input: ProcessFileInput{Type: "image", SourceKey: "src/ok.png", DestKey: "../../boom"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid destination key")
+}
+
+func TestProcessFile_ExecuteWorkflowErrorPropagates(t *testing.T) {
+	fake := &fakeTemporalClient{
+		executeFunc: func(_ context.Context, _ client.StartWorkflowOptions, _ interface{}, _ ...interface{}) (client.WorkflowRun, error) {
+			return nil, assert.AnError
+		},
+	}
+	r := &Resolver{TemporalClient: fake, MinioBucket: "files"}
+	_, err := r.ProcessFile(context.Background(), struct{ Input ProcessFileInput }{
+		Input: ProcessFileInput{Type: "image", SourceKey: "src/ok.png", DestKey: "dst/ok.png"},
+	})
+	require.Error(t, err)
+}

--- a/services/file-processor/internal/middleware/graphql_depth_coverage_test.go
+++ b/services/file-processor/internal/middleware/graphql_depth_coverage_test.go
@@ -1,0 +1,94 @@
+package middleware
+
+// Coverage tests (testing session 9) for the GraphQL depth middleware
+// residual branches: GET pass-through, invalid-JSON 400, body restoration
+// for downstream handlers, and the estimateQueryDepth heuristic table
+// (strings with braces, escaped quotes, # comments, unbalanced braces).
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMaxQueryDepth_GETPassesThrough(t *testing.T) {
+	called := false
+	handler := MaxQueryDepthMiddleware(2, http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		called = true
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/graphql?query={a{b{c{d}}}}", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.True(t, called, "GET requests bypass depth estimation")
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestMaxQueryDepth_InvalidJSONRejected(t *testing.T) {
+	handler := MaxQueryDepthMiddleware(2, http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("downstream must not be called")
+	}))
+	req := httptest.NewRequest(http.MethodPost, "/graphql", strings.NewReader("{broken"))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "invalid request body")
+}
+
+func TestMaxQueryDepth_RestoresBodyForDownstream(t *testing.T) {
+	body := `{"query":"{ health }","variables":{"x":1},"operationName":"Op"}`
+	var downstreamBody string
+	handler := MaxQueryDepthMiddleware(5, http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		data, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		downstreamBody = string(data)
+	}))
+	req := httptest.NewRequest(http.MethodPost, "/graphql", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, body, downstreamBody, "variables/operationName must survive the middleware")
+}
+
+func TestEstimateQueryDepth_Table(t *testing.T) {
+	cases := []struct {
+		name  string
+		query string
+		want  int
+	}{
+		{"empty", "", 0},
+		{"flat", "{ health }", 1},
+		{"nested three", "{ a { b { c } } }", 3},
+		{"braces inside string ignored", `{ a(filter: "{{{") { b } }`, 2},
+		{"escaped quote inside string", `{ a(label: "say \"hi\" {x}") { b } }`, 2},
+		{"line comment ignored", "{ a { b } } # trailing {{{{\n", 2},
+		{"comment then code", "# header {{{\n{ a { b { c } } }", 3},
+		{"unbalanced extra close", "{ a } } }", 1},
+		{"sibling blocks keep max", "{ a { b } c { d { e } } }", 3},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, estimateQueryDepth(tc.query))
+		})
+	}
+}
+
+func TestRequestTimeout_ContextDeadlineApplied(t *testing.T) {
+	var sawDeadline bool
+	handler := RequestTimeoutMiddleware(50*time.Millisecond, http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		_, sawDeadline = r.Context().Deadline()
+	}))
+	req := httptest.NewRequest(http.MethodPost, "/graphql", strings.NewReader("{}"))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.True(t, sawDeadline, "downstream context must carry a deadline")
+}

--- a/services/file-processor/internal/workflow/workflow_testsuite_test.go
+++ b/services/file-processor/internal/workflow/workflow_testsuite_test.go
@@ -1,0 +1,73 @@
+package workflow
+
+// Coverage tests (testing session 9) for FileProcessingWorkflow via the
+// Temporal SDK's built-in testsuite (go.temporal.io/sdk/testsuite — no new
+// dependency). The ResizeImageActivity is mocked via env.OnActivity so no
+// MinIO connection is needed; the workflow body (versioning, ActivityOptions,
+// retry policy wiring, result propagation) is what gets exercised.
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/testsuite"
+)
+
+func newWorkflowEnv(t *testing.T) *testsuite.TestWorkflowEnvironment {
+	t.Helper()
+	ts := &testsuite.WorkflowTestSuite{}
+	env := ts.NewTestWorkflowEnvironment()
+	var a *FileActivities
+	env.RegisterActivity(a.ResizeImageActivity)
+	return env
+}
+
+func TestFileProcessingWorkflow_Success(t *testing.T) {
+	env := newWorkflowEnv(t)
+	var a *FileActivities
+	env.OnActivity(a.ResizeImageActivity, mock.Anything, mock.Anything).Return(
+		&ProcessResult{JobID: "job-1", Success: true, DestKey: "out/img.png"}, nil,
+	)
+
+	job := ProcessJob{
+		ID:        "job-1",
+		Type:      "resize",
+		SourceKey: "in/img.png",
+		DestKey:   "out/img.png",
+		Options:   map[string]interface{}{"width": 100, "height": 100},
+	}
+	env.ExecuteWorkflow(FileProcessingWorkflow, job)
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+
+	var result ProcessResult
+	require.NoError(t, env.GetWorkflowResult(&result))
+	assert.True(t, result.Success)
+	assert.Equal(t, "job-1", result.JobID)
+	assert.Equal(t, "out/img.png", result.DestKey)
+}
+
+func TestFileProcessingWorkflow_ActivityErrorPropagates(t *testing.T) {
+	env := newWorkflowEnv(t)
+	var a *FileActivities
+	env.OnActivity(a.ResizeImageActivity, mock.Anything, mock.Anything).Return(
+		nil, errors.New("resize exploded"),
+	)
+
+	job := ProcessJob{
+		ID:        "job-err",
+		Type:      "resize",
+		SourceKey: "in/x.png",
+		DestKey:   "out/x.png",
+	}
+	env.ExecuteWorkflow(FileProcessingWorkflow, job)
+
+	require.True(t, env.IsWorkflowCompleted())
+	err := env.GetWorkflowError()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "resize exploded")
+}

--- a/services/gateway/cmd/gateway/main_smoke_test.go
+++ b/services/gateway/cmd/gateway/main_smoke_test.go
@@ -1,0 +1,74 @@
+package main
+
+// Coverage smoke (testing session 9) for setupRouter — the single largest 0%
+// block in the gateway (main.go is ~86 statements that Go 1.20+ already counts
+// in the ./... denominator at 0%). One test wires the full router and probes
+// only the routes that need neither a live backend nor the file-processor gRPC
+// client.
+//
+// ⚠ Invariants that keep this safe:
+//   - setupRouter is called EXACTLY ONCE in this package: ginprometheus.NewPrometheus
+//     registers gin metrics on the global registry and panics on a second call,
+//     and SetListenAddress(":9102") spawns a real (leaked-until-exit) listener.
+//   - cfg must be valid or setupRouter calls os.Exit(1): BackendURL must parse and
+//     JWTSecret must be ≥32 chars.
+//   - RedisURL="" → NewRateLimiter errors → rate-limiter-absent branch → nil redis
+//     client → WarmL1Cache/ListenForRevocations early-return (no goroutines, no
+//     Redis dependency).
+//   - grpcConn/fileClient are nil but ProxyOrFileHandler only dereferences them on
+//     POST /files/process/sync, which none of these probes hit.
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/university-ecosystem/gateway/internal/config"
+)
+
+func TestSetupRouter_WiresRoutesAndProbes(t *testing.T) {
+	cfg := &config.Config{
+		Port:               "8080",
+		BackendURL:         "http://127.0.0.1:1",                           // parseable, never dialed by these probes
+		RedisURL:           "",                                             // → rate-limiter-absent branch → nil redis client
+		JWTSecret:          "smoke-test-jwt-secret-at-least-32-chars-long", // ≥32 chars, avoids os.Exit
+		RateLimitRPS:       100,
+		RateLimitBurst:     200,
+		AllowedOrigins:     []string{"http://localhost:3000"},
+		InternalHMACSecret: "smoke-internal-hmac-secret",
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	var router *gin.Engine
+	assert.NotPanics(t, func() {
+		router = setupRouter(cfg, logger, nil, nil, context.Background())
+	}, "setupRouter must wire a valid config without panicking or exiting")
+	if router == nil {
+		t.Fatal("setupRouter returned nil")
+	}
+
+	t.Run("health is public", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
+		assert.Equal(t, http.StatusOK, rec.Code)
+	})
+
+	t.Run("protected v1 route without auth is 401", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/users/me", nil))
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+		assert.Contains(t, rec.Body.String(), "missing authorization header")
+	})
+
+	t.Run("unknown /api route is 404 JSON", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/totally/unknown", nil))
+		assert.Equal(t, http.StatusNotFound, rec.Code)
+		assert.Contains(t, rec.Body.String(), "endpoint not found")
+	})
+}

--- a/services/gateway/middleware/auth_redis_test.go
+++ b/services/gateway/middleware/auth_redis_test.go
@@ -1,0 +1,342 @@
+package middleware
+
+// Coverage tests (testing session 9) for the Redis-backed session-revocation
+// paths that the existing auth_test.go cannot reach because it constructs the
+// middleware with a nil *redis.Client (every revocation check then early-returns
+// "valid" via the m.redis == nil guard).
+//
+// These tests point a REAL go-redis client at a hand-rolled mock RESP server
+// (the respondRESP idiom from services/cmd/uni-cli/main_test.go) so that
+// verifySession / checkSessionInRedis / checkL1Cache / WarmL1Cache execute for
+// real. The integration tier (//go:build integration, testcontainers) covers
+// the live-Redis pub/sub path; these unit tests stay dependency-free.
+//
+// ⚠ XFetch trap: checkL1Cache calls shouldRefreshProbabilistic, which returns a
+// spurious "miss" ~37% of the time even for a fresh entry. WarmL1Cache results
+// are therefore asserted via the raw m.l1cache.Get (deterministic), never via
+// checkL1Cache.
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockRedisConfig configures the canned replies of the mock RESP server.
+type mockRedisConfig struct {
+	existsReply string   // ":1\r\n" (revoked) or ":0\r\n" (not revoked)
+	scanKeys    []string // keys returned by a single-page SCAN (cursor "0")
+	scanErr     bool     // reply "-ERR" to SCAN to exercise the warmup skip path
+}
+
+// respondGatewayRESP writes a canned RESP reply for the uppercased request
+// fragment, covering the commands the gateway middleware exercises.
+func respondGatewayRESP(write func(string), upper string, cfg mockRedisConfig) {
+	switch {
+	case strings.Contains(upper, "HELLO"):
+		write("-ERR unknown command 'HELLO'\r\n") // force RESP2 fallback
+	case strings.Contains(upper, "CLIENT"):
+		write("-ERR unknown command 'CLIENT'\r\n")
+	case strings.Contains(upper, "PING"):
+		write("+PONG\r\n")
+	case strings.Contains(upper, "EXISTS"):
+		reply := cfg.existsReply
+		if reply == "" {
+			reply = ":0\r\n"
+		}
+		write(reply)
+	case strings.Contains(upper, "SCAN"):
+		if cfg.scanErr {
+			write("-ERR scan failed\r\n")
+			return
+		}
+		var b strings.Builder
+		// SCAN reply: 2-element array [cursor-string, keys-array]. Cursor "0" ends iteration.
+		b.WriteString("*2\r\n$1\r\n0\r\n")
+		fmt.Fprintf(&b, "*%d\r\n", len(cfg.scanKeys))
+		for _, k := range cfg.scanKeys {
+			fmt.Fprintf(&b, "$%d\r\n%s\r\n", len(k), k)
+		}
+		write(b.String())
+	default:
+		write("+OK\r\n")
+	}
+}
+
+// startMockRedis spins up a loopback RESP server and returns its redis:// URL
+// plus a cleanup func. No external dependency.
+//
+// The cleanup func closes BOTH the listener AND every accepted connection — a
+// connection-pooling client (go-redis) keeps a warm socket, so closing only the
+// listener would leave that socket fully serving. Closing the conns forces the
+// pooled socket to error and the redial to hit a closed listener (refused),
+// which is what genuinely simulates a Redis outage.
+func startMockRedis(t *testing.T, cfg mockRedisConfig) (string, func()) {
+	t.Helper()
+	var lc net.ListenConfig
+	ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	var mu sync.Mutex
+	var conns []net.Conn
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			mu.Lock()
+			conns = append(conns, conn)
+			mu.Unlock()
+			go func(c net.Conn) {
+				defer func() { _ = c.Close() }()                      //nolint:errcheck // mock cleanup
+				write := func(s string) { _, _ = c.Write([]byte(s)) } //nolint:errcheck // best-effort write
+				buf := make([]byte, 4096)
+				for {
+					n, err := c.Read(buf)
+					if err != nil {
+						return
+					}
+					for _, part := range strings.Split(string(buf[:n]), "*") {
+						if part == "" {
+							continue
+						}
+						respondGatewayRESP(write, strings.ToUpper(part), cfg)
+					}
+				}
+			}(conn)
+		}
+	}()
+
+	return fmt.Sprintf("redis://%s", ln.Addr().String()), func() {
+		_ = ln.Close() //nolint:errcheck // cleanup
+		mu.Lock()
+		for _, c := range conns {
+			_ = c.Close() //nolint:errcheck // cleanup
+		}
+		mu.Unlock()
+	}
+}
+
+// newRedisMiddleware builds a JWTMiddleware whose *redis.Client is connected to
+// the given mock URL, with the connection pre-warmed so the 50ms timeout in
+// checkSessionInRedis covers only the command round-trip (not the RESP2
+// handshake).
+func newRedisMiddleware(t *testing.T, url string) *JWTMiddleware {
+	t.Helper()
+	opt, err := redis.ParseURL(url)
+	require.NoError(t, err)
+	client := redis.NewClient(opt)
+	_ = client.Ping(context.Background()).Err() //nolint:errcheck // warm the pool; HELLO -ERR RESP2 fallback is expected mock noise
+	t.Cleanup(func() { _ = client.Close() })    //nolint:errcheck // cleanup
+	return NewJWTMiddleware(testSecret, client)
+}
+
+func revocableClaims(jti string) Claims {
+	return Claims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			ID:        jti,
+			IssuedAt:  jwt.NewNumericDate(time.Now().Add(-1 * time.Minute)),
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(1 * time.Hour)),
+		},
+		UserID:   "user-1",
+		Role:     "student",
+		IsActive: true,
+	}
+}
+
+func bearerRequest(token string) *http.Request {
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	return req
+}
+
+// ---------------------------------------------------------------------------
+// Validate — revocation paths through real Redis
+// ---------------------------------------------------------------------------
+
+func TestValidate_RevokedSessionRejected(t *testing.T) {
+	url, stop := startMockRedis(t, mockRedisConfig{existsReply: ":1\r\n"}) // jti is revoked
+	defer stop()
+	m := newRedisMiddleware(t, url)
+	router := createTestRouter(m.Validate(context.Background()))
+
+	token := createValidToken(testSecret, revocableClaims("jti-revoked"))
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, bearerRequest(token))
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.Contains(t, rec.Body.String(), "session expired or revoked")
+}
+
+func TestValidate_ActiveSessionPasses(t *testing.T) {
+	url, stop := startMockRedis(t, mockRedisConfig{existsReply: ":0\r\n"}) // not revoked
+	defer stop()
+	m := newRedisMiddleware(t, url)
+
+	handlerCalled := false
+	router := gin.New()
+	router.GET("/test", m.Validate(context.Background()), func(c *gin.Context) {
+		handlerCalled = true
+		c.Status(http.StatusOK)
+	})
+
+	token := createValidToken(testSecret, revocableClaims("jti-active"))
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, bearerRequest(token))
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.True(t, handlerCalled, "downstream handler must run for a valid, non-revoked session")
+}
+
+func TestValidate_MissingJTIRejected(t *testing.T) {
+	url, stop := startMockRedis(t, mockRedisConfig{existsReply: ":0\r\n"})
+	defer stop()
+	m := newRedisMiddleware(t, url)
+	router := createTestRouter(m.Validate(context.Background()))
+
+	// FIX-JTI-01: a token without a jti cannot be correlated with a session →
+	// treated as invalid even though signature + iat + exp are all fine.
+	claims := revocableClaims("")
+	token := createValidToken(testSecret, claims)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, bearerRequest(token))
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestValidate_RedisDownFailsSecure(t *testing.T) {
+	url, stop := startMockRedis(t, mockRedisConfig{existsReply: ":0\r\n"})
+	m := newRedisMiddleware(t, url)
+	stop() // kill the server BEFORE the request → checkSessionInRedis errors
+
+	router := createTestRouter(m.Validate(context.Background()))
+	token := createValidToken(testSecret, revocableClaims("jti-x"))
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, bearerRequest(token))
+
+	// GW-P1-03: Validate uses failSecure=true → Redis outage → 503, never a pass.
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	assert.Contains(t, rec.Body.String(), "session verification temporarily unavailable")
+}
+
+func TestValidate_CookieTokenExtraction(t *testing.T) {
+	url, stop := startMockRedis(t, mockRedisConfig{existsReply: ":0\r\n"})
+	defer stop()
+	m := newRedisMiddleware(t, url)
+
+	handlerCalled := false
+	router := gin.New()
+	router.GET("/test", m.Validate(context.Background()), func(c *gin.Context) {
+		handlerCalled = true
+		c.Status(http.StatusOK)
+	})
+
+	token := createValidToken(testSecret, revocableClaims("jti-cookie"))
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.AddCookie(&http.Cookie{Name: AccessTokenCookieName, Value: token}) // BFF cookie path, no Authorization header
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.True(t, handlerCalled, "Validate must read the access_token_v2 cookie when no Authorization header is present")
+}
+
+// ---------------------------------------------------------------------------
+// Optional — revocation paths
+// ---------------------------------------------------------------------------
+
+func TestOptional_RevokedSessionContinuesUnauthenticated(t *testing.T) {
+	url, stop := startMockRedis(t, mockRedisConfig{existsReply: ":1\r\n"}) // revoked
+	defer stop()
+	m := newRedisMiddleware(t, url)
+
+	var sawUserID bool
+	router := gin.New()
+	router.GET("/test", m.Optional(context.Background()), func(c *gin.Context) {
+		_, sawUserID = c.Get("user_id")
+		c.Status(http.StatusOK)
+	})
+
+	token := createValidToken(testSecret, revocableClaims("jti-revoked"))
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, bearerRequest(token))
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.False(t, sawUserID, "Optional must NOT set user context for a revoked session (continues unauthenticated)")
+}
+
+func TestOptional_RedisDownFailsOpenUnauthenticated(t *testing.T) {
+	url, stop := startMockRedis(t, mockRedisConfig{existsReply: ":0\r\n"})
+	m := newRedisMiddleware(t, url)
+	stop() // Redis down
+
+	var sawUserID bool
+	router := gin.New()
+	router.GET("/test", m.Optional(context.Background()), func(c *gin.Context) {
+		_, sawUserID = c.Get("user_id")
+		c.Status(http.StatusOK)
+	})
+	token := createValidToken(testSecret, revocableClaims("jti-x"))
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, bearerRequest(token))
+
+	// GW-P1-03 fail-open: Optional() passes failSecure=false to verifySession, so a
+	// Redis error yields (isValid=false, shouldDeny=false) → the request continues
+	// as UNAUTHENTICATED (200, no user context). It never treats a possibly-revoked
+	// token as valid, and the 503 branch is unreachable for the optional path.
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.False(t, sawUserID, "a Redis outage must not authenticate the request on the optional path")
+}
+
+// ---------------------------------------------------------------------------
+// WarmL1Cache + ListenForRevocations
+// ---------------------------------------------------------------------------
+
+func TestWarmL1Cache_PopulatesFromScan(t *testing.T) {
+	keys := []string{"revoked:jti:aaa", "revoked:jti:bbb"}
+	url, stop := startMockRedis(t, mockRedisConfig{scanKeys: keys})
+	defer stop()
+	m := newRedisMiddleware(t, url)
+
+	m.WarmL1Cache(context.Background())
+
+	for _, k := range keys {
+		// Assert via the raw LRU (NOT checkL1Cache) to dodge the XFetch flake.
+		entry, ok := m.l1cache.Get(k)
+		require.True(t, ok, "WarmL1Cache should have seeded %s", k)
+		assert.True(t, entry.exists, "warmed revocation entries are marked exists=true")
+	}
+}
+
+func TestWarmL1Cache_ScanErrorSkips(t *testing.T) {
+	url, stop := startMockRedis(t, mockRedisConfig{scanErr: true})
+	defer stop()
+	m := newRedisMiddleware(t, url)
+
+	m.WarmL1Cache(context.Background()) // must return without panicking
+	assert.Equal(t, 0, m.l1cache.Len(), "a SCAN error must leave the L1 cache empty")
+}
+
+func TestWarmL1Cache_NilRedisNoop(t *testing.T) {
+	m := NewJWTMiddleware(testSecret, nil)
+	assert.NotPanics(t, func() { m.WarmL1Cache(context.Background()) })
+}
+
+func TestListenForRevocations_NilRedisNoop(t *testing.T) {
+	m := NewJWTMiddleware(testSecret, nil)
+	assert.NotPanics(t, func() { m.ListenForRevocations(context.Background()) })
+}

--- a/services/gateway/middleware/jwks_errors_test.go
+++ b/services/gateway/middleware/jwks_errors_test.go
@@ -1,0 +1,168 @@
+package middleware
+
+// Coverage tests (testing session 9) for the JWKS parsing error branches.
+// The happy path is already exercised by TestJWKSRefresher in auth_test.go;
+// this file drives the failure branches of fetchJWKSPublicKey,
+// jwkToRSAPublicKey and parseRSAPublicKeyFromPEM.
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func rsaJWKSBody(t *testing.T, pub *rsa.PublicKey) []byte {
+	t.Helper()
+	body := struct {
+		Keys []map[string]string `json:"keys"`
+	}{Keys: []map[string]string{{
+		"kty": "RSA",
+		"n":   base64.RawURLEncoding.EncodeToString(pub.N.Bytes()),
+		"e":   base64.RawURLEncoding.EncodeToString([]byte{1, 0, 1}),
+	}}}
+	b, err := json.Marshal(body)
+	require.NoError(t, err)
+	return b
+}
+
+func jwksServer(t *testing.T, status int, body []byte) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(status)
+		_, _ = w.Write(body) //nolint:errcheck // test handler write
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// ---------------------------------------------------------------------------
+// fetchJWKSPublicKey
+// ---------------------------------------------------------------------------
+
+func TestFetchJWKSPublicKey_Success(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	srv := jwksServer(t, http.StatusOK, rsaJWKSBody(t, &key.PublicKey))
+
+	pub, err := fetchJWKSPublicKey(context.Background(), srv.Client(), srv.URL)
+	require.NoError(t, err)
+	assert.Equal(t, key.N, pub.N)
+}
+
+func TestFetchJWKSPublicKey_Non200(t *testing.T) {
+	srv := jwksServer(t, http.StatusInternalServerError, []byte("boom"))
+	_, err := fetchJWKSPublicKey(context.Background(), srv.Client(), srv.URL)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected status")
+}
+
+func TestFetchJWKSPublicKey_PEMFallback(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	der, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
+	require.NoError(t, err)
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der})
+
+	// Body is not JSON → fetchJWKSPublicKey falls back to PEM parsing.
+	srv := jwksServer(t, http.StatusOK, pemBytes)
+	pub, err := fetchJWKSPublicKey(context.Background(), srv.Client(), srv.URL)
+	require.NoError(t, err)
+	assert.Equal(t, key.N, pub.N)
+}
+
+func TestFetchJWKSPublicKey_NoRSAKey(t *testing.T) {
+	// Valid JSON, but the only key is EC → "no RSA key found".
+	body := []byte(`{"keys":[{"kty":"EC","crv":"P-256","x":"abc","y":"def"}]}`)
+	srv := jwksServer(t, http.StatusOK, body)
+	_, err := fetchJWKSPublicKey(context.Background(), srv.Client(), srv.URL)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no RSA key found")
+}
+
+func TestFetchJWKSPublicKey_RequestError(t *testing.T) {
+	// A cancelled context makes client.Do fail before any response.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	srv := jwksServer(t, http.StatusOK, []byte("{}"))
+	_, err := fetchJWKSPublicKey(ctx, srv.Client(), srv.URL)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "jwks: fetch")
+}
+
+// ---------------------------------------------------------------------------
+// jwkToRSAPublicKey
+// ---------------------------------------------------------------------------
+
+func TestJWKToRSAPublicKey_BadBase64(t *testing.T) {
+	t.Run("bad n", func(t *testing.T) {
+		_, err := jwkToRSAPublicKey("!!!not base64!!!", base64.RawURLEncoding.EncodeToString([]byte{1, 0, 1}))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "decode n")
+	})
+	t.Run("bad e", func(t *testing.T) {
+		_, err := jwkToRSAPublicKey(base64.RawURLEncoding.EncodeToString([]byte{0x01, 0x02}), "###")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "decode e")
+	})
+	t.Run("valid", func(t *testing.T) {
+		pub, err := jwkToRSAPublicKey(
+			base64.RawURLEncoding.EncodeToString([]byte{0x01, 0x00, 0x01}),
+			base64.RawURLEncoding.EncodeToString([]byte{0x01, 0x00, 0x01}),
+		)
+		require.NoError(t, err)
+		assert.Equal(t, 65537, pub.E)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// parseRSAPublicKeyFromPEM
+// ---------------------------------------------------------------------------
+
+func TestParseRSAPublicKeyFromPEM_Errors(t *testing.T) {
+	t.Run("no PEM block", func(t *testing.T) {
+		_, err := parseRSAPublicKeyFromPEM([]byte("definitely not pem"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no PEM block")
+	})
+
+	t.Run("garbage DER", func(t *testing.T) {
+		garbage := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: []byte("junk-der")})
+		_, err := parseRSAPublicKeyFromPEM(garbage)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "parse public key")
+	})
+
+	t.Run("non-RSA key", func(t *testing.T) {
+		ec, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err)
+		der, err := x509.MarshalPKIXPublicKey(&ec.PublicKey)
+		require.NoError(t, err)
+		ecPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der})
+		_, err = parseRSAPublicKeyFromPEM(ecPEM)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not RSA")
+	})
+
+	t.Run("valid RSA", func(t *testing.T) {
+		key, err := rsa.GenerateKey(rand.Reader, 2048)
+		require.NoError(t, err)
+		der, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
+		require.NoError(t, err)
+		pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der})
+		pub, err := parseRSAPublicKeyFromPEM(pemBytes)
+		require.NoError(t, err)
+		assert.Equal(t, key.N, pub.N)
+	})
+}

--- a/services/gateway/middleware/roles_test.go
+++ b/services/gateway/middleware/roles_test.go
@@ -1,0 +1,59 @@
+package middleware
+
+// Coverage tests (testing session 9) for RequireRole, including the TD-10
+// ok-guard branch (a non-string user_role in the gin context must yield 403,
+// not a goroutine panic / 500).
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+// roleRouter wires a preceding middleware that seeds user_role (skipped when
+// seed is nil) followed by RequireRole + a 200 terminal handler.
+func roleRouter(seed interface{}, roles ...string) *gin.Engine {
+	r := gin.New()
+	r.GET("/admin",
+		func(c *gin.Context) {
+			if seed != nil {
+				c.Set("user_role", seed)
+			}
+			c.Next()
+		},
+		RequireRole(roles...),
+		func(c *gin.Context) { c.Status(http.StatusOK) },
+	)
+	return r
+}
+
+func TestRequireRole_NoRoleInContext(t *testing.T) {
+	rec := httptest.NewRecorder()
+	roleRouter(nil, "admin").ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/admin", nil))
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Contains(t, rec.Body.String(), "role not found in token")
+}
+
+func TestRequireRole_NonStringRoleRejected(t *testing.T) {
+	// TD-10: an int in the context must NOT panic the goroutine.
+	rec := httptest.NewRecorder()
+	roleRouter(12345, "admin").ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/admin", nil))
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Contains(t, rec.Body.String(), "insufficient permissions")
+}
+
+func TestRequireRole_RoleNotInSet(t *testing.T) {
+	rec := httptest.NewRecorder()
+	roleRouter("student", "admin", "staff").ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/admin", nil))
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Contains(t, rec.Body.String(), "insufficient permissions")
+}
+
+func TestRequireRole_MatchingRolePasses(t *testing.T) {
+	rec := httptest.NewRecorder()
+	roleRouter("admin", "admin", "staff").ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/admin", nil))
+	assert.Equal(t, http.StatusOK, rec.Code)
+}

--- a/services/ws-hub/pkg/hub/handlers_unit_test.go
+++ b/services/ws-hub/pkg/hub/handlers_unit_test.go
@@ -1,0 +1,389 @@
+package hub
+
+// Coverage tests (testing session 9) for the WebSocket upgrade path:
+// validateUpgradeTicket (mock RESP server — idiom ported from
+// services/cmd/uni-cli/main_test.go), RS256 + JWKS validation via an
+// httptest JWKS server, and the full HandleWebSocket upgrade → join →
+// broadcast → deliver E2E flow with a real gorilla/websocket dial.
+//
+// CAUTION (documented in the session-9 plan): never send {"type":"message"}
+// frames through ReadPump in these tests — handleMessage publishes to a nil
+// *nats.Conn and the panic inside the ReadPump goroutine would kill the test
+// binary. The join/leave message types are NATS-free and safe.
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/gorilla/websocket"
+	"github.com/lestrrat-go/jwx/v2/jwk"
+	goredis "github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/university-ecosystem/ws-hub/pkg/config"
+)
+
+// ---------------------------------------------------------------------------
+// Mock RESP server (GETDEL-aware) — ported from uni-cli's setupMockRedisServer
+// ---------------------------------------------------------------------------
+
+// startTicketRESPServer serves the minimal RESP dialect go-redis needs for
+// ticket validation. getdelReply == "" replies nil ($-1) — ticket not found.
+// respondTicketRESP writes a canned RESP reply for the uppercased request
+// fragment. Extracted from the accept loop to keep startTicketRESPServer under
+// the gocognit gate (mirrors the respondRESP idiom in cmd/uni-cli/main_test.go).
+func respondTicketRESP(write func(string), upper, getdelReply string) {
+	switch {
+	case strings.Contains(upper, "HELLO"):
+		write("-ERR unknown command 'HELLO'\r\n")
+	case strings.Contains(upper, "CLIENT"):
+		write("-ERR unknown command 'CLIENT'\r\n")
+	case strings.Contains(upper, "PING"):
+		write("+PONG\r\n")
+	case strings.Contains(upper, "GETDEL"):
+		if getdelReply == "" {
+			write("$-1\r\n") // RESP nil bulk string → ticket not found
+		} else {
+			write(fmt.Sprintf("$%d\r\n%s\r\n", len(getdelReply), getdelReply))
+		}
+	default:
+		write("+OK\r\n")
+	}
+}
+
+// handleTicketConn serves one mock-Redis connection until it closes.
+func handleTicketConn(c net.Conn, getdelReply string) {
+	defer func() { _ = c.Close() }()                      //nolint:errcheck // mock cleanup
+	write := func(s string) { _, _ = c.Write([]byte(s)) } //nolint:errcheck // best-effort
+	buf := make([]byte, 2048)
+	for {
+		n, err := c.Read(buf)
+		if err != nil {
+			return
+		}
+		for _, part := range strings.Split(string(buf[:n]), "*") {
+			if part == "" {
+				continue
+			}
+			respondTicketRESP(write, strings.ToUpper(part), getdelReply)
+		}
+	}
+}
+
+func startTicketRESPServer(t *testing.T, getdelReply string) string {
+	t.Helper()
+	var lc net.ListenConfig
+	ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() }) //nolint:errcheck // mock server cleanup
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go handleTicketConn(conn, getdelReply)
+		}
+	}()
+	return ln.Addr().String()
+}
+
+func hubWithTicketRedis(t *testing.T, getdelReply string) *Hub {
+	t.Helper()
+	addr := startTicketRESPServer(t, getdelReply)
+	h := setupTestHub()
+	h.redisClient = goredis.NewClient(&goredis.Options{Addr: addr})
+	t.Cleanup(func() { _ = h.redisClient.Close() }) //nolint:errcheck // test cleanup
+	return h
+}
+
+const validTicket = "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff" // pragma: allowlist secret
+
+// ---------------------------------------------------------------------------
+// validateUpgradeTicket
+// ---------------------------------------------------------------------------
+
+func TestValidateUpgradeTicket_NoRedisConfigured(t *testing.T) {
+	h := setupTestHub() // redisClient nil
+	_, err := h.validateUpgradeTicket(context.Background(), validTicket)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "redis not available")
+}
+
+func TestValidateUpgradeTicket_RejectsBadFormat(t *testing.T) {
+	// Format checks run after the nil-redis guard, so a (never-reached)
+	// RESP server is required for these cases to hit the format branches.
+	h := hubWithTicketRedis(t, "unused:unused")
+	cases := []struct {
+		name   string
+		ticket string
+		errSub string
+	}{
+		{"too short", "abc123", "invalid ticket length"},
+		{"too long", strings.Repeat("a", 65), "invalid ticket length"},
+		{"bad charset uppercase", strings.Repeat("A", 64), "invalid ticket charset"},
+		{"bad charset symbol", strings.Repeat("a", 63) + "!", "invalid ticket charset"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := h.validateUpgradeTicket(context.Background(), tc.ticket)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.errSub)
+		})
+	}
+}
+
+func TestValidateUpgradeTicket_NotFound(t *testing.T) {
+	h := hubWithTicketRedis(t, "") // GETDEL → nil
+	_, err := h.validateUpgradeTicket(context.Background(), validTicket)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found or already used")
+}
+
+func TestValidateUpgradeTicket_MalformedPayloads(t *testing.T) {
+	cases := []struct {
+		name  string
+		reply string
+	}{
+		{"no colon", "user-without-jti"},
+		{"empty user", ":jti-only"},
+		{"trailing colon", "user-1:"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := hubWithTicketRedis(t, tc.reply)
+			_, err := h.validateUpgradeTicket(context.Background(), validTicket)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "malformed ticket payload")
+		})
+	}
+}
+
+func TestValidateUpgradeTicket_HappyPath(t *testing.T) {
+	h := hubWithTicketRedis(t, "user-77:jti-42")
+	userID, err := h.validateUpgradeTicket(context.Background(), validTicket)
+	require.NoError(t, err)
+	assert.Equal(t, "user-77", userID)
+}
+
+// ---------------------------------------------------------------------------
+// RS256 / JWKS validation
+// ---------------------------------------------------------------------------
+
+func startJWKSServer(t *testing.T, pub *rsa.PublicKey, kid string) *httptest.Server {
+	t.Helper()
+	key, err := jwk.FromRaw(pub)
+	require.NoError(t, err)
+	require.NoError(t, key.Set(jwk.KeyIDKey, kid))
+	require.NoError(t, key.Set(jwk.AlgorithmKey, "RS256"))
+	set := jwk.NewSet()
+	require.NoError(t, set.AddKey(key))
+	body, err := json.Marshal(set)
+	require.NoError(t, err)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body) //nolint:errcheck // test server best-effort
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func signRS256(t *testing.T, priv *rsa.PrivateKey, kid string, claims jwt.MapClaims) string {
+	t.Helper()
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	token.Header["kid"] = kid
+	signed, err := token.SignedString(priv)
+	require.NoError(t, err)
+	return signed
+}
+
+func TestSetupJWKS_EmptyURLIsNoop(t *testing.T) {
+	h := setupTestHub()
+	require.NoError(t, h.SetupJWKS(context.Background(), ""))
+	assert.False(t, h.HasJWKSCache())
+}
+
+func TestValidateToken_RS256Paths(t *testing.T) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	srv := startJWKSServer(t, &priv.PublicKey, "kid-1")
+
+	h := setupTestHub()
+	ctx := context.Background()
+	require.NoError(t, h.SetupJWKS(ctx, srv.URL))
+	assert.True(t, h.HasJWKSCache())
+
+	t.Run("valid token returns sub", func(t *testing.T) {
+		token := signRS256(t, priv, "kid-1", jwt.MapClaims{
+			"sub": "user-rs",
+			"exp": time.Now().Add(time.Hour).Unix(),
+		})
+		sub, err := h.ValidateToken(ctx, token, nil)
+		require.NoError(t, err)
+		assert.Equal(t, "user-rs", sub)
+	})
+
+	t.Run("expired token rejected", func(t *testing.T) {
+		token := signRS256(t, priv, "kid-1", jwt.MapClaims{
+			"sub": "user-rs",
+			"exp": time.Now().Add(-time.Hour).Unix(),
+		})
+		_, err := h.ValidateToken(ctx, token, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("missing sub rejected", func(t *testing.T) {
+		token := signRS256(t, priv, "kid-1", jwt.MapClaims{
+			"exp": time.Now().Add(time.Hour).Unix(),
+		})
+		_, err := h.ValidateToken(ctx, token, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("unknown kid triggers force-refresh retry then rejects", func(t *testing.T) {
+		// Reset the package-level cooldown so tryForceRefreshJWKS actually fires.
+		_lastJWKSForceRefreshUnix.Store(0)
+		token := signRS256(t, priv, "kid-unknown", jwt.MapClaims{
+			"sub": "user-rs",
+			"exp": time.Now().Add(time.Hour).Unix(),
+		})
+		_, err := h.ValidateToken(ctx, token, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid RS256 token")
+	})
+
+	t.Run("unsupported algorithm rejected", func(t *testing.T) {
+		// HS384-signed token → neither RS256 nor HS256 path accepts it.
+		hsToken := jwt.NewWithClaims(jwt.SigningMethodHS384, jwt.MapClaims{"sub": "x"})
+		signed, err := hsToken.SignedString([]byte("secret")) // pragma: allowlist secret
+		require.NoError(t, err)
+		_, err = h.ValidateToken(ctx, signed, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported JWT algorithm")
+	})
+}
+
+func TestValidateRS256_WithoutJWKSConfigured(t *testing.T) {
+	h := setupTestHub()
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	token := signRS256(t, priv, "kid-x", jwt.MapClaims{
+		"sub": "u",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+	_, err = h.ValidateToken(context.Background(), token, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "JWKS not configured")
+}
+
+// ---------------------------------------------------------------------------
+// HandleWebSocket — full upgrade → join → broadcast → deliver E2E
+// ---------------------------------------------------------------------------
+
+func TestHandleWebSocket_E2EUpgradeJoinAndDeliver(t *testing.T) {
+	h := hubWithTicketRedis(t, "user-e2e:jti-1")
+	cfg := &config.Config{SendBufferSize: 8}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		h.Run(ctx)
+	}()
+	defer func() { cancel(); <-done }()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h.HandleWebSocket(w, r, cfg)
+	}))
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "?ticket=" + validTicket
+	conn, resp, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	require.NoError(t, err)
+	if resp != nil && resp.Body != nil {
+		_ = resp.Body.Close() //nolint:errcheck // handshake response cleanup
+	}
+	defer func() { _ = conn.Close() }() //nolint:errcheck // test cleanup
+
+	// Registered under the ticket's user id.
+	require.Eventually(t, func() bool {
+		h.mu.RLock()
+		defer h.mu.RUnlock()
+		_, ok := h.Clients["user-e2e"]
+		return ok
+	}, 2*time.Second, 10*time.Millisecond)
+
+	// Join a room through ReadPump (NATS-free message type).
+	require.NoError(t, conn.WriteJSON(map[string]string{"type": "join", "room": "room-e2e"}))
+	require.Eventually(t, func() bool {
+		h.mu.RLock()
+		defer h.mu.RUnlock()
+		return len(h.Rooms["room-e2e"]) == 1
+	}, 2*time.Second, 10*time.Millisecond)
+
+	// Room broadcast must reach the dialed connection through WritePump.
+	h.Broadcast <- &Message{Type: "room-news", Room: "room-e2e", Payload: []byte(`{"k":"v"}`)}
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(2*time.Second)))
+	var got Message
+	require.NoError(t, conn.ReadJSON(&got))
+	assert.Equal(t, "room-news", got.Type)
+	assert.Equal(t, "room-e2e", got.Room)
+
+	// Closing the socket unregisters the client via ReadPump teardown.
+	require.NoError(t, conn.Close())
+	require.Eventually(t, func() bool {
+		h.mu.RLock()
+		defer h.mu.RUnlock()
+		_, ok := h.Clients["user-e2e"]
+		return !ok
+	}, 2*time.Second, 10*time.Millisecond)
+}
+
+func TestHandleWebSocket_RejectsDisallowedOrigin(t *testing.T) {
+	SetAllowedOrigins([]string{"http://allowed.example"})
+	defer SetAllowedOrigins(nil)
+
+	h := hubWithTicketRedis(t, "user-origin:jti-1")
+	cfg := &config.Config{SendBufferSize: 8}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h.HandleWebSocket(w, r, cfg)
+	}))
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "?ticket=" + validTicket
+	header := http.Header{"Origin": []string{"http://evil.example"}}
+	conn, resp, err := websocket.DefaultDialer.Dial(wsURL, header) //nolint:bodyclose // closed below when non-nil
+	require.Error(t, err)
+	if resp != nil && resp.Body != nil {
+		_ = resp.Body.Close() //nolint:errcheck // handshake response cleanup
+	}
+	if conn != nil {
+		_ = conn.Close() //nolint:errcheck // defensive
+	}
+}
+
+func TestHandleWebSocket_InvalidTicketRejected(t *testing.T) {
+	h := hubWithTicketRedis(t, "") // GETDEL nil → ticket not found
+	cfg := &config.Config{SendBufferSize: 8}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h.HandleWebSocket(w, r, cfg)
+	}))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "?ticket=" + validTicket) //nolint:noctx // plain GET against local test server
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }() //nolint:errcheck // test cleanup
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}

--- a/services/ws-hub/pkg/hub/hub_nats_test.go
+++ b/services/ws-hub/pkg/hub/hub_nats_test.go
@@ -1,0 +1,374 @@
+package hub
+
+// Coverage tests (testing session 9) for the NATS message handlers, the
+// Run loop + broadcastMessage fan-out and Stop idempotency.
+//
+// The NATS handler closures (handleChat / handleNotifications /
+// handleCacheInvalidation) are invoked DIRECTLY with synthetic *nats.Msg
+// values — no NATS connection is needed. msg.Reply is left empty so the
+// JetStream NakWithDelay branch is never reached (it would require a live
+// connection).
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/university-ecosystem/ws-hub/pkg/config"
+)
+
+// recordingAuthClient records Invalidate calls; mutex-guarded for -race.
+type recordingAuthClient struct {
+	mu          sync.Mutex
+	invalidated [][2]string
+}
+
+func (r *recordingAuthClient) CanJoinRoom(_ context.Context, _, _ string) bool { return true }
+
+func (r *recordingAuthClient) Invalidate(userID, room string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.invalidated = append(r.invalidated, [2]string{userID, room})
+}
+
+func (r *recordingAuthClient) calls() [][2]string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([][2]string, len(r.invalidated))
+	copy(out, r.invalidated)
+	return out
+}
+
+func newNatsTestHub(auth RoomAuthClient, secret string, broadcastCap int) *Hub {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	cfg := &config.Config{
+		MaxClients:          10,
+		BroadcastBufferSize: broadcastCap,
+		BroadcastWorkers:    1,
+		ClientMsgRateLimit:  10,
+		ClientMsgRateBurst:  10,
+		InternalSecret:      secret,
+	}
+	return NewHub(nil, logger, auth, cfg, nil)
+}
+
+func recvBroadcast(t *testing.T, h *Hub) *Message {
+	t.Helper()
+	select {
+	case msg := <-h.Broadcast:
+		return msg
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected a message on h.Broadcast")
+		return nil
+	}
+}
+
+// ---------------------------------------------------------------------------
+// handleChat
+// ---------------------------------------------------------------------------
+
+func TestHandleChat_ValidMessageLandsOnBroadcast(t *testing.T) {
+	h := newNatsTestHub(&mockAuthClient{allowed: true}, "", 10)
+	handler := h.handleChat(context.Background())
+
+	payload := []byte(`{"type":"new_message","room":"room-1","payload":{"text":"hi"}}`)
+	handler(&nats.Msg{Subject: "chat.room-1", Data: payload})
+
+	msg := recvBroadcast(t, h)
+	assert.Equal(t, "new_message", msg.Type)
+	assert.Equal(t, "room-1", msg.Room)
+}
+
+func TestHandleChat_MalformedJSONDropped(t *testing.T) {
+	h := newNatsTestHub(&mockAuthClient{allowed: true}, "", 10)
+	handler := h.handleChat(context.Background())
+
+	handler(&nats.Msg{Subject: "chat.room-1", Data: []byte("{not-json")})
+
+	select {
+	case msg := <-h.Broadcast:
+		t.Fatalf("expected no broadcast for malformed payload, got %+v", msg)
+	default:
+	}
+}
+
+func TestHandleChat_CancelledContextReturnsEarly(t *testing.T) {
+	h := newNatsTestHub(&mockAuthClient{allowed: true}, "", 10)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	handler := h.handleChat(ctx)
+
+	handler(&nats.Msg{Subject: "chat.room-1", Data: []byte(`{"type":"x"}`)})
+
+	select {
+	case msg := <-h.Broadcast:
+		t.Fatalf("expected no broadcast after context cancel, got %+v", msg)
+	default:
+	}
+}
+
+func TestHandleChat_FullChannelDropsWithoutNak(t *testing.T) {
+	h := newNatsTestHub(&mockAuthClient{allowed: true}, "", 1)
+	handler := h.handleChat(context.Background())
+
+	// Fill the capacity-1 channel, then deliver a second message.
+	handler(&nats.Msg{Subject: "chat.a", Data: []byte(`{"type":"first","room":"a"}`)})
+	handler(&nats.Msg{Subject: "chat.a", Data: []byte(`{"type":"second","room":"a"}`)})
+
+	first := recvBroadcast(t, h)
+	assert.Equal(t, "first", first.Type)
+	select {
+	case msg := <-h.Broadcast:
+		t.Fatalf("second message should have been dropped, got %+v", msg)
+	default:
+	}
+}
+
+// ---------------------------------------------------------------------------
+// handleNotifications
+// ---------------------------------------------------------------------------
+
+func TestHandleNotifications_OverridesType(t *testing.T) {
+	h := newNatsTestHub(&mockAuthClient{allowed: true}, "", 10)
+	handler := h.handleNotifications(context.Background())
+
+	payload := []byte(`{"type":"whatever","to":"user-1","payload":{"title":"t"}}`)
+	handler(&nats.Msg{Subject: "notifications.user-1", Data: payload})
+
+	msg := recvBroadcast(t, h)
+	assert.Equal(t, "notification", msg.Type)
+	assert.Equal(t, "user-1", msg.To)
+}
+
+func TestHandleNotifications_MalformedDropped(t *testing.T) {
+	h := newNatsTestHub(&mockAuthClient{allowed: true}, "", 10)
+	handler := h.handleNotifications(context.Background())
+
+	handler(&nats.Msg{Subject: "notifications.u", Data: []byte("not json")})
+
+	select {
+	case <-h.Broadcast:
+		t.Fatal("expected malformed notification to be dropped")
+	default:
+	}
+}
+
+// ---------------------------------------------------------------------------
+// handleCacheInvalidation — HMAC-signed internal events
+// ---------------------------------------------------------------------------
+
+type invalidationData struct {
+	RoomID    string `json:"room_id"`
+	Timestamp uint64 `json:"timestamp"`
+	UserID    string `json:"user_id"`
+}
+
+func signedInvalidationPayload(t *testing.T, secret string, data invalidationData) []byte {
+	t.Helper()
+	dataBytes, err := json.Marshal(data)
+	require.NoError(t, err)
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, err = mac.Write(dataBytes)
+	require.NoError(t, err)
+	signature := hex.EncodeToString(mac.Sum(nil))
+
+	full, err := json.Marshal(map[string]any{
+		"data":      data,
+		"signature": signature,
+	})
+	require.NoError(t, err)
+	return full
+}
+
+func TestHandleCacheInvalidation_ValidSignature(t *testing.T) {
+	auth := &recordingAuthClient{}
+	h := newNatsTestHub(auth, "internal-secret", 10) // pragma: allowlist secret
+	handler := h.handleCacheInvalidation(context.Background())
+
+	payload := signedInvalidationPayload(t, "internal-secret",
+		invalidationData{RoomID: "room-9", Timestamp: 1234, UserID: "user-9"})
+	handler(&nats.Msg{Subject: "cache.invalidate", Data: payload})
+
+	calls := auth.calls()
+	require.Len(t, calls, 1)
+	assert.Equal(t, [2]string{"user-9", "room-9"}, calls[0])
+}
+
+func TestHandleCacheInvalidation_BadSignatureDropped(t *testing.T) {
+	auth := &recordingAuthClient{}
+	h := newNatsTestHub(auth, "internal-secret", 10) // pragma: allowlist secret
+	handler := h.handleCacheInvalidation(context.Background())
+
+	payload := signedInvalidationPayload(t, "WRONG-secret",
+		invalidationData{RoomID: "room-9", Timestamp: 1234, UserID: "user-9"})
+	handler(&nats.Msg{Subject: "cache.invalidate", Data: payload})
+
+	assert.Empty(t, auth.calls())
+}
+
+func TestHandleCacheInvalidation_MalformedAndBadHexDropped(t *testing.T) {
+	auth := &recordingAuthClient{}
+	h := newNatsTestHub(auth, "internal-secret", 10) // pragma: allowlist secret
+	handler := h.handleCacheInvalidation(context.Background())
+
+	handler(&nats.Msg{Subject: "cache.invalidate", Data: []byte("{broken")})
+
+	// Valid JSON but non-hex signature → hex decode error branch.
+	data, err := json.Marshal(map[string]any{
+		"data":      invalidationData{RoomID: "r", Timestamp: 1, UserID: "u"},
+		"signature": "zz-not-hex",
+	})
+	require.NoError(t, err)
+	handler(&nats.Msg{Subject: "cache.invalidate", Data: data})
+
+	assert.Empty(t, auth.calls())
+}
+
+// ---------------------------------------------------------------------------
+// Run loop + broadcastMessage fan-out
+// ---------------------------------------------------------------------------
+
+func startHubRunLoop(t *testing.T, h *Hub) (context.CancelFunc, chan struct{}) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		h.Run(ctx)
+	}()
+	return cancel, done
+}
+
+func registerLoopClient(t *testing.T, h *Hub, id string, sendCap int) *Client {
+	t.Helper()
+	client := &Client{
+		ID:    id,
+		Rooms: make(map[string]bool),
+		Send:  make(chan []byte, sendCap),
+		Hub:   h,
+		ctx:   context.Background(),
+	}
+	select {
+	case h.Register <- client:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run loop did not consume Register")
+	}
+	require.Eventually(t, func() bool {
+		h.mu.RLock()
+		defer h.mu.RUnlock()
+		_, ok := h.Clients[id]
+		return ok
+	}, 2*time.Second, 10*time.Millisecond)
+	return client
+}
+
+func recvSend(t *testing.T, c *Client) Message {
+	t.Helper()
+	select {
+	case data := <-c.Send:
+		var msg Message
+		require.NoError(t, json.Unmarshal(data, &msg))
+		return msg
+	case <-time.After(2 * time.Second):
+		t.Fatalf("client %s did not receive a message", c.ID)
+		return Message{}
+	}
+}
+
+func TestRunLoop_RoomDirectAndGlobalDelivery(t *testing.T) {
+	h := newNatsTestHub(&mockAuthClient{allowed: true}, "", 10)
+	cancel, done := startHubRunLoop(t, h)
+	defer func() { cancel(); <-done }()
+
+	alice := registerLoopClient(t, h, "alice", 8)
+	bob := registerLoopClient(t, h, "bob", 8)
+
+	// Join alice to a room directly under the documented lock hierarchy.
+	h.mu.Lock()
+	h.Rooms["room-1"] = map[*Client]bool{alice: true}
+	h.mu.Unlock()
+	alice.mu.Lock()
+	alice.Rooms["room-1"] = true
+	alice.mu.Unlock()
+
+	// Room-scoped: only alice receives.
+	h.Broadcast <- &Message{Type: "room-msg", Room: "room-1", Payload: []byte(`{}`)}
+	got := recvSend(t, alice)
+	assert.Equal(t, "room-msg", got.Type)
+
+	// Direct: only bob receives.
+	h.Broadcast <- &Message{Type: "direct-msg", To: "bob", Payload: []byte(`{}`)}
+	got = recvSend(t, bob)
+	assert.Equal(t, "direct-msg", got.Type)
+
+	// Global: both receive.
+	h.Broadcast <- &Message{Type: "global-msg", Payload: []byte(`{}`)}
+	assert.Equal(t, "global-msg", recvSend(t, alice).Type)
+	assert.Equal(t, "global-msg", recvSend(t, bob).Type)
+}
+
+func TestRunLoop_OversizedBroadcastDropped(t *testing.T) {
+	h := newNatsTestHub(&mockAuthClient{allowed: true}, "", 10)
+	cancel, done := startHubRunLoop(t, h)
+	defer func() { cancel(); <-done }()
+
+	alice := registerLoopClient(t, h, "alice", 8)
+
+	// Oversized (>60 KB once marshalled) then a small follow-up: only the
+	// follow-up must arrive, proving the oversized one was dropped.
+	big := strings.Repeat("x", 61*1024)
+	payload, err := json.Marshal(map[string]string{"blob": big})
+	require.NoError(t, err)
+	h.Broadcast <- &Message{Type: "oversized", Payload: payload}
+	h.Broadcast <- &Message{Type: "small", Payload: []byte(`{}`)}
+
+	got := recvSend(t, alice)
+	assert.Equal(t, "small", got.Type)
+}
+
+func TestRunLoop_GlobalBroadcastEvictsFullClient(t *testing.T) {
+	h := newNatsTestHub(&mockAuthClient{allowed: true}, "", 10)
+	cancel, done := startHubRunLoop(t, h)
+	defer func() { cancel(); <-done }()
+
+	healthy := registerLoopClient(t, h, "healthy", 8)
+	// Unbuffered Send channel with no reader → safeSend fails → evictOnFull.
+	stuck := registerLoopClient(t, h, "stuck", 0)
+	_ = stuck
+
+	h.Broadcast <- &Message{Type: "global", Payload: []byte(`{}`)}
+	assert.Equal(t, "global", recvSend(t, healthy).Type)
+
+	require.Eventually(t, func() bool {
+		h.mu.RLock()
+		defer h.mu.RUnlock()
+		_, ok := h.Clients["stuck"]
+		return !ok
+	}, 2*time.Second, 10*time.Millisecond, "stuck client should be evicted")
+}
+
+// ---------------------------------------------------------------------------
+// Stop / HasJWKSCache
+// ---------------------------------------------------------------------------
+
+func TestStop_IsIdempotent(t *testing.T) {
+	h := newNatsTestHub(&mockAuthClient{allowed: true}, "", 10)
+	h.Stop()
+	h.Stop() // second call must be a no-op (stopOnce)
+}
+
+func TestHasJWKSCache_FalseWithoutSetup(t *testing.T) {
+	h := newNatsTestHub(&mockAuthClient{allowed: true}, "", 10)
+	assert.False(t, h.HasJWKSCache())
+}

--- a/tests/test_compliance_service_coverage.py
+++ b/tests/test_compliance_service_coverage.py
@@ -1,0 +1,239 @@
+"""Coverage tests for app/services/user/compliance_service.py (testing session 9).
+
+AsyncMock repo + fake-UoW harness (mirrors tests/test_audit_service.py style)
+targeting the previously-uncovered branches: register_user invite validation
+(L249-264) + generic-exception rollback wrap (L291-301), create_user permission
+/ invite branches (L312-320) and the IntegrityError email-vs-other split
+(L336-341), plus export/delete guard clauses (L103, 207, 213).
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from app.core.exceptions.domain import (
+    BusinessRuleViolation,
+    EntityAlreadyExists,
+    EntityNotFound,
+    PermissionDenied,
+)
+from app.models.enums import UserRole
+from app.schemas import schemas
+from app.services.user import compliance_service as compliance_module
+from app.services.user.compliance_service import UserComplianceService
+
+
+class _FakeUoW:
+    """Minimal async-context UoW double exposing the repo + commit/rollback."""
+
+    def __init__(self, repo: AsyncMock) -> None:
+        self.users = repo
+        self.commit = AsyncMock()
+        self.rollback = AsyncMock()
+
+    async def __aenter__(self) -> _FakeUoW:
+        return self
+
+    async def __aexit__(self, *exc) -> None:
+        return None
+
+
+@pytest.fixture
+def repo() -> AsyncMock:
+    mock = AsyncMock()
+    mock.db = AsyncMock()
+    return mock
+
+
+@pytest.fixture
+def svc(repo: AsyncMock) -> UserComplianceService:
+    return UserComplianceService(_FakeUoW(repo), audit=MagicMock())  # type: ignore[arg-type]
+
+
+@pytest.fixture
+def fast_hash(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        compliance_module, "get_password_hash", AsyncMock(return_value="hashed")
+    )
+    monkeypatch.setattr(
+        compliance_module.settings, "password_hibp_check_enabled", False
+    )
+
+
+def _user_create(**overrides) -> schemas.UserCreate:
+    defaults = {
+        "email": "New.User@Example.com",
+        "password": "Password-123!",  # pragma: allowlist secret
+        "full_name": "New User",
+    }
+    defaults.update(overrides)
+    return schemas.UserCreate(**defaults)
+
+
+def _request() -> MagicMock:
+    request = MagicMock()
+    request.client.host = "127.0.0.1"
+    request.headers = {}
+    return request
+
+
+# ---------------------------------------------------------------------------
+# export_user_data / delete_user_data guard clauses
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_export_user_data_missing_user_raises(svc, repo):
+    repo.get.return_value = None
+    user = MagicMock(id=uuid.uuid4())
+    with pytest.raises(EntityNotFound):
+        await svc.export_user_data(user, request=_request())
+
+
+@pytest.mark.asyncio
+async def test_delete_user_data_requires_confirmation(svc):
+    user = MagicMock(id=uuid.uuid4())
+    with pytest.raises(BusinessRuleViolation):
+        await svc.delete_user_data(user, request=_request(), confirm=False)
+
+
+@pytest.mark.asyncio
+async def test_delete_user_data_missing_user_raises(svc, repo):
+    repo._get_orm.return_value = None
+    user = MagicMock(id=uuid.uuid4())
+    with pytest.raises(EntityNotFound):
+        await svc.delete_user_data(user, request=_request(), confirm=True)
+
+
+# ---------------------------------------------------------------------------
+# register_user — invite-code validation (L249-264)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "code_obj",
+    [
+        None,
+        MagicMock(role="student", is_active=True, is_used=False),  # wrong role
+        MagicMock(role="teacher", is_active=False, is_used=False),  # inactive
+        MagicMock(role="teacher", is_active=True, is_used=True),  # already used
+    ],
+)
+async def test_register_user_rejects_invalid_invite(svc, repo, fast_hash, code_obj):
+    repo.check_email_exists.return_value = False
+    repo.get_invite_code.return_value = code_obj
+
+    user_in = _user_create(role=UserRole.TEACHER, invite_code="CODE-1")
+    with pytest.raises(BusinessRuleViolation):
+        await svc.register_user(user_in)
+    repo.create_with_invite.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_register_user_duplicate_email_raises(svc, repo, fast_hash):
+    repo.check_email_exists.return_value = True
+    with pytest.raises(EntityAlreadyExists):
+        await svc.register_user(_user_create())
+
+
+@pytest.mark.asyncio
+async def test_register_user_success_with_valid_invite(svc, repo, fast_hash):
+    repo.check_email_exists.return_value = False
+    valid_code = MagicMock(role="teacher", is_active=True, is_used=False)
+    repo.get_invite_code.return_value = valid_code
+    created = MagicMock()
+    repo.create_with_invite.return_value = created
+
+    user_in = _user_create(role=UserRole.TEACHER, invite_code="CODE-OK")
+    result = await svc.register_user(user_in)
+
+    assert result is created
+    repo.create_with_invite.assert_awaited_once()
+    call_args = repo.create_with_invite.await_args.args
+    user_data = call_args[0]
+    # Email normalized, password replaced by hash, role threaded through.
+    assert user_data["email"] == "new.user@example.com"
+    assert user_data["hashed_password"] == "hashed"  # pragma: allowlist secret
+    assert user_data["role"] == "teacher"
+    assert "password" not in user_data
+    assert call_args[1] is valid_code
+
+
+@pytest.mark.asyncio
+async def test_register_user_wraps_generic_failure(svc, repo, fast_hash):
+    repo.check_email_exists.return_value = False
+    repo.create_with_invite.side_effect = RuntimeError("db down")
+
+    with pytest.raises(BusinessRuleViolation):
+        await svc.register_user(_user_create())
+    svc.uow.rollback.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# create_user — admin guard + invite branches + IntegrityError split
+# ---------------------------------------------------------------------------
+
+
+def _admin() -> MagicMock:
+    admin = MagicMock()
+    admin.role = "admin"
+    return admin
+
+
+@pytest.mark.asyncio
+async def test_create_user_requires_admin(svc, fast_hash):
+    student = MagicMock()
+    student.role = "student"
+    with pytest.raises(PermissionDenied):
+        await svc.create_user(_user_create(), request=_request(), current_user=student)
+
+
+@pytest.mark.asyncio
+async def test_create_user_unknown_invite_code_rejected(svc, repo, fast_hash):
+    repo.get_invite_code.return_value = None
+    data = _user_create(invite_code="MISSING")
+    with pytest.raises(BusinessRuleViolation):
+        await svc.create_user(data, request=_request(), current_user=_admin())
+
+
+@pytest.mark.asyncio
+async def test_create_user_teacher_requires_invite(svc, repo, fast_hash):
+    data = _user_create(role=UserRole.TEACHER)
+    with pytest.raises(BusinessRuleViolation):
+        await svc.create_user(data, request=_request(), current_user=_admin())
+
+
+@pytest.mark.asyncio
+async def test_create_user_success(svc, repo, fast_hash):
+    created = MagicMock()
+    repo.create.return_value = created
+    result = await svc.create_user(
+        _user_create(), request=_request(), current_user=_admin()
+    )
+    assert result is created
+    repo.create.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_create_user_integrity_error_on_email(svc, repo, fast_hash):
+    repo.create.side_effect = IntegrityError(
+        "INSERT", {}, Exception("duplicate key value violates users_email_key")
+    )
+    with pytest.raises(EntityAlreadyExists):
+        await svc.create_user(_user_create(), request=_request(), current_user=_admin())
+    svc.uow.rollback.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_create_user_integrity_error_other_constraint(svc, repo, fast_hash):
+    repo.create.side_effect = IntegrityError(
+        "INSERT", {}, Exception("foreign key constraint groups_fk failed")
+    )
+    with pytest.raises(BusinessRuleViolation):
+        await svc.create_user(_user_create(), request=_request(), current_user=_admin())
+    svc.uow.rollback.assert_awaited_once()

--- a/tests/test_notifications_core_coverage.py
+++ b/tests/test_notifications_core_coverage.py
@@ -1,0 +1,208 @@
+"""Coverage tests for app/services/notifications/core.py (testing session 9).
+
+Pure-function branches (``_current_local_time``, ``_plain_text``,
+``_coerce_optional_text``, ``_normalize_translation_map``, ``_build_delivery_row``,
+``_ensure_aware``) plus real-DB coverage for ``_fetch_active_user_ids`` /
+``_fetch_admin_ids`` (L159-194) including the broadcast safety-limit warning.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import uuid
+from datetime import UTC
+from types import SimpleNamespace
+
+import pytest
+
+from app.services.notifications import core
+
+# ---------------------------------------------------------------------------
+# _current_local_time
+# ---------------------------------------------------------------------------
+
+
+def test_current_local_time_no_user_uses_utc():
+    result = core._current_local_time(None)
+    assert isinstance(result, dt.time)
+    assert result.tzinfo is None
+
+
+def test_current_local_time_valid_timezone():
+    user = SimpleNamespace(preferences=SimpleNamespace(timezone="Europe/Moscow"))
+    result = core._current_local_time(user)
+    assert isinstance(result, dt.time)
+
+
+def test_current_local_time_invalid_timezone_falls_back_to_utc():
+    user = SimpleNamespace(preferences=SimpleNamespace(timezone="Not/AZone"))
+    result = core._current_local_time(user)
+    assert isinstance(result, dt.time)
+
+
+def test_current_local_time_blank_and_non_string_timezones():
+    blank = SimpleNamespace(preferences=SimpleNamespace(timezone="   "))
+    non_str = SimpleNamespace(preferences=SimpleNamespace(timezone=123))
+    no_prefs = SimpleNamespace(preferences=None)
+    for user in (blank, non_str, no_prefs):
+        assert isinstance(core._current_local_time(user), dt.time)
+
+
+# ---------------------------------------------------------------------------
+# _plain_text / _coerce_optional_text
+# ---------------------------------------------------------------------------
+
+
+def test_plain_text_none_and_blank():
+    assert core._plain_text(None) is None
+    assert core._plain_text("   ") is None
+    assert core._plain_text("<p>  </p>") is None
+
+
+def test_plain_text_strips_html_and_collapses_whitespace():
+    assert core._plain_text("<p>Hello   <b>world</b></p>") == "Hello world"
+
+
+def test_plain_text_limit_shortens():
+    long_text = "word " * 50
+    result = core._plain_text(long_text, limit=20)
+    assert result is not None
+    assert len(result) <= 20
+    assert result.endswith("…")
+
+
+def test_coerce_optional_text():
+    assert core._coerce_optional_text(None) is None
+    assert core._coerce_optional_text("  ") is None
+    assert core._coerce_optional_text("  x  ") == "x"
+    assert core._coerce_optional_text(42) == "42"
+
+
+# ---------------------------------------------------------------------------
+# _normalize_translation_map
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_translation_map_empty_inputs():
+    assert core._normalize_translation_map(None) == {}
+    assert core._normalize_translation_map({}) == {}
+
+
+def test_normalize_translation_map_filters_unsupported_and_empty():
+    result = core._normalize_translation_map(
+        {
+            "RU": "  Привет  ",
+            "en": "Hello",
+            "xx": "skip-unsupported",
+            "de": None,
+            "ru ": "",
+        }
+    )
+    assert result == {"ru": "Привет", "en": "Hello"}
+
+
+# ---------------------------------------------------------------------------
+# _build_delivery_row
+# ---------------------------------------------------------------------------
+
+
+def test_build_delivery_row_minimal():
+    nid = uuid.uuid4()
+    created = dt.datetime.now(UTC)
+    row = core._build_delivery_row(nid, created, status="skipped")
+    assert row["notification_id"] == nid
+    assert row["status"] == "skipped"
+    assert row["delivered_at"] is None
+    assert "status_code" not in row
+    assert "detail" not in row
+
+
+def test_build_delivery_row_full():
+    nid = uuid.uuid4()
+    created = dt.datetime.now(UTC)
+    attempted = created + dt.timedelta(seconds=1)
+    row = core._build_delivery_row(
+        nid,
+        created,
+        status="sent",
+        subscription_id=uuid.uuid4(),
+        attempted_at=attempted,
+        delivered=True,
+        status_code=201,
+        detail="ok",
+    )
+    assert row["delivered_at"] == attempted
+    assert row["status_code"] == 201
+    assert row["detail"] == "ok"
+
+
+# ---------------------------------------------------------------------------
+# _ensure_aware
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_aware_none_returns_now():
+    before = dt.datetime.now(UTC)
+    result = core._ensure_aware(None)
+    after = dt.datetime.now(UTC)
+    assert before <= result <= after
+
+
+def test_ensure_aware_naive_gets_utc():
+    naive = dt.datetime(2026, 6, 1, 12, 0, 0)
+    result = core._ensure_aware(naive)
+    assert result.tzinfo is UTC
+
+
+def test_ensure_aware_aware_passthrough():
+    aware = dt.datetime(2026, 6, 1, 12, 0, 0, tzinfo=UTC)
+    assert core._ensure_aware(aware) is aware
+
+
+# ---------------------------------------------------------------------------
+# _fetch_active_user_ids / _fetch_admin_ids (real DB)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fetch_active_user_ids_filters_and_excludes(db_session, user_factory):
+    active_a = await user_factory()
+    active_b = await user_factory()
+    inactive = await user_factory(is_active=False)
+
+    ids = await core._fetch_active_user_ids(db_session)
+    assert active_a.id in ids
+    assert active_b.id in ids
+    assert inactive.id not in ids
+
+    excluded = await core._fetch_active_user_ids(
+        db_session, exclude=[active_a.id, None]
+    )
+    assert active_a.id not in excluded
+    assert active_b.id in excluded
+
+
+@pytest.mark.asyncio
+async def test_fetch_active_user_ids_warns_at_safety_limit(
+    db_session, user_factory, monkeypatch, caplog
+):
+    await user_factory()
+    await user_factory()
+    monkeypatch.setattr(core, "_MAX_BROADCAST_RECIPIENTS", 1)
+
+    with caplog.at_level("WARNING"):
+        ids = await core._fetch_active_user_ids(db_session)
+    assert len(ids) == 1
+    assert any("PERF-20-01" in rec.message for rec in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_fetch_admin_ids_only_active_admins(db_session, user_factory):
+    admin = await user_factory(role="admin")
+    inactive_admin = await user_factory(role="admin", is_active=False)
+    student = await user_factory(role="student")
+
+    ids = await core._fetch_admin_ids(db_session)
+    assert admin.id in ids
+    assert inactive_admin.id not in ids
+    assert student.id not in ids

--- a/tests/test_notifications_delivery_coverage.py
+++ b/tests/test_notifications_delivery_coverage.py
@@ -1,0 +1,336 @@
+"""Coverage tests for app/services/notifications/delivery.py (testing session 9).
+
+Targets the previously-uncovered branches of ``create_notifications_for_users``:
+user_filter exclusion, push-disabled early return, skipped_no_subscription,
+payload badge/tag/actions normalization, skipped_topic, sent/error/exception
+delivery rows and the grade-cache invalidation hook.
+
+Harness mirrors tests/test_notifications_service.py (``configured_push_settings``
+vapid fixture + ``send_web_push`` monkeypatch via the module-level override the
+production code explicitly supports at delivery.py L264-277).
+"""
+
+from __future__ import annotations
+
+import typing
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.models import Notification, NotificationDelivery, PushSubscription
+from app.services import stats_cache
+from app.services import webpush as webpush_module
+from app.services.notifications import delivery as notifications_delivery
+from app.services.notifications.delivery import create_notifications_for_users
+from app.services.webpush import WebPushResult
+
+
+def _reset_vapid_cache() -> None:
+    for cached in ("VAPID_PUBLIC_KEY", "VAPID_PRIVATE_KEY", "WEBPUSH_SUBJECT"):
+        settings.__dict__.pop(cached, None)
+
+
+@pytest.fixture
+def push_configured(monkeypatch: pytest.MonkeyPatch) -> typing.Generator[None]:
+    _reset_vapid_cache()
+    monkeypatch.setattr(settings, "vapid_public_key", "test-public-key")
+    monkeypatch.setattr(settings, "vapid_private_key", "test-private-key")
+    monkeypatch.setattr(settings, "vapid_subject", "mailto:test@example.com")
+    yield
+    _reset_vapid_cache()
+
+
+@pytest.fixture
+def push_disabled(monkeypatch: pytest.MonkeyPatch) -> typing.Generator[None]:
+    _reset_vapid_cache()
+    monkeypatch.setattr(settings, "vapid_public_key", "")
+    monkeypatch.setattr(settings, "vapid_private_key", "")
+    yield
+    _reset_vapid_cache()
+
+
+async def _add_subscription(db: AsyncSession, user_id: uuid.UUID) -> PushSubscription:
+    sub = PushSubscription(
+        user_id=user_id,
+        endpoint=f"https://push.example.com/{uuid.uuid4().hex}",
+        p256dh="p256dh-key",  # pragma: allowlist secret
+        auth="auth-key",  # pragma: allowlist secret
+        created_at=datetime.now(UTC),
+        topics=[],
+    )
+    db.add(sub)
+    await db.flush()
+    return sub
+
+
+async def _delivery_rows_for_user(
+    db: AsyncSession, user_id: uuid.UUID
+) -> list[NotificationDelivery]:
+    notif_ids = (
+        (
+            await db.execute(
+                select(Notification.id).where(Notification.user_id == user_id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    if not notif_ids:
+        return []
+    rows = await db.execute(
+        select(NotificationDelivery).where(
+            NotificationDelivery.notification_id.in_(notif_ids)
+        )
+    )
+    return list(rows.scalars().all())
+
+
+@pytest.fixture
+def no_process_results(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _noop(_results):
+        return None
+
+    monkeypatch.setattr(webpush_module, "process_push_results", _noop)
+
+
+# ---------------------------------------------------------------------------
+# Early returns
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_empty_user_ids_returns_zero(db_session):
+    created = await create_notifications_for_users(db_session, title="T", user_ids=[])
+    assert created == 0
+
+
+@pytest.mark.asyncio
+async def test_user_filter_excluding_all_returns_zero(db_session, user_factory):
+    user = await user_factory()
+
+    def _exclude_all(stmt):
+        return stmt.where(False)
+
+    created = await create_notifications_for_users(
+        db_session,
+        title="Filtered",
+        user_ids=[user.id],
+        user_filter=_exclude_all,
+    )
+    assert created == 0
+    notifs = await _delivery_rows_for_user(db_session, user.id)
+    assert notifs == []
+
+
+@pytest.mark.asyncio
+async def test_push_disabled_creates_notifications_without_deliveries(
+    db_session, user_factory, push_disabled
+):
+    user = await user_factory()
+    created = await create_notifications_for_users(
+        db_session, title="In-app only", user_ids=[user.id]
+    )
+    assert created == 1
+    notif = (
+        await db_session.execute(
+            select(Notification).where(Notification.user_id == user.id)
+        )
+    ).scalar_one()
+    assert notif.title == "In-app only"
+    assert await _delivery_rows_for_user(db_session, user.id) == []
+
+
+# ---------------------------------------------------------------------------
+# Push-enabled paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_subscription_records_skipped_row(
+    db_session, user_factory, push_configured
+):
+    user = await user_factory()
+    created = await create_notifications_for_users(
+        db_session, title="No subs", user_ids=[user.id]
+    )
+    assert created == 1
+    rows = await _delivery_rows_for_user(db_session, user.id)
+    assert [r.status for r in rows] == ["skipped_no_subscription"]
+
+
+@pytest.mark.asyncio
+async def test_sent_path_normalizes_payload(
+    db_session, user_factory, push_configured, no_process_results, monkeypatch
+):
+    user = await user_factory()
+    sub = await _add_subscription(db_session, user.id)
+    payloads: list[dict] = []
+
+    def _fake_send(s: PushSubscription, payload: dict[str, object]) -> WebPushResult:
+        payloads.append(dict(payload))
+        return WebPushResult(
+            subscription_id=s.id,
+            endpoint=s.endpoint,
+            user_id=s.user_id,
+            status="sent",
+            status_code=201,
+        )
+
+    monkeypatch.setattr(notifications_delivery, "send_web_push", _fake_send)
+
+    created = await create_notifications_for_users(
+        db_session,
+        title="Rich",
+        body="Body",
+        url="/rich",
+        badge="/badge.png",
+        tag="rich-tag",
+        payload_data={"extra": "value"},
+        actions=[
+            {"action": "open", "title": "Open", "icon": "/i.png", "junk": "drop"},
+            {"action": "no-title"},  # filtered: missing title
+        ],
+        user_ids=[user.id],
+        topic="system",
+    )
+    assert created == 1
+
+    rows = await _delivery_rows_for_user(db_session, user.id)
+    assert len(rows) == 1
+    assert rows[0].status == "sent"
+    assert rows[0].delivered_at is not None
+    assert rows[0].subscription_id == sub.id
+
+    assert len(payloads) == 1
+    sent_payload = payloads[0]
+    assert sent_payload["badge"] == "/badge.png"
+    assert sent_payload["tag"] == "rich-tag"
+    assert sent_payload["data"] == {"extra": "value"}
+    assert sent_payload["actions"] == [
+        {"action": "open", "title": "Open", "icon": "/i.png"}
+    ]
+    assert sent_payload["topic"] == "system"
+
+
+@pytest.mark.asyncio
+async def test_error_result_records_error_row(
+    db_session, user_factory, push_configured, no_process_results, monkeypatch
+):
+    user = await user_factory()
+    await _add_subscription(db_session, user.id)
+
+    def _fake_send(s: PushSubscription, payload: dict[str, object]) -> WebPushResult:
+        return WebPushResult(
+            subscription_id=s.id,
+            endpoint=s.endpoint,
+            user_id=s.user_id,
+            status="error",
+            status_code=500,
+            error="boom",
+        )
+
+    monkeypatch.setattr(notifications_delivery, "send_web_push", _fake_send)
+
+    await create_notifications_for_users(db_session, title="Err", user_ids=[user.id])
+    rows = await _delivery_rows_for_user(db_session, user.id)
+    assert [r.status for r in rows] == ["error"]
+    assert rows[0].delivered_at is None
+    assert rows[0].detail == "boom"
+
+
+@pytest.mark.asyncio
+async def test_send_exception_records_exception_row(
+    db_session, user_factory, push_configured, no_process_results, monkeypatch
+):
+    user = await user_factory()
+    await _add_subscription(db_session, user.id)
+
+    def _raise_send(s: PushSubscription, payload: dict[str, object]) -> WebPushResult:
+        raise RuntimeError("push exploded")
+
+    monkeypatch.setattr(notifications_delivery, "send_web_push", _raise_send)
+
+    await create_notifications_for_users(db_session, title="Boom", user_ids=[user.id])
+    rows = await _delivery_rows_for_user(db_session, user.id)
+    assert [r.status for r in rows] == ["error"]
+    assert rows[0].detail is not None
+    assert rows[0].detail.startswith("exception:")
+
+
+@pytest.mark.asyncio
+async def test_unsupported_topic_records_skipped_topic_row(
+    db_session, user_factory, push_configured, no_process_results, monkeypatch
+):
+    user = await user_factory()
+    await _add_subscription(db_session, user.id)
+    monkeypatch.setattr(
+        notifications_delivery,
+        "subscription_supports_topic",
+        lambda _sub, _topic: False,
+    )
+
+    sent_calls: list = []
+
+    def _fake_send(s, payload):  # pragma: no cover — must not be called
+        sent_calls.append(payload)
+        return WebPushResult(
+            subscription_id=s.id,
+            endpoint=s.endpoint,
+            user_id=s.user_id,
+            status="sent",
+        )
+
+    monkeypatch.setattr(notifications_delivery, "send_web_push", _fake_send)
+
+    await create_notifications_for_users(
+        db_session, title="Topic", user_ids=[user.id], topic="news"
+    )
+    rows = await _delivery_rows_for_user(db_session, user.id)
+    assert [r.status for r in rows] == ["skipped_topic"]
+    assert sent_calls == []
+
+
+@pytest.mark.asyncio
+async def test_grade_type_invalidates_stats_cache(
+    db_session, user_factory, push_disabled, monkeypatch
+):
+    user = await user_factory()
+    invalidate = AsyncMock()
+    monkeypatch.setattr(stats_cache, "invalidate_user_stats_cache", invalidate)
+
+    await create_notifications_for_users(
+        db_session, title="Grade!", type="grade", user_ids=[user.id]
+    )
+    invalidate.assert_awaited_once()
+    kwargs = invalidate.await_args.kwargs
+    assert kwargs["user_ids"] == [user.id]
+    assert kwargs["kinds"] == ("grades",)
+
+
+@pytest.mark.asyncio
+async def test_translations_populate_localized_columns(
+    db_session, user_factory, push_disabled
+):
+    user = await user_factory()
+    await create_notifications_for_users(
+        db_session,
+        title="Fallback title",
+        body="Fallback body",
+        title_translations={"ru": "Заголовок", "en": "Title-EN", "xx": "skip"},
+        body_translations={"ru": "Тело", "en": "Body-EN"},
+        user_ids=[user.id],
+    )
+    notif = (
+        await db_session.execute(
+            select(Notification).where(Notification.user_id == user.id)
+        )
+    ).scalar_one()
+    assert notif.title == "Заголовок"
+    assert notif.title_en == "Title-EN"
+    assert notif.body == "Тело"
+    assert notif.body_en == "Body-EN"

--- a/tests/test_notifications_news_events_coverage.py
+++ b/tests/test_notifications_news_events_coverage.py
@@ -1,0 +1,168 @@
+"""Coverage tests for app/services/notifications/news_events.py (testing session 9).
+
+Targets ``notify_about_comment`` (previously fully uncovered, L383-413).
+``_fetch_admin_ids`` is imported INSIDE the function from
+app.services.notifications.core, so it is monkeypatched on the core module;
+``create_notifications_for_users`` and ``render_notification_template`` are
+module-level imports on news_events and are patched there.
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.services.notifications import core as notifications_core
+from app.services.notifications import news_events
+
+
+def _make_news(**overrides):
+    defaults = {
+        "id": uuid.uuid4(),
+        "title": "Новость",
+        "title_en": "News title",
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _make_comment(content: str = "Great article!"):
+    return SimpleNamespace(content=content)
+
+
+def _make_author(**overrides):
+    defaults = {"full_name": "Иван Петров", "username": "ivan"}
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+@pytest.fixture
+def fake_create(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+    mock = AsyncMock(return_value=3)
+    monkeypatch.setattr(news_events, "create_notifications_for_users", mock)
+    return mock
+
+
+@pytest.fixture
+def admin_ids(monkeypatch: pytest.MonkeyPatch) -> list[uuid.UUID]:
+    ids = [uuid.uuid4(), uuid.uuid4()]
+    monkeypatch.setattr(
+        notifications_core, "_fetch_admin_ids", AsyncMock(return_value=ids)
+    )
+    return ids
+
+
+@pytest.mark.asyncio
+async def test_notify_about_comment_sends_to_admins(fake_create, admin_ids):
+    news = _make_news()
+    result = await news_events.notify_about_comment(
+        AsyncMock(), news, _make_comment(), _make_author(), locale="ru"
+    )
+
+    assert result == 3
+    fake_create.assert_awaited_once()
+    kwargs = fake_create.await_args.kwargs
+    assert kwargs["type"] == "news.comment"
+    assert kwargs["topic"] == "news"
+    assert kwargs["user_ids"] == admin_ids
+    assert kwargs["title"]
+    assert kwargs["body"]
+    assert kwargs["url"]
+    assert kwargs["tag"]
+
+
+@pytest.mark.asyncio
+async def test_notify_about_comment_no_admins_returns_zero(fake_create, monkeypatch):
+    monkeypatch.setattr(
+        notifications_core, "_fetch_admin_ids", AsyncMock(return_value=[])
+    )
+    result = await news_events.notify_about_comment(
+        AsyncMock(), _make_news(), _make_comment(), _make_author()
+    )
+    assert result == 0
+    fake_create.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_notify_about_comment_no_template_returns_zero(
+    fake_create, admin_ids, monkeypatch
+):
+    monkeypatch.setattr(
+        news_events, "render_notification_template", lambda *a, **k: None
+    )
+    result = await news_events.notify_about_comment(
+        AsyncMock(), _make_news(), _make_comment(), _make_author()
+    )
+    assert result == 0
+    fake_create.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_notify_about_comment_localizes_title_en(
+    fake_create, admin_ids, monkeypatch
+):
+    """English locale resolves the localized news title for the template payload."""
+    captured: dict = {}
+
+    def _capture_template(name, payload, *, locale=None):
+        captured["name"] = name
+        captured["payload"] = dict(payload)
+        captured["locale"] = locale
+        return {
+            "title": "t",
+            "body": "b",
+            "url": "/news/1",
+            "tag": "news-comment",
+            "data": {"k": "v"},
+        }
+
+    monkeypatch.setattr(news_events, "render_notification_template", _capture_template)
+    news = _make_news(title="Русский заголовок", title_en="English title")
+    await news_events.notify_about_comment(
+        AsyncMock(), news, _make_comment("c"), _make_author(), locale="en"
+    )
+
+    assert captured["name"] == "news.comment"
+    assert captured["payload"]["news_title"] == "English title"
+    assert captured["payload"]["news_id"] == news.id
+    kwargs = fake_create.await_args.kwargs
+    assert kwargs["payload_data"] == {"k": "v"}
+
+
+@pytest.mark.asyncio
+async def test_notify_about_comment_author_fallback_to_username(
+    fake_create, admin_ids, monkeypatch
+):
+    """Author without full_name falls back to username in the template payload."""
+    captured: dict = {}
+
+    def _capture_template(name, payload, *, locale=None):
+        captured["payload"] = dict(payload)
+        return {"title": "t", "body": "b", "url": "/u", "tag": "tg"}
+
+    monkeypatch.setattr(news_events, "render_notification_template", _capture_template)
+    author = _make_author(full_name=None, username="fallback-user")
+    await news_events.notify_about_comment(
+        AsyncMock(), _make_news(), _make_comment(), author
+    )
+    assert captured["payload"]["user_name"] == "fallback-user"
+
+
+@pytest.mark.asyncio
+async def test_notify_about_comment_payload_defaults_missing_data(
+    fake_create, admin_ids, monkeypatch
+):
+    """Template without a 'data' key sends an empty payload_data mapping."""
+    monkeypatch.setattr(
+        news_events,
+        "render_notification_template",
+        lambda *a, **k: {"title": "t", "body": "b", "url": "/u", "tag": "tg"},
+    )
+    await news_events.notify_about_comment(
+        AsyncMock(), _make_news(), _make_comment(), _make_author()
+    )
+    kwargs = fake_create.await_args.kwargs
+    assert kwargs["payload_data"] == {}

--- a/tests/test_session_service_coverage.py
+++ b/tests/test_session_service_coverage.py
@@ -1,0 +1,324 @@
+"""Coverage tests for app/services/session_service.py (testing session 9).
+
+Targets the previously-uncovered service surface: session listing / lookup /
+revocation methods (L237-296), the Redis-registration warn path (L41-52),
+``_normalize_sub`` validation (L154-162) and the concurrent-session limit
+branches (L164-192).
+
+Harness mirrors tests/test_auth_jwt_rs256.py (``_make_session_service``) and
+the real-DB recipe from tests/test_active_session_repository.py (explicit
+``created_at``, real ``user_factory()`` ids through all FK columns).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import ActiveSession
+from app.services import session_service as session_service_module
+from app.services.session_service import SessionService, register_session_bg
+
+
+def _make_session_service(db_session: AsyncSession) -> SessionService:
+    """Mirror W136 SW1 helper — bypasses async UnitOfWork pattern for unit tests."""
+    from app.repositories.unit_of_work import UnitOfWork
+
+    uow = UnitOfWork(lambda: db_session)
+    uow._session = db_session  # type: ignore[assignment]
+    uow._bind_repositories(db_session)
+    return SessionService(uow)
+
+
+async def _add_session(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    *,
+    jti: str | None = None,
+    revoked: bool = False,
+    created_offset_minutes: int = 0,
+) -> ActiveSession:
+    now = datetime.now(UTC)
+    session = ActiveSession(
+        user_id=user_id,
+        jti=jti or str(uuid.uuid4()),
+        created_at=now + timedelta(minutes=created_offset_minutes),
+        expires_at=now + timedelta(hours=1),
+        revoked_at=now if revoked else None,
+        last_seen_at=now,
+        ip_address="127.0.0.1",
+        user_agent="pytest",
+    )
+    db.add(session)
+    await db.flush()
+    return session
+
+
+# ---------------------------------------------------------------------------
+# register_session_bg — Redis failure warn path (L41-52)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_register_session_bg_swallows_connection_error(monkeypatch):
+    """Redis registration is fire-and-forget: ConnectionError is logged, not raised."""
+
+    async def _raise_backend():
+        raise ConnectionError("redis down")
+
+    monkeypatch.setattr(session_service_module, "get_session_backend", _raise_backend)
+    # Must not raise.
+    await register_session_bg(
+        uuid.uuid4(),
+        "jti-bg",
+        datetime.now(UTC) + timedelta(hours=1),
+        "127.0.0.1",
+        "pytest",
+    )
+
+
+@pytest.mark.asyncio
+async def test_register_session_bg_happy_path(monkeypatch):
+    """Successful path forwards metadata to the session backend."""
+    calls: list[dict] = []
+
+    class _Backend:
+        async def register_session(self, **kwargs):
+            calls.append(kwargs)
+
+    async def _get_backend():
+        return _Backend()
+
+    monkeypatch.setattr(session_service_module, "get_session_backend", _get_backend)
+    user_id = uuid.uuid4()
+    await register_session_bg(
+        user_id,
+        "jti-ok",
+        datetime.now(UTC) + timedelta(hours=1),
+        "10.0.0.1",
+        "agent",
+    )
+    assert len(calls) == 1
+    assert calls[0]["user_id"] == str(user_id)
+    assert calls[0]["jti"] == "jti-ok"
+    assert calls[0]["metadata"]["ip_address"] == "10.0.0.1"
+
+
+# ---------------------------------------------------------------------------
+# _normalize_sub (L154-162)
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_sub_uuid_passthrough(db_session):
+    svc = _make_session_service(db_session)
+    val = uuid.uuid4()
+    assert svc._normalize_sub(val) is val
+
+
+def test_normalize_sub_string_coerced(db_session):
+    svc = _make_session_service(db_session)
+    val = uuid.uuid4()
+    assert svc._normalize_sub(str(val)) == val
+
+
+def test_normalize_sub_invalid_raises(db_session):
+    svc = _make_session_service(db_session)
+    with pytest.raises(ValueError, match="must be a valid UUID"):
+        svc._normalize_sub("not-a-uuid")
+
+
+# ---------------------------------------------------------------------------
+# _enforce_concurrent_limit (L164-192)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_enforce_limit_noop_when_limit_nonpositive(
+    db_session, user_factory, monkeypatch
+):
+    """limit <= 0 short-circuits without querying active sessions."""
+    user = await user_factory()
+    svc = _make_session_service(db_session)
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setattr(session_service_module.settings, "max_sessions_per_user", 0)
+    # Should return immediately; no exception even with no sessions.
+    await svc._enforce_concurrent_limit(user.id, "jti-x", datetime.now(UTC))
+
+
+@pytest.mark.asyncio
+async def test_enforce_limit_raises_403_when_at_capacity(db_session, user_factory):
+    """ENVIRONMENT=testing caps at 2 sessions; the third login is rejected."""
+    user = await user_factory()
+    await _add_session(db_session, user.id)
+    await _add_session(db_session, user.id)
+    svc = _make_session_service(db_session)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await svc._enforce_concurrent_limit(user.id, "jti-new", datetime.now(UTC))
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.detail == "too_many_sessions"
+
+
+# ---------------------------------------------------------------------------
+# create_access_token — full happy path with metadata merge (L69-152)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_access_token_persists_session_and_metadata(
+    db_session, user_factory, monkeypatch
+):
+    captured: list[tuple] = []
+
+    async def _fake_register(*args):
+        captured.append(args)
+
+    monkeypatch.setattr(session_service_module, "register_session_bg", _fake_register)
+
+    user = await user_factory()
+    svc = _make_session_service(db_session)
+    now = datetime.now(UTC)
+    token, session_dto = await svc.create_access_token(
+        str(user.id),
+        metadata={
+            "ip_address": "192.0.2.1",
+            "user_agent": "pytest-agent",
+            "mfa_required": True,
+            "mfa_completed_at": now,
+            "mfa_verified_at": now,
+        },
+    )
+
+    assert isinstance(token, str) and token.count(".") == 2
+    assert session_dto.ip_address == "192.0.2.1"
+    assert session_dto.user_agent == "pytest-agent"
+    assert session_dto.mfa_required is True
+    # Redis sync awaited with the freshly-minted jti
+    assert len(captured) == 1
+    assert captured[0][1] == session_dto.jti
+
+
+# ---------------------------------------------------------------------------
+# get_active_sessions_for_user / get_session_by_id (L237-255)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_active_sessions_excludes_revoked_and_orders_desc(
+    db_session, user_factory
+):
+    user = await user_factory()
+    older = await _add_session(db_session, user.id, created_offset_minutes=-10)
+    newer = await _add_session(db_session, user.id, created_offset_minutes=-1)
+    await _add_session(db_session, user.id, revoked=True)
+
+    svc = _make_session_service(db_session)
+    sessions = await svc.get_active_sessions_for_user(user.id)
+
+    assert [s.jti for s in sessions] == [newer.jti, older.jti]
+
+
+@pytest.mark.asyncio
+async def test_get_session_by_id_found_and_missing(db_session, user_factory):
+    user = await user_factory()
+    row = await _add_session(db_session, user.id)
+    svc = _make_session_service(db_session)
+
+    found = await svc.get_session_by_id(row.id)
+    assert found is not None
+    assert found.jti == row.jti
+
+    assert await svc.get_session_by_id(uuid.uuid4()) is None
+
+
+# ---------------------------------------------------------------------------
+# revoke_session_by_id / revoke_other_sessions (L257-296)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_revoke_session_by_id_revokes_and_rotates_key(
+    db_session, user_factory, monkeypatch
+):
+    revoked_jtis: list[str] = []
+
+    class _Backend:
+        async def revoke_session(self, jti: str):
+            revoked_jtis.append(jti)
+
+    async def _get_backend():
+        return _Backend()
+
+    monkeypatch.setattr("app.auth.redis_session.get_session_backend", _get_backend)
+
+    user = await user_factory()
+    row = await _add_session(db_session, user.id)
+    old_key = row.signing_key
+    svc = _make_session_service(db_session)
+
+    dto = await svc.revoke_session_by_id(row.id)
+    assert dto is not None
+    assert dto.revoked_at is not None
+    assert dto.signing_key != old_key
+    assert revoked_jtis == [row.jti]
+
+
+@pytest.mark.asyncio
+async def test_revoke_session_by_id_missing_returns_none(db_session):
+    svc = _make_session_service(db_session)
+    assert await svc.revoke_session_by_id(uuid.uuid4()) is None
+
+
+@pytest.mark.asyncio
+async def test_revoke_session_by_id_backend_error_is_suppressed(
+    db_session, user_factory, monkeypatch
+):
+    class _Backend:
+        async def revoke_session(self, jti: str):
+            raise RuntimeError("backend down")
+
+    async def _get_backend():
+        return _Backend()
+
+    monkeypatch.setattr("app.auth.redis_session.get_session_backend", _get_backend)
+
+    user = await user_factory()
+    row = await _add_session(db_session, user.id)
+    svc = _make_session_service(db_session)
+
+    dto = await svc.revoke_session_by_id(row.id)
+    assert dto is not None
+    assert dto.revoked_at is not None
+
+
+@pytest.mark.asyncio
+async def test_revoke_other_sessions_keeps_current_jti(db_session, user_factory):
+    user = await user_factory()
+    current = await _add_session(db_session, user.id, jti="current-jti")
+    await _add_session(db_session, user.id)
+    await _add_session(db_session, user.id)
+    svc = _make_session_service(db_session)
+
+    revoked = await svc.revoke_other_sessions(user.id, "current-jti")
+    assert revoked == 2
+
+    remaining = await svc.get_active_sessions_for_user(user.id)
+    assert [s.jti for s in remaining] == [current.jti]
+
+
+@pytest.mark.asyncio
+async def test_revoke_other_sessions_without_current_revokes_all(
+    db_session, user_factory
+):
+    user = await user_factory()
+    await _add_session(db_session, user.id)
+    await _add_session(db_session, user.id)
+    svc = _make_session_service(db_session)
+
+    revoked = await svc.revoke_other_sessions(user.id, None)
+    assert revoked == 2
+    assert await svc.get_active_sessions_for_user(user.id) == []

--- a/tests/test_smoke_pyo3_ext.py
+++ b/tests/test_smoke_pyo3_ext.py
@@ -1,0 +1,100 @@
+"""PyO3 extension-module smoke + CI-import guard (testing session 9, Stream D).
+
+NOTE ON NAMING: the plan called this `test_smoke_pyo3_sanitizer.py` with
+"sanitizer parity", but `rust_ext` exposes schedule-conflict / partition /
+audit-signature functions — there is no HTML sanitizer in the PyO3 crate (that
+lives in the frontend `wasm-sanitizer`, covered by its own native tests). So
+this file delivers the *substance* the plan needed: a hard CI guard that the
+extension-module build still imports + a small FFI smoke that regression-checks
+the Stream-D1 feature-gate (extension-module stays the default), complementing
+the existing `test_smoke_rust_audit.py` / `test_smoke_rust_partitions.py`
+(which use a silent `importorskip` with no CI enforcement).
+"""
+
+import hashlib
+import hmac
+import os
+
+import pytest
+
+CI = os.environ.get("CI", "").strip().lower() == "true"
+
+try:
+    import rust_ext
+
+    _IMPORT_ERROR: ImportError | None = None
+except ImportError as exc:  # pragma: no cover - exercised only when unbuilt
+    rust_ext = None  # type: ignore[assignment]
+    _IMPORT_ERROR = exc
+
+# FFI tests run wherever the extension is built; they skip cleanly when it is
+# not. The CI hard-fail guard below is what turns a missing build into a CI
+# error rather than a silent skip.
+requires_rust_ext = pytest.mark.skipif(
+    rust_ext is None, reason=f"rust_ext not built: {_IMPORT_ERROR}"
+)
+
+
+def test_rust_ext_importable_in_ci():
+    """In CI the extension-module build MUST import — no silent skip.
+
+    The D1 feature-gate keeps `pyo3/extension-module` as the default feature, so
+    maturin/uv produce the same abi3 wheel. If that import ever breaks in CI,
+    this fails loudly instead of the other smoke files silently skipping.
+    """
+    if CI:
+        assert rust_ext is not None, (
+            "rust_ext must be importable under CI=true after the Stream-D1 "
+            f"feature-gate (extension-module is still default); import failed: {_IMPORT_ERROR}"
+        )
+    elif rust_ext is None:
+        pytest.skip(f"rust_ext not built locally: {_IMPORT_ERROR}")
+
+
+@requires_rust_ext
+def test_detect_conflicts_overlap_same_day_parity():
+    target = rust_ext.ScheduleItem("monday", 0, 3600, "both")
+    overlapping = rust_ext.ScheduleItem("monday", 1800, 5400, "both")
+    disjoint = rust_ext.ScheduleItem("monday", 7200, 9000, "both")
+    other_day = rust_ext.ScheduleItem("tuesday", 0, 3600, "both")
+
+    conflicts = rust_ext.detect_conflicts(target, [overlapping, disjoint, other_day])
+    assert len(conflicts) == 1, "only the overlapping same-day item conflicts"
+    assert conflicts[0].start_time == 1800
+
+
+@requires_rust_ext
+def test_detect_conflicts_respects_parity():
+    target = rust_ext.ScheduleItem("monday", 0, 3600, "odd")
+    even_overlap = rust_ext.ScheduleItem("monday", 1800, 5400, "even")
+    # odd vs even on the same slot must NOT conflict (alternating weeks).
+    assert rust_ext.detect_conflicts(target, [even_overlap]) == []
+
+
+@requires_rust_ext
+def test_batch_detect_conflicts_finds_overlapping_pair():
+    a = rust_ext.ScheduleItem("monday", 0, 3600, "both")
+    b = rust_ext.ScheduleItem("monday", 1800, 5400, "both")
+    c = rust_ext.ScheduleItem("tuesday", 0, 3600, "both")
+    pairs = rust_ext.batch_detect_conflicts([a, b, c])
+    assert len(pairs) == 1, "exactly one overlapping pair (a, b)"
+
+
+@requires_rust_ext
+def test_find_optimal_slot_avoids_existing():
+    existing = [rust_ext.ScheduleItem("monday", 0, 3600, "both")]
+    # 60-minute slot somewhere in Monday's 09:00–12:00 window.
+    slot = rust_ext.find_optimal_slot(60, existing, [("monday", [9, 10, 11])])
+    assert slot is not None, "an open slot exists in the available block"
+    assert slot.weekday == "monday"
+
+
+@requires_rust_ext
+def test_verify_audit_signature_ffi_parity():
+    # Mirrors the native Rust HMAC test: a Python-computed HMAC-SHA256 must
+    # verify through the Rust FFI boundary (and a wrong key must not).
+    key = "ffi-parity-key"
+    log_data = "log_9|user_42|action_export|2026-06-13T00:00:00Z"
+    sig = hmac.new(key.encode(), log_data.encode(), hashlib.sha256).hexdigest()
+    assert rust_ext.verify_audit_signature([key], log_data, sig) is True
+    assert rust_ext.verify_audit_signature(["wrong-key"], log_data, sig) is False

--- a/tests/test_user_analytics_service.py
+++ b/tests/test_user_analytics_service.py
@@ -1,0 +1,323 @@
+"""Coverage tests for app/services/user/analytics_service.py (testing session 9).
+
+Pure-function coverage for ``_dt_to_iso`` / ``_parse_grade_payload`` (mirrors
+tests/test_notification_templates_units.py) plus real-DB coverage for the three
+stats methods with ``skip_cache=True`` (mirrors the repository-tier recipe:
+real ``user_factory()`` ids through all FKs, explicit recent ``created_at``).
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+import app.models as models
+from app.services import stats_cache
+from app.services.user.analytics_service import UserAnalyticsService
+
+
+@pytest.fixture
+def svc(db_session: AsyncSession) -> UserAnalyticsService:
+    return UserAnalyticsService(db_session)
+
+
+# ---------------------------------------------------------------------------
+# _dt_to_iso
+# ---------------------------------------------------------------------------
+
+
+def test_dt_to_iso_none_returns_empty(svc):
+    assert svc._dt_to_iso(None) == ""
+
+
+def test_dt_to_iso_naive_coerced_to_utc(svc):
+    naive = datetime(2026, 6, 1, 12, 0, 0)
+    assert svc._dt_to_iso(naive) == "2026-06-01T12:00:00+00:00"
+
+
+def test_dt_to_iso_aware_converted_to_utc(svc):
+    aware = datetime(2026, 6, 1, 12, 0, 0, tzinfo=UTC)
+    assert svc._dt_to_iso(aware) == "2026-06-01T12:00:00+00:00"
+
+
+# ---------------------------------------------------------------------------
+# _parse_grade_payload
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        None,
+        "",
+        "not-json{",
+        json.dumps(["not", "a", "dict"]),
+        json.dumps({"no_score": 1}),
+        json.dumps({"score": "not-a-number"}),
+    ],
+)
+def test_parse_grade_payload_rejects_invalid(svc, body):
+    assert (
+        svc._parse_grade_payload(body, fallback_title="T", fallback_date=None) is None
+    )
+
+
+def test_parse_grade_payload_full_payload(svc):
+    body = json.dumps(
+        {"score": 4.5, "max": 5, "course": "Math", "date": "2026-06-01T10:00:00+00:00"}
+    )
+    parsed = svc._parse_grade_payload(
+        body, fallback_title="Fallback", fallback_date=None
+    )
+    assert parsed == {
+        "course": "Math",
+        "score": 4.5,
+        "max": 5.0,
+        "date": "2026-06-01T10:00:00+00:00",
+    }
+
+
+def test_parse_grade_payload_fallbacks(svc):
+    """Non-numeric max → None; blank course → fallback title; bad date → fallback date."""
+    fallback_dt = datetime(2026, 6, 2, 9, 0, 0, tzinfo=UTC)
+    body = json.dumps(
+        {"score": "3", "max": "abc", "course": "  ", "date": "not-a-date"}
+    )
+    parsed = svc._parse_grade_payload(
+        body, fallback_title="Physics", fallback_date=fallback_dt
+    )
+    assert parsed is not None
+    assert parsed["score"] == 3.0
+    assert parsed["max"] is None
+    assert parsed["course"] == "Physics"
+    assert parsed["date"] == "2026-06-02T09:00:00+00:00"
+
+
+def test_parse_grade_payload_non_string_date_uses_fallback(svc):
+    body = json.dumps({"score": 5, "date": 12345})
+    parsed = svc._parse_grade_payload(body, fallback_title="T", fallback_date=None)
+    assert parsed is not None
+    assert parsed["date"] == ""
+
+
+# ---------------------------------------------------------------------------
+# Real-DB fixtures
+# ---------------------------------------------------------------------------
+
+
+async def _add_attended_event(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    *,
+    title: str = "Event",
+    event_type: str | None = "workshop",
+    hours_ago: int = 2,
+) -> models.Event:
+    """Event in the recent past (inside any period window) + attendance row."""
+    now = datetime.now(UTC)
+    starts = now - timedelta(hours=hours_ago)
+    event = models.Event(
+        title=title,
+        event_type=event_type,
+        starts_at=starts,
+        ends_at=starts + timedelta(hours=1),
+        created_by=user_id,
+        is_active=True,
+        created_at=now,
+    )
+    db.add(event)
+    await db.flush()
+    attendance = models.EventAttendance(
+        event_id=event.id,
+        user_id=user_id,
+        qr_secret="qr-secret",  # pragma: allowlist secret
+        qr_hmac="qr-hmac",  # pragma: allowlist secret
+        registered_at=now,
+    )
+    db.add(attendance)
+    await db.flush()
+    return event
+
+
+async def _add_grade_notification(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    *,
+    payload: dict | str | None,
+    title: str = "Grade",
+) -> models.Notification:
+    now = datetime.now(UTC)
+    body = (
+        payload if isinstance(payload, str) or payload is None else json.dumps(payload)
+    )
+    notif = models.Notification(
+        user_id=user_id,
+        title=title,
+        body=body,
+        type="grade",
+        created_at=now,
+        read=False,
+    )
+    db.add(notif)
+    await db.flush()
+    return notif
+
+
+# ---------------------------------------------------------------------------
+# get_attendance_stats
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_attendance_stats_empty(svc, user_factory):
+    user = await user_factory()
+    result = await svc.get_attendance_stats(
+        user_id=user.id, period_days=30, skip_cache=True
+    )
+    assert result["percent"] == 0.0
+    assert result["total"] == 0
+    assert result["recent"] == []
+
+
+@pytest.mark.asyncio
+async def test_attendance_stats_with_recent_events(svc, db_session, user_factory):
+    user = await user_factory()
+    await _add_attended_event(db_session, user.id, title="Lecture A")
+    await _add_attended_event(db_session, user.id, title="Lecture B", hours_ago=4)
+
+    result = await svc.get_attendance_stats(
+        user_id=user.id, period_days=30, skip_cache=True
+    )
+    assert result["percent"] == 100.0
+    assert result["present"] == 2
+    assert result["total"] == 2
+    courses = {item["course"] for item in result["recent"]}
+    assert courses == {"Lecture A", "Lecture B"}
+    assert all(item["status"] == "present" for item in result["recent"])
+
+
+@pytest.mark.asyncio
+async def test_attendance_stats_returns_cached_payload(svc, user_factory, monkeypatch):
+    user = await user_factory()
+    sentinel = {"percent": 42.0, "cached": True}
+    monkeypatch.setattr(
+        stats_cache,
+        "get_cached_stats",
+        AsyncMock(return_value=SimpleNamespace(payload=sentinel)),
+    )
+    result = await svc.get_attendance_stats(
+        user_id=user.id, period_days=30, skip_cache=False
+    )
+    assert result is sentinel
+
+
+# ---------------------------------------------------------------------------
+# get_grade_stats
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_grade_stats_parses_and_averages(svc, db_session, user_factory):
+    user = await user_factory()
+    await _add_grade_notification(
+        db_session, user.id, payload={"score": 4, "max": 5, "course": "Math"}
+    )
+    await _add_grade_notification(
+        db_session, user.id, payload={"score": 5, "max": 5, "course": "Physics"}
+    )
+    # Unparseable body is skipped without breaking the aggregate.
+    await _add_grade_notification(db_session, user.id, payload="not-json{")
+
+    result = await svc.get_grade_stats(user_id=user.id, period_days=30, skip_cache=True)
+    assert result["total_grades"] == 2
+    assert result["average"] == pytest.approx(4.5)
+    assert result["scale"] == "5"
+    assert len(result["recent"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_grade_stats_detects_100_scale(svc, db_session, user_factory):
+    user = await user_factory()
+    await _add_grade_notification(
+        db_session, user.id, payload={"score": 87, "max": 100, "course": "Chemistry"}
+    )
+    result = await svc.get_grade_stats(user_id=user.id, period_days=30, skip_cache=True)
+    assert result["scale"] == "100"
+    assert result["average"] == pytest.approx(87.0)
+
+
+@pytest.mark.asyncio
+async def test_grade_stats_empty(svc, user_factory):
+    user = await user_factory()
+    result = await svc.get_grade_stats(user_id=user.id, period_days=30, skip_cache=True)
+    assert result["total_grades"] == 0
+    assert result["average"] == 0.0
+    assert result["recent"] == []
+
+
+@pytest.mark.asyncio
+async def test_grade_stats_returns_cached_payload(svc, user_factory, monkeypatch):
+    user = await user_factory()
+    sentinel = {"average": 5.0, "cached": True}
+    monkeypatch.setattr(
+        stats_cache,
+        "get_cached_stats",
+        AsyncMock(return_value=SimpleNamespace(payload=sentinel)),
+    )
+    result = await svc.get_grade_stats(
+        user_id=user.id, period_days=30, skip_cache=False
+    )
+    assert result is sentinel
+
+
+# ---------------------------------------------------------------------------
+# get_participation_stats
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_participation_stats_with_events(svc, db_session, user_factory):
+    user = await user_factory()
+    await _add_attended_event(
+        db_session, user.id, title="Hackathon", event_type="hackathon"
+    )
+
+    result = await svc.get_participation_stats(
+        user_id=user.id, period_days=30, skip_cache=True
+    )
+    assert result["events"] == 1
+    assert result["recent"][0]["title"] == "Hackathon"
+    assert result["recent"][0]["role"] == "hackathon"
+
+
+@pytest.mark.asyncio
+async def test_participation_stats_empty(svc, user_factory):
+    user = await user_factory()
+    result = await svc.get_participation_stats(
+        user_id=user.id, period_days=30, skip_cache=True
+    )
+    assert result["events"] == 0
+    assert result["recent"] == []
+
+
+@pytest.mark.asyncio
+async def test_participation_stats_returns_cached_payload(
+    svc, user_factory, monkeypatch
+):
+    user = await user_factory()
+    sentinel = {"events": 9, "cached": True}
+    monkeypatch.setattr(
+        stats_cache,
+        "get_cached_stats",
+        AsyncMock(return_value=SimpleNamespace(payload=sentinel)),
+    )
+    result = await svc.get_participation_stats(
+        user_id=user.id, period_days=30, skip_cache=False
+    )
+    assert result is sentinel


### PR DESCRIPTION
Testing session 9 — first all-four-fronts coverage batch.

## Backend 85 → 86 (`4e7338a8d`)
+87 tests across 6 service-layer files (session/analytics/notifications×3/compliance). Measured **86.53%**; gate raised in all 3 locations (pyproject / Makefile / ci.yml). Full hermetic suite **3563 passed**.

## Frontend functions 67 → 68 (`aac5aced9`)
+30 render tests (NavbarOverflowMenu, AdminBackdrop, AdminNotifications, NewsHeader). Measured functions **68.17%**; statements/lines/branches held per the no-cushion rule. **1573 passed**.

## First Go matrix ratchet (`9ae1a41fd`)
Dependency-free unit tests (mock RESP servers, httptest JWKS, Temporal testsuite, gRPC metadata auth). No production-code changes. Measured ×2, gate = floor(measured) − 2:
- **ws-hub 35 → 62** (64.9%): NATS handler closures + Run/broadcast loop + RS256/JWKS + ticket-RESP mock + WS upgrade E2E.
- **file-processor 28 → 49** (51.4%): cmd/* auth helpers + resolver/sanitizeKey + Temporal workflow + depth middleware.
- **gateway 45 → 61** (63.0%): Redis-revocation RESP mock + JWKS error paths + RequireRole + setupRouter smoke (Go 1.20+ counts cmd/gateway in the denominator).

golangci-lint v2.3.0 (root config) + gofmt clean.

## First Rust cargo-test in CI (`33d4fc827` + `0e9a4c145`)
- rust_ext: Variant B feature-gate (extension-module → default; maturin/fuzz/ASan unchanged).
- wasm-sanitizer: 12 native sanitization tests.
- rust-crypto: 9 native RFC KATs (PBKDF2/HMAC/scrypt, cross-validated against RustCrypto refs + RFC text) + browser-parity `tests/wasm.rs`.
- NEW backend `test_smoke_pyo3_ext.py`: CI-import guard + FFI smoke.
- NEW **blocking** `rust-tests` CI job: `cargo test` ×3 crates + `wasm-pack test --headless --chrome`; wired into ci-success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)