### PR TITLE
test(session10): all-4-front coverage batch (backend 88, frontend 68/73/69/68, Go floors, crypto.worker parity)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,11 +290,11 @@ jobs:
       test-group-name: "All-${{ matrix.name }}"
       test-pattern: "tests/"
       python-version: ${{ matrix.python-version }}
-      # Ratchet floor at measured reality (local hermetic ~85.33% after the
-      # service/repository-coverage climb; CI Linux+integration measures higher).
+      # Ratchet floor at measured reality (local hermetic 88.04% after the
+      # session-10 service-layer climb; CI Linux+integration measures ~0.7pp higher).
       # Raise incrementally as the backend coverage campaign lands. Unified with
       # pyproject/Makefile.
-      coverage-threshold: ${{ matrix.coverage-check && 86 || 0 }}
+      coverage-threshold: ${{ matrix.coverage-check && 88 || 0 }}
       run-integration-tests: ${{ matrix.run-integration }}
       parallel-workers: 0 # LOW-W19: 0 = auto-detect workers via pytest-xdist (-n auto)
       python-gil: ${{ matrix.free-threading && '0' || '1' }}  # MOD-24-03
@@ -358,19 +358,25 @@ jobs:
         # Session 9 climb (first Go ratchet): new dependency-free unit tests
         # (mock RESP servers, httptest JWKS, Temporal testsuite, gRPC metadata
         # auth) lifted every service. Floor = floor(measured ×2) − 2 buffer.
+        # Session 10 climb: ws-hub client.go pump/room/handleMessage unit tests
+        # (gorilla conn pairs); gateway Optional()/extractAlg/JWKS-equal-key edges;
+        # file-processor validateProcessFileRequest rejection arms.
         include:
           - service: services/gateway
-            # Measured 63.0% unit-only ×2 (setupRouter smoke + Redis-revocation
-            # RESP mock + JWKS error paths + RequireRole). Floor 61.
-            coverage-threshold: 61
-          - service: services/file-processor
-            # Measured 51.4% unit-only ×2 (cmd/* auth helpers + resolver/sanitizeKey
-            # + Temporal testsuite workflow + depth middleware). Floor 49.
-            coverage-threshold: 49
-          - service: services/ws-hub
-            # Measured 64.9% unit-only ×2 (NATS handler closures + Run/broadcast
-            # loop + RS256/JWKS + ticket-RESP mock + WS upgrade E2E). Floor 62.
+            # Measured 64.3% unit-only ×2 (s9 + s10 Optional RS256-downgrade /
+            # malformed-alg / valid-RS256 / revoked-session + extractAlg arms +
+            # JWKS equal-key). Floor 62.
             coverage-threshold: 62
+          - service: services/file-processor
+            # Measured 52.3% unit-only ×2 (s9 + s10 validateProcessFileRequest
+            # empty-id/unsupported-type/empty-keys/options-limit/oversized-opt).
+            # Floor 50.
+            coverage-threshold: 50
+          - service: services/ws-hub
+            # Measured 67.2% unit-only ×2 (s9 + s10 client.go ReadPump/WritePump/
+            # handleMessage guards/JoinRoom/LeaveRoom/safeSend via gorilla pairs).
+            # Floor 65.
+            coverage-threshold: 65
           - service: services/cmd/uni-cli
             coverage-threshold: 80
     needs: pre-commit-check

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -152,14 +152,14 @@
         "filename": ".github\\workflows\\ci.yml",
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
-        "line_number": 556
+        "line_number": 562
       },
       {
         "type": "Basic Auth Credentials",
         "filename": ".github\\workflows\\ci.yml",
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
-        "line_number": 566
+        "line_number": 572
       }
     ],
     ".github\\workflows\\reusable-backend-tests.yml": [
@@ -2260,5 +2260,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-12T23:08:11Z"
+  "generated_at": "2026-06-13T13:28:04Z"
 }

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ lint-frontend:
 	npm run format:check --prefix $(FRONTEND_DIR)
 
 backend-test:
-	pytest --cov=app --cov-report=xml --cov-report=term-missing --cov-fail-under=86 --junitxml=pytest-report.xml
+	pytest --cov=app --cov-report=xml --cov-report=term-missing --cov-fail-under=88 --junitxml=pytest-report.xml
 
 backend-typecheck:
 	mypy

--- a/frontend/src/api/__tests__/notifications.test.ts
+++ b/frontend/src/api/__tests__/notifications.test.ts
@@ -1,0 +1,264 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { ApiResponseValidationError } from "../validation"
+
+// Mock the generated SDK + the lazy-imported apiClient so the api/notifications
+// wrappers run against canned responses (no MSW / contract validator needed).
+vi.mock("@/api/generated", () => ({
+  adminGetUserTopicsApiV1PushAdminTopicsUserIdGet: vi.fn(),
+  adminUpdateUserTopicsApiV1PushAdminTopicsUserIdPut: vi.fn(),
+  checkScheduleAndGenerateApiV1NotificationsCheckSchedulePost: vi.fn(),
+  clearNotificationsApiV1NotificationsDelete: vi.fn(),
+  unsubscribeApiV1PushUnsubscribePost: vi.fn(),
+  getPushTopicsApiV1PushTopicsGet: vi.fn(),
+  getVapidPublicKeyApiV1PushVapidPublicKeyGet: vi.fn(),
+  listNotificationsApiV1NotificationsGet: vi.fn(),
+  markAllReadApiV1NotificationsReadAllPost: vi.fn(),
+  markReadSingleApiV1NotificationsNotifIdReadPatch: vi.fn(),
+  subscribeApiV1PushSubscribePost: vi.fn(),
+  sendTestApiV1PushTestPost: vi.fn(),
+}))
+
+const apiClientGet = vi.fn()
+const apiClientPost = vi.fn()
+vi.mock("@/api/client", () => ({
+  apiClient: { get: apiClientGet, post: apiClientPost },
+}))
+
+import * as gen from "@/api/generated"
+import {
+  checkSchedule,
+  clearNotifications,
+  deleteSubscription,
+  fetchAdminUserTopics,
+  fetchDeadLetterQueue,
+  fetchNotificationsList,
+  fetchPushTopics,
+  getVapidPublicKey,
+  markAllNotificationsRead,
+  markNotificationRead,
+  purgeDeadLetterJobs,
+  retryDeadLetterJobs,
+  saveSubscription,
+  sendTest,
+  updateAdminUserTopics,
+} from "../notifications"
+
+const UUID = "11111111-1111-4111-8111-111111111111"
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe("fetchNotificationsList", () => {
+  it("returns the validated list payload", async () => {
+    vi.mocked(gen.listNotificationsApiV1NotificationsGet).mockResolvedValue({
+      data: {
+        items: [{ id: UUID, title: "Hi", created_at: "2026-06-01T00:00:00Z", read: false }],
+        unread_count: 1,
+        has_more: false,
+        next_cursor: null,
+      },
+    } as never)
+
+    const result = await fetchNotificationsList({ cursor: null, limit: 20 })
+    expect(result.unread_count).toBe(1)
+    expect(result.items[0]?.title).toBe("Hi")
+    expect(gen.listNotificationsApiV1NotificationsGet).toHaveBeenCalledWith({
+      query: { cursor: undefined, limit: 20 },
+    })
+  })
+
+  it("throws on a schema-invalid payload", async () => {
+    vi.mocked(gen.listNotificationsApiV1NotificationsGet).mockResolvedValue({
+      data: { items: [], unread_count: "nope", has_more: false },
+    } as never)
+    await expect(fetchNotificationsList()).rejects.toBeInstanceOf(ApiResponseValidationError)
+  })
+})
+
+describe("simple notification passthroughs", () => {
+  it("markNotificationRead targets the path param", async () => {
+    await markNotificationRead(UUID)
+    expect(gen.markReadSingleApiV1NotificationsNotifIdReadPatch).toHaveBeenCalledWith({
+      path: { notif_id: UUID },
+    })
+  })
+
+  it("markAllNotificationsRead + clearNotifications delegate", async () => {
+    await markAllNotificationsRead()
+    await clearNotifications()
+    expect(gen.markAllReadApiV1NotificationsReadAllPost).toHaveBeenCalledOnce()
+    expect(gen.clearNotificationsApiV1NotificationsDelete).toHaveBeenCalledOnce()
+  })
+
+  it("checkSchedule forwards the lookahead default + override", async () => {
+    await checkSchedule()
+    expect(
+      gen.checkScheduleAndGenerateApiV1NotificationsCheckSchedulePost
+    ).toHaveBeenLastCalledWith({
+      query: { lookahead_minutes: 15 },
+    })
+    await checkSchedule(30)
+    expect(
+      gen.checkScheduleAndGenerateApiV1NotificationsCheckSchedulePost
+    ).toHaveBeenLastCalledWith({
+      query: { lookahead_minutes: 30 },
+    })
+  })
+})
+
+describe("saveSubscription", () => {
+  const goodSub = {
+    endpoint: " https://push.example/x ",
+    keys: { p256dh: " p ", auth: " a " },
+  } as unknown as PushSubscriptionJSON
+
+  it("trims fields, attaches topics, returns server data", async () => {
+    vi.mocked(gen.subscribeApiV1PushSubscribePost).mockResolvedValue({
+      data: { id: UUID, endpoint: "https://push.example/x" },
+    } as never)
+    const result = await saveSubscription(goodSub, ["system"])
+    expect(result).toEqual({ id: UUID, endpoint: "https://push.example/x" })
+    const body = vi.mocked(gen.subscribeApiV1PushSubscribePost).mock.calls[0]?.[0]?.body
+    expect(body).toMatchObject({
+      endpoint: "https://push.example/x",
+      keys: { p256dh: "p", auth: "a" },
+      topics: ["system"],
+    })
+  })
+
+  it("throws on an incomplete payload (no network call)", async () => {
+    await expect(
+      saveSubscription({
+        endpoint: "",
+        keys: { p256dh: "", auth: "" },
+      } as unknown as PushSubscriptionJSON)
+    ).rejects.toThrow("Invalid push subscription payload")
+    expect(gen.subscribeApiV1PushSubscribePost).not.toHaveBeenCalled()
+  })
+
+  it("throws when the server returns no data", async () => {
+    vi.mocked(gen.subscribeApiV1PushSubscribePost).mockResolvedValue({ data: undefined } as never)
+    await expect(saveSubscription(goodSub)).rejects.toThrow("Failed to save subscription")
+  })
+})
+
+describe("deleteSubscription + sendTest", () => {
+  it("deleteSubscription posts the endpoint", async () => {
+    await deleteSubscription("https://push.example/y")
+    expect(gen.unsubscribeApiV1PushUnsubscribePost).toHaveBeenCalledWith({
+      body: { endpoint: "https://push.example/y" },
+    })
+  })
+
+  it("sendTest returns data + throws when empty", async () => {
+    vi.mocked(gen.sendTestApiV1PushTestPost).mockResolvedValue({ data: { sent: 2 } } as never)
+    expect(await sendTest()).toEqual({ sent: 2 })
+    vi.mocked(gen.sendTestApiV1PushTestPost).mockResolvedValue({ data: undefined } as never)
+    await expect(sendTest()).rejects.toThrow("Failed to send test notification")
+  })
+})
+
+describe("getVapidPublicKey null-normalization", () => {
+  it("returns a trimmed non-empty key", async () => {
+    vi.mocked(gen.getVapidPublicKeyApiV1PushVapidPublicKeyGet).mockResolvedValue({
+      data: { publicKey: "  BJ_key  " },
+    } as never)
+    expect(await getVapidPublicKey()).toBe("BJ_key")
+  })
+
+  it("normalizes blank/missing to null", async () => {
+    vi.mocked(gen.getVapidPublicKeyApiV1PushVapidPublicKeyGet).mockResolvedValue({
+      data: { publicKey: "   " },
+    } as never)
+    expect(await getVapidPublicKey()).toBeNull()
+    vi.mocked(gen.getVapidPublicKeyApiV1PushVapidPublicKeyGet).mockResolvedValue({
+      data: { publicKey: null },
+    } as never)
+    expect(await getVapidPublicKey()).toBeNull()
+  })
+})
+
+describe("fetchPushTopics defaults", () => {
+  it("fills has_preferences + updated_at defaults", async () => {
+    vi.mocked(gen.getPushTopicsApiV1PushTopicsGet).mockResolvedValue({
+      data: { allowed: ["system"], topics: ["system"] },
+    } as never)
+    const result = await fetchPushTopics()
+    expect(result).toEqual({
+      allowed: ["system"],
+      topics: ["system"],
+      has_preferences: false,
+      updated_at: null,
+    })
+  })
+})
+
+describe("admin topics", () => {
+  it("fetchAdminUserTopics validates the response", async () => {
+    vi.mocked(gen.adminGetUserTopicsApiV1PushAdminTopicsUserIdGet).mockResolvedValue({
+      data: {
+        user_id: UUID,
+        email: "a@b.c",
+        topics: ["system"],
+        allowed_topics: ["system"],
+        updated_at: null,
+      },
+    } as never)
+    const result = await fetchAdminUserTopics(UUID)
+    expect(result.email).toBe("a@b.c")
+  })
+
+  it("updateAdminUserTopics sends the body + validates", async () => {
+    vi.mocked(gen.adminUpdateUserTopicsApiV1PushAdminTopicsUserIdPut).mockResolvedValue({
+      data: {
+        user_id: UUID,
+        email: "a@b.c",
+        topics: ["events"],
+        allowed_topics: ["events", "system"],
+      },
+    } as never)
+    const result = await updateAdminUserTopics(UUID, ["events"])
+    expect(result.topics).toEqual(["events"])
+    expect(gen.adminUpdateUserTopicsApiV1PushAdminTopicsUserIdPut).toHaveBeenCalledWith({
+      path: { user_id: UUID },
+      body: { topics: ["events"] },
+    })
+  })
+})
+
+describe("dead-letter queue (lazy apiClient)", () => {
+  it("fetchDeadLetterQueue validates + forwards params/signal", async () => {
+    apiClientGet.mockResolvedValue({
+      data: { items: [], total: 0 },
+    })
+    const controller = new AbortController()
+    const result = await fetchDeadLetterQueue({ limit: 10, offset: 0 }, controller.signal)
+    expect(result).toEqual({ items: [], total: 0 })
+    expect(apiClientGet).toHaveBeenCalledWith("/api/v1/notifications/admin/dead-letter", {
+      params: { limit: 10, offset: 0 },
+      signal: controller.signal,
+    })
+  })
+
+  it("retry + purge post the job ids", async () => {
+    apiClientPost.mockResolvedValue({ data: {} })
+    await retryDeadLetterJobs(["j1"])
+    await purgeDeadLetterJobs(["j2"])
+    expect(apiClientPost).toHaveBeenNthCalledWith(
+      1,
+      "/api/v1/notifications/admin/dead-letter/retry",
+      { job_ids: ["j1"] }
+    )
+    expect(apiClientPost).toHaveBeenNthCalledWith(
+      2,
+      "/api/v1/notifications/admin/dead-letter/purge",
+      { job_ids: ["j2"] }
+    )
+  })
+})

--- a/frontend/src/components/navbar/__tests__/NavbarPieces.test.tsx
+++ b/frontend/src/components/navbar/__tests__/NavbarPieces.test.tsx
@@ -1,0 +1,175 @@
+/**
+ * Render coverage tests (testing session 10) for the small, prop-driven navbar
+ * pieces that prior sessions left untested: DesktopNav, NavbarLogo,
+ * MobileDrawerProfile, MobileDrawerQuickActions, and UserMenu (loading /
+ * unauthenticated / authenticated states). Mirrors the renderWithRouter +
+ * stub-props pattern from NavbarOverflowMenu.test.tsx (session 9 template).
+ */
+import { screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+import { Home, Calendar } from "lucide-react"
+import type { TFunction } from "i18next"
+
+// UserMenu's authed branch renders MessengerButton + NotificationsBell, which
+// require MessengerProvider / notification context renderWithRouter doesn't
+// supply. Stub them — the focus here is UserMenu's own auth-state markup.
+vi.mock("@/components/layout/MessengerButton", () => ({
+  default: () => <div data-testid="messenger-button" />,
+}))
+vi.mock("@/components/feedback/NotificationsBell", () => ({
+  default: () => <div data-testid="notifications-bell" />,
+}))
+
+import { DesktopNav } from "@/components/navbar/DesktopNav"
+import { NavbarLogo } from "@/components/navbar/NavbarLogo"
+import { MobileDrawerProfile } from "@/components/navbar/MobileDrawerProfile"
+import { MobileDrawerQuickActions } from "@/components/navbar/MobileDrawerQuickActions"
+import { UserMenu } from "@/components/navbar/UserMenu"
+import { renderWithRouter } from "@/tests/helpers/renderWithRouter"
+import { testUser } from "@/tests/mocks/handlers"
+import type { NavigationItem } from "@/config/navigation"
+
+const t = ((key: string) => key) as unknown as TFunction
+
+const navItems: NavigationItem[] = [
+  { to: "/news", label: "News", icon: Home },
+  { to: "/events", label: "Events", icon: Calendar },
+]
+
+describe("DesktopNav", () => {
+  it("renders a list item + premium link per nav entry", async () => {
+    await renderWithRouter({
+      ui: () => (
+        <DesktopNav
+          menuLinks={navItems}
+          isActive={(to) => to === "/news"}
+          isSameTarget={() => false}
+          scrollToTop={vi.fn()}
+          markScrollFromBottom={vi.fn()}
+          prefersReducedMotion
+          isCompact={false}
+        />
+      ),
+      authProvider: false,
+    })
+    expect(screen.getByText("News")).toBeInTheDocument()
+    expect(screen.getByText("Events")).toBeInTheDocument()
+    // active entry carries data-active.
+    const newsLink = document.getElementById("navbar-link-news")
+    expect(newsLink).toHaveAttribute("data-active")
+  })
+
+  it("scrolls to top instead of navigating when the link targets the current page", async () => {
+    const scrollToTop = vi.fn()
+    await renderWithRouter({
+      ui: () => (
+        <DesktopNav
+          menuLinks={navItems}
+          isActive={() => false}
+          isSameTarget={(to) => to === "/news"}
+          scrollToTop={scrollToTop}
+          markScrollFromBottom={vi.fn()}
+          prefersReducedMotion
+          isCompact
+        />
+      ),
+      authProvider: false,
+    })
+    await userEvent.click(screen.getByText("News"))
+    expect(scrollToTop).toHaveBeenCalledWith("auto")
+  })
+})
+
+describe("NavbarLogo", () => {
+  it("renders the brand link to /dashboard with alt + brand name", async () => {
+    const onLogoClick = vi.fn()
+    await renderWithRouter({
+      ui: () => (
+        <NavbarLogo
+          t={t}
+          isMobile={false}
+          isCompact={false}
+          isPhone={false}
+          prefersReducedMotion
+          onLogoClick={onLogoClick}
+          markScrollFromBottom={vi.fn()}
+        />
+      ),
+      authProvider: false,
+    })
+    const link = document.getElementById("navbar-logo-link")
+    expect(link).toHaveAttribute("href", "/dashboard")
+    expect(screen.getByText("navigation:brandName")).toBeInTheDocument()
+  })
+})
+
+describe("MobileDrawerProfile", () => {
+  it("renders name + role chip and fires onProfileClick", async () => {
+    const onProfileClick = vi.fn()
+    await renderWithRouter({
+      ui: () => <MobileDrawerProfile user={testUser} onProfileClick={onProfileClick} t={t} />,
+      authProvider: false,
+    })
+    expect(screen.getByText(testUser.full_name as string)).toBeInTheDocument()
+    expect(screen.getByText("navigation:role.student")).toBeInTheDocument()
+    await userEvent.click(screen.getByRole("button"))
+    expect(onProfileClick).toHaveBeenCalledOnce()
+  })
+
+  it("shows the admin role label for admin users", async () => {
+    await renderWithRouter({
+      ui: () => (
+        <MobileDrawerProfile user={{ ...testUser, role: "admin" }} onProfileClick={vi.fn()} t={t} />
+      ),
+      authProvider: false,
+    })
+    expect(screen.getByText("navigation:role.admin")).toBeInTheDocument()
+  })
+})
+
+describe("MobileDrawerQuickActions", () => {
+  it("renders the 3 quick-action buttons and wires their handlers", async () => {
+    const onSearch = vi.fn()
+    const onNotifications = vi.fn()
+    const onSettings = vi.fn()
+    await renderWithRouter({
+      ui: () => (
+        <MobileDrawerQuickActions
+          onSearch={onSearch}
+          onNotifications={onNotifications}
+          onSettings={onSettings}
+          prefersReducedMotion
+          t={(key) => key}
+        />
+      ),
+      authProvider: false,
+    })
+    await userEvent.click(screen.getByRole("button", { name: "navigation:menu.search" }))
+    await userEvent.click(screen.getByRole("button", { name: "navigation:menu.notifications" }))
+    await userEvent.click(screen.getByRole("button", { name: "navigation:menu.settings" }))
+    expect(onSearch).toHaveBeenCalledOnce()
+    expect(onNotifications).toHaveBeenCalledOnce()
+    expect(onSettings).toHaveBeenCalledOnce()
+  })
+})
+
+describe("UserMenu", () => {
+  it("renders the loading skeleton when loading", async () => {
+    await renderWithRouter({
+      ui: () => <UserMenu user={null} isAuth={false} loading go={vi.fn()} t={(key) => key} />,
+    })
+    expect(screen.getByLabelText("common:aria.loadingUserMenu")).toBeInTheDocument()
+  })
+
+  it("renders the authenticated profile affordance + routes to /profile", async () => {
+    const go = vi.fn()
+    await renderWithRouter({
+      ui: () => <UserMenu user={testUser} isAuth loading={false} go={go} t={(key) => key} />,
+    })
+    // The authed branch renders the profile avatar + button (both titled).
+    expect(screen.getAllByTitle("navigation:aria.openProfile").length).toBeGreaterThan(0)
+    await userEvent.click(screen.getByRole("button", { name: "navigation:aria.openProfile" }))
+    expect(go).toHaveBeenCalledWith("/profile")
+  })
+})

--- a/frontend/src/components/ui/__tests__/ContentCard.test.tsx
+++ b/frontend/src/components/ui/__tests__/ContentCard.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * Render coverage tests (testing session 10) for the ContentCard compound
+ * component (all slots + the useContentCardContext hook + Media fallback /
+ * image branches + Title polymorphic `as` + Badge variants). Plain render —
+ * no router/providers needed.
+ */
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { ContentCard, useContentCardContext } from "@/components/ui/ContentCard"
+
+describe("ContentCard slots", () => {
+  it("renders the full compound composition", () => {
+    render(
+      <ContentCard>
+        <ContentCard.Media src="https://img.example/x.jpg" alt="cover" />
+        <ContentCard.Header>
+          <ContentCard.Title>Card Title</ContentCard.Title>
+          <ContentCard.Actions>
+            <button type="button">menu</button>
+          </ContentCard.Actions>
+        </ContentCard.Header>
+        <ContentCard.Meta>
+          <span>2026-06-01</span>
+        </ContentCard.Meta>
+        <ContentCard.Body>Body text</ContentCard.Body>
+        <ContentCard.Footer>
+          <ContentCard.Badge variant="success">Live</ContentCard.Badge>
+        </ContentCard.Footer>
+      </ContentCard>
+    )
+    expect(screen.getByText("Card Title")).toBeInTheDocument()
+    expect(screen.getByText("Body text")).toBeInTheDocument()
+    expect(screen.getByText("menu")).toBeInTheDocument()
+    expect(screen.getByText("2026-06-01")).toBeInTheDocument()
+    expect(screen.getByText("Live")).toBeInTheDocument()
+  })
+
+  it("Media renders the fallback node when src is absent", () => {
+    render(
+      <ContentCard>
+        <ContentCard.Media src={undefined} fallback={<span>no image</span>} />
+      </ContentCard>
+    )
+    expect(screen.getByText("no image")).toBeInTheDocument()
+  })
+
+  it("Title honours the polymorphic `as` prop", () => {
+    render(
+      <ContentCard>
+        <ContentCard.Title as="h2">Heading Two</ContentCard.Title>
+      </ContentCard>
+    )
+    expect(screen.getByRole("heading", { level: 2, name: "Heading Two" })).toBeInTheDocument()
+  })
+
+  it("Badge defaults to the default variant when none given", () => {
+    render(
+      <ContentCard>
+        <ContentCard.Badge>Plain</ContentCard.Badge>
+      </ContentCard>
+    )
+    const badge = screen.getByText("Plain")
+    expect(badge.className).toContain("bg-(--bg-surface-hover)")
+  })
+})
+
+describe("useContentCardContext", () => {
+  it("returns the default context outside an explicit hover state", () => {
+    const Probe = () => {
+      const ctx = useContentCardContext()
+      return <span data-testid="hover">{String(ctx.isHovered)}</span>
+    }
+    render(
+      <ContentCard>
+        <Probe />
+      </ContentCard>
+    )
+    expect(screen.getByTestId("hover")).toHaveTextContent("false")
+  })
+})

--- a/frontend/src/components/ui/__tests__/uiMiscPrimitives.test.tsx
+++ b/frontend/src/components/ui/__tests__/uiMiscPrimitives.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * Render coverage tests (testing session 10) for three untested ui primitives:
+ * Dialog (portal mount / open-close / Escape / backdrop click / title+subtitle
+ * a11y wiring), MediaSlot (no-src fallback / error fallback / loading + image
+ * onLoad+onError branches), and the table primitive family. Mirrors the
+ * uiPrimitives.test.tsx style (plain render, no router).
+ */
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { Dialog } from "@/components/ui/Dialog"
+import { MediaSlot } from "@/components/ui/MediaSlot"
+import {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+
+describe("Dialog", () => {
+  it("renders nothing when closed", () => {
+    render(
+      <Dialog open={false} onClose={vi.fn()} title="Hidden">
+        body
+      </Dialog>
+    )
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+  })
+
+  it("portals an open dialog with title/subtitle a11y wiring", async () => {
+    render(
+      <Dialog open onClose={vi.fn()} title="My Title" subtitle="My Subtitle">
+        <p>dialog body</p>
+      </Dialog>
+    )
+    const dialog = await screen.findByRole("dialog")
+    expect(dialog).toHaveAttribute("aria-modal", "true")
+    expect(dialog).toHaveAttribute("aria-labelledby")
+    expect(dialog).toHaveAttribute("aria-describedby")
+    expect(screen.getByText("My Title")).toBeInTheDocument()
+    expect(screen.getByText("My Subtitle")).toBeInTheDocument()
+    expect(screen.getByText("dialog body")).toBeInTheDocument()
+  })
+
+  it("calls onClose from the close button + backdrop click", async () => {
+    const onClose = vi.fn()
+    render(
+      <Dialog open onClose={onClose} title="Closeable" closeLabel="Dismiss">
+        body
+      </Dialog>
+    )
+    await screen.findByRole("dialog")
+    await userEvent.click(screen.getByRole("button", { name: "Dismiss" }))
+    expect(onClose).toHaveBeenCalled()
+
+    // Backdrop (role=presentation's aria-hidden overlay) click also closes.
+    const overlay = document.querySelector("[aria-hidden='true'].absolute")
+    expect(overlay).not.toBeNull()
+    fireEvent.click(overlay as Element)
+    expect(onClose.mock.calls.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it("renders the footer + fullScreenOnMobile variant", async () => {
+    render(
+      <Dialog
+        open
+        onClose={vi.fn()}
+        title="WithFooter"
+        fullScreenOnMobile
+        footer={<button type="button">Confirm</button>}
+      >
+        body
+      </Dialog>
+    )
+    await screen.findByRole("dialog")
+    expect(screen.getByRole("button", { name: "Confirm" })).toBeInTheDocument()
+  })
+})
+
+describe("MediaSlot", () => {
+  it("renders the default icon fallback when no src", () => {
+    const { container } = render(<MediaSlot src={undefined} alt="x" />)
+    // No <img> rendered in the no-src branch.
+    expect(container.querySelector("img")).toBeNull()
+    expect(container.querySelector("[style*='aspect-ratio']")).not.toBeNull()
+  })
+
+  it("renders a custom fallback node when no src", () => {
+    render(<MediaSlot src={undefined} fallback={<span>placeholder</span>} />)
+    expect(screen.getByText("placeholder")).toBeInTheDocument()
+  })
+
+  it("shows the image, then fires onLoad and clears the loading state", async () => {
+    const onLoad = vi.fn()
+    render(<MediaSlot src="https://img.example/a.jpg" alt="alt-a" onLoad={onLoad} />)
+    const img = screen.getByAltText("alt-a")
+    expect(img).toHaveAttribute("loading", "lazy")
+    fireEvent.load(img)
+    expect(onLoad).toHaveBeenCalledOnce()
+  })
+
+  it("swaps to the error fallback + fires onError on image failure", async () => {
+    const onError = vi.fn()
+    render(
+      <MediaSlot
+        src="https://img.example/bad.jpg"
+        alt="alt-b"
+        onError={onError}
+        fallback={<span>broken</span>}
+      />
+    )
+    fireEvent.error(screen.getByAltText("alt-b"))
+    expect(onError).toHaveBeenCalledOnce()
+    await waitFor(() => expect(screen.getByText("broken")).toBeInTheDocument())
+  })
+})
+
+describe("table primitives", () => {
+  it("renders a full semantic table tree", () => {
+    render(
+      <Table>
+        <TableCaption>Caption</TableCaption>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Name</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          <TableRow data-state="selected">
+            <TableCell>Ada</TableCell>
+          </TableRow>
+        </TableBody>
+        <TableFooter>
+          <TableRow>
+            <TableCell>Total: 1</TableCell>
+          </TableRow>
+        </TableFooter>
+      </Table>
+    )
+    expect(screen.getByRole("table")).toBeInTheDocument()
+    expect(screen.getByText("Caption")).toBeInTheDocument()
+    expect(screen.getByRole("columnheader", { name: "Name" })).toBeInTheDocument()
+    expect(screen.getByText("Ada")).toBeInTheDocument()
+    expect(screen.getByText("Total: 1")).toBeInTheDocument()
+  })
+})

--- a/frontend/src/workers/__tests__/crypto.worker.parity.test.ts
+++ b/frontend/src/workers/__tests__/crypto.worker.parity.test.ts
@@ -1,0 +1,188 @@
+// @vitest-environment node
+/**
+ * crypto.worker.ts ↔ WASM parity KATs (testing session 10, Stream D).
+ *
+ * Drives the worker's message protocol end-to-end against the REAL
+ * uni_wasm_crypto WASM build and asserts byte-exact parity with the RFC
+ * vectors cross-validated in frontend/rust-crypto/src/lib.rs (session 9):
+ * PBKDF2 RFC 7914 §11, HMAC RFC 4231 TC1/TC2, scrypt RFC 7914 §12 V1/V2.
+ *
+ * Mechanics:
+ * - `initSync({ module: bytes })` pre-initializes the wasm-bindgen glue from
+ *   disk BEFORE the worker module loads; the glue caches the instance
+ *   (`if (wasm !== undefined) return wasm` — pkg/uni_wasm_crypto.js:240,261),
+ *   so the worker's own no-arg `init()` resolves from cache and never attempts
+ *   a fetch() (which would fail for file URLs under Node).
+ * - `globalThis.self` is stubbed BEFORE the dynamic worker import so the
+ *   module-scope `self.onmessage =` assignment lands on our capture object
+ *   (a static import would hoist above the stub and crash).
+ * - Coverage note: src/workers/** is coverage-excluded by design — this is a
+ *   parity/regression wave, not a gate mover.
+ *
+ * NEVER pass N=0 to SCRYPT (n.ilog2() panics in the wasm — unrecoverable).
+ */
+
+import { readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+import path from "node:path"
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest"
+
+// RFC vectors — copied verbatim from frontend/rust-crypto/src/lib.rs:47-58
+// (cross-validated against the RustCrypto reference impls in session 9).
+const PBKDF2_PASSWD_SALT_C1 =
+  "55ac046e56e3089fec1691c22544b605f94185216dde0465e68b9d57c20dacbc49ca9cccf179b645991664b39d77ef317c71b845b1e30bd509112041d3a19783" // pragma: allowlist secret
+const HMAC_TC1 = "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7" // pragma: allowlist secret
+const HMAC_TC2 = "5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843" // pragma: allowlist secret
+const SCRYPT_V1 =
+  "77d6576238657b203b19ca42c18a0497f16b4844e3074ae8dfdffa3fede21442fcd0069ded0948f8326a753a0fc81f17e8d3e0fb2e0d3628cf35e20c38d18906" // pragma: allowlist secret
+const SCRYPT_V2 =
+  "fdbabe1c9d3472007856e7190d01e9fe7c6ad7cbc8237830e77376634b3731622eaf30d92e22a3886ff109279d9830dac727afb94a83ee6d8360cbdfa2cc0640" // pragma: allowlist secret
+
+type WorkerMessage = { id: number; result?: unknown; error?: string }
+
+const fakeSelf: {
+  onmessage: ((event: { data: unknown }) => Promise<void> | void) | null
+  postMessage: ReturnType<typeof vi.fn>
+} = {
+  onmessage: null,
+  postMessage: vi.fn(),
+}
+
+async function dispatch(data: unknown): Promise<WorkerMessage | undefined> {
+  fakeSelf.postMessage.mockClear()
+  if (!fakeSelf.onmessage) throw new Error("worker onmessage was not registered")
+  await fakeSelf.onmessage({ data })
+  return fakeSelf.postMessage.mock.calls.at(-1)?.[0] as WorkerMessage | undefined
+}
+
+beforeAll(async () => {
+  const here = path.dirname(fileURLToPath(import.meta.url))
+  const wasmPath = path.resolve(here, "../../../rust-crypto/pkg/uni_wasm_crypto_bg.wasm")
+  const glue = await import("../../../rust-crypto/pkg/uni_wasm_crypto.js")
+  glue.initSync({ module: readFileSync(wasmPath) })
+
+  vi.stubGlobal("self", fakeSelf)
+  await import("../crypto.worker")
+  expect(fakeSelf.onmessage).toBeTypeOf("function")
+})
+
+afterAll(() => {
+  vi.unstubAllGlobals()
+})
+
+describe("crypto.worker PBKDF2 parity", () => {
+  it("matches the RFC 7914 §11 PBKDF2-HMAC-SHA-256 vector (keySize in BITS)", async () => {
+    const msg = await dispatch({
+      type: "PBKDF2",
+      id: 1,
+      payload: { value: "passwd", salt: "salt", iterations: 1, keySize: 512 },
+    })
+    expect(msg).toEqual({ id: 1, result: PBKDF2_PASSWD_SALT_C1 })
+  })
+
+  it("derives keySize/8 bytes (256 bits → 64 hex chars)", async () => {
+    const msg = await dispatch({
+      type: "PBKDF2",
+      id: 2,
+      payload: { value: "pw", salt: "salt", iterations: 2, keySize: 256 },
+    })
+    expect(typeof msg?.result).toBe("string")
+    expect((msg?.result as string).length).toBe(64)
+  })
+})
+
+describe("crypto.worker HMAC-SHA256 parity", () => {
+  it("matches RFC 4231 TC1 as base64 of the KAT hex", async () => {
+    const msg = await dispatch({
+      type: "HMAC_SHA256",
+      id: 3,
+      payload: { key: String.fromCharCode(0x0b).repeat(20), json: "Hi There" },
+    })
+    expect(msg).toEqual({
+      id: 3,
+      result: Buffer.from(HMAC_TC1, "hex").toString("base64"),
+    })
+  })
+
+  it("matches RFC 4231 TC2 as base64 of the KAT hex", async () => {
+    const msg = await dispatch({
+      type: "HMAC_SHA256",
+      id: 4,
+      payload: { key: "Jefe", json: "what do ya want for nothing?" },
+    })
+    expect(msg).toEqual({
+      id: 4,
+      result: Buffer.from(HMAC_TC2, "hex").toString("base64"),
+    })
+  })
+})
+
+describe("crypto.worker SCRYPT parity", () => {
+  it("matches RFC 7914 §12 vector 1 (N=16) as a plain number array", async () => {
+    const msg = await dispatch({
+      type: "SCRYPT",
+      id: 5,
+      payload: {
+        password: new Uint8Array(0),
+        salt: new Uint8Array(0),
+        N: 16,
+        r: 1,
+        p: 1,
+        dkLen: 64,
+      },
+    })
+    expect(msg?.id).toBe(5)
+    expect(msg?.result).toEqual(Array.from(Buffer.from(SCRYPT_V1, "hex")))
+  })
+
+  it("matches RFC 7914 §12 vector 2 (N=1024, r=8, p=16)", { timeout: 30_000 }, async () => {
+    const msg = await dispatch({
+      type: "SCRYPT",
+      id: 6,
+      payload: {
+        password: new TextEncoder().encode("password"),
+        salt: new TextEncoder().encode("NaCl"),
+        N: 1024,
+        r: 8,
+        p: 16,
+        dkLen: 64,
+      },
+    })
+    expect(msg?.result).toEqual(Array.from(Buffer.from(SCRYPT_V2, "hex")))
+  })
+
+  it("invalid params (r=0) surface the worker's error envelope", async () => {
+    const msg = await dispatch({
+      type: "SCRYPT",
+      id: 7,
+      payload: {
+        password: new Uint8Array(0),
+        salt: new Uint8Array(0),
+        N: 16,
+        r: 0,
+        p: 1,
+        dkLen: 64,
+      },
+    })
+    // wasm-bindgen throws the JsValue as a raw JS STRING — the worker's
+    // `error instanceof Error` check is false → generic envelope message.
+    expect(msg).toEqual({ id: 7, error: "Unknown worker error" })
+  })
+})
+
+describe("crypto.worker protocol edges", () => {
+  it("unknown message type posts nothing", async () => {
+    const msg = await dispatch({ type: "NOPE", id: 8, payload: {} })
+    expect(msg).toBeUndefined()
+    expect(fakeSelf.postMessage).not.toHaveBeenCalled()
+  })
+
+  it("passes the request id through on success", async () => {
+    const msg = await dispatch({
+      type: "PBKDF2",
+      id: 999,
+      payload: { value: "a", salt: "b", iterations: 1, keySize: 256 },
+    })
+    expect(msg?.id).toBe(999)
+  })
+})

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -57,20 +57,20 @@ export default defineConfig({
         "src/utils/spotify.ts",
         "src/utils/workerChrome.ts",
       ],
-      // Ratchet floors at measured reality. After the session-9 slice
-      // (NavbarOverflowMenu + AdminBackdrop + AdminNotifications topics flows +
-      // NewsHeader handlers): statements 68.17 / branches 73.08 / functions
-      // 69.09 / lines 68.17. functions RAISED 67→68 (69.09 → 1.09 buffer,
-      // ≥ the ~0.5 no-cushion margin). statements/lines HELD at 67 (68.17 → a
-      // 68 floor is only 0.17 over) and branches HELD at 72 (73.08 → a 73
-      // floor is only 0.08 over). NO-REGRESSION floors, NOT the target — raise
+      // Ratchet floors at measured reality. After the session-10 slice
+      // (api/notifications generated-SDK mocks + NavbarPieces render batch +
+      // ContentCard slots + uiMiscPrimitives Dialog/MediaSlot/table): statements
+      // 68.51 / branches 73.69 / functions 69.92 / lines 68.51. All four RAISED:
+      // statements/lines 67→68 (68.51 → 0.51 buffer), branches 72→73 (73.69 →
+      // 0.69 buffer), functions 68→69 (69.92 → 0.92 buffer) — each clears the
+      // ~0.5pp no-cushion margin. NO-REGRESSION floors, NOT the target — raise
       // incrementally (target 90; local == CI, so there is no integration
       // cushion: keep ≥~0.5pp headroom before any raise).
       thresholds: {
-        statements: 67,
-        branches: 72,
-        functions: 68,
-        lines: 67,
+        statements: 68,
+        branches: 73,
+        functions: 69,
+        lines: 68,
       },
     },
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -362,12 +362,14 @@ omit = [
 [tool.coverage.report]
 show_missing = true
 # Ratchet floor at measured reality. Local hermetic (Windows, pyvips skipped)
-# = 86.53% after the session-9 service-layer climb (session_service /
-# analytics_service / notifications delivery+core+news_events /
-# compliance_service); CI (Linux + integration tier) measures ~0.7pp higher.
+# = 88.04% after the session-10 service-layer climb (user.stats_service /
+# analytics / minio_storage / auth.security_service + webpush / auth_service /
+# mfa.challenge / chat.command_service / orjson_utils / etag / mfa_challenge_cleanup
+# + event_service IntegrityError-retry + user.logic noload-create catch-ups);
+# CI (Linux + integration tier) measures ~0.7pp higher.
 # No-regression floor, NOT the aspirational target — raise incrementally as
 # the campaign adds tests (target 95%). Unified across pyproject / Makefile / ci.yml.
-fail_under = 86
+fail_under = 88
 exclude_lines = [
   "pragma: no cover",
   "def __repr__",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -363,9 +363,12 @@ omit = [
 show_missing = true
 # Ratchet floor at measured reality. Local hermetic (Windows, pyvips skipped)
 # = 88.04% after the session-10 service-layer climb (user.stats_service /
-# analytics / minio_storage / auth.security_service + webpush / auth_service /
+# analytics / minio_storage / webpush / auth_service / security_cleanup /
 # mfa.challenge / chat.command_service / orjson_utils / etag / mfa_challenge_cleanup
 # + event_service IntegrityError-retry + user.logic noload-create catch-ups);
+# NOTE: app/services/auth/security_service.py (AuthSecurityService, wired via
+# app/api/deps/auth.py) was the plan's Tier-1 target but was substituted by the
+# broader auth_service.py test and still has no dedicated suite — a session-11 vein.
 # CI (Linux + integration tier) measures ~0.7pp higher.
 # No-regression floor, NOT the aspirational target — raise incrementally as
 # the campaign adds tests (target 95%). Unified across pyproject / Makefile / ci.yml.

--- a/services/file-processor/internal/service/server_edge_test.go
+++ b/services/file-processor/internal/service/server_edge_test.go
@@ -1,0 +1,91 @@
+package service
+
+// Coverage tests (testing session 10) for validateProcessFileRequest arms that
+// TestGRPCPathTraversalRejection (path-traversal + oversized-key) does not
+// reach: empty id, unsupported type, empty source/dest, options-count limit,
+// and oversized option key/value. Direct gRPC-handler calls with a nil
+// TemporalClient — every case returns at the validation boundary before any
+// workflow start, so no Temporal connection is needed.
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	pb "github.com/university-ecosystem/core/gen/go/file_processor/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestValidateProcessFileRequest_RejectionArms(t *testing.T) {
+	s := &Server{TemporalClient: nil}
+	ctx := context.Background()
+
+	bigOptions := make(map[string]string, maxOptionsCount+1)
+	for i := 0; i < maxOptionsCount+1; i++ {
+		bigOptions[string(rune('a'+i))] = "1"
+	}
+
+	cases := []struct {
+		name         string
+		req          *pb.ProcessFileRequest
+		wantContains string
+	}{
+		{
+			name:         "empty id",
+			req:          &pb.ProcessFileRequest{Type: "image_resize", SourceKey: "s", DestKey: "d"},
+			wantContains: "id is required",
+		},
+		{
+			name:         "unsupported type",
+			req:          &pb.ProcessFileRequest{Id: "x", Type: "audio_normalize", SourceKey: "s", DestKey: "d"},
+			wantContains: "unsupported file type",
+		},
+		{
+			name:         "empty source key",
+			req:          &pb.ProcessFileRequest{Id: "x", Type: "image_resize", SourceKey: "", DestKey: "d"},
+			wantContains: "source_key and dest_key are required",
+		},
+		{
+			name:         "empty dest key",
+			req:          &pb.ProcessFileRequest{Id: "x", Type: "image_resize", SourceKey: "s", DestKey: ""},
+			wantContains: "source_key and dest_key are required",
+		},
+		{
+			name: "options count over limit",
+			req: &pb.ProcessFileRequest{
+				Id: "x", Type: "image_resize", SourceKey: "s", DestKey: "d", Options: bigOptions,
+			},
+			wantContains: "options count",
+		},
+		{
+			name: "option key too long",
+			req: &pb.ProcessFileRequest{
+				Id: "x", Type: "image_resize", SourceKey: "s", DestKey: "d",
+				Options: map[string]string{strings.Repeat("k", maxOptionKeyLen+1): "v"},
+			},
+			wantContains: "exceeds size limit",
+		},
+		{
+			name: "option value too long",
+			req: &pb.ProcessFileRequest{
+				Id: "x", Type: "image_resize", SourceKey: "s", DestKey: "d",
+				Options: map[string]string{"width": strings.Repeat("v", maxOptionValueLen+1)},
+			},
+			wantContains: "exceeds size limit",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := s.ProcessFile(ctx, tc.req)
+			require.Error(t, err)
+			st, ok := status.FromError(err)
+			require.True(t, ok, "expected a gRPC status error")
+			assert.Equal(t, codes.InvalidArgument, st.Code())
+			assert.Contains(t, st.Message(), tc.wantContains)
+		})
+	}
+}

--- a/services/gateway/middleware/auth_edge_test.go
+++ b/services/gateway/middleware/auth_edge_test.go
@@ -1,0 +1,244 @@
+package middleware
+
+// Coverage tests (testing session 10) for auth.go edge paths the prior sessions
+// left uncovered: extractAlgFromHeader error arms, the Optional() RS256 +
+// algorithm-downgrade branches, the Optional() valid-RS256 and revoked-session
+// paths, and StartJWKSRefresher's equal-key (no-rotation) branch.
+//
+// Reuses the same-package helpers from auth_test.go (createTestRouter,
+// createValidToken, testSecret) and auth_redis_test.go (startMockRedis,
+// newRedisMiddleware, revocableClaims, bearerRequest).
+//
+// NOTE: keyFunc's default (unexpected-algorithm) branch is effectively
+// unreachable through the public API — the jwt parser's WithValidMethods
+// allowlist rejects any non-RS256/HS256 token BEFORE keyFunc runs — so it is
+// not chased here (observation only).
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// rsaTestKeys generates an RSA keypair and returns the private key plus its
+// PKIX PEM public encoding (the form NewJWTMiddlewareWithConfig expects).
+func rsaTestKeys(t *testing.T) (*rsa.PrivateKey, string) {
+	t.Helper()
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	pubASN1, err := x509.MarshalPKIXPublicKey(&priv.PublicKey)
+	require.NoError(t, err)
+	pubPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubASN1})
+	return priv, string(pubPEM)
+}
+
+func signRS256(t *testing.T, priv *rsa.PrivateKey, claims Claims) string {
+	t.Helper()
+	tok := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	s, err := tok.SignedString(priv)
+	require.NoError(t, err)
+	return s
+}
+
+func freshClaims(jti string) Claims {
+	return Claims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			ID:        jti,
+			IssuedAt:  jwt.NewNumericDate(time.Now().Add(-1 * time.Minute)),
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+		},
+		UserID:   "user-edge",
+		Role:     "student",
+		IsActive: true,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// extractAlgFromHeader — directly callable error arms
+// ---------------------------------------------------------------------------
+
+func TestExtractAlgFromHeader_ErrorArms(t *testing.T) {
+	t.Run("not three parts", func(t *testing.T) {
+		_, err := extractAlgFromHeader("only.two")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expected 3 dot-separated parts")
+	})
+	t.Run("bad base64 header", func(t *testing.T) {
+		_, err := extractAlgFromHeader("!!!notbase64!!!.payload.sig")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "base64")
+	})
+	t.Run("bad json header", func(t *testing.T) {
+		// base64url("not json") — decodes fine, fails json.Unmarshal.
+		_, err := extractAlgFromHeader("bm90IGpzb24.payload.sig")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "json")
+	})
+	t.Run("missing alg field", func(t *testing.T) {
+		// base64url("{}") = "e30".
+		_, err := extractAlgFromHeader("e30.payload.sig")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "missing 'alg'")
+	})
+	t.Run("valid RS256 header", func(t *testing.T) {
+		// base64url(`{"alg":"RS256"}`).
+		alg, err := extractAlgFromHeader("eyJhbGciOiJSUzI1NiJ9.payload.sig")
+		require.NoError(t, err)
+		assert.Equal(t, "RS256", alg)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Optional() — RS256-configured branches
+// ---------------------------------------------------------------------------
+
+func captureContextHandler() (gin.HandlerFunc, *map[string]any) {
+	captured := map[string]any{}
+	return func(c *gin.Context) {
+		if v, ok := c.Get("user_id"); ok {
+			captured["user_id"] = v
+		}
+		c.Status(http.StatusOK)
+	}, &captured
+}
+
+func TestOptional_RS256Configured_RejectsHS256Downgrade(t *testing.T) {
+	_, pubPEM := rsaTestKeys(t)
+	m := NewJWTMiddlewareWithConfig(testSecret, pubPEM, nil, DefaultL1CacheConfig())
+
+	probe, captured := captureContextHandler()
+	router := gin.New()
+	router.GET("/test", m.Optional(context.Background()), probe)
+
+	// A well-formed HS256 token — a downgrade attempt under RS256 config.
+	hs := createValidToken(testSecret, freshClaims("jti-hs"))
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, bearerRequest(hs))
+
+	assert.Equal(t, http.StatusOK, rec.Code, "optional auth continues")
+	_, hasUser := (*captured)["user_id"]
+	assert.False(t, hasUser, "downgrade attempt must stay unauthenticated")
+}
+
+func TestOptional_RS256Configured_MalformedHeaderUnauthenticated(t *testing.T) {
+	_, pubPEM := rsaTestKeys(t)
+	m := NewJWTMiddlewareWithConfig(testSecret, pubPEM, nil, DefaultL1CacheConfig())
+
+	probe, captured := captureContextHandler()
+	router := gin.New()
+	router.GET("/test", m.Optional(context.Background()), probe)
+
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, bearerRequest("garbage-not-a-jwt"))
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	_, hasUser := (*captured)["user_id"]
+	assert.False(t, hasUser, "malformed token → unauthenticated")
+}
+
+func TestOptional_RS256Configured_ValidTokenSetsContext(t *testing.T) {
+	priv, pubPEM := rsaTestKeys(t)
+	// nil redis → verifySession early-returns valid (m.redis == nil guard).
+	m := NewJWTMiddlewareWithConfig(testSecret, pubPEM, nil, DefaultL1CacheConfig())
+
+	probe, captured := captureContextHandler()
+	router := gin.New()
+	router.GET("/test", m.Optional(context.Background()), probe)
+
+	token := signRS256(t, priv, freshClaims("jti-ok"))
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, bearerRequest(token))
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "user-edge", (*captured)["user_id"], "valid RS256 token sets user context")
+}
+
+func TestOptional_NoTokenContinues(t *testing.T) {
+	m := NewJWTMiddleware(testSecret, nil)
+	probe, captured := captureContextHandler()
+	router := gin.New()
+	router.GET("/test", m.Optional(context.Background()), probe)
+
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/test", nil))
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	_, hasUser := (*captured)["user_id"]
+	assert.False(t, hasUser)
+}
+
+func TestOptional_RevokedSessionContinuesUnauthenticatedHS256(t *testing.T) {
+	// Redis says the jti IS revoked → verifySession reports invalid →
+	// Optional continues without user context (the !isValid arm).
+	url, stop := startMockRedis(t, mockRedisConfig{existsReply: ":1\r\n"})
+	defer stop()
+	m := newRedisMiddleware(t, url) // HS256, redis-backed
+
+	probe, captured := captureContextHandler()
+	router := gin.New()
+	router.GET("/test", m.Optional(context.Background()), probe)
+
+	token := createValidToken(testSecret, revocableClaims("jti-revoked"))
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, bearerRequest(token))
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	_, hasUser := (*captured)["user_id"]
+	assert.False(t, hasUser, "revoked session → unauthenticated, request still proceeds")
+}
+
+func TestOptional_ValidSessionSetsContextHS256(t *testing.T) {
+	url, stop := startMockRedis(t, mockRedisConfig{existsReply: ":0\r\n"})
+	defer stop()
+	m := newRedisMiddleware(t, url)
+
+	probe, captured := captureContextHandler()
+	router := gin.New()
+	router.GET("/test", m.Optional(context.Background()), probe)
+
+	token := createValidToken(testSecret, revocableClaims("jti-live"))
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, bearerRequest(token))
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "user-1", (*captured)["user_id"])
+}
+
+// ---------------------------------------------------------------------------
+// StartJWKSRefresher — equal-key (no-rotation) branch
+// ---------------------------------------------------------------------------
+
+func TestStartJWKSRefresher_EqualKeyNoRotation(t *testing.T) {
+	_, pubPEM := rsaTestKeys(t)
+	// JWKS endpoint that always returns the SAME PEM → the refresher should
+	// detect the unchanged key and NOT count a rotation on the periodic poll.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(pubPEM)) //nolint:errcheck // test server best-effort
+	}))
+	defer srv.Close()
+
+	m := NewJWTMiddlewareWithConfig(testSecret, pubPEM, nil, DefaultL1CacheConfig())
+	ctx, cancel := context.WithCancel(context.Background())
+	// StartJWKSRefresher dereferences its logger arg (no nil-guard), so pass a
+	// real discard logger. Very short interval so a couple of polls happen.
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	go m.StartJWKSRefresher(ctx, srv.URL, 20*time.Millisecond, logger)
+	time.Sleep(80 * time.Millisecond)
+	cancel()
+
+	// The key is still loaded and usable (equal-key poll didn't clobber it).
+	assert.NotNil(t, m.rsaPublicKey.Load(), "public key remains loaded after equal-key polls")
+}

--- a/services/ws-hub/pkg/hub/client_unit_test.go
+++ b/services/ws-hub/pkg/hub/client_unit_test.go
@@ -1,0 +1,378 @@
+package hub
+
+// Coverage tests (testing session 10) for pkg/hub/client.go — the Client
+// pump/room/message machinery that prior sessions exercised only through the
+// single happy-path HandleWebSocket E2E. These drive ReadPump / WritePump /
+// handleMessage / JoinRoom / LeaveRoom / safeSend directly via real gorilla
+// connection pairs and direct calls.
+//
+// CAUTION (session-9 gotcha, still binding): NEVER send a {"type":"message"}
+// frame THROUGH ReadPump in these tests — handleMessage publishes to a nil
+// *nats.Conn and the panic inside the ReadPump goroutine would kill the test
+// binary. The oversized / rate-limit branches of handleMessage are reached via
+// DIRECT calls below (they return before any NATS access). join/leave are
+// NATS-free and safe over the socket.
+//
+// Metric-asserting tests read package-global counters via prometheus/testutil
+// before+after within one test and are NOT marked t.Parallel().
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/university-ecosystem/ws-hub/pkg/config"
+)
+
+// newConnPair returns a connected (server, client) gorilla websocket pair via a
+// throwaway httptest server. net.Pipe does NOT work — *websocket.Conn requires a
+// real handshake. Both ends are closed on cleanup.
+func newConnPair(t *testing.T) (server, client *websocket.Conn) {
+	t.Helper()
+	upgrader := websocket.Upgrader{
+		CheckOrigin: func(*http.Request) bool { return true },
+	}
+	srvCh := make(chan *websocket.Conn, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		srvCh <- c
+	}))
+	t.Cleanup(srv.Close)
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	client, resp, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	require.NoError(t, err)
+	if resp != nil && resp.Body != nil {
+		_ = resp.Body.Close() //nolint:errcheck // handshake response cleanup
+	}
+	select {
+	case server = <-srvCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("server side of websocket pair never arrived")
+	}
+	t.Cleanup(func() {
+		_ = client.Close() //nolint:errcheck // test cleanup
+		_ = server.Close() //nolint:errcheck // test cleanup
+	})
+	return server, client
+}
+
+// newClientOn wires a *Client around the server side of a pair, with a private
+// context so teardown branches are reachable without running the whole hub.
+func newClientOn(h *Hub, serverConn *websocket.Conn, id, userID string) *Client {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &Client{
+		ID:     id,
+		UserID: userID,
+		Conn:   serverConn,
+		Rooms:  make(map[string]bool),
+		Send:   make(chan []byte, 8),
+		Hub:    h,
+		ctx:    ctx,
+		cancel: cancel,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// safeSend
+// ---------------------------------------------------------------------------
+
+func TestSafeSend(t *testing.T) {
+	ok := make(chan []byte, 1)
+	assert.True(t, safeSend(ok, []byte("x")), "buffered channel accepts")
+
+	full := make(chan []byte) // unbuffered, no reader → default branch
+	assert.False(t, safeSend(full, []byte("x")), "full channel returns false")
+
+	closed := make(chan []byte, 1)
+	close(closed)
+	assert.False(t, safeSend(closed, []byte("x")), "send on closed channel recovers to false")
+}
+
+// ---------------------------------------------------------------------------
+// JoinRoom / LeaveRoom (direct)
+// ---------------------------------------------------------------------------
+
+func TestJoinLeaveRoom_Direct(t *testing.T) {
+	h := setupTestHub()
+	go h.Run(context.Background()) // hub ctx for logger; not strictly required here
+	srv, _ := newConnPair(t)
+	c := newClientOn(h, srv, "c-join", "u-join")
+
+	c.JoinRoom("") // empty no-op
+	h.mu.RLock()
+	assert.Empty(t, h.Rooms, "empty room name is a no-op")
+	h.mu.RUnlock()
+
+	c.JoinRoom("room-a")
+	h.mu.RLock()
+	assert.Len(t, h.Rooms["room-a"], 1)
+	h.mu.RUnlock()
+	c.mu.Lock()
+	assert.True(t, c.Rooms["room-a"])
+	c.mu.Unlock()
+
+	c.LeaveRoom("") // empty no-op
+	c.LeaveRoom("never-joined")
+	c.LeaveRoom("room-a")
+	h.mu.RLock()
+	_, stillThere := h.Rooms["room-a"]
+	h.mu.RUnlock()
+	assert.False(t, stillThere, "leaving the last client deletes the room key")
+}
+
+// ---------------------------------------------------------------------------
+// handleMessage (direct — guard paths only, NATS-free)
+// ---------------------------------------------------------------------------
+
+func TestHandleMessage_Oversized(t *testing.T) {
+	h := setupTestHub()
+	srv, _ := newConnPair(t)
+	c := newClientOn(h, srv, "c-big", "u-big")
+
+	before := testutil.ToFloat64(IncomingDropsTotal)
+	big := make([]byte, 61*1024) // > 60 KB ingress limit
+	c.handleMessage(Message{Type: "message", Room: "r"}, big)
+	assert.Equal(t, before+1, testutil.ToFloat64(IncomingDropsTotal))
+
+	select {
+	case notice := <-c.Send:
+		assert.Contains(t, string(notice), "message_too_large")
+	default:
+		t.Fatal("expected a message_too_large notice on Send")
+	}
+}
+
+func TestHandleMessage_OversizedDropsWhenSendFull(t *testing.T) {
+	h := setupTestHub()
+	srv, _ := newConnPair(t)
+	c := newClientOn(h, srv, "c-bigfull", "u-bigfull")
+	// Saturate the Send buffer so the notice hits the default (drop) arm.
+	for i := 0; i < cap(c.Send); i++ {
+		c.Send <- []byte("filler")
+	}
+	before := testutil.ToFloat64(IncomingDropsTotal)
+	c.handleMessage(Message{Type: "message"}, make([]byte, 61*1024))
+	assert.Equal(t, before+1, testutil.ToFloat64(IncomingDropsTotal),
+		"drop is still counted even when the client notice can't be enqueued")
+}
+
+func TestHandleMessage_RateLimited(t *testing.T) {
+	h := setupTestHub()
+	h.clientMsgRateLimit = 0 // deny everything
+	h.clientMsgRateBurst = 0
+	srv, _ := newConnPair(t)
+	c := newClientOn(h, srv, "c-rl", "u-rl")
+
+	c.handleMessage(Message{Type: "message", Room: "r"}, []byte(`{"type":"message"}`))
+	select {
+	case notice := <-c.Send:
+		assert.Contains(t, string(notice), "rate_limit_exceeded")
+	default:
+		t.Fatal("expected a rate_limit_exceeded notice on Send")
+	}
+}
+
+func TestHandleMessage_RateLimitedDropsWhenSendFull(t *testing.T) {
+	h := setupTestHub()
+	h.clientMsgRateLimit = 0
+	h.clientMsgRateBurst = 0
+	srv, _ := newConnPair(t)
+	c := newClientOn(h, srv, "c-rlfull", "u-rlfull")
+	for i := 0; i < cap(c.Send); i++ {
+		c.Send <- []byte("filler")
+	}
+	// Must not panic / block — the notice is silently dropped on a full buffer.
+	c.handleMessage(Message{Type: "message", Room: "r"}, []byte(`{"type":"message"}`))
+}
+
+// ---------------------------------------------------------------------------
+// handleIncomingMessage dispatch (direct)
+// ---------------------------------------------------------------------------
+
+func TestHandleIncomingMessage_JoinLeaveDispatch(t *testing.T) {
+	h := setupTestHub() // mockAuthClient allowed=true
+	srv, _ := newConnPair(t)
+	c := newClientOn(h, srv, "c-disp", "u-disp")
+
+	c.handleIncomingMessage(Message{Type: "join", Room: "room-d"}, nil)
+	h.mu.RLock()
+	assert.Len(t, h.Rooms["room-d"], 1)
+	h.mu.RUnlock()
+
+	c.handleIncomingMessage(Message{Type: "leave", Room: "room-d"}, nil)
+	h.mu.RLock()
+	_, ok := h.Rooms["room-d"]
+	h.mu.RUnlock()
+	assert.False(t, ok)
+}
+
+func TestHandleIncomingMessage_UnknownTypeIncrementsMetric(t *testing.T) {
+	h := setupTestHub()
+	srv, _ := newConnPair(t)
+	c := newClientOn(h, srv, "c-unk", "u-unk")
+
+	before := testutil.ToFloat64(UnknownMsgTypeTotal)
+	c.handleIncomingMessage(Message{Type: "totally-bogus"}, nil)
+	assert.Equal(t, before+1, testutil.ToFloat64(UnknownMsgTypeTotal))
+}
+
+func TestHandleJoin_EmptyRoomNoOp(t *testing.T) {
+	h := setupTestHub()
+	srv, _ := newConnPair(t)
+	c := newClientOn(h, srv, "c-empty", "u-empty")
+	c.handleJoin(Message{Type: "join", Room: ""})
+	h.mu.RLock()
+	assert.Empty(t, h.Rooms)
+	h.mu.RUnlock()
+}
+
+func TestHandleJoin_DeniedIncrementsAuthFailures(t *testing.T) {
+	logger := setupTestHub().Logger
+	cfg := &config.Config{MaxClients: 10, BroadcastBufferSize: 10, BroadcastWorkers: 1}
+	h := NewHub(nil, logger, &mockAuthClient{allowed: false}, cfg, nil)
+	srv, _ := newConnPair(t)
+	c := newClientOn(h, srv, "c-deny", "u-deny")
+
+	before := testutil.ToFloat64(AuthFailuresTotal.WithLabelValues("room_join_denied"))
+	c.handleJoin(Message{Type: "join", Room: "secret"})
+	assert.Equal(t, before+1,
+		testutil.ToFloat64(AuthFailuresTotal.WithLabelValues("room_join_denied")))
+	h.mu.RLock()
+	_, ok := h.Rooms["secret"]
+	h.mu.RUnlock()
+	assert.False(t, ok, "denied join must not create the room")
+}
+
+// ---------------------------------------------------------------------------
+// ReadPump (driven from the client side; NATS-free frames only)
+// ---------------------------------------------------------------------------
+
+func TestReadPump_InvalidJSONThenJoin(t *testing.T) {
+	h := setupTestHub()
+	go h.Run(context.Background())
+	srv, cli := newConnPair(t)
+	c := newClientOn(h, srv, "c-read", "u-read")
+	// Register so the ReadPump teardown's Unregister send has a receiver.
+	h.Register <- c
+	require.Eventually(t, func() bool {
+		h.mu.RLock()
+		defer h.mu.RUnlock()
+		_, ok := h.Clients["c-read"]
+		return ok
+	}, 2*time.Second, 10*time.Millisecond)
+
+	go c.ReadPump()
+
+	require.NoError(t, cli.WriteMessage(websocket.TextMessage, []byte("{not valid json")))
+	require.NoError(t, cli.WriteJSON(map[string]string{"type": "join", "room": "room-r"}))
+	require.Eventually(t, func() bool {
+		h.mu.RLock()
+		defer h.mu.RUnlock()
+		return len(h.Rooms["room-r"]) == 1
+	}, 2*time.Second, 10*time.Millisecond)
+
+	// Closing the client side drives ReadPump teardown → Unregister + limiter delete.
+	require.NoError(t, cli.Close())
+	require.Eventually(t, func() bool {
+		h.mu.RLock()
+		defer h.mu.RUnlock()
+		_, ok := h.Clients["c-read"]
+		return !ok
+	}, 2*time.Second, 10*time.Millisecond)
+}
+
+func TestReadPump_DisallowedTypeOverSocket(t *testing.T) {
+	h := setupTestHub()
+	go h.Run(context.Background())
+	srv, cli := newConnPair(t)
+	c := newClientOn(h, srv, "c-bad", "u-bad")
+	h.Register <- c
+	go c.ReadPump()
+
+	before := testutil.ToFloat64(UnknownMsgTypeTotal)
+	// "ping" is not in allowedMessageTypes → rejected at the parse boundary.
+	require.NoError(t, cli.WriteJSON(map[string]string{"type": "ping"}))
+	require.Eventually(t, func() bool {
+		return testutil.ToFloat64(UnknownMsgTypeTotal) >= before+1
+	}, 2*time.Second, 10*time.Millisecond)
+	require.NoError(t, cli.Close())
+}
+
+func TestReadPump_HubCtxDoneTeardown(t *testing.T) {
+	// When the hub ctx is already cancelled, the teardown select takes the
+	// ctx.Done() arm and closes Send via closeOnce instead of Unregister.
+	logger := setupTestHub().Logger
+	cfg := &config.Config{MaxClients: 10, BroadcastBufferSize: 10, BroadcastWorkers: 1,
+		ClientMsgRateLimit: 10, ClientMsgRateBurst: 10}
+	h := NewHub(nil, logger, &mockAuthClient{allowed: true}, cfg, nil)
+	hubCtx, hubCancel := context.WithCancel(context.Background())
+	h.ctx = hubCtx
+	hubCancel() // hub ctx done before ReadPump teardown runs
+
+	srv, cli := newConnPair(t)
+	c := newClientOn(h, srv, "c-ctx", "u-ctx")
+
+	done := make(chan struct{})
+	go func() { c.ReadPump(); close(done) }()
+	require.NoError(t, cli.Close()) // ends the read loop → teardown
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ReadPump did not exit on closed conn with hub ctx done")
+	}
+	// Send was closed via closeOnce on the ctx.Done() teardown arm.
+	_, open := <-c.Send
+	assert.False(t, open, "Send channel should be closed by the ctx.Done teardown arm")
+}
+
+// ---------------------------------------------------------------------------
+// WritePump
+// ---------------------------------------------------------------------------
+
+func TestWritePump_DeliversThenCloses(t *testing.T) {
+	h := setupTestHub()
+	srv, cli := newConnPair(t)
+	c := newClientOn(h, srv, "c-write", "u-write")
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() { defer wg.Done(); c.WritePump() }()
+
+	c.Send <- []byte(`{"type":"hello"}`)
+	require.NoError(t, cli.SetReadDeadline(time.Now().Add(2*time.Second)))
+	mt, data, err := cli.ReadMessage()
+	require.NoError(t, err)
+	assert.Equal(t, websocket.TextMessage, mt)
+	assert.JSONEq(t, `{"type":"hello"}`, string(data))
+
+	// Closing Send makes WritePump emit a CloseMessage and return.
+	close(c.Send)
+	wg.Wait()
+}
+
+func TestWritePump_ExitsOnCtxCancel(t *testing.T) {
+	h := setupTestHub()
+	srv, _ := newConnPair(t)
+	c := newClientOn(h, srv, "c-wctx", "u-wctx")
+
+	done := make(chan struct{})
+	go func() { c.WritePump(); close(done) }()
+	c.cancel() // ctx.Done() arm → immediate return
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("WritePump did not exit on ctx cancel")
+	}
+}

--- a/tests/test_analytics_service_coverage.py
+++ b/tests/test_analytics_service_coverage.py
@@ -1,0 +1,166 @@
+"""Coverage tests for app/services/analytics.py (testing session 10).
+
+Pure-fn tests for the Polars _compute_* helpers + AsyncMock-repo tests for the
+async wrappers (get_news_repository / get_event_repository are module-level
+imports at analytics.py:25-26 — monkeypatchable).
+
+IMPORTANT: get_user_activity is tested with an AsyncMock session ONLY — its raw
+SQL references the table name `event_attendees` while the real table is
+`event_attendance` (app/models/events.py:126); running it against a real DB
+would fail. The mismatch is filed as a follow-up fix (session 11), out of scope
+for this test-only session.
+
+shutdown() is exercised against a throwaway ThreadPoolExecutor monkeypatched in
+so the shared module pool stays alive for sibling tests.
+"""
+
+from __future__ import annotations
+
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import app.services.analytics as analytics_module
+from app.services.analytics import AnalyticsService, get_analytics_service, shutdown
+
+NEWS_COLUMNS = ["id", "title", "likes_count", "comments_count", "date"]
+EVENT_COLUMNS = ["id", "title", "location", "attendees_count", "max_attendees"]
+
+
+def _news_rows() -> list[tuple]:
+    return [
+        ("n1", "First", 10, 2, "2026-06-01"),
+        ("n2", "Second", 5, 1, "2026-06-01"),
+        ("n3", "Third", 20, 0, "2026-06-02"),
+    ]
+
+
+def _event_rows() -> list[tuple]:
+    return [
+        ("e1", "Hackathon", "Hall A", 30, 50),
+        ("e2", "Lecture", "Hall B", 10, 100),
+        ("e3", "Meetup", "Hall A", 25, 40),
+    ]
+
+
+@pytest.fixture
+def svc() -> AnalyticsService:
+    return AnalyticsService()
+
+
+# ------------------------------------------------------------ pure compute
+
+
+def test_compute_news_stats(svc: AnalyticsService) -> None:
+    stats = svc._compute_news_stats(_news_rows(), NEWS_COLUMNS)
+    assert stats["total"] == 3
+    assert stats["total_likes"] == 35
+    assert stats["total_comments"] == 3
+    by_date = {entry["date"]: entry for entry in stats["by_date"]}
+    assert by_date["2026-06-01"]["count"] == 2
+    assert by_date["2026-06-01"]["total_likes"] == 15
+    assert by_date["2026-06-02"]["total_comments"] == 0
+    assert stats["top_liked"][0]["id"] == "n3"  # sorted by likes desc
+    assert stats["top_liked"][0]["likes_count"] == 20
+
+
+def test_compute_events_stats(svc: AnalyticsService) -> None:
+    stats = svc._compute_events_stats(_event_rows(), EVENT_COLUMNS)
+    assert stats["total"] == 3
+    assert stats["total_attendees"] == 65
+    assert stats["by_location"][0]["location"] == "Hall A"  # 55 attendees
+    assert stats["by_location"][0]["event_count"] == 2
+    assert stats["by_location"][0]["total_attendees"] == 55
+    assert stats["popular"][0]["id"] == "e1"
+    assert stats["popular"][0]["max_attendees"] == 50
+
+
+# -------------------------------------------------------- async wrappers
+
+
+async def test_get_news_stats_empty(
+    svc: AnalyticsService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = MagicMock()
+    repo.get_analytics_data = AsyncMock(return_value=([], []))
+    monkeypatch.setattr(
+        analytics_module, "get_news_repository", MagicMock(return_value=repo)
+    )
+    result = await svc.get_news_stats(AsyncMock())
+    assert result == {"total": 0, "by_date": [], "top_liked": []}
+
+
+async def test_get_news_stats_with_rows(
+    svc: AnalyticsService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = MagicMock()
+    repo.get_analytics_data = AsyncMock(return_value=(_news_rows(), NEWS_COLUMNS))
+    factory = MagicMock(return_value=repo)
+    monkeypatch.setattr(analytics_module, "get_news_repository", factory)
+    session = AsyncMock()
+    result = await svc.get_news_stats(session, start_date=None, end_date=None)
+    assert result["total"] == 3
+    assert result["total_likes"] == 35
+    factory.assert_called_once_with(session)
+
+
+async def test_get_events_stats_empty(
+    svc: AnalyticsService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = MagicMock()
+    repo.get_analytics_data = AsyncMock(return_value=([], []))
+    monkeypatch.setattr(
+        analytics_module, "get_event_repository", MagicMock(return_value=repo)
+    )
+    result = await svc.get_events_stats(AsyncMock())
+    assert result == {"total": 0, "by_location": [], "popular": []}
+
+
+async def test_get_events_stats_with_rows(
+    svc: AnalyticsService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = MagicMock()
+    repo.get_analytics_data = AsyncMock(return_value=(_event_rows(), EVENT_COLUMNS))
+    monkeypatch.setattr(
+        analytics_module, "get_event_repository", MagicMock(return_value=repo)
+    )
+    result = await svc.get_events_stats(AsyncMock(), start_date=None)
+    assert result["total"] == 3
+    assert result["popular"][0]["title"] == "Hackathon"
+
+
+async def test_get_user_activity_mocked_session(svc: AnalyticsService) -> None:
+    """AsyncMock session ONLY — the raw SQL names a non-existent table
+    (`event_attendees` vs real `event_attendance`); see module docstring."""
+    rows = [("news_created", 5), ("events_attended", 2), ("messages_sent", 7)]
+    result_proxy = MagicMock()
+    result_proxy.fetchall.return_value = rows
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=result_proxy)
+    result = await svc.get_user_activity(session, uuid.uuid4())
+    assert result == {"news_created": 5, "events_attended": 2, "messages_sent": 7}
+    session.execute.assert_awaited_once()
+
+
+# ------------------------------------------------------- factory + shutdown
+
+
+def test_get_analytics_service_returns_instance() -> None:
+    instance = get_analytics_service()
+    assert isinstance(instance, AnalyticsService)
+    assert instance._database_url is None
+
+
+def test_init_with_database_url() -> None:
+    assert AnalyticsService("postgres://x")._database_url == "postgres://x"
+
+
+async def test_shutdown_uses_module_executor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    throwaway = ThreadPoolExecutor(max_workers=1, thread_name_prefix="throwaway")
+    monkeypatch.setattr(analytics_module, "_executor", throwaway)
+    await shutdown()
+    assert throwaway._shutdown is True

--- a/tests/test_auth_service_session10.py
+++ b/tests/test_auth_service_session10.py
@@ -1,0 +1,593 @@
+"""Coverage tests for app/services/auth_service.py (testing session 10).
+
+AsyncMock repo + MagicMock-UoW harness (mirrors tests/test_auth_service_coverage.py
+style) targeting the previously-uncovered branches:
+
+- perform_password_reset: token-invalid audit path (L160-166), naive expires_at
+  normalization (L172), HIBP ValueError wrap (L204-205)
+- initiate_email_change: wrong password (L233), invalid email (L239-240),
+  same-email guard (L243), missing db user + full success path (L252-296)
+- confirm_email_change: invalid record (L313), naive expires_at (L320),
+  missing user after update (L346-347), full success path (L354-374)
+- change_password: wrong current password (L387), same password (L389),
+  HIBP ValueError wrap (L396-397), no-active-session revoke-all branch (L411)
+- refresh_pending_email with a user (L441-443)
+- _hash_token production guard (L457)
+- attach_pending_email: None user (L478), DetachedInstanceError fallback +
+  DB-query path (L485-488, L501-505), unexpected inspect error re-raise
+  (L489-496), attach_pending_email_sync non-pydantic assignment (L517)
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException, Request
+from sqlalchemy.orm import exc as orm_exc
+
+import app.auth.security as security_module
+import app.core.csrf as csrf_module
+import app.models as models
+import app.services.auth_service as auth_module
+from app.core.exceptions.domain import EntityNotFound
+from app.schemas import schemas
+from app.services.auth_service import (
+    AuthService,
+    _hash_token,
+    attach_pending_email,
+    attach_pending_email_sync,
+)
+
+
+@pytest.fixture
+def auth_service():
+    audit = MagicMock()
+    auth_repo = MagicMock()
+    user_repo = MagicMock()
+    session_repo = MagicMock()
+    uow = MagicMock()
+    uow.__aenter__.return_value = uow
+    uow.__aexit__.return_value = None
+    uow.commit = AsyncMock()
+    uow.session = MagicMock()
+    uow.session.refresh = AsyncMock()
+
+    return AuthService(
+        audit=audit,
+        auth_repo=auth_repo,
+        user_repo=user_repo,
+        session_repo=session_repo,
+        uow=uow,
+    )
+
+
+@pytest.fixture
+def request_mock():
+    req = MagicMock(spec=Request)
+    req.state = MagicMock()
+    req.headers = {"accept-language": "en"}
+    return req
+
+
+def _spec_user(email: str = "old@example.com") -> MagicMock:
+    user = MagicMock(spec=models.User)
+    user.id = uuid.uuid4()
+    user.email = email
+    user.hashed_password = "argon2-hash"  # pragma: allowlist secret
+    return user
+
+
+# ---------------------------------------------------------------------------
+# perform_password_reset — token-invalid / naive-expiry / HIBP error (L160-205)
+# ---------------------------------------------------------------------------
+
+
+async def test_perform_password_reset_token_invalid(auth_service, request_mock):
+    """Missing token record logs token_invalid and raises 400 (L160-166)."""
+    auth_service.auth_repo.get_valid_password_reset_token = AsyncMock(return_value=None)
+
+    with pytest.raises(HTTPException) as exc:
+        await auth_service.perform_password_reset(
+            "missing-token", "new-password-888", request_mock
+        )
+
+    assert exc.value.status_code == 400
+    auth_service.audit.log.assert_called_with(
+        "password.reset.failed",
+        request_mock,
+        level=logging.WARNING,
+        reason="token_invalid",
+    )
+
+
+async def test_perform_password_reset_naive_expired_token(auth_service, request_mock):
+    """Naive expires_at gets UTC attached (L172) before the expiry comparison."""
+    rec = MagicMock()
+    rec.user_id = uuid.uuid4()
+    rec.expires_at = datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=5)
+    auth_service.auth_repo.get_valid_password_reset_token = AsyncMock(return_value=rec)
+
+    with pytest.raises(HTTPException) as exc:
+        await auth_service.perform_password_reset(
+            "naive-token", "new-password-888", request_mock
+        )
+
+    assert exc.value.status_code == 400
+    auth_service.audit.log.assert_called_with(
+        "password.reset.failed",
+        request_mock,
+        level=logging.WARNING,
+        user_id=rec.user_id,
+        reason="token_expired",
+    )
+
+
+async def test_perform_password_reset_hibp_rejection(
+    auth_service, request_mock, monkeypatch
+):
+    """ValueError from the HIBP check maps to a 400 bad_request (L204-205)."""
+    rec = MagicMock()
+    rec.id = 7
+    rec.user_id = uuid.uuid4()
+    rec.expires_at = datetime.now(UTC) + timedelta(minutes=30)
+    auth_service.auth_repo.get_valid_password_reset_token = AsyncMock(return_value=rec)
+
+    user = MagicMock()
+    user.is_active = True
+    auth_service.user_repo.get = AsyncMock(return_value=user)
+    auth_service.user_repo.update = AsyncMock()
+
+    monkeypatch.setattr(
+        security_module,
+        "validate_password_hibp",
+        AsyncMock(side_effect=ValueError("breached password")),
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await auth_service.perform_password_reset(
+            "valid-token", "new-password-888", request_mock
+        )
+
+    assert exc.value.status_code == 400
+    auth_service.user_repo.update.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# initiate_email_change — guard clauses + success path (L233-296)
+# ---------------------------------------------------------------------------
+
+
+async def test_initiate_email_change_wrong_password(
+    auth_service, request_mock, monkeypatch
+):
+    """Wrong current password raises invalid_password (L233)."""
+    user = _spec_user()
+    payload = schemas.UserEmailChangeIn(
+        email="new@example.com",
+        password="wrong-password",  # pragma: allowlist secret
+    )
+    monkeypatch.setattr(
+        security_module, "verify_password", AsyncMock(return_value=False)
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await auth_service.initiate_email_change(
+            user, payload, request_mock, MagicMock()
+        )
+
+    assert exc.value.status_code == 400
+
+
+async def test_initiate_email_change_invalid_email(
+    auth_service, request_mock, monkeypatch
+):
+    """Email that fails EmailStr re-validation raises invalid_email (L239-240)."""
+    user = _spec_user()
+    # model_construct bypasses schema validation so the service-level
+    # TypeAdapter(EmailStr) re-validation branch executes.
+    payload = schemas.UserEmailChangeIn.model_construct(
+        email="not an email",
+        password="pw",  # pragma: allowlist secret
+    )
+    monkeypatch.setattr(
+        security_module, "verify_password", AsyncMock(return_value=True)
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await auth_service.initiate_email_change(
+            user, payload, request_mock, MagicMock()
+        )
+
+    assert exc.value.status_code == 400
+
+
+async def test_initiate_email_change_same_email(
+    auth_service, request_mock, monkeypatch
+):
+    """Requesting a change to the current email raises email_same (L243)."""
+    user = _spec_user(email="same@example.com")
+    payload = schemas.UserEmailChangeIn(
+        email="same@example.com",
+        password="correct-password",  # pragma: allowlist secret
+    )
+    monkeypatch.setattr(
+        security_module, "verify_password", AsyncMock(return_value=True)
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await auth_service.initiate_email_change(
+            user, payload, request_mock, MagicMock()
+        )
+
+    assert exc.value.status_code == 400
+
+
+async def test_initiate_email_change_missing_db_user(
+    auth_service, request_mock, monkeypatch
+):
+    """Refetch returning no user raises EntityNotFound (L252-253)."""
+    user = _spec_user()
+    payload = schemas.UserEmailChangeIn(
+        email="new@example.com",
+        password="correct-password",  # pragma: allowlist secret
+    )
+    monkeypatch.setattr(
+        security_module, "verify_password", AsyncMock(return_value=True)
+    )
+    auth_service.user_repo.check_email_exists = AsyncMock(return_value=False)
+    auth_service.user_repo.get = AsyncMock(return_value=None)
+
+    with pytest.raises(EntityNotFound):
+        await auth_service.initiate_email_change(
+            user, payload, request_mock, MagicMock()
+        )
+
+
+async def test_initiate_email_change_success(auth_service, request_mock, monkeypatch):
+    """Full happy path: token creation, commit+refresh, email send, audit
+    (L255-296)."""
+    user = _spec_user()
+    user.profile.full_name = "Test User"
+    payload = schemas.UserEmailChangeIn(
+        email="New.Address@Example.com",
+        password="correct-password",  # pragma: allowlist secret
+    )
+
+    db_user = MagicMock(spec=models.User)
+    db_user.id = user.id
+
+    loaded_user = MagicMock()
+    enriched_user = MagicMock()
+
+    monkeypatch.setattr(
+        security_module, "verify_password", AsyncMock(return_value=True)
+    )
+    monkeypatch.setattr(
+        auth_module,
+        "ensure_mfa_relationships_loaded",
+        AsyncMock(return_value=loaded_user),
+    )
+    attach_mock = AsyncMock(return_value=enriched_user)
+    monkeypatch.setattr(auth_module, "attach_pending_email", attach_mock)
+    kick_mock = AsyncMock()
+    monkeypatch.setattr(auth_module.send_auth_email, "kick", kick_mock)
+
+    auth_service.user_repo.check_email_exists = AsyncMock(return_value=False)
+    auth_service.user_repo.get = AsyncMock(return_value=db_user)
+    auth_service.auth_repo.create_email_change_token = AsyncMock()
+
+    result = await auth_service.initiate_email_change(
+        user, payload, request_mock, MagicMock()
+    )
+
+    assert result is enriched_user
+    auth_service.auth_repo.create_email_change_token.assert_awaited_once()
+    create_kwargs = auth_service.auth_repo.create_email_change_token.await_args.kwargs
+    assert create_kwargs["new_email"] == "new.address@example.com"
+    # db_user is spec'd (no model_dump) so the ORM refresh branch executes (L269)
+    auth_service.uow.session.refresh.assert_awaited_once_with(db_user)
+    # enriched_user is not the original user → second attach call fires (L274-275)
+    assert attach_mock.await_count == 2
+    kick_mock.assert_awaited_once()
+    assert kick_mock.await_args.args[0] == "new.address@example.com"
+    auth_service.audit.log.assert_called_with(
+        "users.email.change_requested",
+        request_mock,
+        user_id=user.id,
+        reason="pending_confirmation",
+    )
+
+
+# ---------------------------------------------------------------------------
+# confirm_email_change — guards + success path (L313-374)
+# ---------------------------------------------------------------------------
+
+
+async def test_confirm_email_change_missing_record(auth_service, request_mock):
+    """No matching token record raises email_confirmation_invalid (L313)."""
+    user = _spec_user()
+    auth_service.auth_repo.get_valid_email_change_token = AsyncMock(return_value=None)
+
+    with pytest.raises(HTTPException) as exc:
+        await auth_service.confirm_email_change(user, "token", request_mock)
+
+    assert exc.value.status_code == 400
+
+
+async def test_confirm_email_change_naive_expired_token(auth_service, request_mock):
+    """Naive expires_at gets UTC attached (L320) before the expiry check."""
+    user = _spec_user()
+    record = MagicMock()
+    record.user_id = user.id
+    record.used = False
+    record.expires_at = datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=5)
+    auth_service.auth_repo.get_valid_email_change_token = AsyncMock(return_value=record)
+
+    with pytest.raises(HTTPException) as exc:
+        await auth_service.confirm_email_change(user, "token", request_mock)
+
+    assert exc.value.status_code == 400
+
+
+async def test_confirm_email_change_update_missing_user(auth_service, request_mock):
+    """Update returning no user raises EntityNotFound (L346-347)."""
+    user = _spec_user()
+    record = MagicMock()
+    record.id = 11
+    record.user_id = user.id
+    record.used = False
+    record.new_email = "confirmed@example.com"
+    record.expires_at = datetime.now(UTC) + timedelta(minutes=30)
+
+    auth_service.auth_repo.get_valid_email_change_token = AsyncMock(return_value=record)
+    auth_service.user_repo.check_email_exists = AsyncMock(return_value=False)
+    auth_service.user_repo.update = AsyncMock(return_value=None)
+
+    with pytest.raises(EntityNotFound):
+        await auth_service.confirm_email_change(user, "token", request_mock)
+
+
+async def test_confirm_email_change_success(auth_service, request_mock, monkeypatch):
+    """Full happy path: token consumed, CSRF rotated, audit logged (L343-374)."""
+    user = _spec_user()
+    record = MagicMock()
+    record.id = 12
+    record.user_id = user.id
+    record.used = False
+    record.new_email = "confirmed@example.com"
+    record.expires_at = datetime.now(UTC) + timedelta(minutes=30)
+
+    db_user = MagicMock(spec=models.User)
+    db_user.id = user.id
+
+    auth_service.auth_repo.get_valid_email_change_token = AsyncMock(return_value=record)
+    auth_service.user_repo.check_email_exists = AsyncMock(return_value=False)
+    auth_service.user_repo.update = AsyncMock(return_value=db_user)
+    auth_service.auth_repo.mark_email_change_token_used = AsyncMock()
+    auth_service.auth_repo.invalidate_other_email_change_tokens = AsyncMock()
+
+    attach_mock = AsyncMock()
+    monkeypatch.setattr(auth_module, "attach_pending_email", attach_mock)
+    monkeypatch.setattr(auth_module, "ensure_mfa_relationships_loaded", AsyncMock())
+    csrf_mock = MagicMock()
+    monkeypatch.setattr(csrf_module, "signal_csrf_rotation", csrf_mock)
+
+    result = await auth_service.confirm_email_change(user, "token", request_mock)
+
+    assert result is db_user
+    auth_service.user_repo.update.assert_awaited_once_with(
+        record.user_id, {"email": record.new_email}
+    )
+    auth_service.auth_repo.mark_email_change_token_used.assert_awaited_once_with(12)
+    # db_user is not the original user → second attach call fires (L359-360)
+    assert attach_mock.await_count == 2
+    csrf_mock.assert_called_once_with(request_mock)
+    auth_service.audit.log.assert_called_with(
+        "users.email.changed",
+        request_mock,
+        user_id=user.id,
+        reason="confirmed",
+    )
+
+
+# ---------------------------------------------------------------------------
+# change_password — guards + revoke-all branch (L387-411)
+# ---------------------------------------------------------------------------
+
+
+async def test_change_password_wrong_current_password(
+    auth_service, request_mock, monkeypatch
+):
+    """Wrong current password raises invalid_password (L387)."""
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    user.hashed_password = "argon2-hash"  # pragma: allowlist secret
+    payload = schemas.UserPasswordChangeIn(
+        current_password="wrong-password",  # pragma: allowlist secret
+        new_password="new-password-888",  # pragma: allowlist secret
+    )
+    monkeypatch.setattr(auth_module, "verify_password", AsyncMock(return_value=False))
+
+    with pytest.raises(HTTPException) as exc:
+        await auth_service.change_password(user, payload, request_mock)
+
+    assert exc.value.status_code == 400
+
+
+async def test_change_password_same_password(auth_service, request_mock, monkeypatch):
+    """New password equal to the current one raises password_same (L389)."""
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    user.hashed_password = "argon2-hash"  # pragma: allowlist secret
+    payload = schemas.UserPasswordChangeIn(
+        current_password="current-pass-888",  # pragma: allowlist secret
+        new_password="current-pass-888",  # pragma: allowlist secret
+    )
+    monkeypatch.setattr(
+        auth_module, "verify_password", AsyncMock(side_effect=[True, True])
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await auth_service.change_password(user, payload, request_mock)
+
+    assert exc.value.status_code == 400
+
+
+async def test_change_password_hibp_rejection(auth_service, request_mock, monkeypatch):
+    """ValueError from the HIBP check maps to a 400 bad_request (L396-397)."""
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    user.hashed_password = "argon2-hash"  # pragma: allowlist secret
+    payload = schemas.UserPasswordChangeIn(
+        current_password="current-pass-888",  # pragma: allowlist secret
+        new_password="new-password-888",  # pragma: allowlist secret
+    )
+    monkeypatch.setattr(
+        auth_module, "verify_password", AsyncMock(side_effect=[True, False])
+    )
+    monkeypatch.setattr(
+        auth_module,
+        "validate_password_hibp",
+        AsyncMock(side_effect=ValueError("breached password")),
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await auth_service.change_password(user, payload, request_mock)
+
+    assert exc.value.status_code == 400
+    auth_service.user_repo.update.assert_not_called()
+
+
+async def test_change_password_without_active_session_revokes_all(
+    auth_service, request_mock, monkeypatch
+):
+    """No active session on the request revokes every session (L411)."""
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    user.hashed_password = "argon2-hash"  # pragma: allowlist secret
+    request_mock.state.active_session = None
+    payload = schemas.UserPasswordChangeIn(
+        current_password="current-pass-888",  # pragma: allowlist secret
+        new_password="new-password-888",  # pragma: allowlist secret
+    )
+    monkeypatch.setattr(
+        auth_module, "verify_password", AsyncMock(side_effect=[True, False])
+    )
+    monkeypatch.setattr(auth_module, "validate_password_hibp", AsyncMock())
+    monkeypatch.setattr(
+        auth_module, "get_password_hash", AsyncMock(return_value="new-hash")
+    )
+    monkeypatch.setattr(csrf_module, "signal_csrf_rotation", MagicMock())
+
+    auth_service.user_repo.update = AsyncMock()
+    auth_service.session_repo.revoke_all_for_user = AsyncMock(return_value=3)
+
+    ok, revoked = await auth_service.change_password(user, payload, request_mock)
+
+    assert ok is True
+    assert revoked == 3
+    auth_service.session_repo.revoke_all_for_user.assert_awaited_once_with(
+        user_id=user.id
+    )
+
+
+# ---------------------------------------------------------------------------
+# refresh_pending_email with a user (L440-443)
+# ---------------------------------------------------------------------------
+
+
+async def test_refresh_pending_email_with_pending_request(auth_service):
+    """Pending change request is attached via model_copy (L440-443)."""
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    auth_service.auth_repo.get_active_email_change_request = AsyncMock(
+        return_value=SimpleNamespace(new_email="pending@example.com")
+    )
+
+    result = await auth_service.refresh_pending_email(user)
+
+    user.model_copy.assert_called_once_with(
+        update={"pending_email": "pending@example.com"}
+    )
+    assert result is user.model_copy.return_value
+
+
+# ---------------------------------------------------------------------------
+# _hash_token production guard (L457)
+# ---------------------------------------------------------------------------
+
+
+def test_hash_token_requires_secret_in_production(monkeypatch):
+    """Unset TOKEN_HMAC_SECRET in production raises RuntimeError (L457)."""
+    fake_settings = SimpleNamespace(
+        token_hmac_secret=None,
+        environment="production",
+        secret_key="fallback-secret",  # pragma: allowlist secret
+    )
+    monkeypatch.setattr(auth_module, "settings", fake_settings)
+
+    with pytest.raises(RuntimeError, match="TOKEN_HMAC_SECRET"):
+        _hash_token("some-token")
+
+
+# ---------------------------------------------------------------------------
+# attach_pending_email / attach_pending_email_sync (L478, L485-505, L517)
+# ---------------------------------------------------------------------------
+
+
+async def test_attach_pending_email_none_user():
+    """None user short-circuits to None (L478)."""
+    assert await attach_pending_email(MagicMock(), None) is None
+
+
+async def test_attach_pending_email_detached_instance_falls_back_to_db(monkeypatch):
+    """DetachedInstanceError falls through to the DB query path
+    (L485-488, L501-505) and sets pending_email on the ORM user (L517)."""
+    user = models.User()
+    user.id = uuid.uuid4()
+
+    def _raise_detached(_obj):
+        raise orm_exc.DetachedInstanceError("instance is detached")
+
+    monkeypatch.setattr(auth_module, "inspect", _raise_detached)
+
+    repo = MagicMock()
+    repo.get_active_email_change_request = AsyncMock(
+        return_value=SimpleNamespace(new_email="pending@example.com")
+    )
+    monkeypatch.setattr(auth_module, "AuthRepository", MagicMock(return_value=repo))
+
+    result = await attach_pending_email(MagicMock(), user)
+
+    assert result is user
+    assert result.pending_email == "pending@example.com"
+    repo.get_active_email_change_request.assert_awaited_once_with(user.id)
+
+
+async def test_attach_pending_email_unexpected_inspect_error_reraises(monkeypatch):
+    """Unexpected inspect() errors re-raise as RuntimeError (L489-496)."""
+    user = models.User()
+    user.id = uuid.uuid4()
+
+    def _raise_value(_obj):
+        raise ValueError("boom")
+
+    monkeypatch.setattr(auth_module, "inspect", _raise_value)
+
+    with pytest.raises(RuntimeError, match="unexpected inspect error"):
+        await attach_pending_email(MagicMock(), user)
+
+
+def test_attach_pending_email_sync_sets_attribute_for_plain_object():
+    """Non-pydantic objects get pending_email assigned directly (L516-517)."""
+    obj = SimpleNamespace()
+
+    result = attach_pending_email_sync(obj, "direct@example.com")
+
+    assert result is obj
+    assert result.pending_email == "direct@example.com"

--- a/tests/test_chat_command_session10.py
+++ b/tests/test_chat_command_session10.py
@@ -1,0 +1,576 @@
+"""Coverage tests for app/services/chat/command_service.py (testing session 10).
+
+AsyncMock repo + fake-UoW harness (mirrors tests/test_chat_command_service.py
+style) targeting the previously-uncovered error branches:
+
+- L156-159  send_message idempotency cache hit with a corrupt / legacy entry
+            (falls through to the normal send path);
+- L207      send_message total attachment payload size guard;
+- L234-239  idempotency "pending" slot pre-reservation (Redis SET NX);
+- L278      upload TimeoutError -> errors.files.upload_timeout (except* arm);
+- L283/285-290  Phase 1 failure cleanup (partial upload removal + slot release);
+- L359-372  Phase 2 (DB write) failure cleanup arm (file cleanup + slot release
+            + re-raise);
+- L380-381  send_message degraded fallback when the post-commit reload misses;
+- L430-436  idempotency completed-slot store (SETEX slim format);
+- L502      forward_messages defensive TOCTOU reload-gap 404;
+- L581-582  forward_messages degraded reload path (session.refresh + manual
+            MessageResponse);
+- L968      rename_chat whitespace-only name re-validation;
+- L984      clear_history non-participant + non-admin forbidden;
+- L1021-1023  clear_history commit-failure rollback + re-raise;
+- L1093-1095  delete_chat commit-failure rollback + re-raise.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+import app.deps.cache as cache_module
+import app.services.chat.command_service as cs_module
+from app.services.chat.command_service import (
+    ChatMaintenanceService,
+    ChatMessageDispatcher,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers (mirroring tests/test_chat_command_service.py)
+# ---------------------------------------------------------------------------
+
+
+def _mock_uow():
+    uow = MagicMock()
+    uow.chats = MagicMock()
+    uow.session = AsyncMock()
+    uow.commit = AsyncMock()
+    uow.rollback = AsyncMock()
+    uow.__aenter__ = AsyncMock(return_value=uow)
+    uow.__aexit__ = AsyncMock(return_value=False)
+    return uow
+
+
+def _mock_attachment_service():
+    svc = MagicMock()
+    svc.process_upload = AsyncMock(
+        return_value={
+            "url": "https://s3.example.com/file.pdf",
+            "file_type": "application/pdf",
+            "filename": "file.pdf",
+            "size": 1024,
+        }
+    )
+    svc.cleanup_files = AsyncMock()
+    svc.collect_urls = AsyncMock(return_value=[])
+    return svc
+
+
+def _mock_user(role: str = "student") -> MagicMock:
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    user.email = "test@example.com"
+    user.role = role
+    return user
+
+
+def _mock_chat(
+    owner_id: uuid.UUID,
+    *participant_ids: uuid.UUID,
+    chat_type: str = "dm",
+    created_by: uuid.UUID | None = None,
+):
+    chat = MagicMock()
+    chat.id = uuid.uuid4()
+    chat.created_at = datetime.now(UTC)
+    chat.updated_at = datetime.now(UTC)
+    chat.messages = []
+    chat.chat_type = chat_type
+    chat.created_by = created_by
+    participants = []
+    for pid in [owner_id, *participant_ids]:
+        p = MagicMock()
+        p.id = pid
+        participants.append(p)
+    chat.participants = participants
+    return chat
+
+
+def _patch_ws(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    """Replace the module-level ws_manager (consuming-module patch)."""
+    ws = MagicMock()
+    ws.is_online = MagicMock(return_value=False)
+    ws.broadcast_to_chat = AsyncMock()
+    monkeypatch.setattr(cs_module, "ws_manager", ws)
+    return ws
+
+
+def _patch_cache(monkeypatch: pytest.MonkeyPatch, *, get_value=None) -> AsyncMock:
+    """Patch get_cache_client at its source module (lazily imported per call)."""
+    cache = AsyncMock()
+    cache.get.return_value = get_value
+    monkeypatch.setattr(cache_module, "get_cache_client", AsyncMock(return_value=cache))
+    return cache
+
+
+def _capture_create_message(uow) -> list:
+    """create_message stand-in: stamps the flush-time fields on the real Message."""
+    created: list = []
+
+    async def _capture(msg):
+        msg.id = uuid.uuid4()
+        msg.created_at = datetime.now(UTC)
+        msg.read_status = False
+        msg.sender = None
+        msg.attachments = []
+        created.append(msg)
+
+    uow.chats.create_message = AsyncMock(side_effect=_capture)
+    return created
+
+
+def _leaves(exc: BaseException) -> list[BaseException]:
+    """Flatten (possibly nested) ExceptionGroups into leaf exceptions."""
+    if isinstance(exc, BaseExceptionGroup):
+        out: list[BaseException] = []
+        for sub in exc.exceptions:
+            out.extend(_leaves(sub))
+        return out
+    leaves = [exc]
+    if exc.__context__ is not None and exc.__context__ is not exc:
+        leaves.extend(_leaves(exc.__context__))
+    return leaves
+
+
+# ---------------------------------------------------------------------------
+# send_message — total payload size guard (L207)
+# ---------------------------------------------------------------------------
+
+
+async def test_send_message_total_size_exceeded(monkeypatch):
+    monkeypatch.setattr(cs_module.settings, "chat_attachment_max_files", 10)
+    monkeypatch.setattr(cs_module.settings, "chat_attachment_max_total_bytes", 100)
+
+    uow = _mock_uow()
+    user = _mock_user()
+    chat = _mock_chat(user.id)
+    uow.chats.get_by_id = AsyncMock(return_value=chat)
+    uow.chats.check_participant = AsyncMock(return_value=True)
+
+    dispatcher = ChatMessageDispatcher(uow, _mock_attachment_service(), MagicMock())
+
+    f1, f2 = MagicMock(size=80), MagicMock(size=80)
+    with pytest.raises(HTTPException) as excinfo:
+        await dispatcher.send_message(chat.id, user, "big", [f1, f2], "en")
+    assert excinfo.value.status_code == 400
+    uow.chats.create_message.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# send_message — corrupt idempotency cache entry falls through (L156-159)
+# plus pending-slot reservation (L234-239) + completed store (L430-436)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "cached",
+    [
+        "not-json",  # ValueError from json.loads
+        '{"status": "pending"}',  # KeyError: no message_id
+        '{"message_id": "zzz"}',  # ValueError from uuid.UUID
+    ],
+)
+async def test_send_message_corrupt_idempotency_entry_falls_through(
+    monkeypatch, cached
+):
+    """A legacy / pending / corrupt cached value must NOT short-circuit the send.
+
+    The except (ValueError, KeyError, TypeError) arm passes through to the
+    normal flow, which then pre-reserves the pending slot (SET NX) and finally
+    promotes it to the slim completed entry (SETEX).
+    """
+    cache = _patch_cache(monkeypatch, get_value=cached)
+    _patch_ws(monkeypatch)
+
+    uow = _mock_uow()
+    user = _mock_user()
+    chat = _mock_chat(user.id)
+    uow.chats.get_by_id = AsyncMock(return_value=chat)
+    uow.chats.check_participant = AsyncMock(return_value=True)
+    uow.chats.update_timestamp_by_id = AsyncMock()
+    uow.chats.add = MagicMock()
+    created = _capture_create_message(uow)
+
+    async def _get_last(ids):
+        m = created[0]
+        resp = MagicMock()
+        resp.model_dump.return_value = {
+            "id": m.id,
+            "chat_id": m.chat_id,
+            "sender_id": m.sender_id,
+            "content": m.content,
+            "created_at": m.created_at,
+            "read_status": False,
+            "sender": None,
+            "attachments": [],
+        }
+        resp.replied_to = None
+        return {m.id: resp}
+
+    uow.chats.get_last_messages = AsyncMock(side_effect=_get_last)
+
+    dispatcher = ChatMessageDispatcher(uow, _mock_attachment_service(), MagicMock())
+    result = await dispatcher.send_message(
+        chat.id, user, "Hello", [], "en", idempotency_key="idem-corrupt"
+    )
+
+    assert result is not None
+    uow.chats.create_message.assert_awaited_once()
+    # Pending-slot pre-reservation (L234-239): SET NX with a 300 s TTL.
+    cache.set.assert_awaited_once()
+    set_args, set_kwargs = cache.set.await_args
+    assert set_args[0].startswith("idm:msg:")
+    assert json.loads(set_args[1]) == {"status": "pending"}
+    assert set_kwargs == {"nx": True, "ex": 300}
+    # Completed-slot promotion (L430-436): SETEX with the slim format.
+    cache.setex.assert_awaited_once()
+    key, ttl, slim = cache.setex.await_args.args
+    assert key.startswith("idm:msg:")
+    assert ttl == 86400
+    assert json.loads(slim) == {
+        "status": "completed",
+        "message_id": str(result.id),
+    }
+
+
+# ---------------------------------------------------------------------------
+# send_message — upload TimeoutError maps to errors.files.upload_timeout (L278)
+# ---------------------------------------------------------------------------
+
+
+async def test_send_message_upload_timeout_maps_to_400(monkeypatch):
+    monkeypatch.setattr(cs_module.settings, "chat_attachment_max_files", 5)
+    _patch_ws(monkeypatch)
+
+    uow = _mock_uow()
+    user = _mock_user()
+    chat = _mock_chat(user.id)
+    uow.chats.get_by_id = AsyncMock(return_value=chat)
+    uow.chats.check_participant = AsyncMock(return_value=True)
+
+    attachment_svc = _mock_attachment_service()
+    attachment_svc.process_upload = AsyncMock(side_effect=TimeoutError())
+
+    dispatcher = ChatMessageDispatcher(uow, attachment_svc, MagicMock())
+
+    with pytest.raises(Exception) as excinfo:
+        await dispatcher.send_message(
+            chat.id, user, "with file", [MagicMock(size=10)], "en"
+        )
+
+    leaves = _leaves(excinfo.value)
+    assert any(
+        isinstance(leaf, HTTPException) and leaf.status_code == 400 for leaf in leaves
+    )
+    uow.chats.create_message.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# send_message — Phase 1 failure cleanup (L282-283, L284-290)
+# ---------------------------------------------------------------------------
+
+
+async def test_send_message_phase1_failure_cleans_partial_uploads_and_slot(
+    monkeypatch,
+):
+    """One upload succeeds, the second fails: the saved url must be cleaned up
+    and the idempotency pending slot released (cache DELETE)."""
+    monkeypatch.setattr(cs_module.settings, "chat_attachment_max_files", 5)
+    cache = _patch_cache(monkeypatch, get_value=None)
+    _patch_ws(monkeypatch)
+
+    uow = _mock_uow()
+    user = _mock_user()
+    chat = _mock_chat(user.id)
+    uow.chats.get_by_id = AsyncMock(return_value=chat)
+    uow.chats.check_participant = AsyncMock(return_value=True)
+
+    good_file = MagicMock(size=10)
+    bad_file = MagicMock(size=10)
+
+    async def _process(upload, chat_id, *, locale):
+        if upload is bad_file:
+            # Yield once so the good upload (scheduled first) completes.
+            await asyncio.sleep(0)
+            raise RuntimeError("scan failed")
+        return {
+            "url": "https://s3.example.com/ok.bin",
+            "file_type": "application/octet-stream",
+            "filename": "ok.bin",
+            "size": 10,
+        }
+
+    attachment_svc = _mock_attachment_service()
+    attachment_svc.process_upload = AsyncMock(side_effect=_process)
+
+    dispatcher = ChatMessageDispatcher(uow, attachment_svc, MagicMock())
+
+    with pytest.raises(Exception) as excinfo:
+        await dispatcher.send_message(
+            chat.id,
+            user,
+            "with files",
+            [good_file, bad_file],
+            "en",
+            idempotency_key="idem-phase1",
+        )
+
+    assert any(isinstance(leaf, RuntimeError) for leaf in _leaves(excinfo.value))
+    # Partial upload removed (L282-283).
+    attachment_svc.cleanup_files.assert_awaited_once_with(
+        ["https://s3.example.com/ok.bin"]
+    )
+    # Pending slot released (L284-290).
+    cache.delete.assert_awaited_once()
+    uow.chats.create_message.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# send_message — Phase 2 (DB write) failure cleanup (L359-372)
+# ---------------------------------------------------------------------------
+
+
+async def test_send_message_phase2_failure_cleans_files_and_slot(monkeypatch):
+    monkeypatch.setattr(cs_module.settings, "chat_attachment_max_files", 5)
+    cache = _patch_cache(monkeypatch, get_value=None)
+    _patch_ws(monkeypatch)
+
+    uow = _mock_uow()
+    user = _mock_user()
+    chat = _mock_chat(user.id)
+    uow.chats.get_by_id = AsyncMock(return_value=chat)
+    uow.chats.check_participant = AsyncMock(return_value=True)
+    uow.chats.update_timestamp_by_id = AsyncMock()
+    uow.chats.add = MagicMock()
+    _capture_create_message(uow)
+    uow.commit = AsyncMock(side_effect=RuntimeError("db down"))
+
+    attachment_svc = _mock_attachment_service()
+    dispatcher = ChatMessageDispatcher(uow, attachment_svc, MagicMock())
+
+    with pytest.raises(RuntimeError, match="db down"):
+        await dispatcher.send_message(
+            chat.id,
+            user,
+            "with file",
+            [MagicMock(size=10)],
+            "en",
+            idempotency_key="idem-phase2",
+        )
+
+    # Uploaded file cleaned up (L363-364) + pending slot released (L365-371).
+    attachment_svc.cleanup_files.assert_awaited_once_with(
+        ["https://s3.example.com/file.pdf"]
+    )
+    cache.delete.assert_awaited_once()
+    # No completed-slot promotion after a Phase 2 failure.
+    cache.setex.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# send_message — degraded fallback when the reload misses (L378-400)
+# ---------------------------------------------------------------------------
+
+
+async def test_send_message_fallback_when_reload_missing(monkeypatch):
+    """get_last_messages returning {} forces the session.refresh fallback that
+    builds the MessageResponse field-by-field from the ORM row (L380-381)."""
+    _patch_ws(monkeypatch)
+
+    uow = _mock_uow()
+    user = _mock_user()
+    chat = _mock_chat(user.id)
+    uow.chats.get_by_id = AsyncMock(return_value=chat)
+    uow.chats.check_participant = AsyncMock(return_value=True)
+    uow.chats.update_timestamp_by_id = AsyncMock()
+    uow.chats.add = MagicMock()
+    created = _capture_create_message(uow)
+    uow.chats.get_last_messages = AsyncMock(return_value={})
+
+    dispatcher = ChatMessageDispatcher(uow, _mock_attachment_service(), MagicMock())
+    result = await dispatcher.send_message(chat.id, user, "Hello fallback", [], "en")
+
+    uow.session.refresh.assert_awaited_once_with(created[0])
+    assert result.id == created[0].id
+    assert result.content == "Hello fallback"
+    assert result.read_status is False
+    assert result.reply_to is None
+    assert result.attachments == []
+
+
+# ---------------------------------------------------------------------------
+# forward_messages — defensive TOCTOU reload gap (L498-502)
+# ---------------------------------------------------------------------------
+
+
+async def test_forward_messages_reload_gap_raises_404(monkeypatch):
+    _patch_ws(monkeypatch)
+
+    uow = _mock_uow()
+    user = _mock_user()
+    dest_chat = _mock_chat(user.id)
+    uow.chats.get_by_id = AsyncMock(return_value=dest_chat)
+    uow.chats.check_participant = AsyncMock(return_value=True)
+    uow.chats.message_exists_in_chat = AsyncMock(return_value=True)
+    # Existence checks passed, but the batched load comes back short.
+    uow.chats.get_last_messages = AsyncMock(return_value={})
+
+    dispatcher = ChatMessageDispatcher(uow, _mock_attachment_service(), MagicMock())
+
+    with pytest.raises(HTTPException) as excinfo:
+        await dispatcher.forward_messages(
+            dest_chat.id, user, uuid.uuid4(), [uuid.uuid4()], "en"
+        )
+    assert excinfo.value.status_code == 404
+    uow.chats.create_message.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# forward_messages — degraded reload path (L578-596, incl. L581-582)
+# ---------------------------------------------------------------------------
+
+
+async def test_forward_messages_degraded_reload_refreshes_orm(monkeypatch):
+    """When the FINAL reload returns nothing, the response is built from the
+    refreshed ORM row (session.refresh + field-by-field MessageResponse)."""
+    _patch_ws(monkeypatch)
+
+    uow = _mock_uow()
+    user = _mock_user()
+    dest_chat = _mock_chat(user.id)
+    source_chat_id = uuid.uuid4()
+    mid = uuid.uuid4()
+
+    src = MagicMock()
+    src.id = mid
+    src.sender_id = uuid.uuid4()
+    src.content = "forwarded text"
+    src.attachments = []
+
+    uow.chats.get_by_id = AsyncMock(return_value=dest_chat)
+    uow.chats.check_participant = AsyncMock(return_value=True)
+    uow.chats.message_exists_in_chat = AsyncMock(return_value=True)
+    # First call: source batch load; second call: post-commit reload misses.
+    uow.chats.get_last_messages = AsyncMock(side_effect=[{mid: src}, {}])
+    uow.chats.get_user_display_names = AsyncMock(
+        return_value={src.sender_id: "Anna Original"}
+    )
+    uow.chats.update_timestamp_by_id = AsyncMock()
+    uow.chats.add = MagicMock()
+    created = _capture_create_message(uow)
+
+    dispatcher = ChatMessageDispatcher(uow, _mock_attachment_service(), MagicMock())
+    responses = await dispatcher.forward_messages(
+        dest_chat.id, user, source_chat_id, [mid], "en"
+    )
+
+    assert len(responses) == 1
+    resp = responses[0]
+    uow.session.refresh.assert_awaited_once_with(created[0])
+    assert resp.id == created[0].id
+    assert resp.content == "forwarded text"
+    assert resp.sender_id == user.id
+    assert resp.forwarded_from_name == "Anna Original"
+    assert resp.reply_to is None
+    uow.commit.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# rename_chat — whitespace-only name re-validation (L966-968)
+# ---------------------------------------------------------------------------
+
+
+async def test_rename_chat_whitespace_only_name_rejected():
+    user = _mock_user()
+    chat = _mock_chat(user.id, uuid.uuid4(), chat_type="group", created_by=user.id)
+    uow = _mock_uow()
+    uow.chats.get_by_id = AsyncMock(return_value=chat)
+    uow.chats.rename_chat = AsyncMock()
+
+    svc = ChatMaintenanceService(uow, _mock_attachment_service())
+
+    with pytest.raises(HTTPException) as excinfo:
+        await svc.rename_chat(chat.id, user, "   ", "en")
+    assert excinfo.value.status_code == 400
+    uow.chats.rename_chat.assert_not_called()
+    uow.commit.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# clear_history — non-participant + non-admin forbidden (L983-984)
+# ---------------------------------------------------------------------------
+
+
+async def test_clear_history_non_participant_non_admin_forbidden():
+    user = _mock_user(role="student")
+    chat = _mock_chat(uuid.uuid4())  # user is NOT a participant
+    uow = _mock_uow()
+    uow.chats.get_by_id = AsyncMock(return_value=chat)
+
+    svc = ChatMaintenanceService(uow, _mock_attachment_service())
+
+    with pytest.raises(HTTPException) as excinfo:
+        await svc.clear_history(chat.id, user, "en")
+    assert excinfo.value.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# clear_history — commit failure rolls back + re-raises (L1021-1023)
+# ---------------------------------------------------------------------------
+
+
+async def test_clear_history_commit_failure_rolls_back():
+    admin = _mock_user(role="admin")
+    chat = _mock_chat(admin.id)
+    chat.messages = [MagicMock(id=uuid.uuid4())]
+    uow = _mock_uow()
+    uow.chats.get_by_id = AsyncMock(return_value=chat)
+    uow.chats.delete_messages = AsyncMock()
+    uow.chats.update_timestamp_by_id = AsyncMock()
+    uow.chats.add = MagicMock()
+    uow.commit = AsyncMock(side_effect=RuntimeError("commit failed"))
+
+    svc = ChatMaintenanceService(uow, _mock_attachment_service())
+
+    with pytest.raises(RuntimeError, match="commit failed"):
+        await svc.clear_history(chat.id, admin, "en")
+    uow.rollback.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# delete_chat — commit failure rolls back + re-raises (L1093-1095)
+# ---------------------------------------------------------------------------
+
+
+async def test_delete_chat_commit_failure_rolls_back():
+    admin = _mock_user(role="admin")
+    other = _mock_user()
+    chat = _mock_chat(admin.id, other.id)
+    uow = _mock_uow()
+    uow.chats.get_by_id = AsyncMock(return_value=chat)
+    uow.chats.delete_chat = AsyncMock()
+    uow.chats.add = MagicMock()
+    uow.commit = AsyncMock(side_effect=RuntimeError("commit failed"))
+
+    svc = ChatMaintenanceService(uow, _mock_attachment_service())
+
+    with pytest.raises(RuntimeError, match="commit failed"):
+        await svc.delete_chat(chat.id, admin, "en")
+    uow.rollback.assert_awaited_once()
+    # ChatDeleted StoredEvents were staged for both participants before failure.
+    assert uow.chats.add.call_count == 2

--- a/tests/test_core_small_session10.py
+++ b/tests/test_core_small_session10.py
@@ -1,0 +1,394 @@
+"""Coverage tests for three small core/service modules (testing session 10).
+
+Direct-call tests targeting the previously-uncovered line ranges:
+
+1. ``app/core/orjson_utils.py`` — lines 26-63: the ``ImportError`` fallback
+   block (``OrJsonMock``). Exercised by loading a fresh module copy from the
+   real file path with ``sys.modules["orjson"] = None`` so the fallback branch
+   executes; coverage attributes the executed lines to the real file because
+   the spec is created from the original path.
+2. ``app/core/etag.py`` — lines 88-89 + 95-142: ``ETagMiddleware.__init__``
+   and ``dispatch``. Driven by calling ``dispatch`` directly with a minimal
+   ASGI-scope ``Request`` plus a stub ``call_next`` (no async_client / ASGI
+   requests). The ``conditional_response`` helper (150-193) is already covered
+   by tests/test_etag.py and is not re-tested here.
+3. ``app/services/mfa_challenge_cleanup.py`` — lines 39 + 81-116:
+   ``MfaChallengeCleanupConfig.normalized_grace_period`` and the
+   ``start_mfa_challenge_cleanup_scheduler`` loop/stop closures, with the DB
+   cleanup function and ``_METRICS`` monkeypatched at the consuming module.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, ClassVar
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import Request, Response
+from fastapi.responses import StreamingResponse
+
+import app.core.orjson_utils as orjson_utils_module
+import app.services.mfa_challenge_cleanup as mfa_cleanup_module
+from app.core.etag import ETagMiddleware, compute_etag, format_etag
+from app.services.mfa_challenge_cleanup import (
+    MfaChallengeCleanupConfig,
+    start_mfa_challenge_cleanup_scheduler,
+)
+
+# ---------------------------------------------------------------------------
+# 1. app/core/orjson_utils.py — ImportError fallback block (lines 26-63)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fallback(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Load a fresh copy of orjson_utils with the ``orjson`` import blocked.
+
+    Setting ``sys.modules["orjson"] = None`` makes ``import orjson`` raise
+    ``ImportError`` ("import of orjson halted"), which drives the module's
+    fallback branch. The module copy is loaded under a private name so the
+    real ``app.core.orjson_utils`` entry in sys.modules stays untouched;
+    monkeypatch restores the original ``orjson`` entry afterwards.
+    """
+    monkeypatch.setitem(sys.modules, "orjson", None)
+    path = Path(orjson_utils_module.__file__)
+    spec = importlib.util.spec_from_file_location(
+        "_orjson_utils_fallback_s10", str(path)
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_fallback_options_and_sentinels(fallback: Any) -> None:
+    # In fallback mode the combined options collapse to 0, but OPT_NAIVE_UTC
+    # stays a non-zero sentinel so bitwise detection still works (LOW-W19).
+    assert fallback.ORJSON_OPTIONS == 0
+    assert fallback.orjson.OPT_NAIVE_UTC == 1
+    assert fallback.orjson.OPT_SERIALIZE_NUMPY == 0
+    assert fallback.orjson.OPT_UTC_Z == 0
+
+
+def test_fallback_dumps_and_loads_roundtrip(fallback: Any) -> None:
+    raw = fallback.orjson.dumps({"a": 1, "b": "x"})
+    assert isinstance(raw, bytes)
+    assert json.loads(raw) == {"a": 1, "b": "x"}
+    # loads accepts both bytes and str.
+    assert fallback.orjson.loads(raw) == {"a": 1, "b": "x"}
+    assert fallback.orjson.loads(raw.decode("utf-8")) == {"a": 1, "b": "x"}
+
+
+def test_fallback_naive_datetime_with_flag_treated_as_utc(fallback: Any) -> None:
+    naive = datetime(2024, 1, 1, 12, 30)
+    raw = fallback.orjson.dumps({"t": naive}, option=fallback.orjson.OPT_NAIVE_UTC)
+    assert json.loads(raw)["t"] == naive.replace(tzinfo=UTC).isoformat()
+
+
+def test_fallback_naive_datetime_without_flag_raises(fallback: Any) -> None:
+    with pytest.raises(TypeError, match="not JSON serializable"):
+        fallback.orjson.dumps({"t": datetime(2024, 1, 1)})
+
+
+def test_fallback_aware_datetime_with_flag_falls_back_to_default(
+    fallback: Any,
+) -> None:
+    # Aware datetimes are NOT rewritten by OPT_NAIVE_UTC — they fall through
+    # to the caller-supplied default serializer.
+    aware = datetime(2024, 1, 1, tzinfo=UTC)
+    raw = fallback.orjson.dumps(
+        {"t": aware}, default=str, option=fallback.orjson.OPT_NAIVE_UTC
+    )
+    assert json.loads(raw)["t"] == str(aware)
+
+
+def test_fallback_custom_default_serializer(fallback: Any) -> None:
+    class _Marker:
+        pass
+
+    raw = fallback.orjson.dumps({"m": _Marker()}, default=lambda _o: "marker")
+    assert json.loads(raw)["m"] == "marker"
+
+
+def test_fallback_unserializable_without_default_raises(fallback: Any) -> None:
+    with pytest.raises(TypeError):
+        fallback.orjson.dumps({"o": object()})
+
+
+def test_fallback_module_level_wrappers_use_mock(fallback: Any) -> None:
+    # orjson_dumps / orjson_dumps_str / orjson_loads delegate to the mock.
+    raw = fallback.orjson_dumps({"k": 2})
+    assert fallback.orjson_loads(raw) == {"k": 2}
+    assert fallback.orjson_dumps_str({"k": 2}) == raw.decode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# 2. app/core/etag.py — ETagMiddleware.__init__ + dispatch (88-89, 95-142)
+# ---------------------------------------------------------------------------
+
+
+def _build_request(
+    *,
+    method: str = "GET",
+    path: str = "/api/v1/items",
+    if_none_match: str | None = None,
+) -> Request:
+    """Minimal ASGI ``Request`` mirroring tests/test_cached_endpoint.py."""
+    headers: list[tuple[bytes, bytes]] = []
+    if if_none_match is not None:
+        headers.append((b"if-none-match", if_none_match.encode("latin-1")))
+    scope = {
+        "type": "http",
+        "method": method,
+        "path": path,
+        "raw_path": path.encode("latin-1"),
+        "headers": headers,
+        "query_string": b"",
+        "scheme": "http",
+        "server": ("testserver", 80),
+    }
+    return Request(scope)  # type: ignore[arg-type]
+
+
+def _middleware(**kwargs: Any) -> ETagMiddleware:
+    async def _app(scope: Any, receive: Any, send: Any) -> None:  # pragma: no cover
+        raise AssertionError("ASGI app must not be invoked in direct dispatch tests")
+
+    return ETagMiddleware(_app, **kwargs)
+
+
+def _next(response: Any) -> Any:
+    async def call_next(_request: Request) -> Any:
+        return response
+
+    return call_next
+
+
+def test_init_stores_custom_skip_paths() -> None:
+    mw = _middleware(skip_paths=("/custom",))
+    assert mw.skip_paths == ("/custom",)
+    # Default skip paths preserved when not overridden.
+    assert "/healthz" in _middleware().skip_paths
+
+
+@pytest.mark.asyncio
+async def test_dispatch_non_get_request_passes_through() -> None:
+    sentinel = Response(content=b"{}", media_type="application/json")
+    out = await _middleware().dispatch(_build_request(method="POST"), _next(sentinel))
+    assert out is sentinel
+    assert "etag" not in out.headers
+
+
+@pytest.mark.asyncio
+async def test_dispatch_skip_path_passes_through() -> None:
+    sentinel = Response(content=b"{}", media_type="application/json")
+    out = await _middleware().dispatch(_build_request(path="/healthz"), _next(sentinel))
+    assert out is sentinel
+    assert "etag" not in out.headers
+
+
+@pytest.mark.asyncio
+async def test_dispatch_non_200_response_passes_through() -> None:
+    sentinel = Response(
+        content=b'{"detail":"missing"}',
+        status_code=404,
+        media_type="application/json",
+    )
+    out = await _middleware().dispatch(_build_request(), _next(sentinel))
+    assert out is sentinel
+    assert "etag" not in out.headers
+
+
+@pytest.mark.asyncio
+async def test_dispatch_non_json_response_passes_through() -> None:
+    sentinel = Response(content=b"<html></html>", media_type="text/html")
+    out = await _middleware().dispatch(_build_request(), _next(sentinel))
+    assert out is sentinel
+    assert "etag" not in out.headers
+
+
+@pytest.mark.asyncio
+async def test_dispatch_streaming_response_skipped() -> None:
+    # PERF-W19-09: StreamingResponse must not be buffered for ETag hashing.
+    streaming = StreamingResponse(iter([b"{}"]), media_type="application/json")
+    out = await _middleware().dispatch(_build_request(), _next(streaming))
+    assert out is streaming
+    assert "etag" not in out.headers
+
+
+@pytest.mark.asyncio
+async def test_dispatch_response_without_body_attribute_passes_through() -> None:
+    class _NoBody:
+        status_code = 200
+        headers: ClassVar[dict[str, str]] = {"content-type": "application/json"}
+
+    sentinel = _NoBody()
+    out = await _middleware().dispatch(_build_request(), _next(sentinel))
+    assert out is sentinel
+
+
+@pytest.mark.asyncio
+async def test_dispatch_adds_etag_to_json_response() -> None:
+    body = b'{"a":1}'
+    response = Response(content=body, media_type="application/json")
+    out = await _middleware().dispatch(_build_request(), _next(response))
+    assert out.status_code == 200
+    assert out.body == body
+    assert out.headers["etag"] == format_etag(compute_etag(body))
+    assert "application/json" in out.headers["content-type"]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_matching_if_none_match_returns_304() -> None:
+    body = b'{"a":1}'
+    etag = format_etag(compute_etag(body))
+    response = Response(content=body, media_type="application/json")
+    out = await _middleware().dispatch(
+        _build_request(if_none_match=etag), _next(response)
+    )
+    assert out.status_code == 304
+    assert out.body == b""
+    assert out.headers["etag"] == etag
+
+
+@pytest.mark.asyncio
+async def test_dispatch_weak_if_none_match_matches() -> None:
+    # RFC 7232 weak comparison: W/"<tag>" matches the strong ETag we compute.
+    body = b'{"a":1}'
+    weak = f'W/"{compute_etag(body)}"'
+    response = Response(content=body, media_type="application/json")
+    out = await _middleware().dispatch(
+        _build_request(if_none_match=weak), _next(response)
+    )
+    assert out.status_code == 304
+
+
+@pytest.mark.asyncio
+async def test_dispatch_non_matching_if_none_match_returns_full_body() -> None:
+    body = b'{"a":1}'
+    response = Response(content=body, media_type="application/json")
+    out = await _middleware().dispatch(
+        _build_request(if_none_match='"deadbeef"'), _next(response)
+    )
+    assert out.status_code == 200
+    assert out.body == body
+
+
+# ---------------------------------------------------------------------------
+# 3. app/services/mfa_challenge_cleanup.py — config clamp (39) +
+#    start_mfa_challenge_cleanup_scheduler loop/stop closures (81-116)
+# ---------------------------------------------------------------------------
+
+
+class _FakeRun:
+    def __init__(self) -> None:
+        self.deleted: int | None = None
+
+    def observe_deleted(self, count: int) -> None:
+        self.deleted = count
+
+
+class _FakeTrack:
+    def __init__(self, run: _FakeRun) -> None:
+        self._run = run
+
+    async def __aenter__(self) -> _FakeRun:
+        return self._run
+
+    async def __aexit__(self, *exc: object) -> bool:
+        return False  # propagate exceptions, mirroring the real metrics CM
+
+
+class _FakeMetrics:
+    def __init__(self) -> None:
+        self.run = _FakeRun()
+
+    def track_execution(self) -> _FakeTrack:
+        return _FakeTrack(self.run)
+
+
+def test_config_normalization_clamps_interval_and_grace() -> None:
+    cfg = MfaChallengeCleanupConfig(interval_seconds=5, grace_period_seconds=-10)
+    assert cfg.normalized_interval() == 30  # floor of 30 seconds
+    assert cfg.normalized_grace_period() == 0  # never negative (line 39)
+    cfg2 = MfaChallengeCleanupConfig(interval_seconds=120, grace_period_seconds=45)
+    assert cfg2.normalized_interval() == 120
+    assert cfg2.normalized_grace_period() == 45
+
+
+@pytest.mark.asyncio
+async def test_scheduler_runs_cleanup_then_stop_cancels(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Happy path: one loop iteration runs, then _stop() cancels the sleeper."""
+    fake_metrics = _FakeMetrics()
+    monkeypatch.setattr(mfa_cleanup_module, "_METRICS", fake_metrics)
+    cleanup = AsyncMock(return_value=3)
+    monkeypatch.setattr(mfa_cleanup_module, "cleanup_stale_mfa_challenges", cleanup)
+
+    # Explicit config exercises the `config or ...` left branch + clamping.
+    config = MfaChallengeCleanupConfig(interval_seconds=0, grace_period_seconds=-7)
+    stop = await start_mfa_challenge_cleanup_scheduler(config=config)
+    await asyncio.sleep(0.05)  # let the first loop iteration complete
+
+    cleanup.assert_awaited_with(grace_period_seconds=0)
+    assert fake_metrics.run.deleted == 3
+
+    # Task is parked in asyncio.sleep(30) — _stop() cancels and awaits it.
+    await stop()
+
+
+@pytest.mark.asyncio
+async def test_cancel_during_cleanup_hits_inner_cancelled_branch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cancelling while cleanup is mid-flight exercises the inner
+    ``except asyncio.CancelledError: raise`` re-raise (line 95)."""
+    fake_metrics = _FakeMetrics()
+    monkeypatch.setattr(mfa_cleanup_module, "_METRICS", fake_metrics)
+    started = asyncio.Event()
+
+    async def _blocking(**_kwargs: object) -> int:
+        started.set()
+        await asyncio.sleep(3600)  # parked here until the task is cancelled
+        return 0  # pragma: no cover - never reached
+
+    monkeypatch.setattr(mfa_cleanup_module, "cleanup_stale_mfa_challenges", _blocking)
+
+    stop = await start_mfa_challenge_cleanup_scheduler()
+    await asyncio.wait_for(started.wait(), timeout=2)
+
+    # Cancellation propagates from inside the inner try: inner re-raise (95)
+    # → outer CancelledError handler (100-102) → _stop awaits the task.
+    await stop()
+
+
+@pytest.mark.asyncio
+async def test_stop_after_loop_crash_swallows_task_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the loop dies with a non-network error, _stop() hits the
+    ``task.done()`` branch and suppresses the retrieved exception."""
+    fake_metrics = _FakeMetrics()
+    monkeypatch.setattr(mfa_cleanup_module, "_METRICS", fake_metrics)
+    crashed = asyncio.Event()
+
+    async def _boom(**_kwargs: object) -> int:
+        crashed.set()
+        raise ValueError("boom")
+
+    monkeypatch.setattr(mfa_cleanup_module, "cleanup_stale_mfa_challenges", _boom)
+
+    # config=None exercises the `config or MfaChallengeCleanupConfig()` branch.
+    stop = await start_mfa_challenge_cleanup_scheduler()
+    await asyncio.wait_for(crashed.wait(), timeout=2)
+    await asyncio.sleep(0.05)  # let the ValueError finish the task
+
+    # task.done() → task.result() raises ValueError → suppress(Exception).
+    await stop()

--- a/tests/test_event_service.py
+++ b/tests/test_event_service.py
@@ -608,3 +608,111 @@ async def test_get_event_detail_refreshes_secret_material(
     assert out is not None
     assert out.my_qr_token == "tok"
     assert out.is_registered is True
+
+
+# ---------------------------------------------------------------------------
+# IntegrityError race-retry path (testing session 10) — covers
+# event_service.py:327-363, which the existing race test does not reach
+# (it sets mock_repo.commit.side_effect, but register_attendance commits via
+# self.uow.commit()). Here uow.commit raises IntegrityError on the FIRST call
+# and succeeds on the retry.
+# ---------------------------------------------------------------------------
+
+
+def _registration_event():
+    ev = MagicMock()
+    ev.is_active = True
+    ev.ends_at = datetime.now(UTC) + timedelta(hours=1)
+    return ev
+
+
+@pytest.mark.asyncio
+async def test_register_attendance_integrity_retry_updates_registered_at(
+    event_service, mock_uow, mock_repo
+):
+    data = schemas.EventAttendanceCreate(event_id=uuid4())
+    user_id = uuid4()
+
+    mock_repo.get_for_registration.return_value = _registration_event()
+    # 1st get_attendance (pre-create) None; 2nd (post-race) returns a DTO with
+    # registered_at=None → the retry_updates branch fires.
+    raced = EventAttendanceDTO(
+        id=uuid4(), event_id=data.event_id, user_id=user_id, registered_at=None
+    )
+    updated = EventAttendanceDTO(
+        id=raced.id,
+        event_id=data.event_id,
+        user_id=user_id,
+        registered_at=datetime.now(UTC),
+    )
+    mock_repo.get_attendance.side_effect = [None, raced]
+    mock_repo.create_attendance.return_value = raced
+    mock_repo.update_attendance.return_value = updated
+    # uow.commit: 1st call (after create) raises, retry commit succeeds.
+    mock_uow.commit.side_effect = [
+        IntegrityError("dup", {}, Exception()),
+        None,
+    ]
+
+    with patch(
+        "app.services.event_service.attendance_tokens.issue_token",
+        return_value="tok",
+    ):
+        result = await event_service.register_attendance(data, user_id)
+
+    mock_uow.rollback.assert_awaited_once()
+    mock_repo.update_attendance.assert_awaited_once()
+    assert result.qr_token == "tok"
+
+
+@pytest.mark.asyncio
+async def test_register_attendance_integrity_retry_already_registered(
+    event_service, mock_uow, mock_repo
+):
+    data = schemas.EventAttendanceCreate(event_id=uuid4())
+    user_id = uuid4()
+
+    mock_repo.get_for_registration.return_value = _registration_event()
+    # Post-race DTO already has registered_at set → retry_updates stays empty,
+    # so update_attendance + the retry commit are skipped (347-354 not taken).
+    already = EventAttendanceDTO(
+        id=uuid4(),
+        event_id=data.event_id,
+        user_id=user_id,
+        registered_at=datetime.now(UTC),
+    )
+    mock_repo.get_attendance.side_effect = [None, already]
+    mock_repo.create_attendance.return_value = already
+    mock_uow.commit.side_effect = [IntegrityError("dup", {}, Exception())]
+
+    with patch(
+        "app.services.event_service.attendance_tokens.issue_token",
+        return_value="tok2",
+    ):
+        result = await event_service.register_attendance(data, user_id)
+
+    mock_uow.rollback.assert_awaited_once()
+    mock_repo.update_attendance.assert_not_awaited()
+    assert result.qr_token == "tok2"
+
+
+@pytest.mark.asyncio
+async def test_register_attendance_integrity_not_found_raises_value_error(
+    event_service, mock_uow, mock_repo
+):
+    data = schemas.EventAttendanceCreate(event_id=uuid4())
+    user_id = uuid4()
+
+    mock_repo.get_for_registration.return_value = _registration_event()
+    # Post-race get_attendance still None → fall to repo.get; a found event →
+    # ValueError (registration failed), covering 335-337.
+    mock_repo.get_attendance.side_effect = [None, None]
+    mock_repo.create_attendance.return_value = EventAttendanceDTO(
+        id=uuid4(), event_id=data.event_id, user_id=user_id, registered_at=None
+    )
+    mock_repo.get.return_value = MagicMock()  # event exists
+    mock_uow.commit.side_effect = [IntegrityError("dup", {}, Exception())]
+
+    with pytest.raises(ValueError):
+        await event_service.register_attendance(data, user_id)
+    mock_uow.rollback.assert_awaited_once()

--- a/tests/test_mfa_challenge_session10.py
+++ b/tests/test_mfa_challenge_session10.py
@@ -1,0 +1,512 @@
+"""Coverage tests for app/auth/mfa/challenge.py (testing session 10).
+
+Direct-call tests (no ASGI) for the MFA challenge module, targeting the
+previously-uncovered line ranges from the fresh coverage run:
+
+- L90-91         ``_extract_attempt_limit`` int() coercion failure -> None
+- L232           ``_register_failed_attempt`` lock-raise when UPDATE..RETURNING
+                 reports ``locked_at`` was just set by this very update
+- L284-292       ``issue_dummy_challenge`` timing-normalization write
+- L314           ``get_challenge`` list-typed challenge_type filter (real DB)
+- L331, 334      ``get_challenge`` naive expires_at / consumed_at normalization
+- L386-387       ``consume_challenge`` revoked-session guard
+- L395-403       ``consume_challenge`` v_method inference branches
+- L407, 413-416  TOTP code-required + user-not-found guards
+- L428, 442      TOTP empty-secret skip + invalid-code raise
+- L447-465       recovery-code branch (code required / user missing / invalid
+                 code / success fall-through)
+- L473, 480-483  WebAuthn response-required + user-not-found guards
+- L490, 493, 496, 502-510  WebAuthn payload type-confusion guards routed
+                 through the failed-attempt wrap
+
+Harness mirrors tests/test_compliance_service_coverage.py (AsyncMock +
+module-level monkeypatch.setattr) and tests/test_mfa_challenge_cleanup.py
+(real ``db_session`` + ``user_factory`` for the FK-backed rows).
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pyotp
+import pytest
+from fastapi import HTTPException
+
+import app.auth.mfa.challenge as challenge_module
+import app.auth.mfa.recovery as recovery_module
+from app.auth.constants import (
+    CHALLENGE_TYPE_RECOVERY_CODE,
+    CHALLENGE_TYPE_TOTP_AUTH,
+    CHALLENGE_TYPE_WEBAUTHN_AUTH,
+    MFA_METHOD_RECOVERY_CODE,
+    MFA_METHOD_TOTP,
+    MFA_METHOD_WEBAUTHN,
+)
+from app.auth.mfa.challenge import (
+    _extract_attempt_limit,
+    _register_failed_attempt,
+    consume_challenge,
+    get_challenge,
+    issue_dummy_challenge,
+)
+from app.models import MfaChallenge
+from app.models.auth import ChallengeState
+
+
+def _fake_challenge(**overrides: Any) -> SimpleNamespace:
+    """Plain attribute bag standing in for an ORM MfaChallenge row."""
+    defaults: dict[str, Any] = {
+        "id": uuid.uuid4(),
+        "user_id": uuid.uuid4(),
+        "session_id": None,
+        "challenge_type": CHALLENGE_TYPE_TOTP_AUTH,
+        "token": "fake-challenge-token",  # pragma: allowlist secret
+        "expires_at": datetime.now(UTC) + timedelta(minutes=5),
+        "consumed_at": None,
+        "locked_at": None,
+        "payload": None,
+        "attempt_count": 0,
+        "state": ChallengeState.PENDING,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _result_with_challenge(challenge: SimpleNamespace | None) -> MagicMock:
+    """Mimic ``(await db.execute(stmt)).scalars().first()`` chains."""
+    result = MagicMock()
+    result.scalars.return_value.first.return_value = challenge
+    return result
+
+
+@pytest.fixture
+def patched_get_challenge(monkeypatch: pytest.MonkeyPatch):
+    """Patch the module-global ``get_challenge`` used by consume_challenge."""
+
+    def _patch(challenge: SimpleNamespace) -> AsyncMock:
+        stub = AsyncMock(return_value=challenge)
+        monkeypatch.setattr(challenge_module, "get_challenge", stub)
+        return stub
+
+    return _patch
+
+
+@pytest.fixture
+def failed_attempt_spy(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+    """Replace the atomic UPDATE..RETURNING helper so failure paths no-op."""
+    spy = AsyncMock(return_value=None)
+    monkeypatch.setattr(challenge_module, "_register_failed_attempt", spy)
+    return spy
+
+
+# ---------------------------------------------------------------------------
+# _extract_attempt_limit (L90-91)
+# ---------------------------------------------------------------------------
+
+
+def test_extract_attempt_limit_swallows_uncoercible_fallback() -> None:
+    """A fallback that int() rejects returns None instead of raising."""
+    assert _extract_attempt_limit(None, fallback="not-an-int") is None  # type: ignore[arg-type]
+    assert _extract_attempt_limit(None, fallback=object()) is None  # type: ignore[arg-type]
+
+
+def test_extract_attempt_limit_rejects_non_positive() -> None:
+    assert _extract_attempt_limit(None, fallback=0) is None
+    assert _extract_attempt_limit(None, fallback=-3) is None
+
+
+# ---------------------------------------------------------------------------
+# _register_failed_attempt (L232)
+# ---------------------------------------------------------------------------
+
+
+async def test_register_failed_attempt_raises_when_lock_just_acquired() -> None:
+    """RETURNING row with a non-null locked_at must raise the locked error."""
+    db = AsyncMock()
+    result = MagicMock()
+    result.one_or_none.return_value = (3, datetime.now(UTC))
+    db.execute = AsyncMock(return_value=result)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _register_failed_attempt(
+            db,
+            _fake_challenge(),
+            method=MFA_METHOD_TOTP,
+            limit=3,
+            locale="en",
+        )
+
+    assert exc_info.value.status_code == 429
+    db.commit.assert_awaited_once()
+
+
+async def test_register_failed_attempt_noop_when_row_already_finalized() -> None:
+    """No RETURNING row (already consumed/locked concurrently) is a no-op."""
+    db = AsyncMock()
+    result = MagicMock()
+    result.one_or_none.return_value = None
+    db.execute = AsyncMock(return_value=result)
+
+    await _register_failed_attempt(
+        db,
+        _fake_challenge(),
+        method=MFA_METHOD_TOTP,
+        limit=3,
+        locale="en",
+    )
+
+    db.commit.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# issue_dummy_challenge (L284-292)
+# ---------------------------------------------------------------------------
+
+
+async def test_issue_dummy_challenge_executes_deterministic_delay() -> None:
+    db = AsyncMock()
+
+    await issue_dummy_challenge(db)
+
+    db.execute.assert_awaited_once()
+    executed = db.execute.await_args.args[0]
+    assert "pg_sleep" in str(executed)
+    db.flush.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# get_challenge (L314 real DB; L331 / L334 naive-datetime normalization)
+# ---------------------------------------------------------------------------
+
+
+async def test_get_challenge_accepts_list_of_challenge_types(
+    db_session, user_factory
+) -> None:
+    """List-typed challenge_type applies the IN() filter (L314)."""
+    user = await user_factory()
+    challenge = MfaChallenge(
+        user_id=user.id,
+        challenge_type=CHALLENGE_TYPE_TOTP_AUTH,
+        token=f"s10-list-{uuid.uuid4().hex}",  # pragma: allowlist secret
+        expires_at=datetime.now(UTC) + timedelta(minutes=5),
+    )
+    db_session.add(challenge)
+    await db_session.flush()
+
+    found = await get_challenge(
+        db_session,
+        token=challenge.token,
+        challenge_type=[CHALLENGE_TYPE_TOTP_AUTH, CHALLENGE_TYPE_WEBAUTHN_AUTH],
+        user_id=user.id,
+    )
+
+    assert found.id == challenge.id
+
+
+async def test_get_challenge_normalizes_naive_expires_at() -> None:
+    """Naive (tz-less) expires_at is coerced to UTC before comparison (L331)."""
+    naive_future = datetime.now(UTC).replace(tzinfo=None) + timedelta(minutes=5)
+    challenge = _fake_challenge(expires_at=naive_future)
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_result_with_challenge(challenge))
+
+    found = await get_challenge(
+        db, token=challenge.token, challenge_type=CHALLENGE_TYPE_TOTP_AUTH
+    )
+
+    assert found is challenge
+
+
+async def test_get_challenge_rejects_naive_consumed_at() -> None:
+    """Naive consumed_at is coerced to UTC and still rejects the challenge (L334)."""
+    naive_past = datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=1)
+    challenge = _fake_challenge(consumed_at=naive_past)
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_result_with_challenge(challenge))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await get_challenge(
+            db, token=challenge.token, challenge_type=CHALLENGE_TYPE_TOTP_AUTH
+        )
+
+    assert exc_info.value.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# consume_challenge — session guard + method inference (L386-387, L395-403)
+# ---------------------------------------------------------------------------
+
+
+async def test_consume_challenge_rejects_revoked_session(
+    patched_get_challenge,
+) -> None:
+    challenge = _fake_challenge(session_id=uuid.uuid4())
+    patched_get_challenge(challenge)
+    db = AsyncMock()
+    db.get = AsyncMock(return_value=SimpleNamespace(revoked_at=datetime.now(UTC)))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await consume_challenge(
+            db,
+            challenge_token=challenge.token,
+            challenge_type=CHALLENGE_TYPE_TOTP_AUTH,
+        )
+
+    assert exc_info.value.status_code == 400
+
+
+async def test_consume_challenge_infers_totp_and_requires_code(
+    patched_get_challenge,
+) -> None:
+    """TOTP_AUTH type infers MFA_METHOD_TOTP and demands a code (L395-399, 407)."""
+    challenge = _fake_challenge(challenge_type=CHALLENGE_TYPE_TOTP_AUTH)
+    patched_get_challenge(challenge)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await consume_challenge(
+            AsyncMock(),
+            challenge_token=challenge.token,
+            challenge_type=CHALLENGE_TYPE_TOTP_AUTH,
+        )
+
+    assert exc_info.value.status_code == 400
+
+
+async def test_consume_challenge_infers_webauthn_and_requires_response(
+    patched_get_challenge,
+) -> None:
+    """WEBAUTHN_AUTH type infers webauthn and demands a response (L400-401, 473)."""
+    challenge = _fake_challenge(challenge_type=CHALLENGE_TYPE_WEBAUTHN_AUTH)
+    patched_get_challenge(challenge)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await consume_challenge(
+            AsyncMock(),
+            challenge_token=challenge.token,
+            challenge_type=CHALLENGE_TYPE_WEBAUTHN_AUTH,
+        )
+
+    assert exc_info.value.status_code == 400
+
+
+async def test_consume_challenge_infers_recovery_and_requires_code(
+    patched_get_challenge,
+) -> None:
+    """RECOVERY_CODE type infers recovery method and demands a code (L402-403, 447-450)."""
+    challenge = _fake_challenge(challenge_type=CHALLENGE_TYPE_RECOVERY_CODE)
+    patched_get_challenge(challenge)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await consume_challenge(
+            AsyncMock(),
+            challenge_token=challenge.token,
+            challenge_type=CHALLENGE_TYPE_RECOVERY_CODE,
+        )
+
+    assert exc_info.value.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# consume_challenge — TOTP branch (L413-415, L428, L442)
+# ---------------------------------------------------------------------------
+
+
+async def test_consume_challenge_totp_user_missing(patched_get_challenge) -> None:
+    challenge = _fake_challenge()
+    patched_get_challenge(challenge)
+    db = AsyncMock()
+    db.get = AsyncMock(return_value=None)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await consume_challenge(
+            db,
+            challenge_token=challenge.token,
+            challenge_type=CHALLENGE_TYPE_TOTP_AUTH,
+            provided_method=MFA_METHOD_TOTP,
+            provided_code="123456",
+        )
+
+    assert exc_info.value.status_code == 400
+
+
+async def test_consume_challenge_totp_invalid_code_registers_failed_attempt(
+    patched_get_challenge, failed_attempt_spy
+) -> None:
+    """Empty-secret enrollment is skipped (L428); a wrong code raises (L442)."""
+    secret = pyotp.random_base32()
+    totp = pyotp.TOTP(secret)
+    now_ts = time.time()
+    valid_codes = {totp.at(now_ts - 30), totp.at(now_ts), totp.at(now_ts + 30)}
+    wrong_code = next(
+        code
+        for code in ("000000", "111111", "222222", "333333")
+        if code not in valid_codes
+    )
+
+    challenge = _fake_challenge()
+    patched_get_challenge(challenge)
+    db = AsyncMock()
+    db.get = AsyncMock(return_value=SimpleNamespace(id=challenge.user_id))
+    enrollments = MagicMock()
+    enrollments.scalars.return_value.all.return_value = [
+        SimpleNamespace(secret=""),  # skipped via `continue`
+        SimpleNamespace(secret=secret),
+    ]
+    db.execute = AsyncMock(return_value=enrollments)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await consume_challenge(
+            db,
+            challenge_token=challenge.token,
+            challenge_type=CHALLENGE_TYPE_TOTP_AUTH,
+            provided_method=MFA_METHOD_TOTP,
+            provided_code=wrong_code,
+        )
+
+    assert exc_info.value.status_code == 400
+    failed_attempt_spy.assert_awaited_once()
+    assert failed_attempt_spy.await_args.kwargs["method"] == MFA_METHOD_TOTP
+
+
+# ---------------------------------------------------------------------------
+# consume_challenge — recovery-code branch (L447-465 + success fall-through)
+# ---------------------------------------------------------------------------
+
+
+async def test_consume_challenge_recovery_user_missing(
+    patched_get_challenge,
+) -> None:
+    challenge = _fake_challenge(challenge_type=CHALLENGE_TYPE_RECOVERY_CODE)
+    patched_get_challenge(challenge)
+    db = AsyncMock()
+    db.get = AsyncMock(return_value=None)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await consume_challenge(
+            db,
+            challenge_token=challenge.token,
+            challenge_type=CHALLENGE_TYPE_RECOVERY_CODE,
+            provided_method=MFA_METHOD_RECOVERY_CODE,
+            provided_code="AAAA-BBBB",
+        )
+
+    assert exc_info.value.status_code == 400
+
+
+async def test_consume_challenge_recovery_invalid_code_registers_failed_attempt(
+    patched_get_challenge,
+    failed_attempt_spy,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    challenge = _fake_challenge(challenge_type=CHALLENGE_TYPE_RECOVERY_CODE)
+    patched_get_challenge(challenge)
+    monkeypatch.setattr(
+        recovery_module, "verify_recovery_code", AsyncMock(return_value=False)
+    )
+    db = AsyncMock()
+    db.get = AsyncMock(return_value=SimpleNamespace(id=challenge.user_id))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await consume_challenge(
+            db,
+            challenge_token=challenge.token,
+            challenge_type=CHALLENGE_TYPE_RECOVERY_CODE,
+            provided_method=MFA_METHOD_RECOVERY_CODE,
+            provided_code="AAAA-BBBB",
+        )
+
+    assert exc_info.value.status_code == 400
+    failed_attempt_spy.assert_awaited_once()
+    assert failed_attempt_spy.await_args.kwargs["method"] == MFA_METHOD_RECOVERY_CODE
+
+
+async def test_consume_challenge_recovery_success_consumes_challenge(
+    patched_get_challenge, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    challenge = _fake_challenge(challenge_type=CHALLENGE_TYPE_RECOVERY_CODE)
+    patched_get_challenge(challenge)
+    monkeypatch.setattr(
+        recovery_module, "verify_recovery_code", AsyncMock(return_value=True)
+    )
+    db = AsyncMock()
+    db.get = AsyncMock(return_value=SimpleNamespace(id=challenge.user_id))
+
+    consumed, session = await consume_challenge(
+        db,
+        challenge_token=challenge.token,
+        challenge_type=CHALLENGE_TYPE_RECOVERY_CODE,
+        provided_method=MFA_METHOD_RECOVERY_CODE,
+        provided_code="AAAA-BBBB",
+    )
+
+    assert consumed is challenge
+    assert session is None
+    assert challenge.consumed_at is not None
+    assert challenge.state == ChallengeState.CONSUMED
+    db.commit.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# consume_challenge — WebAuthn branch (L480-483, L490, L493, L496, L502-510)
+# ---------------------------------------------------------------------------
+
+
+async def test_consume_challenge_webauthn_user_missing(
+    patched_get_challenge,
+) -> None:
+    challenge = _fake_challenge(challenge_type=CHALLENGE_TYPE_WEBAUTHN_AUTH)
+    patched_get_challenge(challenge)
+    db = AsyncMock()
+    db.get = AsyncMock(return_value=None)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await consume_challenge(
+            db,
+            challenge_token=challenge.token,
+            challenge_type=CHALLENGE_TYPE_WEBAUTHN_AUTH,
+            provided_method=MFA_METHOD_WEBAUTHN,
+            provided_webauthn_response={"id": "credential"},
+        )
+
+    assert exc_info.value.status_code == 400
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param(None, id="payload-not-dict"),
+        pytest.param({"options": "not-a-dict"}, id="options-not-dict"),
+        pytest.param({"options": {"challenge": 123}}, id="challenge-not-string"),
+    ],
+)
+async def test_consume_challenge_webauthn_payload_type_confusion(
+    patched_get_challenge,
+    failed_attempt_spy,
+    payload: dict[str, Any] | None,
+) -> None:
+    """Each malformed payload shape raises TypeError, lands in the except wrap
+    (L502-510) and surfaces as invalid_code after recording a failed attempt."""
+    challenge = _fake_challenge(
+        challenge_type=CHALLENGE_TYPE_WEBAUTHN_AUTH, payload=payload
+    )
+    patched_get_challenge(challenge)
+    db = AsyncMock()
+    db.get = AsyncMock(return_value=SimpleNamespace(id=challenge.user_id))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await consume_challenge(
+            db,
+            challenge_token=challenge.token,
+            challenge_type=CHALLENGE_TYPE_WEBAUTHN_AUTH,
+            provided_method=MFA_METHOD_WEBAUTHN,
+            provided_webauthn_response={"id": "credential"},
+        )
+
+    assert exc_info.value.status_code == 400
+    failed_attempt_spy.assert_awaited_once()
+    assert failed_attempt_spy.await_args.kwargs["method"] == MFA_METHOD_WEBAUTHN

--- a/tests/test_minio_storage_coverage.py
+++ b/tests/test_minio_storage_coverage.py
@@ -1,0 +1,205 @@
+"""Coverage tests for app/services/minio_storage.py (testing session 10).
+
+The Minio SDK class is patched at the module seam (app.services.minio_storage.Minio)
+BEFORE constructing MinIOClient — all SDK calls become MagicMocks executed through
+the real thread pool (they're sync mocks, safe).
+
+S3Error signature verified against the installed minio package
+(.venv/.../minio/error.py:98): S3Error(response, code, message, resource,
+request_id, host_id, ...) — response comes FIRST.
+
+get_minio_client() singleton tests temporarily rebind app.core.config.settings to a
+SimpleNamespace via monkeypatch (the function does a call-time `from app.core.config
+import settings`, so it sees the stub; monkeypatch restores the ORIGINAL settings
+object afterwards — identity preserved, no config reload → mutmut clean-test safe).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import timedelta
+from io import BytesIO
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from minio.error import S3Error
+
+import app.services.minio_storage as minio_module
+from app.services.minio_storage import MinIOClient, get_minio_client
+
+
+def _s3_error(code: str = "NoSuchBucket") -> S3Error:
+    return S3Error(
+        MagicMock(),  # response
+        code,
+        "boom",
+        "resource",
+        "request-id",
+        "host-id",
+    )
+
+
+@pytest.fixture
+def minio_cls(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    cls = MagicMock(name="MinioClass")
+    monkeypatch.setattr(minio_module, "Minio", cls)
+    return cls
+
+
+@pytest.fixture
+def client(minio_cls: MagicMock) -> MinIOClient:
+    return MinIOClient(
+        endpoint="minio:9000",
+        access_key="test-access",  # pragma: allowlist secret
+        secret_key="test-secret",  # pragma: allowlist secret
+        secure=False,
+        default_bucket="uploads",
+    )
+
+
+# ------------------------------------------------------------- initialize
+
+
+async def test_initialize_bucket_exists(client: MinIOClient) -> None:
+    client._client.bucket_exists.return_value = True
+    await client.initialize()
+    assert client._initialized is True
+    client._client.make_bucket.assert_not_called()
+
+
+async def test_initialize_creates_missing_bucket(client: MinIOClient) -> None:
+    client._client.bucket_exists.return_value = False
+    await client.initialize()
+    client._client.make_bucket.assert_called_once_with("uploads")
+    assert client._initialized is True
+
+
+async def test_initialize_short_circuits_second_call(client: MinIOClient) -> None:
+    client._client.bucket_exists.return_value = True
+    await client.initialize()
+    await client.initialize()
+    client._client.bucket_exists.assert_called_once()
+
+
+async def test_initialize_s3_error_logged_and_raised(
+    client: MinIOClient, caplog: pytest.LogCaptureFixture
+) -> None:
+    client._client.bucket_exists.side_effect = _s3_error()
+    with caplog.at_level(logging.ERROR), pytest.raises(S3Error):
+        await client.initialize()
+    assert "Failed to initialize MinIO" in caplog.text
+    assert client._initialized is False
+
+
+# ------------------------------------------------------------ upload_file
+
+
+async def test_upload_file_default_bucket(client: MinIOClient) -> None:
+    data = BytesIO(b"hello world")
+    data.seek(5)  # upload must rewind before sizing
+    result = await client.upload_file("docs/a.txt", data, content_type="text/plain")
+    assert result == "docs/a.txt"
+    args, kwargs = client._client.put_object.call_args
+    assert args[0] == "uploads"
+    assert args[1] == "docs/a.txt"
+    assert args[3] == 11  # full buffer size, post-rewind
+    assert kwargs["content_type"] == "text/plain"
+
+
+async def test_upload_file_explicit_bucket(client: MinIOClient) -> None:
+    await client.upload_file("b.bin", BytesIO(b"x"), bucket="custom")
+    args, kwargs = client._client.put_object.call_args
+    assert args[0] == "custom"
+    assert kwargs["content_type"] == "application/octet-stream"
+
+
+# --------------------------------------------------------- presigned URLs
+
+
+async def test_get_presigned_url(client: MinIOClient) -> None:
+    client._client.presigned_get_object.return_value = "https://signed/get"
+    url = await client.get_presigned_url("obj", expires=timedelta(minutes=5))
+    assert url == "https://signed/get"
+    args, kwargs = client._client.presigned_get_object.call_args
+    assert args == ("uploads", "obj")
+    assert kwargs["expires"] == timedelta(minutes=5)
+
+
+async def test_get_presigned_upload_url_explicit_bucket(client: MinIOClient) -> None:
+    client._client.presigned_put_object.return_value = "https://signed/put"
+    url = await client.get_presigned_upload_url("obj2", bucket="media")
+    assert url == "https://signed/put"
+    args, _ = client._client.presigned_put_object.call_args
+    assert args == ("media", "obj2")
+
+
+# ----------------------------------------------------------- delete_object
+
+
+async def test_delete_object(client: MinIOClient) -> None:
+    await client.delete_object("old.txt")
+    client._client.remove_object.assert_called_once_with("uploads", "old.txt")
+
+
+# -------------------------------------------------------- get_minio_client
+
+
+def test_get_minio_client_default_credentials_warns(
+    minio_cls: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setattr(minio_module, "_minio_client", None)
+    stub_settings = SimpleNamespace(
+        minio_endpoint="minio:9000", minio_secure=False, minio_bucket="uploads"
+    )  # no access/secret attrs -> getattr defaults ("minioadmin") kick in
+    monkeypatch.setattr("app.core.config.settings", stub_settings)
+
+    with caplog.at_level(logging.WARNING):
+        instance = get_minio_client()
+
+    assert "default credentials" in caplog.text
+    assert isinstance(instance, MinIOClient)
+    _, kwargs = minio_cls.call_args
+    assert kwargs["access_key"] == "minioadmin"  # pragma: allowlist secret
+
+
+def test_get_minio_client_custom_credentials_no_warning(
+    minio_cls: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setattr(minio_module, "_minio_client", None)
+    stub_settings = SimpleNamespace(
+        minio_endpoint="s3.internal:9000",
+        minio_secure=True,
+        minio_bucket="media",
+        minio_access_key="real-access",  # pragma: allowlist secret
+        minio_secret_key="real-secret",  # pragma: allowlist secret
+    )
+    monkeypatch.setattr("app.core.config.settings", stub_settings)
+
+    with caplog.at_level(logging.WARNING):
+        instance = get_minio_client()
+
+    assert "default credentials" not in caplog.text
+    assert instance._default_bucket == "media"
+    args, kwargs = minio_cls.call_args
+    assert args[0] == "s3.internal:9000"
+    assert kwargs["secure"] is True
+
+
+def test_get_minio_client_fast_path_identity(
+    minio_cls: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(minio_module, "_minio_client", None)
+    stub_settings = SimpleNamespace(
+        minio_endpoint="minio:9000", minio_secure=False, minio_bucket="uploads"
+    )
+    monkeypatch.setattr("app.core.config.settings", stub_settings)
+
+    first = get_minio_client()
+    second = get_minio_client()  # fast path — no lock, same instance
+    assert first is second
+    minio_cls.assert_called_once()

--- a/tests/test_security_cleanup_session10.py
+++ b/tests/test_security_cleanup_session10.py
@@ -1,0 +1,68 @@
+"""Coverage tests (testing session 10) for the session-cleanup scheduler loop
+(app/services/session_cleanup.py:161-184) which the existing
+tests/test_session_cleanup.py does not reach (it covers SessionCleanupConfig +
+cleanup_expired_sessions with a patched delete fn, but not the
+start_session_cleanup_scheduler background loop / _stop teardown).
+
+Approach: patch cleanup_expired_sessions to a fast AsyncMock, start the
+scheduler, let the immediate first tick run, then call the returned stop()
+which cancels the loop (covers the CancelledError teardown 182-184 + _stop).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+import app.services.session_cleanup as session_cleanup_module
+from app.services.session_cleanup import (
+    SessionCleanupConfig,
+    start_session_cleanup_scheduler,
+)
+
+
+@pytest.mark.asyncio
+async def test_scheduler_runs_first_tick_then_stops(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ticks = 0
+
+    async def _fake_cleanup() -> int:
+        nonlocal ticks
+        ticks += 1
+        return 3
+
+    monkeypatch.setattr(
+        session_cleanup_module, "cleanup_expired_sessions", _fake_cleanup
+    )
+
+    stop = await start_session_cleanup_scheduler(
+        config=SessionCleanupConfig(interval_seconds=30)
+    )
+    # The first cleanup runs immediately, before the 30s sleep; yield to it.
+    await asyncio.sleep(0.05)
+    assert ticks >= 1, "scheduler should run an immediate first tick"
+
+    # stop() cancels the loop task → CancelledError teardown path runs and is
+    # suppressed inside _stop's cancel branch.
+    await stop()
+
+
+@pytest.mark.asyncio
+async def test_scheduler_stop_before_first_sleep(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    started = asyncio.Event()
+
+    async def _fake_cleanup() -> int:
+        started.set()
+        return 0
+
+    monkeypatch.setattr(
+        session_cleanup_module, "cleanup_expired_sessions", _fake_cleanup
+    )
+
+    stop = await start_session_cleanup_scheduler(config=SessionCleanupConfig())
+    await asyncio.wait_for(started.wait(), timeout=2.0)
+    await stop()

--- a/tests/test_user_logic_session10.py
+++ b/tests/test_user_logic_session10.py
@@ -1,0 +1,105 @@
+"""Coverage catch-up (testing session 10) for app/services/user/logic.py
+update_user_attributes create-when-None branches (36/49/70/72 + profile-dict)
+and anonymize_user_data's cover_url cleanup (line 87) — the noload-create arms
+the existing test_services_mock.py tests skip (they pass users with
+pre-populated relations).
+
+Pure in-memory: build a User stub whose profile/preferences/education_path are
+all None and assert update_user_attributes creates each child + the else-setattr
+fallback. delete_static_file is patched (no real I/O).
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+import app.models as models
+import app.services.user.logic as logic_module
+from app.services.user.logic import anonymize_user_data, update_user_attributes
+
+
+def _bare_user() -> SimpleNamespace:
+    # All nested relations None → exercises the "if not user.X: create" arms.
+    return SimpleNamespace(
+        id=uuid.uuid4(),
+        preferences=None,
+        profile=None,
+        education_path=None,
+        email="u@example.com",
+        full_name=None,
+    )
+
+
+def test_update_attributes_creates_all_nested_children() -> None:
+    user = _bare_user()
+    update_user_attributes(
+        user,  # type: ignore[arg-type]
+        {
+            "preferences": {"timezone": "UTC"},  # preferences-dict create (36)
+            "dnd_enabled": True,  # preferences_fields (already-created reuse)
+            "full_name": "Ann",  # profile_fields create (49)
+            "profile": {"about": "hi"},  # profile-dict branch
+            "course": 2,  # education_fields create (70-72)
+            "some_core_field": "x",  # else: setattr on user (87)
+        },
+    )
+    assert isinstance(user.preferences, models.UserPreferences)
+    assert user.preferences.timezone == "UTC"
+    assert user.preferences.dnd_enabled is True
+    assert isinstance(user.profile, models.UserProfile)
+    assert user.profile.full_name == "Ann"
+    assert user.profile.about == "hi"
+    assert isinstance(user.education_path, models.EducationPath)
+    assert user.education_path.course == 2
+    assert user.some_core_field == "x"
+
+
+async def test_anonymize_user_data_clears_avatar_and_cover(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    deleted: list[str] = []
+
+    async def _fake_delete(url: str) -> None:
+        deleted.append(url)
+
+    monkeypatch.setattr(
+        logic_module, "delete_static_file", AsyncMock(side_effect=_fake_delete)
+    )
+
+    profile = SimpleNamespace(
+        avatar_url="static/avatar.png",
+        cover_url="static/cover.png",  # exercises the cover_url branch (line 87)
+        full_name="Real Name",
+        about="bio",
+        telegram="@x",
+        achievements="stuff",
+        position="dev",
+        department="eng",
+        status="active",
+    )
+    user = SimpleNamespace(
+        id=uuid.uuid4(),
+        profile=profile,
+        education_path=None,
+        preferences=None,
+        spotify=None,
+        email="real@example.com",
+        hashed_password="hash",  # pragma: allowlist secret
+        is_active=True,
+        mfa_required=True,
+        mfa_default_method="totp",
+        mfa_last_verified_at=object(),
+    )
+
+    email = await anonymize_user_data(user)  # type: ignore[arg-type]
+
+    assert email == f"deleted+{user.id}@deleted.example.com"
+    assert "static/avatar.png" in deleted
+    assert "static/cover.png" in deleted
+    assert user.profile.full_name == "Deleted User"
+    assert user.profile.status == "deleted"
+    assert user.is_active is False

--- a/tests/test_user_stats_service_coverage.py
+++ b/tests/test_user_stats_service_coverage.py
@@ -1,0 +1,334 @@
+"""Coverage tests for app/services/user/stats_service.py (testing session 10).
+
+AsyncMock-repo harness (pattern A, mirrors tests/test_compliance_service_coverage.py).
+NOTE: StatsService is currently UNWIRED in app/ (the live /stats/* path injects
+UserAnalyticsService instead) — these tests pin its behavior so a future re-wiring
+doesn't regress; deletion of the module is a separate product decision.
+
+Covers: _dt_to_iso (None/naive/aware), _parse_grade_payload (all reject + fallback
+branches), get_attendance_stats (empty + math + rn/date-source/title branches),
+get_grade_stats (average/trend/scale/recent-cap/invalid-entry filtering),
+get_participation_stats (duration clamp + unique groups + recent cap + trend).
+All calls use skip_cache=True for the pure paths; one skip_cache=False sanity
+call exercises the stats_cache.cache_stats wrapper against the conftest mock cache.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta, timezone
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.services.user.stats_service import StatsService
+
+NOW = datetime.now(UTC)
+
+
+@pytest.fixture
+def repo() -> AsyncMock:
+    return AsyncMock()
+
+
+@pytest.fixture
+def svc(repo: AsyncMock) -> StatsService:
+    return StatsService(stats_repo=repo)
+
+
+def _attendance_row(
+    *,
+    rn: int | None = 1,
+    current_total: int = 0,
+    current_attended: int = 0,
+    previous_total: int = 0,
+    previous_attended: int = 0,
+    starts_at: datetime | None = None,
+    registered_at: datetime | None = None,
+    title: str | None = "Lecture",
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        rn=rn,
+        current_total=current_total,
+        current_attended=current_attended,
+        previous_total=previous_total,
+        previous_attended=previous_attended,
+        starts_at=starts_at,
+        registered_at=registered_at,
+        title=title,
+    )
+
+
+def _notification(body: str | None, *, title: str = "Course X") -> SimpleNamespace:
+    return SimpleNamespace(body=body, title=title, created_at=NOW)
+
+
+def _participation_row(
+    *,
+    hours: float = 2.0,
+    event_type: str | None = "workshop",
+    title: str = "Event",
+    starts_at: datetime | None = None,
+) -> SimpleNamespace:
+    start = starts_at or NOW
+    return SimpleNamespace(
+        starts_at=start,
+        ends_at=start + timedelta(hours=hours),
+        event_type=event_type,
+        title=title,
+    )
+
+
+# ---------------------------------------------------------------- _dt_to_iso
+
+
+def test_dt_to_iso_none_returns_empty(svc: StatsService) -> None:
+    assert svc._dt_to_iso(None) == ""
+
+
+def test_dt_to_iso_naive_assumes_utc(svc: StatsService) -> None:
+    naive = datetime(2026, 6, 1, 12, 0, 0)
+    assert svc._dt_to_iso(naive) == "2026-06-01T12:00:00+00:00"
+
+
+def test_dt_to_iso_aware_converts_to_utc(svc: StatsService) -> None:
+    plus3 = datetime(2026, 6, 1, 15, 0, 0, tzinfo=timezone(timedelta(hours=3)))
+    assert svc._dt_to_iso(plus3) == "2026-06-01T12:00:00+00:00"
+
+
+# ---------------------------------------------------- get_attendance_stats
+
+
+async def test_attendance_empty_rows(svc: StatsService, repo: AsyncMock) -> None:
+    repo.get_attendance_stats_raw.return_value = []
+    result = await svc.get_attendance_stats(
+        user_id=uuid.uuid4(), period_days=30, skip_cache=True
+    )
+    assert result["percent"] == 0.0
+    assert result["present"] == 0
+    assert result["total"] == 0
+    assert result["trend"] == 0.0
+    assert result["period_key"] == "30d"
+    assert result["recent"] == []
+
+
+async def test_attendance_math_and_recent_branches(
+    svc: StatsService, repo: AsyncMock
+) -> None:
+    starts = NOW - timedelta(days=1)
+    registered = NOW - timedelta(days=2)
+    repo.get_attendance_stats_raw.return_value = [
+        _attendance_row(
+            rn=1,
+            current_total=4,
+            current_attended=3,
+            previous_total=2,
+            previous_attended=1,
+            starts_at=starts,
+            title="Math",
+        ),
+        # rn=None rows are aggregate-only and must be skipped from `recent`
+        _attendance_row(rn=None, starts_at=starts, title="Skipped"),
+        # starts_at missing -> falls back to registered_at; empty title -> None
+        _attendance_row(rn=2, starts_at=None, registered_at=registered, title=""),
+    ]
+    result = await svc.get_attendance_stats(
+        user_id=uuid.uuid4(), period_days=30, skip_cache=True
+    )
+    assert result["percent"] == 75.0
+    assert result["present"] == 3
+    assert result["total"] == 4
+    assert result["trend"] == 25.0  # 75% now vs 50% previous
+    assert len(result["recent"]) == 2
+    assert result["recent"][0]["course"] == "Math"
+    assert result["recent"][0]["date"] == starts.astimezone(UTC).isoformat()
+    assert result["recent"][1]["course"] is None
+    assert result["recent"][1]["date"] == registered.astimezone(UTC).isoformat()
+
+
+async def test_attendance_with_cache_wrapper_path(
+    svc: StatsService, repo: AsyncMock
+) -> None:
+    """skip_cache=False exercises the cache_stats decorator read+store path."""
+    repo.get_attendance_stats_raw.return_value = []
+    result = await svc.get_attendance_stats(
+        user_id=uuid.uuid4(), period_days=90, period_key="custom"
+    )
+    assert result["period_key"] == "custom"
+
+
+async def test_attendance_period_key_fallback_to_days(
+    svc: StatsService, repo: AsyncMock
+) -> None:
+    repo.get_attendance_stats_raw.return_value = []
+    result = await svc.get_attendance_stats(
+        user_id=uuid.uuid4(), period_days=180, period_key=None, skip_cache=True
+    )
+    assert result["period_key"] == "180d"
+
+
+# -------------------------------------------------- _parse_grade_payload
+
+
+def test_parse_grade_payload_empty_body(svc: StatsService) -> None:
+    assert svc._parse_grade_payload(None, fallback_title="T", fallback_date=NOW) is None
+    assert svc._parse_grade_payload("", fallback_title="T", fallback_date=NOW) is None
+
+
+def test_parse_grade_payload_invalid_json(svc: StatsService) -> None:
+    assert (
+        svc._parse_grade_payload("{not json", fallback_title="T", fallback_date=NOW)
+        is None
+    )
+
+
+def test_parse_grade_payload_non_dict(svc: StatsService) -> None:
+    assert (
+        svc._parse_grade_payload("[1, 2]", fallback_title="T", fallback_date=NOW)
+        is None
+    )
+
+
+def test_parse_grade_payload_validation_error(svc: StatsService) -> None:
+    assert (
+        svc._parse_grade_payload('{"score": -1}', fallback_title="T", fallback_date=NOW)
+        is None
+    )
+
+
+def test_parse_grade_payload_fallbacks(svc: StatsService) -> None:
+    fallback_date = datetime(2026, 6, 1, 10, 0, 0, tzinfo=UTC)
+    entry = svc._parse_grade_payload(
+        '{"score": 4.5, "course": "  ", "date": "not-a-date"}',
+        fallback_title="Algebra",
+        fallback_date=fallback_date,
+    )
+    assert entry is not None
+    assert entry["course"] == "Algebra"  # blank course -> fallback title
+    assert entry["score"] == 4.5
+    assert entry["max"] is None
+    assert entry["date"] == "2026-06-01T10:00:00+00:00"  # bad date -> fallback
+
+
+def test_parse_grade_payload_explicit_fields(svc: StatsService) -> None:
+    entry = svc._parse_grade_payload(
+        '{"score": 87, "max": 100, "course": "Physics", "date": "2026-05-30T09:00:00+00:00"}',
+        fallback_title="ignored",
+        fallback_date=None,
+    )
+    assert entry is not None
+    assert entry["course"] == "Physics"
+    assert entry["max"] == 100
+    assert entry["date"] == "2026-05-30T09:00:00+00:00"
+
+
+# ------------------------------------------------------- get_grade_stats
+
+
+async def test_grade_stats_empty(svc: StatsService, repo: AsyncMock) -> None:
+    repo.get_grade_notifications.return_value = []
+    result = await svc.get_grade_stats(
+        user_id=uuid.uuid4(), period_days=30, skip_cache=True
+    )
+    assert result["average"] == 0.0
+    assert result["scale"] == "5"
+    assert result["trend"] == 0.0
+    assert result["recent"] == []
+    assert result["period_key"] == "30d"
+
+
+async def test_grade_stats_average_trend_and_filtering(
+    svc: StatsService, repo: AsyncMock
+) -> None:
+    current = [
+        _notification('{"score": 5}'),
+        _notification('{"score": 4}'),
+        _notification("not json"),  # filtered out
+        _notification(None),  # filtered out
+    ]
+    previous = [_notification('{"score": 3}')]
+    repo.get_grade_notifications.side_effect = [current, previous]
+    result = await svc.get_grade_stats(
+        user_id=uuid.uuid4(), period_days=30, skip_cache=True
+    )
+    assert result["average"] == 4.5
+    assert result["trend"] == 1.5  # 4.5 - 3.0
+    assert result["scale"] == "5"
+    assert len(result["recent"]) == 2
+
+
+async def test_grade_stats_scale_100_via_max(
+    svc: StatsService, repo: AsyncMock
+) -> None:
+    repo.get_grade_notifications.side_effect = [
+        [_notification('{"score": 4, "max": 100}')],
+        [],
+    ]
+    result = await svc.get_grade_stats(
+        user_id=uuid.uuid4(), period_days=30, skip_cache=True
+    )
+    assert result["scale"] == "100"
+
+
+async def test_grade_stats_scale_100_via_score(
+    svc: StatsService, repo: AsyncMock
+) -> None:
+    repo.get_grade_notifications.side_effect = [
+        [_notification('{"score": 87}')],
+        [],
+    ]
+    result = await svc.get_grade_stats(
+        user_id=uuid.uuid4(), period_days=30, skip_cache=True
+    )
+    assert result["scale"] == "100"
+
+
+async def test_grade_stats_recent_capped_at_five(
+    svc: StatsService, repo: AsyncMock
+) -> None:
+    current = [_notification(f'{{"score": {i}}}') for i in range(1, 8)]
+    repo.get_grade_notifications.side_effect = [current, []]
+    result = await svc.get_grade_stats(
+        user_id=uuid.uuid4(), period_days=30, skip_cache=True
+    )
+    assert len(result["recent"]) == 5
+
+
+# ----------------------------------------------- get_participation_stats
+
+
+async def test_participation_empty(svc: StatsService, repo: AsyncMock) -> None:
+    repo.get_participation_stats_raw.return_value = []
+    result = await svc.get_participation_stats(
+        user_id=uuid.uuid4(), period_days=30, skip_cache=True
+    )
+    assert result["events"] == 0
+    assert result["hours"] == 0.0
+    assert result["groups"] == 0
+    assert result["trend"] == 0
+    assert result["recent"] == []
+
+
+async def test_participation_math_groups_and_recent_cap(
+    svc: StatsService, repo: AsyncMock
+) -> None:
+    rows: list[Any] = [
+        _participation_row(hours=2.0, event_type="workshop", title="A"),
+        _participation_row(hours=1.5, event_type="lecture", title="B"),
+        _participation_row(hours=-1.0, event_type="workshop", title="C"),  # clamped
+        _participation_row(hours=0.5, event_type=None, title="D"),
+        _participation_row(hours=0.5, event_type="lecture", title="E"),
+        _participation_row(hours=0.5, event_type="lecture", title="F"),
+    ]
+    repo.get_participation_stats_raw.return_value = rows
+    result = await svc.get_participation_stats(
+        user_id=uuid.uuid4(), period_days=30, skip_cache=True
+    )
+    assert result["events"] == 6
+    assert result["hours"] == 5.0  # negative duration clamped to 0
+    assert result["groups"] == 2  # workshop + lecture; None excluded
+    assert result["trend"] == 1
+    assert len(result["recent"]) == 5  # capped
+    assert result["recent"][0]["title"] == "A"

--- a/tests/test_webpush_session10.py
+++ b/tests/test_webpush_session10.py
@@ -1,0 +1,403 @@
+"""Coverage tests for app/services/webpush.py (testing session 10).
+
+Direct-call tests targeting the previously-uncovered branches: lazy sync-URL
+driver rewrites + idempotent init (L58, L81), ``_mask_endpoint`` urlparse
+ValueError fallback (L188-189), the ``_normalize_payload`` edge zone
+(L319-320, 326-328, 334, 338, 348-356, 359-361, 365-369, 374, 376-379, 381,
+385, 395, 397), ``_check_rate_limit`` short-circuit / delegate / exceeded
+paths (L492-502), ``build_payload`` template-merge + actions/vibrate/silent/
+timestamp/ttl branches (L547, 574, 576, 579, 586-591, 598-601), and the
+Urgency/Topic header lines in ``send_web_push`` (L618, 621).
+
+Harness mirrors tests/test_webpush_service_full.py (MagicMock subscription +
+mocked pywebpush transport) with monkeypatch.setattr patching at the
+consuming module per the session conventions. No DB access needed.
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import app.services.webpush as webpush_module
+from app.core.ratelimit import RateLimitExceeded, RateLimitInfo
+from app.services.webpush import (
+    _check_rate_limit,
+    _get_sync_url,
+    _initialize_sync_resources,
+    _mask_endpoint,
+    _normalize_payload,
+    build_payload,
+    send_web_push,
+)
+
+# ---------------------------------------------------------------------------
+# Lazy sync URL + idempotent init (L58, L81)
+# ---------------------------------------------------------------------------
+
+
+class TestSyncUrlAndInit:
+    def test_get_sync_url_rewrites_asyncpg_driver(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """asyncpg URLs are rewritten to the sync psycopg driver (L58)."""
+        monkeypatch.setattr(webpush_module, "_sync_url_cache", None)
+        monkeypatch.setattr(
+            webpush_module,
+            "settings",
+            SimpleNamespace(
+                database_url="postgresql+asyncpg://u:p@localhost:5432/db"  # pragma: allowlist secret
+            ),
+        )
+        url = _get_sync_url()
+        assert url.drivername == "postgresql+psycopg"
+
+    def test_get_sync_url_rewrites_aiosqlite_driver(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """aiosqlite URLs are rewritten to plain sqlite (L59-60)."""
+        monkeypatch.setattr(webpush_module, "_sync_url_cache", None)
+        monkeypatch.setattr(
+            webpush_module,
+            "settings",
+            SimpleNamespace(database_url="sqlite+aiosqlite:///./x.db"),
+        )
+        url = _get_sync_url()
+        assert url.drivername == "sqlite"
+
+    def test_initialize_sync_resources_early_return(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When _Session is already set, no new engine is created (L81)."""
+        sentinel_factory = MagicMock()
+        fake_create_engine = MagicMock()
+        monkeypatch.setattr(webpush_module, "_Session", sentinel_factory)
+        monkeypatch.setattr(webpush_module, "create_engine", fake_create_engine)
+        _initialize_sync_resources()
+        fake_create_engine.assert_not_called()
+        assert webpush_module._Session is sentinel_factory
+
+
+# ---------------------------------------------------------------------------
+# _mask_endpoint urlparse failure (L188-189)
+# ---------------------------------------------------------------------------
+
+
+class TestMaskEndpoint:
+    def test_invalid_url_falls_back_to_digest_only(self) -> None:
+        """urlparse ValueError (invalid IPv6 bracket) hits the fallback (L188-189)."""
+        masked = _mask_endpoint("http://[not-a-valid-ipv6")
+        assert masked is not None
+        assert masked.startswith("…#")
+
+    def test_blank_endpoint_returns_none(self) -> None:
+        assert _mask_endpoint("   ") is None
+
+
+# ---------------------------------------------------------------------------
+# _normalize_payload edge zone (L319-397)
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizePayloadEdges:
+    def test_meta_ttl_invalid_in_meta_source_skipped(self) -> None:
+        """Non-int ttl inside _meta is dropped (L319-320)."""
+        _payload, meta = _normalize_payload(
+            {"title": "T", "_meta": {"ttl": "garbage", "urgency": "high"}}
+        )
+        assert "ttl" not in meta
+        assert meta["urgency"] == "high"
+
+    def test_actions_in_raw_without_options(self) -> None:
+        """Top-level actions populate options + actionUrls data (L326-328)."""
+        payload, _meta = _normalize_payload(
+            {
+                "title": "T",
+                "actions": [{"action": "go", "title": "Go", "url": "/go"}],
+            }
+        )
+        assert payload["options"]["actions"] == [{"action": "go", "title": "Go"}]
+        assert payload["data"]["actionUrls"] == {"go": "/go"}
+
+    def test_option_key_with_none_value_skipped(self) -> None:
+        """None-valued option keys in raw are skipped (L334)."""
+        payload, _meta = _normalize_payload({"title": "T", "icon": None, "tag": "x"})
+        assert "icon" not in payload["options"]
+        assert payload["options"]["tag"] == "x"
+
+    def test_vibrate_in_raw_without_options(self) -> None:
+        """Top-level vibrate is sanitized into options (L338)."""
+        payload, _meta = _normalize_payload({"title": "T", "vibrate": [5, 10.5]})
+        assert payload["options"]["vibrate"] == [5, 10]
+
+    def test_meta_extracted_from_options_block(self) -> None:
+        """ttl/urgency inside options move into meta (L350-352, 355-356)."""
+        payload, meta = _normalize_payload(
+            {"options": {"body": "B", "ttl": "240", "urgency": "high"}}
+        )
+        assert meta["ttl"] == 240
+        assert meta["urgency"] == "high"
+        assert "ttl" not in payload["options"]
+        assert "urgency" not in payload["options"]
+
+    def test_meta_ttl_invalid_in_options_skipped(self) -> None:
+        """Non-int ttl inside options is dropped, not crashed (L353-354)."""
+        _payload, meta = _normalize_payload({"options": {"body": "B", "ttl": "bad"}})
+        assert "ttl" not in meta
+
+    def test_meta_from_options_does_not_override_meta_source(self) -> None:
+        """_meta wins over options for the same meta key (L348-349)."""
+        _payload, meta = _normalize_payload(
+            {"_meta": {"urgency": "low"}, "options": {"body": "B", "urgency": "high"}}
+        )
+        assert meta["urgency"] == "low"
+
+    def test_actions_inside_options(self) -> None:
+        """Valid actions in options are re-prepared + urls extracted (L359-361)."""
+        payload, _meta = _normalize_payload(
+            {
+                "options": {
+                    "body": "B",
+                    "actions": [{"action": "a1", "title": "A1", "url": "/a1"}],
+                }
+            }
+        )
+        assert payload["options"]["actions"] == [{"action": "a1", "title": "A1"}]
+        assert payload["data"]["actionUrls"] == {"a1": "/a1"}
+
+    def test_invalid_actions_inside_options_popped(self) -> None:
+        """Garbage actions in options are removed entirely (L363)."""
+        payload, _meta = _normalize_payload(
+            {"options": {"body": "B", "actions": "garbage"}}
+        )
+        assert "actions" not in payload["options"]
+
+    def test_vibrate_inside_options_sanitized(self) -> None:
+        """Valid vibrate in options is kept after sanitizing (L365-367)."""
+        payload, _meta = _normalize_payload(
+            {"options": {"body": "B", "vibrate": [1, 2.7]}}
+        )
+        assert payload["options"]["vibrate"] == [1, 2]
+
+    def test_vibrate_inside_options_invalid_popped(self) -> None:
+        """Non-numeric vibrate in options is popped (L368-369)."""
+        payload, _meta = _normalize_payload(
+            {"options": {"body": "B", "vibrate": ["loud"]}}
+        )
+        assert "vibrate" not in payload["options"]
+
+    def test_boolean_flags_coerced(self) -> None:
+        """renotify/requireInteraction/silent are coerced to bool (L374)."""
+        payload, _meta = _normalize_payload(
+            {"options": {"body": "B", "renotify": 1, "silent": 0}}
+        )
+        assert payload["options"]["renotify"] is True
+        assert payload["options"]["silent"] is False
+
+    def test_timestamp_inside_options_coerced_to_int(self) -> None:
+        """String timestamps become ints (L376-377)."""
+        payload, _meta = _normalize_payload(
+            {"options": {"body": "B", "timestamp": "99"}}
+        )
+        assert payload["options"]["timestamp"] == 99
+
+    def test_timestamp_inside_options_invalid_popped(self) -> None:
+        """Un-castable timestamps are dropped (L378-379)."""
+        payload, _meta = _normalize_payload(
+            {"options": {"body": "B", "timestamp": "abc"}}
+        )
+        assert "timestamp" not in payload["options"]
+
+    def test_body_defaulted_when_options_present_without_body(self) -> None:
+        """Missing body in options branch is defaulted to '' (L381)."""
+        payload, _meta = _normalize_payload({"options": {"tag": "t"}})
+        assert payload["options"]["body"] == ""
+
+    def test_unknown_option_keys_dropped(self) -> None:
+        """Keys outside _OPTION_KEYS do not survive cleaning (L385)."""
+        payload, _meta = _normalize_payload(
+            {"options": {"body": "B", "custom_key": "z"}}
+        )
+        assert "custom_key" not in payload["options"]
+
+    def test_url_and_type_propagate_to_data(self) -> None:
+        """Top-level url + type land in payload data (L395, 397)."""
+        payload, _meta = _normalize_payload(
+            {"title": "T", "url": "  /dest  ", "type": "alert"}
+        )
+        assert payload["data"]["url"] == "/dest"
+        assert payload["data"]["type"] == "alert"
+
+
+# ---------------------------------------------------------------------------
+# _check_rate_limit (L492-502)
+# ---------------------------------------------------------------------------
+
+
+class TestCheckRateLimit:
+    async def test_zero_limit_short_circuits(self) -> None:
+        """limit <= 0 returns an allow-all info without touching Redis (L492-493)."""
+        info = await _check_rate_limit("user:1", namespace="webpush", limit=0)
+        assert info.allowed is True
+        assert info.remaining == 0
+        assert info.retry_after == 0
+
+    async def test_disabled_rate_limiting_short_circuits(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """settings.rate_limit_enabled=False short-circuits (L492-493)."""
+        monkeypatch.setattr(
+            webpush_module, "settings", SimpleNamespace(rate_limit_enabled=False)
+        )
+        info = await _check_rate_limit("user:1", namespace="webpush", limit=7)
+        assert info.allowed is True
+        assert info.remaining == 7
+
+    async def test_delegates_to_enforce_rate_limit(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Enabled path delegates to enforce_rate_limit with the strategy (L494-500)."""
+        monkeypatch.setattr(
+            webpush_module, "settings", SimpleNamespace(rate_limit_enabled=True)
+        )
+        expected = RateLimitInfo(True, 4, 0)
+        fake_enforce = AsyncMock(return_value=expected)
+        strategy = object()
+        monkeypatch.setattr(webpush_module, "enforce_rate_limit", fake_enforce)
+        monkeypatch.setattr(
+            webpush_module, "get_default_strategy", MagicMock(return_value=strategy)
+        )
+        info = await _check_rate_limit("user:42", namespace="webpush", limit=5)
+        assert info is expected
+        fake_enforce.assert_awaited_once_with(
+            identifier="user:42",
+            limit=5,
+            window_seconds=60,
+            strategy=strategy,
+        )
+
+    async def test_rate_limit_exceeded_returns_exc_info(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """RateLimitExceeded is swallowed and its info returned (L501-502)."""
+        monkeypatch.setattr(
+            webpush_module, "settings", SimpleNamespace(rate_limit_enabled=True)
+        )
+        denied = RateLimitInfo(False, 0, 30)
+        fake_enforce = AsyncMock(side_effect=RateLimitExceeded(denied))
+        monkeypatch.setattr(webpush_module, "enforce_rate_limit", fake_enforce)
+        monkeypatch.setattr(
+            webpush_module, "get_default_strategy", MagicMock(return_value=object())
+        )
+        info = await _check_rate_limit("user:9", namespace="webpush", limit=3)
+        assert info is denied
+
+
+# ---------------------------------------------------------------------------
+# build_payload edge branches (L547, 574-601)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPayloadEdges:
+    @pytest.fixture
+    def no_template(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Force the template-less branch so source == raw input."""
+        monkeypatch.setattr(
+            webpush_module, "render_notification_template", lambda *a, **k: {}
+        )
+
+    def test_template_merge_skips_none_values(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """None input values do not override template defaults (L547)."""
+        monkeypatch.setattr(
+            webpush_module,
+            "render_notification_template",
+            lambda *a, **k: {"title": "Template Title", "body": "TB"},
+        )
+        result = build_payload("typed", {"title": None, "icon": "i.png"})
+        assert result["title"] == "Template Title"
+        assert result["options"]["body"] == "TB"
+        assert result["options"]["icon"] == "i.png"
+
+    def test_actions_and_action_urls(self, no_template: None) -> None:
+        """Actions populate options + actionUrls data (L574, 576)."""
+        result = build_payload(
+            "t",
+            {
+                "title": "T",
+                "actions": [{"action": "open", "title": "Open", "url": "/x"}],
+            },
+        )
+        assert result["options"]["actions"] == [{"action": "open", "title": "Open"}]
+        assert result["data"]["actionUrls"] == {"open": "/x"}
+
+    def test_vibrate_sanitized(self, no_template: None) -> None:
+        """Vibrate list survives into options (L579)."""
+        result = build_payload("t", {"title": "T", "vibrate": [10, 20.5]})
+        assert result["options"]["vibrate"] == [10, 20]
+
+    def test_silent_with_valid_timestamp(self, no_template: None) -> None:
+        """silent + castable timestamp produce both options (L586-591)."""
+        result = build_payload("t", {"title": "T", "silent": True, "timestamp": "1234"})
+        assert result["options"]["silent"] is True
+        assert result["options"]["timestamp"] == 1234
+
+    def test_silent_with_invalid_timestamp_suppressed(self, no_template: None) -> None:
+        """Un-castable timestamp is suppressed without crashing (L588-590)."""
+        result = build_payload("t", {"title": "T", "silent": 0, "timestamp": "nope"})
+        assert result["options"]["silent"] is False
+        assert "timestamp" not in result["options"]
+
+    def test_meta_ttl_string_coerced(self, no_template: None) -> None:
+        """String ttl is cast to int into _meta (L598-599)."""
+        result = build_payload("t", {"title": "T", "ttl": "300"})
+        assert result["_meta"]["ttl"] == 300
+
+    def test_meta_ttl_invalid_skipped(self, no_template: None) -> None:
+        """Un-castable ttl is skipped; other meta keys survive (L600-601)."""
+        result = build_payload("t", {"title": "T", "ttl": "soon", "urgency": "high"})
+        assert result["_meta"] == {"urgency": "high"}
+
+
+# ---------------------------------------------------------------------------
+# send_web_push Urgency/Topic headers (L618, 621)
+# ---------------------------------------------------------------------------
+
+
+class TestSendWebPushHeaders:
+    def _make_sub(self) -> MagicMock:
+        sub = MagicMock()
+        sub.id = uuid.uuid4()
+        sub.endpoint = "https://push.example.com/headers"
+        sub.user_id = uuid.uuid4()
+        sub.p256dh = "key"
+        sub.auth = "auth"  # pragma: allowlist secret
+        sub.user = None
+        return sub
+
+    def test_urgency_and_topic_headers_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """urgency/topic meta become Urgency/Topic headers (L618, 621)."""
+        captured: dict[str, Any] = {}
+
+        def fake_webpush(**kwargs: Any) -> None:
+            captured.update(kwargs)
+
+        monkeypatch.setattr(webpush_module, "webpush", fake_webpush)
+        result = send_web_push(
+            self._make_sub(),
+            {"title": "T", "urgency": "high", "topic": "sys-updates"},
+        )
+        assert result.status == "sent"
+        headers = captured["headers"]
+        assert headers["Urgency"] == "high"
+        assert headers["Topic"] == "sys-updates"
+        # high urgency maps to the 5-minute TTL
+        assert headers["TTL"] == "300"
+        assert captured["ttl"] == 300


### PR DESCRIPTION
## Testing session 10 — continue full-project coverage across all 4 fronts

Tenth coverage batch. Four independent streams, gates ratcheted only to ≤ floor(measured).

### Stream A — Backend 86 → 88
Local hermetic `uv run pytest --cov=app` = **88.04%** (3732 passed, +163 vs session 9). Gate moved in pyproject.toml + Makefile + ci.yml. 11 new/extended test files: `user.stats_service` (unwired — pinned), `analytics` (`_compute_*` + mockable repos), `minio_storage` (SDK patched at seam), `session_cleanup` scheduler, `user.logic` noload-create + anonymize, 5 agent files (webpush/auth_service/mfa.challenge/chat.command/core_small), `event_service` IntegrityError-retry arms.

### Stream B — Frontend 67/72/68/67 → 68/73/69/68
`npm run test:ci` = **68.51 / 73.69 / 69.92 / 68.51**; all four dims cleared the +0.5 no-cushion margin. New tests: `api/notifications` (generated-SDK mocks), `NavbarPieces` (DesktopNav/NavbarLogo/MobileDrawer*/UserMenu), `ContentCard` slots, `uiMiscPrimitives` (Dialog/MediaSlot/table). tsc 0, eslint 0.

### Stream C — Go floors ws-hub 62→65 / gateway 61→62 / file-processor 49→50
Dependency-free unit tests, ZERO production-code changes, ws-hub upgrade limiter untouched. `client_unit_test.go` (ReadPump/WritePump/handleMessage guards/JoinRoom/LeaveRoom/safeSend via gorilla conn pairs), `auth_edge_test.go` (Optional RS256 branches + extractAlg + JWKS equal-key), `server_edge_test.go` (validateProcessFileRequest arms). golangci-lint v2.3.0 + gofmt clean. Measured ×2, gate = floor−2.

### Stream D — crypto.worker.ts ↔ WASM parity (no gate move; src/workers/** is coverage-excluded)
@vitest-environment-node parity test against the real uni_wasm_crypto build; asserts byte-exact RFC 7914/4231 KAT parity + error envelope + protocol edges.

### Honest notes
- `analytics.get_user_activity` raw SQL names `event_attendees` vs the real `event_attendance` table → latent prod bug, mocked-session-only test, filed for a follow-up.
- `StatsService` is unwired dead code (deletion is a product decision); tests pin it.
- file-processor config MINIO-empty guard is unreachable through `Load()` (viper SetDefault beats an empty bound env) → that one test dropped, documented.
- Go `−2` buffer is conservative (actual headroom ws-hub +2.2 / gateway +2.3 / file-processor +2.3).
- Chromatic Visual Regression shows `skipping` by design (billing quota).

🤖 Generated with [Claude Code](https://claude.com/claude-code)