### PR TITLE
test(session11): all-4-front coverage batch + aggressive gate ratchet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,20 +363,20 @@ jobs:
         # file-processor validateProcessFileRequest rejection arms.
         include:
           - service: services/gateway
-            # Measured 64.3% unit-only ×2 (s9 + s10 Optional RS256-downgrade /
-            # malformed-alg / valid-RS256 / revoked-session + extractAlg arms +
-            # JWKS equal-key). Floor 62.
-            coverage-threshold: 62
+            # Measured 67.5% unit-only ×2 (s11 getEnvFloat64/getEnvSlice config
+            # branches + ProxyOrFileHandler dispatch GET/POST-nonfile/POST-file
+            # routing). Floor 65 = floor(67.5) − 2.
+            coverage-threshold: 65
           - service: services/file-processor
             # Measured 52.3% unit-only ×2 (s9 + s10 validateProcessFileRequest
             # empty-id/unsupported-type/empty-keys/options-limit/oversized-opt).
             # Floor 50.
             coverage-threshold: 50
           - service: services/ws-hub
-            # Measured 67.2% unit-only ×2 (s9 + s10 client.go ReadPump/WritePump/
-            # handleMessage guards/JoinRoom/LeaveRoom/safeSend via gorilla pairs).
-            # Floor 65.
-            coverage-threshold: 65
+            # Measured 68.3% unit-only (s11 validateHMAC empty/wrong-alg/missing-sub/
+            # rotation/all-fail/valid branches + handleRegister max-clients reject).
+            # min-of-two 68.3 → Floor 66 = floor(68.3) − 2.
+            coverage-threshold: 66
           - service: services/cmd/uni-cli
             coverage-threshold: 80
     needs: pre-commit-check

--- a/app/services/analytics.py
+++ b/app/services/analytics.py
@@ -197,7 +197,7 @@ class AnalyticsService:
             UNION ALL
             SELECT
                 'events_attended' as type, COUNT(*) as count
-            FROM event_attendees WHERE user_id = :user_id
+            FROM event_attendance WHERE user_id = :user_id
             UNION ALL
             SELECT
                 'messages_sent' as type, COUNT(*) as count

--- a/frontend/src/components/schedule/__tests__/ScheduleDesktopTable.test.tsx
+++ b/frontend/src/components/schedule/__tests__/ScheduleDesktopTable.test.tsx
@@ -1,0 +1,256 @@
+/**
+ * Session 11 coverage: src/components/schedule/ScheduleDesktopTable.tsx
+ *
+ * The W120 SW3 ARIA-grid component. All schedule data arrives as PROPS (the
+ * `useScheduleData` import is type-only — never mock it). The only hooks the
+ * component CALLS are useTranslation (real i18n), useSchedulePage (real
+ * <SchedulePageProvider>), and the zustand scheduleUIStore (reset per-test).
+ *
+ * Gotchas baked in (verified from source):
+ *  - LessonCard is rendered WITHOUT `onOpen` → it has NO role → query cards via
+ *    getByLabelText, never getByRole("button"). Delete buttons ARE real <button>.
+ *  - aria-labels use an en-dash `–` (U+2013) in the time range, NOT a hyphen.
+ *  - compactMode MUST be false (reset in beforeEach) for the note indicator +
+ *    details row to render.
+ *  - authProvider:false — the component reads `user` from props, not AuthContext.
+ */
+import { fireEvent, screen, within } from "@testing-library/react"
+import type { ComponentProps } from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { ScheduleDesktopTable } from "@/components/schedule/ScheduleDesktopTable"
+import type { Lesson } from "@/components/schedule/scheduleUtils"
+import { SchedulePageProvider } from "@/contexts/SchedulePageContext"
+import { useScheduleUIStore } from "@/stores/scheduleUIStore"
+import { renderWithRouter } from "@/tests/helpers/renderWithRouter"
+
+const WEEKDAYS = ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday"] as const
+const WEEKDAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat"] as const
+
+const LESSON_MON_1: Lesson = {
+  id: "l1",
+  weekday: "monday",
+  parity: "both",
+  start_time: "09:00",
+  end_time: "10:30",
+  subject: "Linear Algebra",
+  teacher: "Ada Lovelace",
+  room: "101",
+  lesson_type: "lecture",
+  group_id: "g1",
+}
+
+const LESSON_MON_2: Lesson = {
+  id: "l2",
+  weekday: "monday",
+  parity: "both",
+  start_time: "10:40",
+  end_time: "12:10",
+  subject: "Programming",
+  teacher: "Alan Turing",
+  room: "202",
+  lesson_type: "practice",
+  group_id: "g1",
+}
+
+const LESSON_WED_1: Lesson = {
+  id: "l3",
+  weekday: "wednesday",
+  parity: "both",
+  start_time: "13:00",
+  end_time: "14:30",
+  subject: "Databases",
+  teacher: "Edgar Codd",
+  room: "303",
+  lesson_type: "lab",
+  group_id: "g1",
+}
+
+const ALL_LESSONS: Lesson[] = [LESSON_MON_1, LESSON_MON_2, LESSON_WED_1]
+
+type Props = ComponentProps<typeof ScheduleDesktopTable>
+
+function baseProps(overrides: Partial<Props> = {}): Props {
+  return {
+    schedule: ALL_LESSONS,
+    rawSchedule: ALL_LESSONS,
+    weekdayBackend: [...WEEKDAYS],
+    weekdayLabels: [...WEEKDAY_LABELS],
+    hasToday: true,
+    todayIdx: 0,
+    conflictedIds: new Set<string>(),
+    user: null,
+    refresh: vi.fn(),
+    currentLesson: null,
+    currentProgress: 0,
+    isOnline: true,
+    onDeleteLesson: vi.fn(),
+    getLessonTypeColor: () => "var(--lt-lecture-badge)",
+    getLessonTypeLabel: (val) => val ?? "Lecture",
+    notesMap: new Map<string, boolean>(),
+    ...overrides,
+  }
+}
+
+function renderTable(props: Props) {
+  return renderWithRouter({
+    ui: () => (
+      <SchedulePageProvider>
+        <ScheduleDesktopTable {...props} />
+      </SchedulePageProvider>
+    ),
+    authProvider: false,
+  })
+}
+
+beforeEach(() => {
+  // scheduleUIStore persists hiddenWeekdays + compactMode to localStorage; reset
+  // to defaults so all 6 days are visible and cards render non-compact (required
+  // for the note indicator + details row).
+  useScheduleUIStore.setState({ hiddenWeekdays: [], compactMode: false })
+})
+
+describe("ScheduleDesktopTable", () => {
+  it("renders an ARIA grid with rows, columnheaders, rowheaders, and gridcells", async () => {
+    await renderTable(baseProps())
+
+    const grid = screen.getByRole("grid", { name: "Schedule" })
+    expect(grid).toBeInTheDocument()
+    // colCount = visibleDays(6) + 1 = 7; rowCount = tableRows(2) + 1 = 3.
+    expect(grid).toHaveAttribute("aria-colcount", "7")
+    expect(grid).toHaveAttribute("aria-rowcount", "3")
+
+    // 1 header row + 2 data rows (Monday has 2 lessons → buildTable yields 2 rows).
+    expect(within(grid).getAllByRole("row")).toHaveLength(3)
+
+    const columnHeaders = within(grid).getAllByRole("columnheader")
+    expect(columnHeaders).toHaveLength(7)
+    expect(within(grid).getByRole("columnheader", { name: /№/ })).toBeInTheDocument()
+    expect(within(grid).getByRole("columnheader", { name: /Mon/ })).toBeInTheDocument()
+    expect(within(grid).getByRole("columnheader", { name: /Wed/ })).toBeInTheDocument()
+
+    const rowHeaders = within(grid).getAllByRole("rowheader")
+    expect(rowHeaders).toHaveLength(2)
+    expect(rowHeaders[0]).toHaveTextContent("1")
+    expect(rowHeaders[1]).toHaveTextContent("2")
+
+    // 2 rows × 6 day columns = 12 gridcells (lesson + empty mix).
+    expect(within(grid).getAllByRole("gridcell")).toHaveLength(12)
+
+    // canEdit=false (user:null) → no delete affordances anywhere.
+    expect(within(grid).queryByRole("button", { name: "Delete lesson" })).toBeNull()
+  })
+
+  it("places lessons in their correct day columns", async () => {
+    await renderTable(baseProps())
+
+    // LessonCard has no role (onOpen not passed) → query by accessible label.
+    // aria-label = [subject, "HH:MM–HH:MM", room].join(", ") with an en-dash.
+    expect(screen.getByLabelText("Linear Algebra, 09:00–10:30, 101")).toBeInTheDocument()
+    expect(screen.getByLabelText("Programming, 10:40–12:10, 202")).toBeInTheDocument()
+    expect(screen.getByLabelText("Databases, 13:00–14:30, 303")).toBeInTheDocument()
+
+    expect(screen.getByText("Linear Algebra")).toBeInTheDocument()
+    expect(screen.getByText("Programming")).toBeInTheDocument()
+    expect(screen.getByText("Databases")).toBeInTheDocument()
+    expect(screen.getAllByText(/Linear Algebra|Programming|Databases/)).toHaveLength(3)
+  })
+
+  it("marks a conflicted lesson with the conflict label, title, and indicator", async () => {
+    await renderTable(baseProps({ conflictedIds: new Set(["l1"]) }))
+
+    const conflictCard = screen.getByLabelText(
+      "Linear Algebra, 09:00–10:30, 101, Schedule conflict"
+    )
+    expect(conflictCard).toBeInTheDocument()
+    expect(conflictCard).toHaveAttribute("title", "Schedule conflict")
+    expect(conflictCard.className).toContain("sched-conflict")
+    expect(within(conflictCard).getByText("Schedule conflict")).toBeInTheDocument()
+
+    // Non-conflicted lesson keeps the plain label (no ", Schedule conflict" suffix).
+    expect(screen.getByLabelText("Programming, 10:40–12:10, 202")).toBeInTheDocument()
+  })
+
+  it("fires onDeleteLesson with the lesson id when an admin clicks delete", async () => {
+    const onDeleteLesson = vi.fn()
+    await renderTable(baseProps({ user: { role: "admin" } as Props["user"], onDeleteLesson }))
+
+    const targetCard = screen.getByLabelText("Linear Algebra, 09:00–10:30, 101")
+    const deleteBtn = within(targetCard).getByRole("button", { name: "Delete lesson" })
+    expect(deleteBtn).toHaveAttribute("id", "delete-lesson-l1")
+
+    fireEvent.click(deleteBtn)
+
+    expect(onDeleteLesson).toHaveBeenCalledTimes(1)
+    expect(onDeleteLesson).toHaveBeenCalledWith("l1")
+  })
+
+  it("renders the EmptyState when there are no lessons (online)", async () => {
+    await renderTable(baseProps({ schedule: [], rawSchedule: [], isOnline: true }))
+
+    expect(screen.getByText("No lessons scheduled")).toBeInTheDocument()
+    expect(screen.getByText("Select a group to view schedule")).toBeInTheDocument()
+    // EmptyState title renders as a heading (titleAs default "h2").
+    expect(screen.getByRole("heading", { name: "No lessons scheduled" })).toBeInTheDocument()
+    expect(screen.queryByLabelText(/Linear Algebra/)).toBeNull()
+
+    const grid = screen.getByRole("grid", { name: "Schedule" })
+    expect(within(grid).getAllByRole("columnheader")).toHaveLength(7)
+    // No data rows → aria-rowcount = 0 + 1 = 1.
+    expect(grid).toHaveAttribute("aria-rowcount", "1")
+  })
+
+  it("renders OfflineFallback (not EmptyState) when offline with no cached schedule", async () => {
+    const refresh = vi.fn()
+    await renderTable(baseProps({ schedule: [], rawSchedule: [], isOnline: false, refresh }))
+
+    // Offline branch → OfflineFallback, NOT EmptyState. Distinguish by the absence
+    // of the EmptyState string + the retry button wiring (namespace-agnostic).
+    expect(screen.queryByText("No lessons scheduled")).toBeNull()
+
+    const buttons = screen.getAllByRole("button")
+    expect(buttons.length).toBeGreaterThanOrEqual(2)
+
+    // First button is OfflineFallback's solid "Retry" → onClick calls onRetry (refresh).
+    fireEvent.click(buttons[0]!)
+    expect(refresh).toHaveBeenCalledTimes(1)
+  })
+
+  it("renders a note indicator only on lessons present in notesMap", async () => {
+    await renderTable(baseProps({ notesMap: new Map<string, boolean>([["l1", true]]) }))
+
+    // compactMode false (beforeEach) → note indicator <span title="Has a note"> renders.
+    expect(screen.getAllByTitle("Has a note")).toHaveLength(1)
+
+    const l1Card = screen.getByLabelText("Linear Algebra, 09:00–10:30, 101")
+    expect(within(l1Card).getByTitle("Has a note")).toBeInTheDocument()
+
+    // l2/l3 not in notesMap → notesMap.get(...) ?? false → no indicator.
+    const l2Card = screen.getByLabelText("Programming, 10:40–12:10, 202")
+    expect(within(l2Card).queryByTitle("Has a note")).toBeNull()
+  })
+
+  it("hides weekday columns present in hiddenWeekdays (store-driven)", async () => {
+    // Hide Tuesday (1) + Saturday (5) → 4 visible days.
+    useScheduleUIStore.setState({ hiddenWeekdays: [1, 5], compactMode: false })
+    await renderTable(baseProps())
+
+    const grid = screen.getByRole("grid", { name: "Schedule" })
+    expect(grid).toHaveAttribute("aria-colcount", "5") // 4 days + 1
+    expect(within(grid).getAllByRole("columnheader")).toHaveLength(5)
+    expect(within(grid).queryByRole("columnheader", { name: /Tue/ })).toBeNull()
+    expect(within(grid).queryByRole("columnheader", { name: /Sat/ })).toBeNull()
+    expect(within(grid).getByRole("columnheader", { name: /Mon/ })).toBeInTheDocument()
+  })
+
+  it("labels empty grid cells with the fallback 'Empty' aria-label", async () => {
+    // One Monday lesson → row 0 Monday filled, the other 5 day-columns empty.
+    await renderTable(baseProps({ schedule: [LESSON_MON_1], rawSchedule: [LESSON_MON_1] }))
+
+    const grid = screen.getByRole("grid", { name: "Schedule" })
+    // 1 row × 6 day columns = 6 gridcells; 1 lesson + 5 empty (aria-label "Empty").
+    expect(within(grid).getAllByRole("gridcell", { name: "Empty" })).toHaveLength(5)
+    // The filled Monday cell carries the stable keyboard-nav id (W120 SW3).
+    expect(grid.querySelector("#sched-cell-0-0")).not.toBeNull()
+  })
+})

--- a/frontend/src/hooks/__tests__/useBookmarks.test.ts
+++ b/frontend/src/hooks/__tests__/useBookmarks.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Session 11 coverage: src/hooks/useBookmarks.ts
+ *
+ * localStorage + BroadcastChannel external store (useSyncExternalStore). No MSW,
+ * no QueryClient. The module-level `bookmarkSet`/`channel` singletons persist
+ * across tests in this file, so afterEach drains all bookmarks + clears storage.
+ * vi.resetModules() gives a fresh module for the load-from-storage branches.
+ */
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { useBookmarks } from "../useBookmarks"
+
+const STORAGE_KEY = "news:bookmarks"
+const CHANNEL_NAME = "ecosystem.news.bookmarks"
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+afterEach(() => {
+  // Drain the module-level bookmarkSet back to empty (no public reset).
+  const { result, unmount } = renderHook(() => useBookmarks())
+  act(() => {
+    for (const id of [...result.current.bookmarks]) result.current.toggleBookmark(id)
+  })
+  unmount()
+  localStorage.clear()
+  vi.restoreAllMocks()
+})
+
+describe("useBookmarks", () => {
+  it("starts empty", () => {
+    const { result } = renderHook(() => useBookmarks())
+    expect(result.current.bookmarks).toBeInstanceOf(Set)
+    expect(result.current.bookmarkCount).toBe(0)
+    expect(result.current.isBookmarked("x")).toBe(false)
+  })
+
+  it("toggleBookmark adds + persists to localStorage", () => {
+    const { result } = renderHook(() => useBookmarks())
+    act(() => result.current.toggleBookmark("a1"))
+    expect(result.current.isBookmarked("a1")).toBe(true)
+    expect(result.current.bookmarkCount).toBe(1)
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "[]")).toContain("a1")
+  })
+
+  it("toggleBookmark toggles off + removes", () => {
+    const { result } = renderHook(() => useBookmarks())
+    act(() => result.current.toggleBookmark("a1"))
+    act(() => result.current.toggleBookmark("a1"))
+    expect(result.current.isBookmarked("a1")).toBe(false)
+    expect(result.current.bookmarkCount).toBe(0)
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "[]")).toEqual([])
+  })
+
+  it("tracks multiple bookmarks + interleaved add/remove", () => {
+    const { result } = renderHook(() => useBookmarks())
+    act(() => {
+      result.current.toggleBookmark("a")
+      result.current.toggleBookmark("b")
+      result.current.toggleBookmark("c")
+    })
+    expect(result.current.bookmarkCount).toBe(3)
+    act(() => result.current.toggleBookmark("b"))
+    expect(result.current.bookmarkCount).toBe(2)
+    expect(result.current.isBookmarked("b")).toBe(false)
+  })
+
+  it("hydrates bookmarkSet from localStorage on module load", async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(["seed1", "seed2"]))
+    vi.resetModules()
+    const { useBookmarks: freshUseBookmarks } = await import("../useBookmarks")
+    const { result } = renderHook(() => freshUseBookmarks())
+    expect(result.current.bookmarkCount).toBe(2)
+    expect(result.current.isBookmarked("seed1")).toBe(true)
+  })
+
+  it("malformed localStorage JSON -> empty Set (catch)", async () => {
+    localStorage.setItem(STORAGE_KEY, "{not-json")
+    vi.resetModules()
+    const { useBookmarks: freshUseBookmarks } = await import("../useBookmarks")
+    const { result } = renderHook(() => freshUseBookmarks())
+    expect(result.current.bookmarkCount).toBe(0)
+  })
+
+  it("persist swallows storage errors (Safari private-browsing guard)", () => {
+    const { result } = renderHook(() => useBookmarks())
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("QuotaExceeded")
+    })
+    // No throw; in-memory set still updates.
+    act(() => result.current.toggleBookmark("x"))
+    expect(result.current.isBookmarked("x")).toBe(true)
+  })
+
+  it("syncs from another tab via BroadcastChannel", async () => {
+    const { result } = renderHook(() => useBookmarks())
+    const otherTab = new BroadcastChannel(CHANNEL_NAME)
+    act(() => otherTab.postMessage(["x1", "x2"]))
+    await waitFor(() => expect(result.current.isBookmarked("x1")).toBe(true))
+    expect(result.current.bookmarkCount).toBe(2)
+    otherTab.close()
+  })
+
+  it("broadcastUpdate emits to other tabs", async () => {
+    const { result } = renderHook(() => useBookmarks())
+    const otherTab = new BroadcastChannel(CHANNEL_NAME)
+    const messages: string[][] = []
+    otherTab.onmessage = (e: MessageEvent<string[]>) => messages.push(e.data)
+    act(() => result.current.toggleBookmark("o1"))
+    await waitFor(() => expect(messages).toContainEqual(["o1"]))
+    otherTab.close()
+  })
+
+  it("degrades gracefully when BroadcastChannel is unsupported", async () => {
+    vi.resetModules()
+    vi.stubGlobal(
+      "BroadcastChannel",
+      class {
+        constructor() {
+          throw new Error("unsupported")
+        }
+      }
+    )
+    const { useBookmarks: freshUseBookmarks } = await import("../useBookmarks")
+    const { result } = renderHook(() => freshUseBookmarks())
+    // ensureChannel catch -> channel stays null; toggle still works, no throw.
+    act(() => result.current.toggleBookmark("nb1"))
+    expect(result.current.isBookmarked("nb1")).toBe(true)
+    vi.unstubAllGlobals()
+  })
+})

--- a/frontend/src/hooks/__tests__/useLessonNotes.test.ts
+++ b/frontend/src/hooks/__tests__/useLessonNotes.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Session 11 coverage: src/hooks/useLessonNotes.ts (useLessonNotes + useLessonNotesMap)
+ *
+ * 300ms debounced save (fake timers) + cleanup-on-unmount + per-id presence map.
+ * idb-keyval is mocked with a self-contained in-memory Map (ESM namespace exports
+ * are frozen, so vi.spyOn(namespace,...) is impossible — a hoisted vi.mock is the
+ * robust path). Happy paths use the map; error branches use mockRejectedValueOnce.
+ * logError is mocked to assert the swallowed-error branches.
+ */
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { logError } from "@/app/logger"
+import { useLessonNotes, useLessonNotesMap, type LessonNote } from "../useLessonNotes"
+
+const idb = vi.hoisted(() => {
+  const store = new Map<string, unknown>()
+  return {
+    store,
+    get: vi.fn(async (key: string) => store.get(key)),
+    set: vi.fn(async (key: string, value: unknown) => {
+      store.set(key, value)
+    }),
+    del: vi.fn(async (key: string) => {
+      store.delete(key)
+    }),
+  }
+})
+
+vi.mock("idb-keyval", () => ({ get: idb.get, set: idb.set, del: idb.del }))
+vi.mock("@/app/logger", async (orig) => ({
+  ...(await orig<typeof import("@/app/logger")>()),
+  logError: vi.fn(),
+}))
+
+const KEY = (id: string) => `schedule:notes:${id}`
+
+beforeEach(() => {
+  vi.useRealTimers()
+  idb.store.clear()
+  idb.get.mockClear()
+  idb.set.mockClear()
+  idb.del.mockClear()
+  vi.mocked(logError).mockClear()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe("useLessonNotes", () => {
+  it("initial load — no stored note -> null", async () => {
+    const { result } = renderHook(() => useLessonNotes("lessonA"))
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.note).toBeNull()
+    expect(result.current.hasNote).toBe(false)
+  })
+
+  it("initial load — pre-stored note", async () => {
+    idb.store.set(KEY("lessonB"), { text: "stored note", updatedAt: 111 })
+    const { result } = renderHook(() => useLessonNotes("lessonB"))
+    await waitFor(() => expect(result.current.note?.text).toBe("stored note"))
+    expect(result.current.hasNote).toBe(true)
+  })
+
+  it("null lessonId -> no load, note null", async () => {
+    const { result } = renderHook(() => useLessonNotes(null))
+    expect(result.current.note).toBeNull()
+    expect(result.current.isLoading).toBe(false)
+  })
+
+  it("setNote writes to IDB after the 300ms debounce", async () => {
+    vi.useFakeTimers()
+    const { result } = renderHook(() => useLessonNotes("lessonC"))
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+    act(() => result.current.setNote("hello"))
+    expect(result.current.note?.text).toBe("hello") // immediate state set
+    expect(idb.store.get(KEY("lessonC"))).toBeUndefined() // not yet written
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300)
+    })
+    expect((idb.store.get(KEY("lessonC")) as LessonNote).text).toBe("hello")
+  })
+
+  it("setNote coalesces rapid calls (clearTimeout) — single write of last value", async () => {
+    vi.useFakeTimers()
+    const { result } = renderHook(() => useLessonNotes("lessonCo"))
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+    act(() => {
+      result.current.setNote("a")
+      result.current.setNote("ab")
+      result.current.setNote("abc")
+    })
+    expect(result.current.note?.text).toBe("abc")
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300)
+    })
+    expect((idb.store.get(KEY("lessonCo")) as LessonNote).text).toBe("abc")
+    expect(idb.set).toHaveBeenCalledTimes(1)
+  })
+
+  it("setNote with whitespace text deletes instead of writing", async () => {
+    idb.store.set(KEY("lessonD"), { text: "existing", updatedAt: 1 })
+    vi.useFakeTimers()
+    const { result } = renderHook(() => useLessonNotes("lessonD"))
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+    act(() => result.current.setNote("   "))
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300)
+    })
+    expect(idb.store.get(KEY("lessonD"))).toBeUndefined() // del branch ran
+    expect(idb.del).toHaveBeenCalled()
+  })
+
+  it("setNote is a no-op when lessonId is null", () => {
+    const { result } = renderHook(() => useLessonNotes(null))
+    act(() => result.current.setNote("x"))
+    expect(result.current.note).toBeNull()
+  })
+
+  it("clearNote clears state + deletes from IDB", async () => {
+    idb.store.set(KEY("lessonE"), { text: "to clear", updatedAt: 1 })
+    const { result } = renderHook(() => useLessonNotes("lessonE"))
+    await waitFor(() => expect(result.current.note?.text).toBe("to clear"))
+    await act(async () => {
+      result.current.clearNote()
+      await Promise.resolve()
+    })
+    expect(result.current.note).toBeNull()
+    expect(result.current.hasNote).toBe(false)
+    expect(idb.store.get(KEY("lessonE"))).toBeUndefined()
+  })
+
+  it("clearNote is a no-op when lessonId is undefined", () => {
+    const { result } = renderHook(() => useLessonNotes(undefined))
+    act(() => result.current.clearNote())
+    expect(result.current.note).toBeNull()
+  })
+
+  it("unmount cancels a pending debounced write", async () => {
+    vi.useFakeTimers()
+    const { result, unmount } = renderHook(() => useLessonNotes("lessonF"))
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+    act(() => result.current.setNote("pending"))
+    unmount()
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300)
+    })
+    expect(idb.set).not.toHaveBeenCalled()
+    expect(idb.store.get(KEY("lessonF"))).toBeUndefined()
+  })
+
+  it("load error -> note null (catch)", async () => {
+    idb.get.mockRejectedValueOnce(new Error("idb fail"))
+    const { result } = renderHook(() => useLessonNotes("lessonErr"))
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.note).toBeNull()
+  })
+
+  it("setNote IDB write error -> logError swallows it", async () => {
+    vi.useFakeTimers()
+    idb.set.mockRejectedValueOnce(new Error("write fail"))
+    const { result } = renderHook(() => useLessonNotes("lessonWr"))
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+    act(() => result.current.setNote("boom"))
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300)
+      await Promise.resolve() // flush the rejected set()'s .catch microtask
+    })
+    // NOTE: cannot use waitFor() here — fake timers freeze its polling clock.
+    expect(logError).toHaveBeenCalled()
+    expect(vi.mocked(logError).mock.calls[0]?.[0]).toBe("[schedule:notes]")
+  })
+})
+
+describe("useLessonNotesMap", () => {
+  it("batch loads a presence map (trims whitespace)", async () => {
+    idb.store.set(KEY("m1"), { text: "has note", updatedAt: 1 })
+    idb.store.set(KEY("m3"), { text: "  ", updatedAt: 1 })
+    const { result } = renderHook(() => useLessonNotesMap(["m1", "m2", "m3"]))
+    await waitFor(() => expect(result.current.size).toBe(3))
+    expect(result.current.get("m1")).toBe(true)
+    expect(result.current.get("m2")).toBe(false)
+    expect(result.current.get("m3")).toBe(false)
+  })
+
+  it("empty lessonIds -> empty map (no load)", () => {
+    const { result } = renderHook(() => useLessonNotesMap([]))
+    expect(result.current.size).toBe(0)
+  })
+
+  it("stable depKey -> no re-fetch when array ref changes but ids match", async () => {
+    const { result, rerender } = renderHook(({ ids }) => useLessonNotesMap(ids), {
+      initialProps: { ids: ["x", "y"] },
+    })
+    await waitFor(() => expect(result.current.size).toBe(2))
+    const callsAfterFirst = idb.get.mock.calls.length
+    rerender({ ids: ["x", "y"] }) // new array ref, same join key
+    expect(idb.get.mock.calls.length).toBe(callsAfterFirst)
+  })
+
+  it("get rejection -> entry false (per-id catch)", async () => {
+    idb.get.mockRejectedValueOnce(new Error("x"))
+    const { result } = renderHook(() => useLessonNotesMap(["e1"]))
+    await waitFor(() => expect(result.current.size).toBe(1))
+    expect(result.current.get("e1")).toBe(false)
+  })
+})

--- a/frontend/src/hooks/__tests__/useNewsInteraction.test.ts
+++ b/frontend/src/hooks/__tests__/useNewsInteraction.test.ts
@@ -1,0 +1,484 @@
+/**
+ * Session 11 coverage: src/hooks/useNewsInteraction.ts
+ *
+ * like/comment/edit/delete optimistic mutations + offline IndexedDB queue.
+ *
+ * Stateful MSW server simulation: the hook runs `onMutate` (optimistic) then
+ * `onSettled` (invalidateQueries → refetch). A *static* GET body would silently
+ * revert every optimistic update on that refetch, so handlers here keep a mutable
+ * `state` that the POST/PATCH/DELETE mutate on success — the refetch then CONFIRMS
+ * the optimistic change (deterministic, no waitFor race). For the offline path the
+ * GET *also* errors when `navigator.onLine === false`, mirroring a real offline
+ * refetch (React Query keeps the last/optimistic data instead of reverting).
+ *
+ * MSW v2 intercepts the raw axios instance (`@/api/client`) on relative `/news/...`
+ * paths (NOT `/api/...` → setupTests' contract validator skips them). useAuth is
+ * mocked via a hoisted holder so `user` is controllable without a provider.
+ * Offline = `navigator.onLine = false`; the SW-sync block is skipped (jsdom has no
+ * `serviceWorker`/`SyncManager`), so the IDB queue write succeeds silently.
+ */
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { IDBFactory } from "fake-indexeddb"
+import { http, HttpResponse } from "msw"
+import { createElement, type PropsWithChildren } from "react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { server } from "@/tests/mocks/server"
+import type { User } from "@/types/User"
+import { useNewsInteraction, type NewsComment, type NewsInteractions } from "../useNewsInteraction"
+
+const authMock = vi.hoisted(() => ({ user: null as User | null }))
+vi.mock("@/contexts/AuthContext", () => ({ useAuth: () => ({ user: authMock.user }) }))
+
+const NEWS_ID = "news-1"
+const STORE = "pending-news-interactions"
+const DB_NAME = "notification-interactions"
+const DB_VERSION = 3
+
+const baseInteractions: NewsInteractions = {
+  likes_count: 3,
+  is_liked: false,
+  comments: [],
+  comments_count: 0,
+}
+
+function makeWrapper() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  const wrapper = ({ children }: PropsWithChildren) =>
+    createElement(QueryClientProvider, { client: qc }, children)
+  return { qc, wrapper }
+}
+
+function setOnline(value: boolean) {
+  Object.defineProperty(navigator, "onLine", { configurable: true, value })
+}
+
+type Behavior = "ok" | "500" | "401" | "offline"
+
+/**
+ * Register stateful handlers for one test. `state` is the simulated server truth:
+ * the GET returns it (or network-errors when offline), and each `"ok"` mutation
+ * mutates it so the post-mutation refetch confirms the optimistic update.
+ */
+function setupServer(opts: {
+  initial: NewsInteractions
+  like?: Behavior
+  comment?: Behavior
+  patch?: Behavior
+  del?: Behavior
+}): NewsInteractions {
+  // structuredClone-equivalent; note JSON drops `comments_count: undefined` keys,
+  // which is exactly the "undefined → fall back to comments.length" branch we want.
+  const state: NewsInteractions = JSON.parse(JSON.stringify(opts.initial))
+
+  const errResp = (b: Behavior | undefined) => {
+    if (b === "500") return new HttpResponse(null, { status: 500 })
+    if (b === "401") return HttpResponse.json({ detail: "x" }, { status: 401 })
+    if (b === "offline") return HttpResponse.error()
+    return null
+  }
+
+  const handlers = [
+    http.get("*/news/:newsId/interactions", () =>
+      navigator.onLine ? HttpResponse.json(state) : HttpResponse.error()
+    ),
+  ]
+
+  if (opts.like) {
+    handlers.push(
+      http.post("*/news/:newsId/like", () => {
+        const e = errResp(opts.like)
+        if (e) return e
+        state.is_liked = !state.is_liked
+        state.likes_count = state.is_liked ? state.likes_count + 1 : state.likes_count - 1
+        return new HttpResponse(null, { status: 200 })
+      })
+    )
+  }
+
+  if (opts.comment) {
+    handlers.push(
+      http.post("*/news/:newsId/comment", async ({ request }) => {
+        const e = errResp(opts.comment)
+        if (e) return e
+        const body = (await request.json()) as { content: string }
+        const created: NewsComment = {
+          id: `c-srv-${state.comments.length}`,
+          content: body.content,
+          user_id: authMock.user?.id ?? "",
+          user_name: authMock.user?.full_name ?? "You",
+          created_at: "2026-06-13T00:00:00Z",
+        }
+        state.comments = [...state.comments, created]
+        state.comments_count = state.comments.length
+        return HttpResponse.json(created)
+      })
+    )
+  }
+
+  if (opts.patch) {
+    handlers.push(
+      http.patch("*/news/comments/:commentId", async ({ request, params }) => {
+        const e = errResp(opts.patch)
+        if (e) return e
+        const body = (await request.json()) as { content: string }
+        state.comments = state.comments.map((c) =>
+          c.id === params.commentId ? { ...c, content: body.content } : c
+        )
+        return HttpResponse.json({ id: params.commentId, content: body.content })
+      })
+    )
+  }
+
+  if (opts.del) {
+    handlers.push(
+      http.delete("*/news/comments/:commentId", ({ params }) => {
+        const e = errResp(opts.del)
+        if (e) return e
+        state.comments = state.comments.filter((c) => c.id !== params.commentId)
+        state.comments_count = state.comments.length
+        return new HttpResponse(null, { status: 204 })
+      })
+    )
+  }
+
+  server.use(...handlers)
+  return state
+}
+
+type QueueEntry = { url: string; payload: unknown; method: string; timestamp: number }
+
+function readQueue(): Promise<QueueEntry[]> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION)
+    req.onupgradeneeded = () => {
+      const db = req.result
+      if (!db.objectStoreNames.contains(STORE))
+        db.createObjectStore(STORE, { keyPath: "id", autoIncrement: true })
+    }
+    req.onsuccess = () => {
+      const db = req.result
+      if (!db.objectStoreNames.contains(STORE)) {
+        resolve([])
+        return
+      }
+      const tx = db.transaction(STORE, "readonly")
+      const all = tx.objectStore(STORE).getAll()
+      all.onsuccess = () => resolve(all.result as QueueEntry[])
+      all.onerror = () => reject(all.error)
+    }
+    req.onerror = () => reject(req.error)
+  })
+}
+
+beforeEach(() => {
+  // Fresh fake-indexeddb factory per test. The hook's openDatabase()
+  // (useNewsInteraction.ts) opens a connection it never closes, so
+  // indexedDB.deleteDatabase blocks on it and the NEXT offline test's open()
+  // deadlocks behind the pending (blocked) delete — every test passes alone but
+  // the suite hangs (12 timeouts). A new IDBFactory drops all connections + DBs
+  // atomically; same root cause sw.test.ts:237 documents ("deleteDatabase removed
+  // to prevent hook timeouts with fake-indexeddb").
+  globalThis.indexedDB = new IDBFactory() as unknown as typeof globalThis.indexedDB
+  setOnline(true)
+  authMock.user = { id: "u-1", full_name: "Test User" } as User
+})
+
+afterEach(() => {
+  setOnline(true)
+  authMock.user = null
+})
+
+describe("useNewsInteraction — query", () => {
+  it("loads interactions via GET", async () => {
+    const { wrapper } = makeWrapper()
+    setupServer({ initial: baseInteractions })
+    const { result } = renderHook(() => useNewsInteraction(NEWS_ID), { wrapper })
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.interactions).toEqual(baseInteractions)
+  })
+
+  it("initialData seeds immediately (all defaulting branches)", () => {
+    const { wrapper } = makeWrapper()
+    setupServer({ initial: baseInteractions })
+    const { result } = renderHook(
+      () => useNewsInteraction(NEWS_ID, { initialData: { likes_count: 9, is_liked: true } }),
+      { wrapper }
+    )
+    expect(result.current.interactions?.likes_count).toBe(9)
+    expect(result.current.interactions?.is_liked).toBe(true)
+    expect(result.current.interactions?.comments).toEqual([])
+    expect(result.current.interactions?.comments_count).toBe(0)
+  })
+})
+
+describe("useNewsInteraction — toggleLike", () => {
+  it("online happy path flips optimistically and the refetch confirms it", async () => {
+    const { qc, wrapper } = makeWrapper()
+    setupServer({ initial: { ...baseInteractions, is_liked: false, likes_count: 3 }, like: "ok" })
+    const { result } = renderHook(() => useNewsInteraction(NEWS_ID), { wrapper })
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    act(() => result.current.toggleLike())
+    await waitFor(() => {
+      const d = qc.getQueryData<NewsInteractions>(["news", NEWS_ID, "interactions"])
+      expect(d?.is_liked).toBe(true)
+      expect(d?.likes_count).toBe(4)
+    })
+    await waitFor(() => expect(result.current.isLiking).toBe(false))
+  })
+
+  it("server 500 rolls back", async () => {
+    const { qc, wrapper } = makeWrapper()
+    setupServer({ initial: { ...baseInteractions, is_liked: false, likes_count: 3 }, like: "500" })
+    const { result } = renderHook(() => useNewsInteraction(NEWS_ID), { wrapper })
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    act(() => result.current.toggleLike())
+    await waitFor(() => expect(result.current.isLiking).toBe(false))
+    await waitFor(() => {
+      const d = qc.getQueryData<NewsInteractions>(["news", NEWS_ID, "interactions"])
+      expect(d?.is_liked).toBe(false)
+      expect(d?.likes_count).toBe(3)
+    })
+  })
+
+  it("401 rethrows and does NOT queue", async () => {
+    const { wrapper } = makeWrapper()
+    setupServer({ initial: baseInteractions, like: "401" })
+    const { result } = renderHook(() => useNewsInteraction(NEWS_ID), { wrapper })
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    act(() => result.current.toggleLike())
+    await waitFor(() => expect(result.current.isLiking).toBe(false))
+    expect(await readQueue()).toEqual([])
+  })
+
+  it("offline queues to IndexedDB (mutation treated as success)", async () => {
+    const { qc, wrapper } = makeWrapper()
+    setupServer({
+      initial: { ...baseInteractions, is_liked: false, likes_count: 3 },
+      like: "offline",
+    })
+    const { result } = renderHook(() => useNewsInteraction(NEWS_ID), { wrapper })
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    setOnline(false)
+    act(() => result.current.toggleLike())
+    await waitFor(() => expect(result.current.isLiking).toBe(false))
+    const q = await readQueue()
+    expect(q).toHaveLength(1)
+    expect(q[0]!.url).toBe(`/api/v1/news/${NEWS_ID}/like`)
+    expect(q[0]!.method).toBe("POST")
+    expect(q[0]!.payload).toEqual({})
+    // offline refetch also errors → optimistic flip is NOT reverted
+    const d = qc.getQueryData<NewsInteractions>(["news", NEWS_ID, "interactions"])
+    expect(d?.is_liked).toBe(true)
+  })
+})
+
+describe("useNewsInteraction — addComment", () => {
+  const withComment = (over: Partial<NewsInteractions> = {}): NewsInteractions => ({
+    likes_count: 0,
+    is_liked: false,
+    comments: [
+      {
+        id: "c0",
+        content: "old",
+        user_id: "u0",
+        user_name: "X",
+        created_at: "2026-01-01T00:00:00Z",
+      },
+    ],
+    comments_count: 1,
+    ...over,
+  })
+
+  it("online optimistic append uses the auth user", async () => {
+    const { qc, wrapper } = makeWrapper()
+    setupServer({ initial: withComment(), comment: "ok" })
+    const { result } = renderHook(() => useNewsInteraction(NEWS_ID), { wrapper })
+    await waitFor(() => expect(result.current.interactions?.comments.length).toBe(1))
+    act(() => result.current.addComment("hello"))
+    await waitFor(() => {
+      const d = qc.getQueryData<NewsInteractions>(["news", NEWS_ID, "interactions"])
+      expect(d?.comments.length).toBe(2)
+    })
+    const d = qc.getQueryData<NewsInteractions>(["news", NEWS_ID, "interactions"])
+    const last = d!.comments[d!.comments.length - 1]!
+    expect(last.content).toBe("hello")
+    expect(last.user_id).toBe("u-1")
+    expect(last.user_name).toBe("Test User")
+    expect(d?.comments_count).toBe(2)
+  })
+
+  it("optimistic user_name falls back to 'You' + user_id '' when user null", async () => {
+    authMock.user = null
+    const { qc, wrapper } = makeWrapper()
+    setupServer({ initial: withComment(), comment: "ok" })
+    const { result } = renderHook(() => useNewsInteraction(NEWS_ID), { wrapper })
+    await waitFor(() => expect(result.current.interactions?.comments.length).toBe(1))
+    act(() => result.current.addComment("hi"))
+    await waitFor(() => {
+      const d = qc.getQueryData<NewsInteractions>(["news", NEWS_ID, "interactions"])
+      expect(d?.comments.length).toBe(2)
+    })
+    const d = qc.getQueryData<NewsInteractions>(["news", NEWS_ID, "interactions"])
+    const last = d!.comments[d!.comments.length - 1]!
+    expect(last.user_name).toBe("You")
+    expect(last.user_id).toBe("")
+  })
+
+  it("server 500 rolls back", async () => {
+    const { qc, wrapper } = makeWrapper()
+    setupServer({ initial: withComment(), comment: "500" })
+    const { result } = renderHook(() => useNewsInteraction(NEWS_ID), { wrapper })
+    await waitFor(() => expect(result.current.interactions?.comments.length).toBe(1))
+    act(() => result.current.addComment("nope"))
+    await waitFor(() => expect(result.current.isCommenting).toBe(false))
+    await waitFor(() => {
+      const d = qc.getQueryData<NewsInteractions>(["news", NEWS_ID, "interactions"])
+      expect(d?.comments.length).toBe(1)
+    })
+  })
+
+  it("offline queues the comment payload", async () => {
+    const { wrapper } = makeWrapper()
+    setupServer({ initial: withComment(), comment: "offline" })
+    const { result } = renderHook(() => useNewsInteraction(NEWS_ID), { wrapper })
+    await waitFor(() => expect(result.current.interactions?.comments.length).toBe(1))
+    setOnline(false)
+    act(() => result.current.addComment("offline comment"))
+    await waitFor(() => expect(result.current.isCommenting).toBe(false))
+    const q = await readQueue()
+    expect(q).toHaveLength(1)
+    expect(q[0]!.url).toBe(`/api/v1/news/${NEWS_ID}/comment`)
+    expect(q[0]!.method).toBe("POST")
+    expect(q[0]!.payload).toEqual({ content: "offline comment" })
+  })
+
+  it("comments_count falls back to comments.length when undefined", async () => {
+    const { qc, wrapper } = makeWrapper()
+    setupServer({ initial: withComment({ comments_count: undefined }), comment: "ok" })
+    const { result } = renderHook(() => useNewsInteraction(NEWS_ID), { wrapper })
+    await waitFor(() => expect(result.current.interactions?.comments.length).toBe(1))
+    act(() => result.current.addComment("x"))
+    await waitFor(() => {
+      const d = qc.getQueryData<NewsInteractions>(["news", NEWS_ID, "interactions"])
+      expect(d?.comments_count).toBe(2) // (undefined ?? 1) + 1
+    })
+  })
+})
+
+describe("useNewsInteraction — updateComment + deleteComment", () => {
+  const oneComment = (): NewsInteractions => ({
+    likes_count: 0,
+    is_liked: false,
+    comments: [
+      {
+        id: "c1",
+        content: "orig",
+        user_id: "u0",
+        user_name: "X",
+        created_at: "2026-01-01T00:00:00Z",
+      },
+    ],
+    comments_count: 1,
+  })
+
+  const twoComments = (): NewsInteractions => ({
+    likes_count: 0,
+    is_liked: false,
+    comments: [
+      { id: "c1", content: "a", user_id: "u", user_name: "X", created_at: "z" },
+      { id: "c2", content: "b", user_id: "u", user_name: "X", created_at: "z" },
+    ],
+    comments_count: 2,
+  })
+
+  it("updateComment online edits optimistically", async () => {
+    const { qc, wrapper } = makeWrapper()
+    setupServer({ initial: oneComment(), patch: "ok" })
+    const { result } = renderHook(() => useNewsInteraction(NEWS_ID), { wrapper })
+    await waitFor(() => expect(result.current.interactions?.comments.length).toBe(1))
+    act(() => result.current.updateComment("c1", "edited"))
+    await waitFor(() => {
+      const d = qc.getQueryData<NewsInteractions>(["news", NEWS_ID, "interactions"])
+      expect(d?.comments.find((c) => c.id === "c1")?.content).toBe("edited")
+    })
+  })
+
+  it("updateComment 500 rolls back", async () => {
+    const { qc, wrapper } = makeWrapper()
+    setupServer({ initial: oneComment(), patch: "500" })
+    const { result } = renderHook(() => useNewsInteraction(NEWS_ID), { wrapper })
+    await waitFor(() => expect(result.current.interactions?.comments.length).toBe(1))
+    act(() => result.current.updateComment("c1", "x"))
+    await waitFor(() => expect(result.current.isUpdatingComment).toBe(false))
+    await waitFor(() => {
+      const d = qc.getQueryData<NewsInteractions>(["news", NEWS_ID, "interactions"])
+      expect(d?.comments.find((c) => c.id === "c1")?.content).toBe("orig")
+    })
+  })
+
+  it("updateComment offline queues a PATCH", async () => {
+    const { wrapper } = makeWrapper()
+    setupServer({ initial: oneComment(), patch: "offline" })
+    const { result } = renderHook(() => useNewsInteraction(NEWS_ID), { wrapper })
+    await waitFor(() => expect(result.current.interactions?.comments.length).toBe(1))
+    setOnline(false)
+    act(() => result.current.updateComment("c1", "x"))
+    await waitFor(() => expect(result.current.isUpdatingComment).toBe(false))
+    const q = await readQueue()
+    expect(q[0]!.url).toBe("/api/v1/news/comments/c1")
+    expect(q[0]!.method).toBe("PATCH")
+    expect(q[0]!.payload).toEqual({ content: "x" })
+  })
+
+  it("deleteComment online removes optimistically", async () => {
+    const { qc, wrapper } = makeWrapper()
+    setupServer({ initial: twoComments(), del: "ok" })
+    const { result } = renderHook(() => useNewsInteraction(NEWS_ID), { wrapper })
+    await waitFor(() => expect(result.current.interactions?.comments.length).toBe(2))
+    act(() => result.current.deleteComment("c1"))
+    await waitFor(() => {
+      const d = qc.getQueryData<NewsInteractions>(["news", NEWS_ID, "interactions"])
+      expect(d?.comments.length).toBe(1)
+      expect(d?.comments_count).toBe(1)
+    })
+  })
+
+  it("deleteComment 500 rolls back", async () => {
+    const { qc, wrapper } = makeWrapper()
+    setupServer({ initial: twoComments(), del: "500" })
+    const { result } = renderHook(() => useNewsInteraction(NEWS_ID), { wrapper })
+    await waitFor(() => expect(result.current.interactions?.comments.length).toBe(2))
+    act(() => result.current.deleteComment("c1"))
+    await waitFor(() => expect(result.current.isDeletingComment).toBe(false))
+    await waitFor(() => {
+      const d = qc.getQueryData<NewsInteractions>(["news", NEWS_ID, "interactions"])
+      expect(d?.comments.length).toBe(2)
+    })
+  })
+
+  it("deleteComment offline queues a DELETE", async () => {
+    const { wrapper } = makeWrapper()
+    setupServer({
+      initial: {
+        likes_count: 0,
+        is_liked: false,
+        comments: [{ id: "c2", content: "b", user_id: "u", user_name: "X", created_at: "z" }],
+        comments_count: 1,
+      },
+      del: "offline",
+    })
+    const { result } = renderHook(() => useNewsInteraction(NEWS_ID), { wrapper })
+    await waitFor(() => expect(result.current.interactions?.comments.length).toBe(1))
+    setOnline(false)
+    act(() => result.current.deleteComment("c2"))
+    await waitFor(() => expect(result.current.isDeletingComment).toBe(false))
+    const q = await readQueue()
+    expect(q[0]!.url).toBe("/api/v1/news/comments/c2")
+    expect(q[0]!.method).toBe("DELETE")
+    expect(q[0]!.payload).toEqual({})
+  })
+})

--- a/frontend/src/hooks/__tests__/useScheduleConfig.test.tsx
+++ b/frontend/src/hooks/__tests__/useScheduleConfig.test.tsx
@@ -1,0 +1,253 @@
+/**
+ * Session 11 coverage: src/hooks/useScheduleConfig.ts
+ *
+ * i18n-only hook (no MSW, no QueryClient). Tests drive it with controlled
+ * createInstance() i18n instances via <I18nextProvider> so the parsed weekday /
+ * lessonType structure is deterministic (we assert against our own resource,
+ * exercising identical code paths to the real bundle). Broken-resource variants
+ * cover the asRecord guards + every toConfig fallback branch + the
+ * minimalWeekdayFallback / minimalLessonTypeFallback empty-config branches.
+ */
+import { renderHook } from "@testing-library/react"
+import { createInstance, type i18n as I18nType } from "i18next"
+import type { PropsWithChildren, ReactElement } from "react"
+import { createElement } from "react"
+import { I18nextProvider, initReactI18next } from "react-i18next"
+import { describe, expect, it } from "vitest"
+
+import {
+  defaultLessonTypeColor,
+  minimalLessonTypeFallback,
+  minimalWeekdayFallback,
+} from "@/components/schedule/scheduleUtils"
+import { useScheduleConfig } from "../useScheduleConfig"
+
+function makeI18n(schedule: Record<string, unknown>): I18nType {
+  const inst = createInstance()
+  // Inline resources + no backend → init resolves synchronously.
+  void inst.use(initReactI18next).init({
+    lng: "en",
+    fallbackLng: false, // missing keys return the key string (so asRecord -> {})
+    ns: ["schedule"],
+    defaultNS: "schedule",
+    resources: { en: { schedule } },
+    interpolation: { escapeValue: false },
+    react: { useSuspense: false },
+    keySeparator: ".",
+  })
+  return inst
+}
+
+function wrap(inst: I18nType) {
+  const Wrapper = ({ children }: PropsWithChildren): ReactElement =>
+    createElement(I18nextProvider, { i18n: inst }, children)
+  Wrapper.displayName = "TestI18nWrapper"
+  return Wrapper
+}
+
+const VALID = {
+  weekdays: {
+    order: ["mon", "tue", "wed", "thu", "fri", "sat"],
+    items: {
+      mon: { backend: ["Monday", "Понедельник"], long: "Monday", short: "Mon" },
+      tue: { backend: ["Tuesday"], long: "Tuesday", short: "Tue" },
+      wed: { backend: ["Wednesday"], long: "Wednesday", short: "Wed" },
+      thu: { backend: ["Thursday"], long: "Thursday", short: "Thu" },
+      fri: { backend: ["Friday"], long: "Friday", short: "Fri" },
+      sat: { backend: ["Saturday"], long: "Saturday", short: "Sat" },
+    },
+  },
+  lessonTypes: {
+    order: ["lecture", "practice", "lab", "project"],
+    items: {
+      lecture: { backend: ["lecture", "Лекция"], label: "Lecture", color: "var(--badge-lec)" },
+      practice: { backend: ["practice"], label: "Practical", color: "var(--badge-prac)" },
+      lab: { backend: ["lab"], label: "Lab", color: "var(--badge-lab)" },
+      project: { backend: ["project"], label: "Project", color: "var(--badge-proj)" },
+    },
+  },
+}
+
+function renderValid() {
+  return renderHook(() => useScheduleConfig(), { wrapper: wrap(makeI18n(VALID)) })
+}
+
+describe("useScheduleConfig — weekday config (valid resource)", () => {
+  it("builds weekdayConfigs from order + items", () => {
+    const { result } = renderValid()
+    expect(result.current.weekdayConfigs.map((c) => c.id)).toEqual([
+      "mon",
+      "tue",
+      "wed",
+      "thu",
+      "fri",
+      "sat",
+    ])
+    expect(result.current.weekdayConfigs[0]).toEqual({
+      id: "mon",
+      backend: ["Monday", "Понедельник"],
+      long: "Monday",
+      short: "Mon",
+    })
+  })
+
+  it("derives weekdayBackend / weekdayLabels / weekdayShort", () => {
+    const { result } = renderValid()
+    expect(result.current.weekdayBackend).toEqual([
+      "Monday",
+      "Tuesday",
+      "Wednesday",
+      "Thursday",
+      "Friday",
+      "Saturday",
+    ])
+    expect(result.current.weekdayLabels[0]).toBe("Monday")
+    expect(result.current.weekdayShort[0]).toBe("Mon")
+    expect(result.current.weekdayLabels).toHaveLength(6)
+  })
+
+  it("getDayLabel resolves id, backend alias, and falls back to the value", () => {
+    const { result } = renderValid()
+    expect(result.current.getDayLabel("mon")).toBe("Monday")
+    expect(result.current.getDayLabel("Понедельник")).toBe("Monday") // backend alias
+    expect(result.current.getDayLabel("nonexistent-xyz")).toBe("nonexistent-xyz")
+  })
+
+  it("normalizeLessons rewrites weekday to the canonical backend (changed path)", () => {
+    const { result } = renderValid()
+    const input = [
+      { id: "l1", weekday: "mon", parity: "both", start_time: null, end_time: null } as never,
+    ]
+    const out = result.current.normalizeLessons(input)
+    expect(out).not.toBe(input) // new array
+    expect((out[0] as { weekday: string }).weekday).toBe("Monday")
+  })
+
+  it("normalizeLessons returns the same array when already canonical (unchanged)", () => {
+    const { result } = renderValid()
+    const input = [
+      { id: "l1", weekday: "Monday", parity: "both", start_time: null, end_time: null } as never,
+    ]
+    expect(result.current.normalizeLessons(input)).toBe(input)
+  })
+
+  it("normalizeLessons leaves non-string weekday + null elements untouched", () => {
+    const { result } = renderValid()
+    const input = [
+      { id: "l", weekday: 123, parity: "both", start_time: null, end_time: null } as never,
+      null as never,
+    ]
+    expect(result.current.normalizeLessons(input)).toBe(input)
+  })
+
+  it("normalizeLessons returns same array for unknown weekday (no canonical)", () => {
+    const { result } = renderValid()
+    const input = [
+      { id: "l", weekday: "zzz", parity: "both", start_time: null, end_time: null } as never,
+    ]
+    expect(result.current.normalizeLessons(input)).toBe(input)
+  })
+})
+
+describe("useScheduleConfig — lesson type config (valid resource)", () => {
+  it("builds lessonTypeConfigs + labels + options + default", () => {
+    const { result } = renderValid()
+    expect(result.current.lessonTypeConfigs.map((c) => c.id)).toEqual([
+      "lecture",
+      "practice",
+      "lab",
+      "project",
+    ])
+    expect(result.current.lessonTypeConfigs[0]!.color).toBe("var(--badge-lec)")
+    expect(result.current.lessonTypeLabels.get("lecture")).toBe("Lecture")
+    expect(result.current.lessonTypeLabels.get("Лекция")).toBe("Lecture") // backend alias
+    expect(result.current.lessonTypeLabels.get("nope")).toBeUndefined()
+    expect(result.current.lessonTypeOptions[0]).toEqual({ value: "lecture", label: "Lecture" })
+    expect(result.current.defaultLessonType).toBe("lecture")
+  })
+
+  it("getLessonTypeColor: id hit, backend hit, null + unknown fall back", () => {
+    const { result } = renderValid()
+    expect(result.current.getLessonTypeColor("lecture")).toBe("var(--badge-lec)")
+    expect(result.current.getLessonTypeColor("Лекция")).toBe("var(--badge-lec)")
+    expect(result.current.getLessonTypeColor(null)).toBe(defaultLessonTypeColor)
+    expect(result.current.getLessonTypeColor("unknown")).toBe(defaultLessonTypeColor)
+  })
+
+  it("toBackendLessonType: id -> backend[0], null -> '', unknown -> value", () => {
+    const { result } = renderValid()
+    expect(result.current.toBackendLessonType("lecture")).toBe("lecture")
+    expect(result.current.toBackendLessonType(null)).toBe("")
+    expect(result.current.toBackendLessonType("not-an-id")).toBe("not-an-id")
+  })
+})
+
+describe("useScheduleConfig — fallback branches (broken resources)", () => {
+  it("weekdays.items array -> asRecord {} + empty order -> minimalWeekdayFallback", () => {
+    const inst = makeI18n({ weekdays: { items: [], order: [] } })
+    const { result } = renderHook(() => useScheduleConfig(), { wrapper: wrap(inst) })
+    expect(result.current.weekdayConfigs).toEqual(minimalWeekdayFallback)
+  })
+
+  it("lessonTypes primitives -> asRecord {} + empty -> [minimalLessonTypeFallback]", () => {
+    const inst = makeI18n({ lessonTypes: { items: 42, order: 99 } })
+    const { result } = renderHook(() => useScheduleConfig(), { wrapper: wrap(inst) })
+    expect(result.current.lessonTypeConfigs).toEqual([minimalLessonTypeFallback])
+    expect(result.current.defaultLessonType).toBe("lesson")
+  })
+
+  it("weekdays.order not array -> uses Object.keys(items)", () => {
+    const inst = makeI18n({
+      weekdays: { items: { foo: { backend: ["F"], long: "Foo", short: "Fo" } } },
+    })
+    const { result } = renderHook(() => useScheduleConfig(), { wrapper: wrap(inst) })
+    expect(result.current.weekdayConfigs[0]!.id).toBe("foo")
+    expect(result.current.weekdayConfigs[0]!.long).toBe("Foo")
+  })
+
+  it("toConfig: entry undefined + no fallback-by-id -> inline id fallback", () => {
+    const inst = makeI18n({ weekdays: { order: ["xyz"], items: {} } })
+    const { result } = renderHook(() => useScheduleConfig(), { wrapper: wrap(inst) })
+    expect(result.current.weekdayConfigs[0]).toEqual({
+      id: "xyz",
+      backend: ["xyz"],
+      long: "xyz",
+      short: "xyz",
+    })
+  })
+
+  it("toConfig: backend as a single string -> wrapped in array", () => {
+    const inst = makeI18n({
+      weekdays: { order: ["d1"], items: { d1: { backend: "SoloBackend", long: "L", short: "S" } } },
+    })
+    const { result } = renderHook(() => useScheduleConfig(), { wrapper: wrap(inst) })
+    expect(result.current.weekdayConfigs[0]!.backend).toEqual(["SoloBackend"])
+  })
+
+  it("toConfig second loop appends items not present in order", () => {
+    const inst = makeI18n({
+      weekdays: {
+        order: ["a"],
+        items: {
+          a: { backend: ["A"], long: "AA", short: "A" },
+          b: { backend: ["B"], long: "BB", short: "B" },
+        },
+      },
+    })
+    const { result } = renderHook(() => useScheduleConfig(), { wrapper: wrap(inst) })
+    expect(result.current.weekdayConfigs.map((c) => c.id)).toEqual(["a", "b"])
+  })
+
+  it("lessonType toConfig: backend-string + label/color fallbacks", () => {
+    const inst = makeI18n({
+      lessonTypes: { order: ["q"], items: { q: { backend: "single" } } },
+    })
+    const { result } = renderHook(() => useScheduleConfig(), { wrapper: wrap(inst) })
+    expect(result.current.lessonTypeConfigs[0]).toEqual({
+      id: "q",
+      backend: ["single"],
+      label: "q",
+      color: defaultLessonTypeColor,
+    })
+  })
+})

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -57,19 +57,18 @@ export default defineConfig({
         "src/utils/spotify.ts",
         "src/utils/workerChrome.ts",
       ],
-      // Ratchet floors at measured reality. After the session-10 slice
-      // (api/notifications generated-SDK mocks + NavbarPieces render batch +
-      // ContentCard slots + uiMiscPrimitives Dialog/MediaSlot/table): statements
-      // 68.51 / branches 73.69 / functions 69.92 / lines 68.51. All four RAISED:
-      // statements/lines 67→68 (68.51 → 0.51 buffer), branches 72→73 (73.69 →
-      // 0.69 buffer), functions 68→69 (69.92 → 0.92 buffer) — each clears the
-      // ~0.5pp no-cushion margin. NO-REGRESSION floors, NOT the target — raise
-      // incrementally (target 90; local == CI, so there is no integration
-      // cushion: keep ≥~0.5pp headroom before any raise).
+      // Ratchet floors at measured reality. After the session-11 hook batch
+      // (useScheduleConfig + useBookmarks + useLessonNotes + useNewsInteraction +
+      // ScheduleDesktopTable): statements 69.22 / branches 74.72 / functions 71.76
+      // / lines 69.22. RAISED: branches 73→74 (74.72 → 0.72 buffer), functions
+      // 69→71 (71.76 → 0.76 buffer, aggressive +2). statements/lines HOLD at 68
+      // (69.22 < 69.5 — short of the ~0.5pp no-cushion margin). NO-REGRESSION
+      // floors, NOT the target — raise incrementally (target 90; local == CI, so
+      // there is no integration cushion: keep ≥~0.5pp headroom before any raise).
       thresholds: {
         statements: 68,
-        branches: 73,
-        functions: 69,
+        branches: 74,
+        functions: 71,
         lines: 68,
       },
     },

--- a/services/gateway/internal/config/config_test.go
+++ b/services/gateway/internal/config/config_test.go
@@ -254,3 +254,77 @@ func restoreEnv(t *testing.T, key, value string) {
 		}
 	}
 }
+
+// TestGetEnvFloat64 covers getEnvFloat64: unset/empty → default, valid float
+// parse, and the parse-error warn-path (previously uncovered). t.Setenv auto-
+// restores via t.Cleanup, so there's no errcheck surface on os.Setenv.
+func TestGetEnvFloat64(t *testing.T) {
+	const key = "TEST_FLOAT64_XYZ"
+
+	tests := []struct {
+		name     string
+		setEnv   bool
+		envValue string
+		def      float64
+		want     float64
+	}{
+		{name: "unset returns default", setEnv: false, def: 1.0, want: 1.0},
+		{name: "empty string returns default", setEnv: true, envValue: "", def: 0.5, want: 0.5},
+		{name: "valid float is parsed", setEnv: true, envValue: "0.1", def: 1.0, want: 0.1},
+		{name: "integer-looking float is parsed", setEnv: true, envValue: "2", def: 1.0, want: 2.0},
+		{name: "negative float is parsed", setEnv: true, envValue: "-3.5", def: 1.0, want: -3.5},
+		{name: "parse error returns default (warn path)", setEnv: true, envValue: "not_a_float", def: 0.25, want: 0.25},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.setEnv {
+				t.Setenv(key, tc.envValue)
+			} else if err := os.Unsetenv(key); err != nil {
+				t.Fatalf("failed to unset env: %v", err)
+			}
+
+			got := getEnvFloat64(key, tc.def)
+
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestGetEnvSlice covers getEnvSlice: unset/empty → default, comma-split with
+// per-part TrimSpace + skip-empty, and the all-empty-after-trim fallback
+// (previously uncovered). The "whitespace is NOT a separator" case pins the
+// strings.Split(s, ",") contract (guards against a future strings.Fields swap).
+func TestGetEnvSlice(t *testing.T) {
+	const key = "TEST_SLICE_XYZ"
+
+	tests := []struct {
+		name     string
+		setEnv   bool
+		envValue string
+		def      []string
+		want     []string
+	}{
+		{name: "unset returns default", setEnv: false, def: []string{"a", "b"}, want: []string{"a", "b"}},
+		{name: "empty string returns default", setEnv: true, envValue: "", def: []string{"x"}, want: []string{"x"}},
+		{name: "single item is trimmed", setEnv: true, envValue: "  one  ", def: []string{"fallback"}, want: []string{"one"}},
+		{name: "comma-separated items split and trimmed", setEnv: true, envValue: "a, b ,c", def: []string{"fallback"}, want: []string{"a", "b", "c"}},
+		{name: "empty-after-trim parts are skipped", setEnv: true, envValue: "a,,  ,b", def: []string{"fallback"}, want: []string{"a", "b"}},
+		{name: "all-empty-after-trim returns default", setEnv: true, envValue: " , ,  ", def: []string{"fallback-1", "fallback-2"}, want: []string{"fallback-1", "fallback-2"}},
+		{name: "whitespace is not a separator (only comma)", setEnv: true, envValue: "alpha beta", def: []string{"fallback"}, want: []string{"alpha beta"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.setEnv {
+				t.Setenv(key, tc.envValue)
+			} else if err := os.Unsetenv(key); err != nil {
+				t.Fatalf("failed to unset env: %v", err)
+			}
+
+			got := getEnvSlice(key, tc.def)
+
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/services/gateway/internal/handlers/handlers_test.go
+++ b/services/gateway/internal/handlers/handlers_test.go
@@ -354,3 +354,106 @@ func TestFileProcessSyncHandler_Errors(t *testing.T) {
 		assert.Contains(t, w.Body.String(), "processing_failed")
 	})
 }
+
+// spyFileProcessingClient wraps mockFileProcessingServiceClient to record whether
+// ProcessFile was invoked, so the dispatch test can assert which branch of
+// ProxyOrFileHandler fired without standing up a real gRPC server.
+type spyFileProcessingClient struct {
+	mock   *mockFileProcessingServiceClient
+	called *bool
+}
+
+func (s *spyFileProcessingClient) ProcessFile(ctx context.Context, in *pb.ProcessFileRequest, opts ...grpc.CallOption) (*pb.ProcessFileResponse, error) {
+	if s.called != nil {
+		*s.called = true
+	}
+	return s.mock.ProcessFile(ctx, in, opts...)
+}
+
+// TestProxyOrFileHandler_Dispatch verifies the router/dispatch decision in
+// ProxyOrFileHandler (handlers.go:93-100): only POST /v1/files/process/sync is
+// routed to the gRPC file handler; every other method/path falls through to the
+// reverse proxy. The gRPC handler body itself is covered by
+// TestFileProcessSyncHandler_Errors — here we exercise only the dispatch branch.
+func TestProxyOrFileHandler_Dispatch(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.Background()
+
+	const proxySentinelStatus = http.StatusTeapot // 418 — unmistakable proxy sentinel
+	const proxySentinelBody = "proxied-ok"
+
+	// There's no injectable proxyFn in ProxyOrFileHandler, so the proxy "spy" must
+	// be a real httptest backend behind createTestProxy. It records the hit and
+	// returns a sentinel status so we can assert status passthrough.
+	newRouter := func(proxyCalled, grpcCalled *bool) *gin.Engine {
+		backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			*proxyCalled = true
+			w.WriteHeader(proxySentinelStatus)
+			if _, err := w.Write([]byte(proxySentinelBody)); err != nil {
+				t.Errorf("backend write failed: %v", err)
+			}
+		}))
+		t.Cleanup(backend.Close)
+
+		proxy := createTestProxy(backend.URL)
+		grpcMock := &spyFileProcessingClient{
+			mock:   &mockFileProcessingServiceClient{resp: &pb.ProcessFileResponse{JobId: "dispatch-job", DestKey: "out.png"}},
+			called: grpcCalled,
+		}
+		dummyConn := &grpc.ClientConn{} // non-nil to pass the grpcConn==nil guard
+
+		r := gin.New()
+		// The /v1/*path wildcard makes c.Param("path") resolve to the captured
+		// suffix (handlers.go:94). Any() registers the handler for all verbs.
+		r.Any("/v1/*path", ProxyOrFileHandler(proxy, nil, ctx, dummyConn, grpcMock, logger))
+		return r
+	}
+
+	t.Run("GET any path routes to proxy", func(t *testing.T) {
+		var proxyCalled, grpcCalled bool
+		router := newRouter(&proxyCalled, &grpcCalled)
+
+		w := newCloseNotifyingRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/v1/files/process/sync", nil)
+		router.ServeHTTP(w, req)
+
+		// Even on the file path, a GET fails the method guard → proxy branch.
+		assert.True(t, proxyCalled, "GET must route to the reverse proxy")
+		assert.False(t, grpcCalled, "gRPC handler must not fire for GET")
+		assert.Equal(t, proxySentinelStatus, w.Code, "proxy backend status must pass through")
+		assert.Contains(t, w.Body.String(), proxySentinelBody)
+	})
+
+	t.Run("POST non-file path routes to proxy", func(t *testing.T) {
+		var proxyCalled, grpcCalled bool
+		router := newRouter(&proxyCalled, &grpcCalled)
+
+		w := newCloseNotifyingRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/v1/other/endpoint", bytes.NewReader([]byte("{}")))
+		req.Header.Set("Content-Type", "application/json")
+		router.ServeHTTP(w, req)
+
+		// path == "/other/endpoint" != "/files/process/sync" → proxy branch.
+		assert.True(t, proxyCalled, "POST to a non-file path must route to the reverse proxy")
+		assert.False(t, grpcCalled, "gRPC handler must not fire for a non-file POST path")
+		assert.Equal(t, proxySentinelStatus, w.Code, "proxy backend status must pass through")
+		assert.Contains(t, w.Body.String(), proxySentinelBody)
+	})
+
+	t.Run("POST files process sync routes to gRPC", func(t *testing.T) {
+		var proxyCalled, grpcCalled bool
+		router := newRouter(&proxyCalled, &grpcCalled)
+
+		w := newCloseNotifyingRecorder()
+		reqBody := `{"id":"550e8400-e29b-41d4-a716-446655440000","type":"resize","source_key":"in.png","dest_key":"out.png"}`
+		req := httptest.NewRequest(http.MethodPost, "/v1/files/process/sync", bytes.NewReader([]byte(reqBody)))
+		req.Header.Set("Content-Type", "application/json")
+		router.ServeHTTP(w, req)
+
+		// method==POST && path=="/files/process/sync" → gRPC branch (handlers.go:95-98).
+		assert.True(t, grpcCalled, "POST /v1/files/process/sync must route to the gRPC file handler")
+		assert.False(t, proxyCalled, "reverse proxy must not fire for the file-process path")
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Body.String(), "out.png")
+	})
+}

--- a/services/ws-hub/pkg/hub/handlers_unit_test.go
+++ b/services/ws-hub/pkg/hub/handlers_unit_test.go
@@ -387,3 +387,119 @@ func TestHandleWebSocket_InvalidTicketRejected(t *testing.T) {
 	defer func() { _ = resp.Body.Close() }() //nolint:errcheck // test cleanup
 	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 }
+
+// ---------------------------------------------------------------------------
+// validateHMAC — direct branch coverage (testing session 11)
+//
+// ValidateToken routes by the token's alg header BEFORE calling validateHMAC,
+// so the wrong-alg branch inside validateHMAC's keyFunc is unreachable through
+// ValidateToken. These tests call (*Hub).validateHMAC directly (white-box, same
+// package) to cover every branch of handlers.go:352-380.
+// ---------------------------------------------------------------------------
+
+// signHS256 forges an HS256 token signed with secret (mirrors the inline forge
+// pattern already used in hub_test.go).
+func signHS256(t *testing.T, secret string, claims jwt.MapClaims) string {
+	t.Helper()
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	signed, err := token.SignedString([]byte(secret))
+	require.NoError(t, err)
+	return signed
+}
+
+func TestValidateHMAC_EmptySecrets(t *testing.T) {
+	h := setupTestHub()
+	// len(secrets) == 0 → handlers.go:354 returns jwt.ErrTokenSignatureInvalid directly.
+	sub, err := h.validateHMAC("any.token.value", nil)
+	assert.Empty(t, sub)
+	assert.ErrorIs(t, err, jwt.ErrTokenSignatureInvalid)
+
+	// Also exercise the explicit empty-slice form.
+	_, err = h.validateHMAC("any.token.value", []string{})
+	assert.ErrorIs(t, err, jwt.ErrTokenSignatureInvalid)
+}
+
+func TestValidateHMAC_WrongAlg(t *testing.T) {
+	h := setupTestHub()
+	secret := "hmac-secret" // pragma: allowlist secret
+
+	t.Run("RS256-signed token hits unexpected-signing-method", func(t *testing.T) {
+		priv, err := rsa.GenerateKey(rand.Reader, 2048)
+		require.NoError(t, err)
+		rsToken := signRS256(t, priv, "kid-x", jwt.MapClaims{
+			"sub": "user-rs",
+			"exp": time.Now().Add(time.Hour).Unix(),
+		})
+		// Direct call — keyFunc rejects t.Method != HS256 → lastErr → returned at :377.
+		sub, err := h.validateHMAC(rsToken, []string{secret})
+		assert.Empty(t, sub)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unexpected signing method")
+	})
+
+	t.Run("none-alg token hits unexpected-signing-method", func(t *testing.T) {
+		noneTok := jwt.New(jwt.SigningMethodNone)
+		noneTok.Claims = jwt.MapClaims{"sub": "user-none"}
+		signed, err := noneTok.SignedString(jwt.UnsafeAllowNoneSignatureType)
+		require.NoError(t, err)
+		sub, err := h.validateHMAC(signed, []string{secret})
+		assert.Empty(t, sub)
+		require.Error(t, err)
+	})
+}
+
+func TestValidateHMAC_MissingSubClaim(t *testing.T) {
+	h := setupTestHub()
+	secret := "hmac-secret" // pragma: allowlist secret
+	// Valid signature + valid claims, but no "sub" → handlers.go:373 returns
+	// jwt.ErrTokenInvalidClaims directly.
+	token := signHS256(t, secret, jwt.MapClaims{
+		"exp": time.Now().Add(time.Hour).Unix(),
+		// deliberately no "sub"
+	})
+	sub, err := h.validateHMAC(token, []string{secret})
+	assert.Empty(t, sub)
+	assert.ErrorIs(t, err, jwt.ErrTokenInvalidClaims)
+}
+
+func TestValidateHMAC_MultiSecretRotation(t *testing.T) {
+	h := setupTestHub()
+	oldSecret := "old-rotated-out-secret" // pragma: allowlist secret
+	newSecret := "new-rotated-out-secret" // pragma: allowlist secret
+	// Signed with the SECOND secret → first secret's Parse fails (lastErr set,
+	// continue), second secret succeeds → loop returns sub at :371.
+	token := signHS256(t, newSecret, jwt.MapClaims{
+		"sub": "user-rotated",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+	sub, err := h.validateHMAC(token, []string{oldSecret, newSecret})
+	require.NoError(t, err)
+	assert.Equal(t, "user-rotated", sub)
+}
+
+func TestValidateHMAC_AllSecretsFail(t *testing.T) {
+	h := setupTestHub()
+	token := signHS256(t, "the-real-secret", jwt.MapClaims{ // pragma: allowlist secret
+		"sub": "user-x",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+	// Neither candidate secret matches → both Parse calls fail, lastErr returned
+	// at handlers.go:377. jwt/v5 joins ErrTokenSignatureInvalid into the parse
+	// error, so errors.Is unwraps it (assert.Equal would FAIL — it's wrapped).
+	sub, err := h.validateHMAC(token, []string{"wrong-1", "wrong-2"}) // pragma: allowlist secret
+	assert.Empty(t, sub)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, jwt.ErrTokenSignatureInvalid)
+}
+
+func TestValidateHMAC_ValidHS256(t *testing.T) {
+	h := setupTestHub()
+	secret := "hmac-secret" // pragma: allowlist secret
+	token := signHS256(t, secret, jwt.MapClaims{
+		"sub": "user-ok",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+	sub, err := h.validateHMAC(token, []string{secret})
+	require.NoError(t, err)
+	assert.Equal(t, "user-ok", sub)
+}

--- a/services/ws-hub/pkg/hub/hub_test.go
+++ b/services/ws-hub/pkg/hub/hub_test.go
@@ -398,3 +398,47 @@ func TestValidateToken(t *testing.T) {
 		assert.Error(t, err)
 	})
 }
+
+// TestHub_HandleRegister_MaxClientsReject covers the capacity-reject branch in
+// hub.go:219 (h.maxClients > 0 && len(h.Clients) >= h.maxClients). The 2nd
+// client must hit closeOnce.Do(close(Send)) + Conn.Close() and NOT be added to
+// the Clients map. newConnPair / newClientOn live in client_unit_test.go (same
+// package). A non-nil *websocket.Conn is REQUIRED: handleRegister calls
+// client.Conn.Close() on reject (hub.go:225) — a nil Conn would nil-panic.
+func TestHub_HandleRegister_MaxClientsReject(t *testing.T) {
+	h := setupTestHub()
+	h.maxClients = 1 // private field, white-box override (cfg.MaxClients=10 default)
+	ctx := context.Background()
+
+	// First client: real server-side conn, registers successfully.
+	srv1, _ := newConnPair(t)
+	c1 := newClientOn(h, srv1, "cap-client-1", "u1")
+	h.handleRegister(ctx, c1)
+
+	h.mu.RLock()
+	require.Len(t, h.Clients, 1, "first client should register")
+	_, ok1 := h.Clients["cap-client-1"]
+	h.mu.RUnlock()
+	require.True(t, ok1)
+
+	// Second client: hub is at capacity → reject branch (hub.go:219-228).
+	srv2, _ := newConnPair(t)
+	c2 := newClientOn(h, srv2, "cap-client-2", "u2")
+	h.handleRegister(ctx, c2)
+
+	// Rejected client is NOT in the map.
+	h.mu.RLock()
+	assert.Len(t, h.Clients, 1, "second client must be rejected at capacity")
+	_, ok2 := h.Clients["cap-client-2"]
+	h.mu.RUnlock()
+	assert.False(t, ok2, "rejected client must not appear in Clients map")
+
+	// Reject path ran closeOnce.Do(close(Send)) — a receive on a closed empty
+	// channel returns immediately with ok=false.
+	select {
+	case _, recvOK := <-c2.Send:
+		assert.False(t, recvOK, "rejected client's Send channel must be closed")
+	default:
+		t.Errorf("expected rejected client's Send channel to be closed (closeOnce ran), got open channel")
+	}
+}

--- a/tests/test_auth_security_service_session11.py
+++ b/tests/test_auth_security_service_session11.py
@@ -1,0 +1,237 @@
+"""Session 11 coverage: app/services/auth/security_service.py + analytics regression.
+
+AuthSecurityService(db, locale) is tested with an AsyncMock db (the AsyncMock-db
+idiom from tests/test_services_mock.py). ActiveSession instances are built as
+plain un-flushed objects with only the attributes the methods read (expires_at,
+mfa_verified_at, last_seen_at, id) — SQLAlchemy declarative __init__ accepts
+arbitrary kwargs and unset Mapped columns read as None on a transient instance.
+
+settings.mfa_step_up_ttl_seconds (default 300) is monkeypatched per test via the
+imported singleton (same object as app.services.auth.security_service.settings).
+
+NOTE: app/services/auth/security_service.py is already 100% covered (A0) via authed
+integration fixtures; these are DIRECT unit tests that pin its expiry / MFA-TTL /
+last-seen behavior precisely (a hot path on every authed request). They do not move
+the coverage gate — they add regression protection.
+
+Item-4 regression: AnalyticsService.get_user_activity raw SQL must reference the
+real `event_attendance` table (app/models/events.py:126), NOT `event_attendees`.
+analytics.py:200 was fixed `event_attendees` -> `event_attendance` in this session;
+test_get_user_activity_sql_references_real_table guards it.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException, status
+
+from app.core.config import settings
+from app.models import ActiveSession
+from app.services.analytics import AnalyticsService
+from app.services.auth.security_service import AuthSecurityService
+
+
+def _make_session(
+    *,
+    expires_at: datetime | None = None,
+    mfa_verified_at: datetime | None = None,
+    last_seen_at: datetime | None = None,
+) -> ActiveSession:
+    """Un-flushed ActiveSession with only the time fields the service reads.
+    id is a real UUID so the sync_last_seen UPDATE .where(id == ...) compiles
+    (never executed — db.execute is an AsyncMock)."""
+    s = ActiveSession()
+    s.id = uuid.uuid4()
+    if expires_at is not None:
+        s.expires_at = expires_at
+    s.mfa_verified_at = mfa_verified_at
+    s.last_seen_at = last_seen_at
+    return s
+
+
+@pytest.fixture
+def db() -> AsyncMock:
+    return AsyncMock()
+
+
+@pytest.fixture
+def svc(db: AsyncMock) -> AuthSecurityService:
+    return AuthSecurityService(db=db, locale="en")
+
+
+# ── validate_session_expiry ───────────────────────────────────────────────────
+def test_validate_session_expiry_expired_raises(svc: AuthSecurityService) -> None:
+    past = datetime.now(UTC) - timedelta(hours=1)
+    session = _make_session(expires_at=past)
+    with pytest.raises(HTTPException) as exc_info:
+        svc.validate_session_expiry(session)
+    assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
+    assert exc_info.value.headers == {"WWW-Authenticate": "Bearer"}
+
+
+def test_validate_session_expiry_future_passes(svc: AuthSecurityService) -> None:
+    future = datetime.now(UTC) + timedelta(hours=1)
+    session = _make_session(expires_at=future)
+    assert svc.validate_session_expiry(session) is None
+
+
+def test_validate_session_expiry_naive_expires_at_coerced(
+    svc: AuthSecurityService,
+) -> None:
+    naive_future = (datetime.now(UTC) + timedelta(hours=1)).replace(tzinfo=None)
+    session = _make_session(expires_at=naive_future)
+    assert svc.validate_session_expiry(session) is None
+
+
+def test_validate_session_expiry_naive_past_still_raises(
+    svc: AuthSecurityService,
+) -> None:
+    naive_past = (datetime.now(UTC) - timedelta(hours=1)).replace(tzinfo=None)
+    session = _make_session(expires_at=naive_past)
+    with pytest.raises(HTTPException) as exc_info:
+        svc.validate_session_expiry(session)
+    assert exc_info.value.status_code == 401
+
+
+# ── handle_mfa_ttl ─────────────────────────────────────────────────────────────
+async def test_handle_mfa_ttl_zero_is_noop(
+    svc: AuthSecurityService, db: AsyncMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(settings, "mfa_step_up_ttl_seconds", 0)
+    old = datetime.now(UTC) - timedelta(days=7)
+    session = _make_session(mfa_verified_at=old)
+    await svc.handle_mfa_ttl(session)
+    assert session.mfa_verified_at == old
+    db.commit.assert_not_awaited()
+
+
+async def test_handle_mfa_ttl_expired_clears_and_commits(
+    svc: AuthSecurityService, db: AsyncMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(settings, "mfa_step_up_ttl_seconds", 300)
+    session = _make_session(mfa_verified_at=datetime.now(UTC) - timedelta(seconds=600))
+    await svc.handle_mfa_ttl(session)
+    assert session.mfa_verified_at is None
+    db.commit.assert_awaited_once()
+
+
+async def test_handle_mfa_ttl_within_window_no_clear(
+    svc: AuthSecurityService, db: AsyncMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(settings, "mfa_step_up_ttl_seconds", 300)
+    recent = datetime.now(UTC) - timedelta(seconds=60)
+    session = _make_session(mfa_verified_at=recent)
+    await svc.handle_mfa_ttl(session)
+    assert session.mfa_verified_at == recent
+    db.commit.assert_not_awaited()
+
+
+async def test_handle_mfa_ttl_none_verified_is_noop(
+    svc: AuthSecurityService, db: AsyncMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(settings, "mfa_step_up_ttl_seconds", 300)
+    session = _make_session(mfa_verified_at=None)
+    await svc.handle_mfa_ttl(session)
+    db.commit.assert_not_awaited()
+
+
+async def test_handle_mfa_ttl_naive_verified_coerced_and_cleared(
+    svc: AuthSecurityService, db: AsyncMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(settings, "mfa_step_up_ttl_seconds", 300)
+    naive_old = (datetime.now(UTC) - timedelta(seconds=600)).replace(tzinfo=None)
+    session = _make_session(mfa_verified_at=naive_old)
+    await svc.handle_mfa_ttl(session)  # coercion prevents TypeError
+    assert session.mfa_verified_at is None
+    db.commit.assert_awaited_once()
+
+
+# ── sync_last_seen ─────────────────────────────────────────────────────────────
+async def test_sync_last_seen_none_writes(
+    svc: AuthSecurityService, db: AsyncMock
+) -> None:
+    session = _make_session(last_seen_at=None)
+    await svc.sync_last_seen(session)
+    db.execute.assert_awaited_once()
+    db.commit.assert_awaited_once()
+    assert session.last_seen_at is not None
+
+
+async def test_sync_last_seen_recent_no_write(
+    svc: AuthSecurityService, db: AsyncMock
+) -> None:
+    recent = datetime.now(UTC) - timedelta(seconds=60)
+    session = _make_session(last_seen_at=recent)
+    await svc.sync_last_seen(session)  # cached_session defaults False (300s window)
+    db.execute.assert_not_awaited()
+    db.commit.assert_not_awaited()
+    assert session.last_seen_at == recent
+
+
+async def test_sync_last_seen_old_writes(
+    svc: AuthSecurityService, db: AsyncMock
+) -> None:
+    old = datetime.now(UTC) - timedelta(seconds=400)  # 400s >= 300s
+    session = _make_session(last_seen_at=old)
+    await svc.sync_last_seen(session)
+    db.execute.assert_awaited_once()
+    db.commit.assert_awaited_once()
+    assert session.last_seen_at > old
+
+
+async def test_sync_last_seen_cached_uses_600s_window(
+    svc: AuthSecurityService, db: AsyncMock
+) -> None:
+    # 400s ago: >= 300s (would write) but < 600s (cached => no write)
+    age_400 = datetime.now(UTC) - timedelta(seconds=400)
+    session = _make_session(last_seen_at=age_400)
+    await svc.sync_last_seen(session, cached_session=True)
+    db.execute.assert_not_awaited()
+    db.commit.assert_not_awaited()
+    assert session.last_seen_at == age_400
+
+
+async def test_sync_last_seen_cached_writes_past_600s(
+    svc: AuthSecurityService, db: AsyncMock
+) -> None:
+    age_700 = datetime.now(UTC) - timedelta(seconds=700)  # >= 600s
+    session = _make_session(last_seen_at=age_700)
+    await svc.sync_last_seen(session, cached_session=True)
+    db.execute.assert_awaited_once()
+    db.commit.assert_awaited_once()
+
+
+async def test_sync_last_seen_naive_last_seen_coerced(
+    svc: AuthSecurityService, db: AsyncMock
+) -> None:
+    naive_old = (datetime.now(UTC) - timedelta(seconds=400)).replace(tzinfo=None)
+    session = _make_session(last_seen_at=naive_old)
+    await svc.sync_last_seen(session)  # coercion prevents TypeError
+    db.execute.assert_awaited_once()
+
+
+# ── analytics.py:200 regression (event_attendees -> event_attendance) ─────────
+async def test_get_user_activity_sql_references_real_table() -> None:
+    """REGRESSION: get_user_activity's raw SQL must reference the real
+    `event_attendance` table, not the non-existent `event_attendees`.
+    Bug fixed at app/services/analytics.py:200 in session 11.
+    """
+    result_proxy = MagicMock()
+    result_proxy.fetchall.return_value = []
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=result_proxy)
+    svc = AnalyticsService()
+    await svc.get_user_activity(session, uuid.uuid4())
+    session.execute.assert_awaited_once()
+    sql_text = str(session.execute.await_args.args[0])
+    assert "event_attendance" in sql_text, (
+        "get_user_activity SQL must FROM the real table event_attendance; "
+        f"got:\n{sql_text}"
+    )
+    assert "event_attendees" not in sql_text, (
+        "analytics.py:200 still references the non-existent table event_attendees"
+    )

--- a/tests/test_config_mixins_coverage.py
+++ b/tests/test_config_mixins_coverage.py
@@ -1,0 +1,593 @@
+"""Session-11 — config-mixin validator/property coverage.
+
+Targets the UNtested validators + cached_property/property accessors of the five
+Pydantic config mixins composed by ``app.core.config.security.SecuritySettings``:
+``JwtSettingsMixin``, ``CspSettingsMixin``, ``CorsSettingsMixin``,
+``MfaSettingsMixin``, ``RateLimitSettingsMixin``.
+
+Idiom (mirrors ``tests/test_wave131_cookie_migration.py``): instantiate a FRESH
+``SecuritySettings()`` per test + ``monkeypatch.setenv``. NEVER mutate the global
+``settings`` singleton or any class descriptor — that is the mutmut-isolation
+landmine (mutmut forks per-mutant and shared module/class state corrupts the run).
+
+ENVIRONMENT NOTE: ``tests/conftest.py`` sets OS env at import — ``ENVIRONMENT=testing``,
+``SECRET_KEY=<32-char>``, ``ALGORITHM=HS256``, ``RATE_LIMIT_STORAGE_BACKEND=memory``…
+OS env overrides ``.env`` in pydantic-settings, so default-branch tests run under a
+DEV environment (production guards bypassed). Production-branch tests use the
+``prod_env`` fixture which sets ``ENVIRONMENT=production`` PLUS neutralizes the
+unrelated prod-only validators (``AUDIT_LOG_SECRET`` / ``SECRET_KEY`` /
+``INTERNAL_HMAC_SECRET`` / ``ALGORITHM``) so ONLY the validator under test can raise.
+
+``SecuritySettings`` inherits ``BaseAppSettings`` directly (NOT ``AppGeneralSettings``),
+so it has NO ``environment`` / ``is_development`` field. The CSP/CORS mixins key off
+``getattr(self, "is_development", False)`` → False, so on a bare ``SecuritySettings()``
+``strict_security_headers_enabled`` is True (the non-dev branch) — asserted explicitly.
+
+Two branches are intentionally NOT covered here (honest scope — they are unreachable
+from ``SecuritySettings``):
+  * ``CorsSettingsMixin.cors_allow_credentials_effective`` strict-mode per-origin
+    https loop (shadowed — ``cors_allow_origins_list`` already filters non-https
+    non-local origins before that loop runs).
+  * ``CspSettingsMixin._development_connect_overrides`` populated branch (requires
+    ``is_development=True``, only present on the full ``Settings`` model).
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from app.core.config.security import SecuritySettings
+
+
+@pytest.fixture
+def prod_env(monkeypatch):
+    """Production environment with all UNRELATED prod-only validators neutralized,
+    so a single prod-branch test can isolate one validator's raise.
+
+    Individual tests override ONE of these (last-write-wins on ``monkeypatch.setenv``)
+    to drive the specific prod validator under test (e.g. a SHORT ``SECRET_KEY`` or
+    an ``HS256`` ``ALGORITHM``).
+    """
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("AUDIT_LOG_SECRET", "a" * 32)  # pragma: allowlist secret
+    monkeypatch.setenv("SECRET_KEY", "p" * 48)  # pragma: allowlist secret
+    monkeypatch.setenv("INTERNAL_HMAC_SECRET", "i" * 48)  # pragma: allowlist secret
+    monkeypatch.setenv("ALGORITHM", "RS256")
+    monkeypatch.setenv("JWT_PRIVATE_KEY_PATH", "")
+    return monkeypatch
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# JwtSettingsMixin
+# ─────────────────────────────────────────────────────────────────────────────
+class TestJwtSettingsMixin:
+    # ── secret_key file loading (J1) ──────────────────────────────────────
+    def test_secret_key_file_env_reads_file(self, tmp_path, monkeypatch):
+        key_file = tmp_path / "secret_key"
+        expected = (
+            "file-loaded-secret-key-32-chars-minimum-xx"  # pragma: allowlist secret
+        )
+        key_file.write_text(expected, encoding="utf-8")
+        monkeypatch.setenv("SECRET_KEY_FILE", str(key_file))
+        s = SecuritySettings()
+        assert s.secret_key == expected
+
+    def test_secret_key_file_nonreadable_raises(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SECRET_KEY_FILE", str(tmp_path / "does-not-exist"))
+        with pytest.raises(ValidationError) as exc:
+            SecuritySettings()
+        assert "SECRET_KEY_FILE" in str(exc.value)
+        assert "non-readable file" in str(exc.value)
+
+    # ── secret_key entropy (J2, J3, J4) ───────────────────────────────────
+    def test_secret_key_empty_raises(self, monkeypatch):
+        monkeypatch.setenv("SECRET_KEY", "")
+        with pytest.raises(ValidationError) as exc:
+            SecuritySettings()
+        assert "SECRET_KEY must not be empty" in str(exc.value)
+
+    def test_secret_key_short_in_production_raises(self, prod_env):
+        prod_env.setenv("SECRET_KEY", "tooshort")  # pragma: allowlist secret
+        with pytest.raises(ValidationError) as exc:
+            SecuritySettings()
+        assert "SECRET_KEY must be at least 32 characters long in production" in str(
+            exc.value
+        )
+
+    def test_secret_key_short_in_dev_allowed(self, monkeypatch):
+        # conftest ENVIRONMENT=testing → dev branch; short key allowed
+        monkeypatch.setenv("SECRET_KEY", "shortdevkey")  # pragma: allowlist secret
+        s = SecuritySettings()
+        assert s.secret_key == "shortdevkey"  # pragma: allowlist secret
+
+    # ── jwt_signing_keys entropy (J5, J6, J7) ─────────────────────────────
+    def test_jwt_signing_keys_short_hmac_in_prod_raises(self, prod_env):
+        prod_env.setenv("JWT_SIGNING_KEYS", "kid1:short")  # pragma: allowlist secret
+        with pytest.raises(ValidationError) as exc:
+            SecuritySettings()
+        assert (
+            "JWT_SIGNING_KEYS entries must be at least 32 characters long in production"
+            in str(exc.value)
+        )
+
+    def test_jwt_signing_keys_pem_block_exempt_in_prod(self, prod_env):
+        prod_env.setenv(
+            "JWT_SIGNING_KEYS",
+            "kid1:-----BEGIN PRIVATE KEY-----",  # pragma: allowlist secret
+        )
+        # PEM blocks are exempt from the 32-char entropy rule → construction succeeds.
+        s = SecuritySettings()
+        assert "kid1" in str(s.jwt_signing_keys)
+
+    def test_jwt_signing_keys_empty_returns_unchanged(self, monkeypatch):
+        monkeypatch.setenv("JWT_SIGNING_KEYS", "")
+        s = SecuritySettings()
+        assert s.jwt_signing_keys == ""
+
+    # ── algorithm (J8, J9, J10, J17) ──────────────────────────────────────
+    def test_algorithm_hs256_in_prod_raises(self, prod_env):
+        prod_env.setenv("ALGORITHM", "HS256")
+        with pytest.raises(ValidationError) as exc:
+            SecuritySettings()
+        assert "HS256 is prohibited in non-local environments" in str(exc.value)
+
+    def test_algorithm_hs256_in_dev_allowed_and_uppercased(self, monkeypatch):
+        monkeypatch.setenv("ENVIRONMENT", "development")
+        monkeypatch.setenv("ALGORITHM", "hs256")
+        s = SecuritySettings()
+        assert s.algorithm == "HS256"  # validate_jwt_algorithm uppercases
+        assert s.ALGORITHM == "HS256"  # cached_property delegates (J17)
+
+    def test_algorithm_rs256_passthrough_uppercase(self, monkeypatch):
+        monkeypatch.setenv("ALGORITHM", "rs256")
+        s = SecuritySettings()
+        assert s.algorithm == "RS256"
+
+    # ── jwt_audience (J11, J12) ───────────────────────────────────────────
+    def test_jwt_audience_empty_raises(self, monkeypatch):
+        monkeypatch.setenv("JWT_AUDIENCE", "   ")
+        with pytest.raises(ValidationError) as exc:
+            SecuritySettings()
+        assert "JWT_AUDIENCE must not be empty" in str(exc.value)
+
+    def test_jwt_audience_default_and_strip(self, monkeypatch):
+        s = SecuritySettings()
+        assert s.jwt_audience == "university-ecosystem-api"
+        monkeypatch.setenv("JWT_AUDIENCE", "  custom-aud  ")
+        s2 = SecuritySettings()
+        assert s2.jwt_audience == "custom-aud"
+
+    # ── signing key registry / active kid / active secret (J13, J15, J16) ─
+    def test_signing_key_registry_multi_key_parse_and_cache(self, monkeypatch):
+        monkeypatch.setenv(
+            "JWT_SIGNING_KEYS",
+            "k1:secret-one-32-characters-padding-xxx,"  # pragma: allowlist secret
+            "k2:secret-two-32-characters-padding-x",  # pragma: allowlist secret
+        )
+        monkeypatch.setenv("JWT_ACTIVE_KID", "k2")
+        s = SecuritySettings()
+        reg = s.jwt_signing_key_registry
+        assert reg == {
+            "k1": "secret-one-32-characters-padding-xxx",  # pragma: allowlist secret
+            "k2": "secret-two-32-characters-padding-x",  # pragma: allowlist secret
+        }
+        # value-keyed cache: second access returns the SAME object
+        assert s.jwt_signing_key_registry is reg
+        assert "_jwt_registry_cache" in s.__dict__
+        assert s.jwt_signing_active_kid == "k2"
+        assert (
+            s.jwt_signing_active_secret
+            == "secret-two-32-characters-padding-x"  # pragma: allowlist secret
+        )
+
+    def test_signing_key_registry_fallback_to_secret_key(self, monkeypatch):
+        # No JWT_SIGNING_KEYS; HS256 (conftest) + no RS256 key path → fallback to secret_key.
+        monkeypatch.setenv("JWT_SIGNING_KEYS", "")
+        monkeypatch.setenv("JWT_PRIVATE_KEY_PATH", "")  # forces the else-branch
+        s = SecuritySettings()
+        reg = s.jwt_signing_key_registry
+        assert list(reg.keys()) == ["primary"]
+        assert reg["primary"] == s.secret_key
+        assert s.jwt_signing_active_kid == "primary"
+        # SECRET_KEY cached_property delegates to the active secret (J17 secret half)
+        assert s.SECRET_KEY == s.jwt_signing_active_secret == s.secret_key
+
+    def test_active_kid_mismatch_raises(self, monkeypatch):
+        monkeypatch.setenv(
+            "JWT_SIGNING_KEYS",
+            "k1:secret-one-32-characters-padding-xxx",  # pragma: allowlist secret
+        )
+        monkeypatch.setenv("JWT_ACTIVE_KID", "nonexistent")
+        s = SecuritySettings()
+        with pytest.raises(RuntimeError) as exc:
+            _ = s.jwt_signing_active_kid
+        assert (
+            "JWT_ACTIVE_KID must match one of the configured JWT_SIGNING_KEYS"
+            in str(exc.value)
+        )
+
+    # ── _build_jwt_signing_key_entries malformed (J14, lazy RuntimeError) ──
+    @pytest.mark.parametrize(
+        ("value", "substr"),
+        [
+            ("badkeynocolon", "must be in '<kid>:<secret>' format"),
+            (
+                ":secretonly",
+                "must specify a non-empty kid value",
+            ),  # pragma: allowlist secret
+            (
+                "kid1:",
+                "must specify a non-empty secret value",
+            ),  # pragma: allowlist secret
+            (
+                "dup:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,"  # pragma: allowlist secret
+                "dup:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",  # pragma: allowlist secret
+                "must use unique kid values",
+            ),
+        ],
+    )
+    def test_signing_keys_malformed_raises_runtimeerror(
+        self, value, substr, monkeypatch
+    ):
+        # Run in default (testing) env: the entropy validator skips non-':' entries
+        # and accepts ':' entries, so construction succeeds; the RuntimeError fires
+        # lazily at registry access (_build_jwt_signing_key_entries).
+        monkeypatch.setenv("JWT_SIGNING_KEYS", value)
+        s = SecuritySettings()
+        with pytest.raises(RuntimeError) as exc:
+            _ = s.jwt_signing_key_registry
+        assert substr in str(exc.value)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# CspSettingsMixin (UNtested half only — cookie_samesite covered by test_wave131)
+# ─────────────────────────────────────────────────────────────────────────────
+class TestCspSettingsMixin:
+    def test_coep_value_valid_normalized(self, monkeypatch):
+        monkeypatch.setenv("COEP_VALUE", "  CREDENTIALLESS  ")
+        s = SecuritySettings()
+        assert s.coep_value == "credentialless"
+        assert s.coep_header_value == "credentialless"
+
+    def test_coep_value_invalid_raises(self, monkeypatch):
+        monkeypatch.setenv("COEP_VALUE", "bogus")
+        with pytest.raises(ValidationError) as exc:
+            SecuritySettings()
+        assert "COEP_VALUE must be either 'require-corp' or 'credentialless'" in str(
+            exc.value
+        )
+
+    def test_corp_value_valid_normalized(self, monkeypatch):
+        monkeypatch.setenv("CORP_VALUE", "Cross-Origin")
+        s = SecuritySettings()
+        assert s.corp_value == "cross-origin"
+        assert s.corp_header_value == "cross-origin"
+
+    def test_corp_value_invalid_raises(self, monkeypatch):
+        monkeypatch.setenv("CORP_VALUE", "nope")
+        with pytest.raises(ValidationError) as exc:
+            SecuritySettings()
+        assert (
+            "CORP_VALUE must be one of 'same-origin', 'same-site', or 'cross-origin'"
+            in str(exc.value)
+        )
+
+    def test_strict_security_headers_default_true_without_is_development(self):
+        # SecuritySettings has no is_development → getattr(..., False)=False → not False = True
+        s = SecuritySettings()
+        assert s.strict_security_headers_enabled is True
+        assert s.cookie_secure is True
+        assert s.security_csp_report_only_effective is False
+        assert s.should_inject_csp_nonce is True
+
+    def test_strict_security_headers_explicit_false(self, monkeypatch):
+        monkeypatch.setenv("ENABLE_STRICT_SECURITY_HEADERS", "false")
+        s = SecuritySettings()
+        assert s.strict_security_headers_enabled is False
+        assert s.cookie_secure is False
+        # report_only_effective = not strict = True (inferred branch)
+        assert s.security_csp_report_only_effective is True
+        assert s.should_inject_csp_nonce is False  # report_only True → return False
+
+    def test_csp_report_only_effective_explicit(self, monkeypatch):
+        monkeypatch.setenv("SECURITY_CSP_REPORT_ONLY", "true")
+        s = SecuritySettings()
+        assert s.security_csp_report_only_effective is True
+
+    def test_coep_corp_enabled_flags(self, monkeypatch):
+        monkeypatch.setenv("ENABLE_COEP", "true")
+        monkeypatch.setenv("ENABLE_CORP", "false")
+        s = SecuritySettings()
+        assert s.coep_enabled is True
+        assert s.corp_enabled is False
+
+    def test_connect_src_values_dedup_and_self_prepend(self, monkeypatch):
+        monkeypatch.setenv(
+            "SECURITY_CONNECT_SRC_EXTRA",
+            "https://api.spotify.com,https://api.spotify.com,'self'",
+        )
+        s = SecuritySettings()
+        vals = s.security_connect_src_values
+        assert vals[0] == "'self'"
+        # dedup: spotify appears once; 'self' appears once even though re-listed
+        assert vals.count("https://api.spotify.com") == 1
+        assert vals.count("'self'") == 1
+
+    def test_development_connect_overrides_empty_without_is_development(self):
+        s = SecuritySettings()
+        assert s._development_connect_overrides() == []
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# CorsSettingsMixin
+# ─────────────────────────────────────────────────────────────────────────────
+class TestCorsSettingsMixin:
+    def test_frontend_origins_list_dedup_and_rstrip(self, monkeypatch):
+        monkeypatch.setenv(
+            "FRONTEND_ORIGINS", "https://a.com/,https://a.com,https://b.com"
+        )
+        monkeypatch.setenv("FRONTEND_ORIGIN", "")
+        monkeypatch.setenv("APP_BASE_URL", "")
+        monkeypatch.setenv("WEBAUTHN_ORIGIN", "")
+        s = SecuritySettings()
+        assert s.frontend_origins_list == ["https://a.com", "https://b.com"]
+
+    def test_frontend_origins_no_localhost_autoadd_without_is_development(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv("FRONTEND_ORIGINS", "https://prod.com")
+        monkeypatch.setenv("FRONTEND_ORIGIN", "")
+        monkeypatch.setenv("APP_BASE_URL", "")
+        monkeypatch.setenv("WEBAUTHN_ORIGIN", "")
+        s = SecuritySettings()
+        assert "http://localhost:5173" not in s.frontend_origins_list
+
+    def test_cors_allow_origins_https_filter_excludes_nonlocal_http(self, monkeypatch):
+        # strict_security_headers_enabled defaults True → https-only filter active
+        monkeypatch.setenv("FRONTEND_ORIGINS", "http://evil.com")
+        monkeypatch.setenv("FRONTEND_ORIGIN", "")
+        monkeypatch.setenv("APP_BASE_URL", "")
+        monkeypatch.setenv("WEBAUTHN_ORIGIN", "")
+        s = SecuritySettings()
+        assert "http://evil.com" not in s.cors_allow_origins_list
+
+    def test_cors_allow_origins_keeps_localhost_http(self, monkeypatch):
+        monkeypatch.setenv("FRONTEND_ORIGINS", "http://localhost:5173")
+        monkeypatch.setenv("FRONTEND_ORIGIN", "")
+        monkeypatch.setenv("APP_BASE_URL", "")
+        monkeypatch.setenv("WEBAUTHN_ORIGIN", "")
+        s = SecuritySettings()
+        assert "http://localhost:5173" in s.cors_allow_origins_list
+
+    def test_cors_credentials_effective_false_when_disabled(self, monkeypatch):
+        monkeypatch.setenv("CORS_ALLOW_CREDENTIALS", "false")
+        s = SecuritySettings()
+        assert s.cors_allow_credentials_effective is False
+
+    def test_cors_credentials_effective_false_when_no_origins(self, monkeypatch):
+        monkeypatch.setenv("FRONTEND_ORIGINS", "")
+        monkeypatch.setenv("FRONTEND_ORIGIN", "")
+        monkeypatch.setenv("APP_BASE_URL", "")
+        monkeypatch.setenv("WEBAUTHN_ORIGIN", "")
+        s = SecuritySettings()
+        assert s.cors_allow_origins_list == []
+        assert s.cors_allow_credentials_effective is False
+
+    def test_cors_credentials_effective_true_happy(self, monkeypatch):
+        monkeypatch.setenv("FRONTEND_ORIGINS", "https://prod.com")
+        monkeypatch.setenv("FRONTEND_ORIGIN", "")
+        monkeypatch.setenv("APP_BASE_URL", "")
+        monkeypatch.setenv("WEBAUTHN_ORIGIN", "")
+        s = SecuritySettings()
+        assert s.cors_allow_credentials_effective is True
+
+    def test_trusted_hosts_list_str_and_list(self, monkeypatch):
+        monkeypatch.setenv("TRUSTED_HOSTS", "a.com, b.com ,")
+        s = SecuritySettings()
+        assert s.trusted_hosts_list == ["a.com", "b.com"]
+
+    def test_allowed_hosts_empty_no_dev_defaults(self, monkeypatch):
+        monkeypatch.setenv("ALLOWED_HOSTS", "")
+        s = SecuritySettings()  # no is_development → result stays []
+        assert s.allowed_hosts_list == []
+
+    def test_allowed_vs_trusted_hosts_are_distinct(self, monkeypatch):
+        # Middleware reads allowed_hosts_list, NOT trusted_hosts_list (CLAUDE.md gotcha).
+        monkeypatch.setenv("TRUSTED_HOSTS", "trusted.example")
+        monkeypatch.setenv("ALLOWED_HOSTS", "allowed.example")
+        s = SecuritySettings()
+        assert s.trusted_hosts_list == ["trusted.example"]
+        assert s.allowed_hosts_list == ["allowed.example"]
+        assert s.allowed_hosts_list != s.trusted_hosts_list
+
+    def test_internal_allowed_ips_list(self, monkeypatch):
+        monkeypatch.setenv("INTERNAL_ALLOWED_IPS", "10.0.0.1, 10.0.0.2 ,")
+        s = SecuritySettings()
+        assert s.internal_allowed_ips_list == ["10.0.0.1", "10.0.0.2"]
+
+    def test_cors_methods_custom_and_default(self, monkeypatch):
+        monkeypatch.setenv("CORS_ALLOW_METHODS", "GET,POST")
+        s = SecuritySettings()
+        assert s.cors_allow_methods_list == ["GET", "POST"]
+        monkeypatch.setenv("CORS_ALLOW_METHODS", "")
+        s2 = SecuritySettings()
+        assert s2.cors_allow_methods_list == [
+            "GET",
+            "POST",
+            "PUT",
+            "PATCH",
+            "DELETE",
+            "OPTIONS",
+        ]
+
+    def test_cors_headers_custom_and_default(self, monkeypatch):
+        monkeypatch.setenv("CORS_ALLOW_HEADERS", "X-Custom")
+        s = SecuritySettings()
+        assert s.cors_allow_headers_list == ["X-Custom"]
+        monkeypatch.setenv("CORS_ALLOW_HEADERS", "")
+        s2 = SecuritySettings()
+        assert s2.cors_allow_headers_list == ["Authorization", "Content-Type"]
+
+    def test_cors_expose_headers_appends_request_and_trace(self, monkeypatch):
+        monkeypatch.setenv("CORS_EXPOSE_HEADERS", "X-Foo")
+        monkeypatch.setenv("REQUEST_ID_HEADER", "x-request-id")
+        monkeypatch.setenv("TRACE_HEADER", "x-trace-id")
+        s = SecuritySettings()
+        exposed = s.cors_expose_headers_list
+        assert "X-Foo" in exposed
+        assert "x-request-id" in exposed
+        assert "x-trace-id" in exposed
+
+    def test_trusted_proxies_list(self, monkeypatch):
+        monkeypatch.setenv("TRUSTED_PROXIES", "10.0.0.0/8, 192.168.0.0/16")
+        s = SecuritySettings()
+        assert s.trusted_proxies_list == ["10.0.0.0/8", "192.168.0.0/16"]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# MfaSettingsMixin (env-independent validators — run in default env)
+# ─────────────────────────────────────────────────────────────────────────────
+class TestMfaSettingsMixin:
+    def test_totp_issuer_empty_raises(self, monkeypatch):
+        monkeypatch.setenv("MFA_TOTP_ISSUER", "   ")
+        with pytest.raises(ValidationError) as exc:
+            SecuritySettings()
+        assert "MFA_TOTP_ISSUER must not be empty" in str(exc.value)
+
+    def test_totp_issuer_valid(self, monkeypatch):
+        monkeypatch.setenv("MFA_TOTP_ISSUER", "  My University  ")
+        s = SecuritySettings()
+        assert s.mfa_totp_issuer == "My University"
+
+    @pytest.mark.parametrize(
+        ("env_name", "msg"),
+        [
+            (
+                "MFA_CHALLENGE_TTL_SECONDS",
+                "MFA_CHALLENGE_TTL_SECONDS must be greater than zero",
+            ),
+            (
+                "MFA_CHALLENGE_MAX_ATTEMPTS",
+                "MFA_CHALLENGE_MAX_ATTEMPTS must be greater than zero",
+            ),
+            (
+                "MFA_STEP_UP_TTL_SECONDS",
+                "MFA_STEP_UP_TTL_SECONDS must be greater than zero",
+            ),
+        ],
+    )
+    def test_positive_mfa_values_zero_raises(self, env_name, msg, monkeypatch):
+        monkeypatch.setenv(env_name, "0")
+        with pytest.raises(ValidationError) as exc:
+            SecuritySettings()
+        assert msg in str(exc.value)
+
+    def test_password_min_length_zero_raises(self, monkeypatch):
+        monkeypatch.setenv("PASSWORD_MIN_LENGTH", "0")
+        with pytest.raises(ValidationError) as exc:
+            SecuritySettings()
+        assert "PASSWORD_MIN_LENGTH must be greater than zero" in str(exc.value)
+
+    def test_password_max_less_than_min_raises(self, monkeypatch):
+        monkeypatch.setenv("PASSWORD_MIN_LENGTH", "50")
+        monkeypatch.setenv("PASSWORD_MAX_LENGTH", "10")
+        with pytest.raises(ValidationError) as exc:
+            SecuritySettings()
+        assert "PASSWORD_MAX_LENGTH must be >= PASSWORD_MIN_LENGTH" in str(exc.value)
+
+    @pytest.mark.parametrize("bad", ["-1", "5"])
+    def test_password_character_classes_out_of_range_raises(self, bad, monkeypatch):
+        monkeypatch.setenv("PASSWORD_MIN_CHARACTER_CLASSES", bad)
+        with pytest.raises(ValidationError) as exc:
+            SecuritySettings()
+        assert "PASSWORD_MIN_CHARACTER_CLASSES must be between 0 and 4" in str(
+            exc.value
+        )
+
+    @pytest.mark.parametrize("bad", ["-1", "5"])
+    def test_password_zxcvbn_score_out_of_range_raises(self, bad, monkeypatch):
+        monkeypatch.setenv("PASSWORD_ZXCVBN_MIN_SCORE", bad)
+        with pytest.raises(ValidationError) as exc:
+            SecuritySettings()
+        assert "PASSWORD_ZXCVBN_MIN_SCORE must be between 0 and 4" in str(exc.value)
+
+    def test_password_hibp_timeout_zero_raises(self, monkeypatch):
+        monkeypatch.setenv("PASSWORD_HIBP_TIMEOUT_SECONDS", "0")
+        with pytest.raises(ValidationError) as exc:
+            SecuritySettings()
+        assert "PASSWORD_HIBP_TIMEOUT_SECONDS must be greater than zero" in str(
+            exc.value
+        )
+
+    def test_totp_skew_negative_raises(self, monkeypatch):
+        monkeypatch.setenv("MFA_TOTP_INITIAL_SKEW_WINDOWS", "-1")
+        with pytest.raises(ValidationError) as exc:
+            SecuritySettings()
+        assert "MFA_TOTP_INITIAL_SKEW_WINDOWS must be zero or positive" in str(
+            exc.value
+        )
+
+    def test_totp_skew_zero_allowed(self, monkeypatch):
+        monkeypatch.setenv("MFA_TOTP_INITIAL_SKEW_WINDOWS", "0")
+        s = SecuritySettings()
+        assert s.mfa_totp_initial_skew_windows == 0
+
+    def test_character_classes_and_zxcvbn_boundaries_ok(self, monkeypatch):
+        # boundary happy values lock the passing branches (0..4 inclusive)
+        monkeypatch.setenv("PASSWORD_MIN_CHARACTER_CLASSES", "4")
+        monkeypatch.setenv("PASSWORD_ZXCVBN_MIN_SCORE", "0")
+        s = SecuritySettings()
+        assert s.password_min_character_classes == 4
+        assert s.password_zxcvbn_min_score == 0
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# RateLimitSettingsMixin
+# ─────────────────────────────────────────────────────────────────────────────
+class TestRateLimitSettingsMixin:
+    """The config layer ONLY validates ``rate_limit_storage_backend`` ∈ {memory, redis}.
+    There is NO validator on ``rate_limit_storage_uri`` — the "memory:// is not a valid
+    Redis scheme" rule lives at the consumption sites (``app/core/ratelimit/logic.py``,
+    ``app/core/middleware/setup.py``), NOT in this mixin. conftest sets
+    ``RATE_LIMIT_STORAGE_BACKEND=memory`` + ``RATE_LIMIT_STORAGE_URI=redis://localhost``
+    (a harmless dev mismatch — the URI is unused when backend=memory).
+    """
+
+    def test_storage_backend_redis_normalized(self, monkeypatch):
+        monkeypatch.setenv("RATE_LIMIT_STORAGE_BACKEND", "  REDIS  ")
+        s = SecuritySettings()
+        assert s.rate_limit_storage_backend == "redis"
+
+    def test_storage_backend_memory_normalized(self, monkeypatch):
+        monkeypatch.setenv("RATE_LIMIT_STORAGE_BACKEND", "Memory")
+        s = SecuritySettings()
+        assert s.rate_limit_storage_backend == "memory"
+
+    def test_storage_backend_invalid_raises(self, monkeypatch):
+        monkeypatch.setenv("RATE_LIMIT_STORAGE_BACKEND", "postgres")
+        with pytest.raises(ValidationError) as exc:
+            SecuritySettings()
+        assert "RATE_LIMIT_STORAGE_BACKEND must be 'memory' or 'redis'" in str(
+            exc.value
+        )
+
+    def test_rate_limit_default_list_coerces_csv(self, monkeypatch):
+        monkeypatch.setenv("RATE_LIMIT_DEFAULT", "100/minute, 1000/hour ,")
+        s = SecuritySettings()
+        assert s.rate_limit_default_list == ["100/minute", "1000/hour"]
+
+    def test_rate_limit_default_list_single(self, monkeypatch):
+        monkeypatch.setenv("RATE_LIMIT_DEFAULT", "200/minute")
+        s = SecuritySettings()
+        assert s.rate_limit_default_list == ["200/minute"]
+
+    def test_rate_limit_sensitive_value_coercion(self, monkeypatch):
+        monkeypatch.setenv("RATE_LIMIT_SENSITIVE", "  3/minute  ")
+        s = SecuritySettings()
+        assert s.rate_limit_sensitive_value == "3/minute"
+
+    def test_rate_limit_sensitive_value_empty_to_none(self, monkeypatch):
+        monkeypatch.setenv("RATE_LIMIT_SENSITIVE", "   ")
+        s = SecuritySettings()
+        assert s.rate_limit_sensitive_value is None

--- a/tests/test_core_handlers_session11.py
+++ b/tests/test_core_handlers_session11.py
@@ -1,0 +1,300 @@
+"""Session 11 coverage: app/core/exceptions/handlers.py + app/core/middleware/request_id.py.
+
+Handlers tested with a duck-typed SimpleNamespace request (resolve_locale +
+str(request.url) only need .url/.headers/.query_params). RequestIDMiddleware
+tested as a raw ASGI callable with async receive/send mocks.
+
+asyncio_mode = "auto" (pyproject) — async test fns need no decorator.
+"""
+
+from __future__ import annotations
+
+import json
+import types
+import uuid
+from typing import Any
+
+import pytest
+from fastapi import HTTPException, status
+from fastapi.responses import JSONResponse
+
+from app.core.exceptions.domain import (
+    BusinessRuleViolation,
+    DomainException,
+    EntityAlreadyExists,
+    EntityNotFound,
+    PermissionDenied,
+)
+from app.core.exceptions.handlers import (
+    _loc_to_pointer,
+    domain_exception_handler,
+    http_exception_handler,
+)
+from app.core.middleware.request_id import (
+    _REQUEST_ID_SAFE_CHARS,
+    RequestIDMiddleware,
+    request_id_ctx,
+)
+
+
+def _make_request(
+    url: str = "http://testserver/api/v1/x", locale: str | None = None
+) -> Any:
+    """Duck-typed request: handlers only call resolve_locale(request=...) and
+    str(request.url). resolve_locale reads .query_params/.headers via getattr."""
+    query_params = None
+    if locale is not None:
+        query_params = types.SimpleNamespace(
+            get=lambda key, _loc=locale: _loc if key == "lang" else None
+        )
+    return types.SimpleNamespace(url=url, headers=None, query_params=query_params)
+
+
+# ── _loc_to_pointer (RFC 6901) ────────────────────────────────────────────────
+def test_loc_to_pointer_empty() -> None:
+    assert _loc_to_pointer(()) == ""
+
+
+def test_loc_to_pointer_basic_path() -> None:
+    assert _loc_to_pointer(("body", "user", "email")) == "/body/user/email"
+
+
+def test_loc_to_pointer_int_segment() -> None:
+    assert _loc_to_pointer(("body", "items", 0, "name")) == "/body/items/0/name"
+
+
+def test_loc_to_pointer_escapes_tilde_and_slash() -> None:
+    assert _loc_to_pointer(("a/b~c",)) == "/a~1b~0c"
+    # tilde escaped before slash: literal "~1" -> "~01" not "~11"
+    assert _loc_to_pointer(("~1",)) == "/~01"
+
+
+# ── domain_exception_handler ──────────────────────────────────────────────────
+async def test_domain_handler_entity_not_found_404() -> None:
+    exc = EntityNotFound("User", "abc-123")
+    resp = await domain_exception_handler(_make_request(), exc)
+    assert isinstance(resp, JSONResponse)
+    assert resp.status_code == status.HTTP_404_NOT_FOUND
+    assert resp.media_type == "application/problem+json"
+    body = json.loads(resp.body)
+    assert body["type"] == "https://api.university.edu/probs/not-found"
+    assert body["status"] == 404
+    assert body["instance"] == "http://testserver/api/v1/x"
+    assert isinstance(body["title"], str) and body["title"]
+    assert isinstance(body["detail"], str) and body["detail"]
+    assert "trace_id" in body
+
+
+async def test_domain_handler_already_exists_409() -> None:
+    exc = EntityAlreadyExists("News", 42)
+    resp = await domain_exception_handler(_make_request(), exc)
+    assert resp.status_code == status.HTTP_409_CONFLICT
+    body = json.loads(resp.body)
+    assert body["type"] == "https://api.university.edu/probs/conflict"
+    # errors.already_exists en = "Record already exists: {identifier}"
+    assert body["detail"] == "Record already exists: 42"
+
+
+async def test_domain_handler_permission_denied_403() -> None:
+    exc = PermissionDenied()
+    resp = await domain_exception_handler(_make_request(), exc)
+    assert resp.status_code == status.HTTP_403_FORBIDDEN
+    body = json.loads(resp.body)
+    assert body["type"] == "https://api.university.edu/probs/forbidden"
+    assert isinstance(body["title"], str) and body["title"]
+
+
+async def test_domain_handler_business_rule_400() -> None:
+    exc = BusinessRuleViolation("Capacity exceeded")
+    resp = await domain_exception_handler(_make_request(), exc)
+    assert resp.status_code == status.HTTP_400_BAD_REQUEST
+    body = json.loads(resp.body)
+    assert body["type"] == "https://api.university.edu/probs/business-rule"
+    assert body["detail"] == "Capacity exceeded"  # exc.message verbatim
+
+
+async def test_domain_handler_generic_fallback_400() -> None:
+    exc = DomainException("raw domain failure")
+    resp = await domain_exception_handler(_make_request(), exc)
+    assert resp.status_code == status.HTTP_400_BAD_REQUEST
+    body = json.loads(resp.body)
+    assert body["type"] == "about:blank"
+    assert body["detail"] == "raw domain failure"  # str(exc)
+
+
+async def test_domain_handler_localizes_ru() -> None:
+    # resolve_locale reads request.query_params.get("lang") -> "ru"
+    exc_en = EntityNotFound("User", 1)
+    resp_en = await domain_exception_handler(_make_request(), exc_en)
+    title_en = json.loads(resp_en.body)["title"]
+
+    exc_ru = EntityNotFound("User", 1)
+    resp_ru = await domain_exception_handler(_make_request(locale="ru"), exc_ru)
+    body_ru = json.loads(resp_ru.body)
+    # RU localization differs from EN (proves the query-param locale path ran)
+    assert body_ru["title"] != title_en
+    assert isinstance(body_ru["title"], str) and body_ru["title"]
+
+
+# ── http_exception_handler ────────────────────────────────────────────────────
+async def test_http_handler_404() -> None:
+    exc = HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="missing")
+    resp = await http_exception_handler(_make_request(), exc)
+    assert resp.status_code == 404
+    assert resp.media_type == "application/problem+json"
+    body = json.loads(resp.body)
+    assert body["type"] == "about:blank"
+    assert body["detail"] == "missing"  # exc.detail
+    assert body["instance"] == "http://testserver/api/v1/x"
+    assert isinstance(body["title"], str) and body["title"]
+
+
+async def test_http_handler_unmapped_status() -> None:
+    exc = HTTPException(status_code=418, detail="teapot")
+    resp = await http_exception_handler(_make_request(), exc)
+    assert resp.status_code == 418
+    body = json.loads(resp.body)
+    assert isinstance(body["title"], str) and body["title"]
+    assert body["detail"] == "teapot"
+
+
+async def test_http_handler_passes_headers() -> None:
+    exc = HTTPException(
+        status_code=401, detail="auth", headers={"WWW-Authenticate": "Bearer"}
+    )
+    resp = await http_exception_handler(_make_request(), exc)
+    assert resp.status_code == 401
+    assert resp.headers["www-authenticate"] == "Bearer"
+    body = json.loads(resp.body)
+    assert isinstance(body["title"], str) and body["title"]
+
+
+async def test_asgi_json_problem_emits_problem_json() -> None:
+    from app.core.exceptions.handlers import asgi_json_problem
+
+    sent: list[dict] = []
+
+    async def send(msg: dict) -> None:
+        sent.append(msg)
+
+    await asgi_json_problem(
+        send,
+        status_code=403,
+        title_key="titles.forbidden",
+        detail_text="nope",
+        locale="en",
+        instance="http://x/y",
+        headers={"X-Custom": "v"},
+    )
+    start = sent[0]
+    assert start["type"] == "http.response.start"
+    assert start["status"] == 403
+    # ASGI header keys are encoded preserving input case — lookup case-insensitively
+    hdrs = {k.lower(): v for k, v in start["headers"]}
+    assert hdrs[b"content-type"] == b"application/problem+json"
+    assert hdrs[b"x-custom"] == b"v"
+    body = json.loads(sent[1]["body"])
+    assert body["detail"] == "nope"  # detail_text wins
+    assert body["status"] == 403
+    assert isinstance(body["title"], str) and body["title"]
+
+
+# ── RequestIDMiddleware ───────────────────────────────────────────────────────
+def _http_scope(headers: list[tuple[bytes, bytes]] | None = None) -> dict[str, Any]:
+    return {"type": "http", "method": "GET", "path": "/", "headers": headers or []}
+
+
+async def _noop_receive() -> dict[str, Any]:
+    return {"type": "http.request", "body": b"", "more_body": False}
+
+
+class _CapturingApp:
+    """Inner ASGI app: emits http.response.start (so the wrapped send appends
+    x-request-id) and records the request_id_ctx value visible to handlers."""
+
+    def __init__(self) -> None:
+        self.seen_scope: dict[str, Any] | None = None
+        self.ctx_during_call: str | None = None
+
+    async def __call__(self, scope: dict, receive: Any, send: Any) -> None:
+        self.seen_scope = scope
+        self.ctx_during_call = request_id_ctx.get()
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"ok"})
+
+
+async def test_request_id_non_http_passthrough() -> None:
+    inner = _CapturingApp()
+    mw = RequestIDMiddleware(inner)
+    sent: list[dict] = []
+
+    async def send(m: dict) -> None:
+        sent.append(m)
+
+    scope = {"type": "lifespan"}
+    await mw(scope, _noop_receive, send)
+    assert inner.seen_scope == scope  # delegated untouched
+
+
+async def test_request_id_generated_when_absent() -> None:
+    inner = _CapturingApp()
+    mw = RequestIDMiddleware(inner)
+    sent: list[dict] = []
+
+    async def send(m: dict) -> None:
+        sent.append(m)
+
+    scope = _http_scope(headers=[])
+    await mw(scope, _noop_receive, send)
+    rid = scope["state"]["request_id"]
+    assert rid and uuid.UUID(rid)  # generated UUID4 (parses)
+    start = next(m for m in sent if m["type"] == "http.response.start")
+    assert (b"x-request-id", rid.encode("ascii")) in start["headers"]
+    assert inner.ctx_during_call == rid  # ctx var live during handler
+    assert request_id_ctx.get() == ""  # reset in finally
+
+
+async def test_request_id_incoming_header_sanitized() -> None:
+    inner = _CapturingApp()
+    mw = RequestIDMiddleware(inner)
+    sent: list[dict] = []
+
+    async def send(m: dict) -> None:
+        sent.append(m)
+
+    raw = "abc-123_DEF\r\nInjected: x  /<>;"  # CRLF + spaces + meta chars
+    scope = _http_scope(headers=[(b"x-request-id", raw.encode("latin-1"))])
+    await mw(scope, _noop_receive, send)
+    rid = scope["state"]["request_id"]
+    assert rid == "abc-123_DEFInjectedx"  # only alnum + - + _ survive
+    assert all(c in _REQUEST_ID_SAFE_CHARS for c in rid)
+
+
+async def test_request_id_truncated_to_64() -> None:
+    inner = _CapturingApp()
+    mw = RequestIDMiddleware(inner)
+    sent: list[dict] = []
+
+    async def send(m: dict) -> None:
+        sent.append(m)
+
+    raw = "a" * 200
+    scope = _http_scope(headers=[(b"x-request-id", raw.encode("ascii"))])
+    await mw(scope, _noop_receive, send)
+    assert scope["state"]["request_id"] == "a" * 64
+
+
+async def test_request_id_context_reset_on_inner_exception() -> None:
+    class _Boom:
+        async def __call__(self, scope: dict, receive: Any, send: Any) -> None:
+            raise RuntimeError("boom")
+
+    mw = RequestIDMiddleware(_Boom())
+
+    async def send(m: dict) -> None:
+        pass
+
+    scope = _http_scope(headers=[(b"x-request-id", b"fixed-id")])
+    with pytest.raises(RuntimeError):
+        await mw(scope, _noop_receive, send)
+    assert request_id_ctx.get() == ""  # finally still ran

--- a/tests/test_localization_formatting_session11.py
+++ b/tests/test_localization_formatting_session11.py
@@ -1,0 +1,138 @@
+"""Session 11 coverage: app/core/localization/formatting.py pure functions.
+
+No DB, no async. Exercises _normalize_weekday_token, translate (fallback chain +
+.format), translate_lesson_type (alias/canonical/unknown/None/empty), and
+resolve_weekday_index + weekday_aliases (alias resolution incl. localized RU/EN
+short forms). Translation values asserted are read verbatim from
+app/core/localization/dictionary.py.
+"""
+
+from __future__ import annotations
+
+from app.core.localization.formatting import (
+    _normalize_weekday_token,
+    resolve_weekday_index,
+    translate,
+    translate_lesson_type,
+    weekday_aliases,
+)
+
+
+# ── _normalize_weekday_token ──────────────────────────────────────────────────
+def test_normalize_weekday_token_none_returns_none() -> None:
+    assert _normalize_weekday_token(None) is None
+
+
+def test_normalize_weekday_token_empty_string_returns_none() -> None:
+    assert _normalize_weekday_token("") is None
+
+
+def test_normalize_weekday_token_strips_nonalpha_and_lowercases() -> None:
+    assert _normalize_weekday_token("Mon-2!") == "mon"
+    assert _normalize_weekday_token("ПН.") == "пн"  # cyrillic kept (isalpha)
+
+
+def test_normalize_weekday_token_all_nonalpha_returns_none() -> None:
+    assert _normalize_weekday_token("123 ---") is None
+
+
+# ── translate ─────────────────────────────────────────────────────────────────
+def test_translate_resolved_locale_ru() -> None:
+    assert translate("schedule.lesson.type.lecture", locale="ru") == "Лекция"
+
+
+def test_translate_falls_back_to_default_locale() -> None:
+    # "de" is unsupported -> resolve_locale normalizes to "en"
+    assert translate("schedule.lesson.type.lecture", locale="de") == "Lecture"
+
+
+def test_translate_missing_key_returns_default() -> None:
+    assert translate("no.such.key.session11", default="FALLBACK") == "FALLBACK"
+
+
+def test_translate_missing_key_no_default_returns_key() -> None:
+    assert translate("no.such.key.session11") == "no.such.key.session11"
+
+
+def test_translate_format_interpolation() -> None:
+    out = translate("errors.already_exists", locale="en", identifier="X42")
+    assert out == "Record already exists: X42"
+
+
+def test_translate_format_missing_kwarg_returns_unformatted() -> None:
+    # kwargs present but missing the {identifier} placeholder -> KeyError swallowed
+    out = translate("errors.already_exists", locale="en", wrong_kwarg="z")
+    assert out == "Record already exists: {identifier}"
+
+
+def test_translate_no_kwargs_returns_text_unchanged() -> None:
+    assert translate("notifications.default_title", locale="en") == "Notification"
+
+
+# ── translate_lesson_type ─────────────────────────────────────────────────────
+def test_translate_lesson_type_none() -> None:
+    assert translate_lesson_type(None) is None
+
+
+def test_translate_lesson_type_empty_returns_empty() -> None:
+    assert translate_lesson_type("   ") == ""  # stripped to "" then returned
+
+
+def test_translate_lesson_type_ru_alias() -> None:
+    assert translate_lesson_type("Лекция", locale="ru") == "Лекция"
+    assert translate_lesson_type("лк", locale="en") == "Lecture"
+
+
+def test_translate_lesson_type_canonical_english() -> None:
+    assert translate_lesson_type("practice", locale="en") == "Practical class"
+
+
+def test_translate_lesson_type_canonical_via_translations_fallback() -> None:
+    # "lab" is a TRANSLATIONS key but NOT an _LESSON_TYPE_ALIASES key
+    # -> exercises the canonical-resolved-from-translations branch
+    assert translate_lesson_type("lab", locale="en") == "Lab work"
+
+
+def test_translate_lesson_type_unknown_returns_raw() -> None:
+    assert translate_lesson_type("Physics 101", locale="en") == "Physics 101"
+
+
+# ── weekday_aliases + resolve_weekday_index ───────────────────────────────────
+def test_weekday_aliases_contains_english_canonical_and_short() -> None:
+    aliases = weekday_aliases()
+    assert aliases["monday"] == 0
+    assert aliases["mon"] == 0
+    assert aliases["sunday"] == 6
+    assert aliases["sun"] == 6
+
+
+def test_weekday_aliases_contains_localized_russian() -> None:
+    aliases = weekday_aliases()
+    assert aliases["понедельник"] == 0
+    assert aliases["пн"] == 0
+    assert aliases["воскресенье"] == 6
+    assert aliases["вс"] == 6
+
+
+def test_weekday_aliases_is_cached() -> None:
+    assert weekday_aliases() is weekday_aliases()  # lru_cache returns same dict
+
+
+def test_resolve_weekday_index_english() -> None:
+    assert resolve_weekday_index("Wednesday") == 2
+    assert resolve_weekday_index("wed") == 2
+    assert resolve_weekday_index("FRI") == 4
+
+
+def test_resolve_weekday_index_russian() -> None:
+    assert resolve_weekday_index("Вторник") == 1
+    assert resolve_weekday_index("сб") == 5
+
+
+def test_resolve_weekday_index_none_input() -> None:
+    assert resolve_weekday_index(None) is None
+    assert resolve_weekday_index("   ") is None
+
+
+def test_resolve_weekday_index_unknown() -> None:
+    assert resolve_weekday_index("Caturday") is None


### PR DESCRIPTION
## Testing Session 11 — all-4-front coverage batch

Continues the testing-roadmap arc (ratchet each CI coverage gate only to `≤ floor(measured)`). All gate raises decided AFTER post-work re-measure.

### Backend (HOLD gate 88)
NEW: `test_config_mixins_coverage` (jwt/cors/mfa/rate_limit + csp untested-half validators via `SecuritySettings()` + monkeypatch.setenv + ValidationError), `test_localization_formatting_session11` (pure weekday/lesson-type helpers), `test_core_handlers_session11` (exceptions/handlers + RequestIDMiddleware), `test_auth_security_service_session11` (AsyncMock db: session-expiry / mfa-ttl / last-seen). **PROD FIX**: `analytics.py:200` `FROM event_attendees → event_attendance` (the real table; paired regression test). Full hermetic suite **3858 passed**, TOTAL 88% → HOLD (rounds < 89).

### Frontend (branches 73→74, functions 69→71)
NEW vitest: useScheduleConfig, useBookmarks, useLessonNotes, useNewsInteraction (stateful-server MSW + fresh-IDBFactory isolation), ScheduleDesktopTable (W120 SW3 ARIA-grid). Measured stmts 69.22 / branches 74.72 / functions 71.76 / lines 69.22. RAISED branches→74 (0.72 buffer) + functions→71 (0.76 buffer, +2); stmts/lines HOLD 68. tsc 0, eslint 0.

### Go (gateway 62→65, ws-hub 65→66)
gateway: getEnvFloat64/getEnvSlice + ProxyOrFileHandler dispatch (measured 67.5%). ws-hub: validateHMAC branches + handleRegister max-clients reject (measured 68.3%). Floors = floor(measured)−2. gofmt + golangci-lint v2.3.0 clean.

### Rust (maintain)
rust_ext 19 / wasm-sanitizer 12 / rust-crypto 9 pass; crypto.worker↔WASM parity in the vitest suite. No gate.

Gate raises: backend HOLD 88 · frontend branches 74 + functions 71 · Go gateway 65 + ws-hub 66.

🤖 Generated with [Claude Code](https://claude.com/claude-code)