### PR TITLE
test(session13): +9.93pp frontend coverage jump via render-test sweep

### DIFF
--- a/frontend/src/components/dashboard/__tests__/EventsCard.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/EventsCard.test.tsx
@@ -1,0 +1,97 @@
+import { createElement } from "react"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+const { eventsState, mockNavigate } = vi.hoisted(() => ({
+  eventsState: {
+    current: { data: [] as unknown[] | undefined, isLoading: false, isFetching: false },
+  },
+  mockNavigate: vi.fn(),
+}))
+
+vi.mock("framer-motion", async () =>
+  (await import("@/tests/helpers/framerMotionMock")).framerMotionMock()
+)
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "en", changeLanguage: () => Promise.resolve() },
+  }),
+}))
+vi.mock("@/hooks/useMediaQuery", () => ({ default: () => true }))
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({
+    children,
+    to,
+    ...rest
+  }: { children?: unknown; to?: unknown } & Record<string, unknown>) =>
+    createElement("a", { href: typeof to === "string" ? to : "#", ...rest }, children as never),
+  useNavigate: () => mockNavigate,
+}))
+vi.mock("@/contexts/LanguageContext", () => ({
+  useLanguage: () => ({ language: "en", setLanguage: vi.fn() }),
+}))
+vi.mock("@/hooks/useDashboardEvents", () => ({
+  useDashboardEvents: () => eventsState.current,
+  prefetchDashboardEvents: vi.fn(),
+}))
+vi.mock("@/api/hooks/events", () => ({
+  prefetchEventsListQuery: vi.fn(),
+  EVENTS_PAGE_SIZE: 20,
+}))
+
+import { EventsCard } from "@/components/dashboard/EventsCard"
+import type { Event } from "@/types/Event"
+
+const inTwoDays = new Date(Date.now() + 2 * 24 * 3600 * 1000).toISOString()
+const EVENTS = [
+  { id: 1, title: "Hackathon 2026", starts_at: inTwoDays, location: "ГУК-305" },
+] as unknown as Event[]
+
+function renderCard() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <EventsCard />
+    </QueryClientProvider>
+  )
+}
+
+describe("EventsCard", () => {
+  beforeEach(() => {
+    eventsState.current = { data: EVENTS, isLoading: false, isFetching: false }
+    mockNavigate.mockReset()
+  })
+
+  it("renders the heading, view-all link, and scope toggles", () => {
+    renderCard()
+    expect(screen.getByText("dashboard:events.heading")).toBeInTheDocument()
+    expect(screen.getByText("dashboard:viewAll")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "dashboard:scope.today" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "dashboard:scope.week" })).toBeInTheDocument()
+  })
+
+  it("shows an event after switching to the week scope", async () => {
+    const user = userEvent.setup()
+    renderCard()
+    await user.click(screen.getByRole("button", { name: "dashboard:scope.week" }))
+    expect(screen.getByText("Hackathon 2026")).toBeInTheDocument()
+  })
+
+  it("shows the empty state when no events match the scope", () => {
+    eventsState.current = { data: [], isLoading: false, isFetching: false }
+    renderCard()
+    expect(screen.getByText("dashboard:events.empty")).toBeInTheDocument()
+  })
+
+  it("marks the card aria-busy while events load", () => {
+    eventsState.current = { data: undefined, isLoading: true, isFetching: false }
+    renderCard()
+    expect(screen.getByText("dashboard:events.heading").closest("[aria-busy]")).toHaveAttribute(
+      "aria-busy",
+      "true"
+    )
+  })
+})

--- a/frontend/src/components/dashboard/__tests__/ScheduleTimeline.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/ScheduleTimeline.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from "@testing-library/react"
+import { describe, it, expect, vi } from "vitest"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "en", changeLanguage: () => Promise.resolve() },
+  }),
+}))
+vi.mock("@/hooks/useCountUp", () => ({
+  useCountUp: (n: number) => ({ ref: { current: null }, value: n }),
+}))
+
+import { ScheduleTimeline } from "@/components/dashboard/ScheduleTimeline"
+import type { DashboardLesson } from "@/hooks/useDashboardSchedule"
+
+const LESSONS: DashboardLesson[] = [
+  {
+    id: "l1",
+    subject: "Linear Algebra",
+    teacher: "Dr. Ivanova",
+    room: "ГУК-305",
+    lesson_type: "lecture",
+    weekday: "monday",
+    start_time: "09:00",
+    end_time: "10:30",
+    parity: "both",
+  },
+  {
+    id: "l2",
+    subject: "Discrete Mathematics",
+    teacher: "Prof. Petrov",
+    room: "ЛК-201",
+    lesson_type: "practice",
+    weekday: "monday",
+    start_time: "10:45",
+    end_time: "12:15",
+    parity: "both",
+  },
+]
+
+const baseProps = {
+  lessons: LESSONS,
+  minutesNow: 600,
+  currentLesson: null,
+  nextLesson: null,
+}
+
+describe("ScheduleTimeline", () => {
+  it("renders a lesson block per in-range lesson", () => {
+    render(<ScheduleTimeline {...baseProps} />)
+    expect(screen.getByRole("img", { name: /Linear Algebra/ })).toBeInTheDocument()
+    expect(screen.getByRole("img", { name: /Discrete Mathematics/ })).toBeInTheDocument()
+  })
+
+  it("renders the now-indicator legend", () => {
+    render(<ScheduleTimeline {...baseProps} />)
+    expect(screen.getByText("dashboard:now")).toBeInTheDocument()
+  })
+
+  it("renders the lesson-count legend when lessons are present", () => {
+    render(<ScheduleTimeline {...baseProps} />)
+    expect(screen.getByText(/dashboard:timeline\.lessonCount/)).toBeInTheDocument()
+  })
+
+  it("renders a current-lesson block when a lesson is current", () => {
+    render(<ScheduleTimeline {...baseProps} currentLesson={LESSONS[0]!} />)
+    expect(screen.getByRole("img", { name: /Linear Algebra/ })).toBeInTheDocument()
+  })
+
+  it("renders no lesson blocks when there are no lessons", () => {
+    render(<ScheduleTimeline {...baseProps} lessons={[]} />)
+    expect(screen.queryByRole("img")).not.toBeInTheDocument()
+    expect(screen.getByText("dashboard:now")).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/events/EventCard/__tests__/EventActions.test.tsx
+++ b/frontend/src/components/events/EventCard/__tests__/EventActions.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, it, expect, vi } from "vitest"
+
+vi.mock("framer-motion", async () =>
+  (await import("@/tests/helpers/framerMotionMock")).framerMotionMock()
+)
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "en", changeLanguage: () => Promise.resolve() },
+  }),
+}))
+
+import { EventActions } from "@/components/events/EventCard/EventActions"
+
+const baseProps = {
+  eventId: "evt-1",
+  isActive: true,
+  isEnded: false,
+  isRegistered: false,
+  participantCount: 42,
+  loading: false,
+  onRegister: vi.fn(),
+  onUnregister: vi.fn(),
+}
+
+describe("EventActions", () => {
+  it("renders participant count and a register button for an eligible student", () => {
+    render(<EventActions {...baseProps} />)
+    expect(screen.getByText("events:card.participants")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "events:card.actions.register" })).toBeInTheDocument()
+  })
+
+  it("shows the ended badge and no register button for an ended event", () => {
+    render(<EventActions {...baseProps} isEnded />)
+    expect(screen.getByText("events:card.statuses.ended")).toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: "events:card.actions.register" })
+    ).not.toBeInTheDocument()
+  })
+
+  it("renders unregister + QR controls when registered with a token", async () => {
+    const user = userEvent.setup()
+    const onUnregister = vi.fn()
+    render(
+      <EventActions
+        {...baseProps}
+        isRegistered
+        qrToken="qr-token-123"
+        onUnregister={onUnregister}
+      />
+    )
+    expect(screen.getAllByRole("button")).toHaveLength(2)
+    await user.click(screen.getByRole("button", { name: "events:card.actions.unregister" }))
+    expect(onUnregister).toHaveBeenCalledOnce()
+  })
+
+  it("fires onRegister when the register button is clicked", async () => {
+    const user = userEvent.setup()
+    const onRegister = vi.fn()
+    render(<EventActions {...baseProps} onRegister={onRegister} />)
+    await user.click(screen.getByRole("button", { name: "events:card.actions.register" }))
+    expect(onRegister).toHaveBeenCalledOnce()
+  })
+})

--- a/frontend/src/components/events/EventCard/__tests__/EventAdminActions.test.tsx
+++ b/frontend/src/components/events/EventCard/__tests__/EventAdminActions.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, it, expect, vi } from "vitest"
+
+vi.mock("framer-motion", async () =>
+  (await import("@/tests/helpers/framerMotionMock")).framerMotionMock()
+)
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "en", changeLanguage: () => Promise.resolve() },
+  }),
+}))
+
+import { EventAdminActions } from "@/components/events/EventCard/EventAdminActions"
+
+const baseProps = {
+  menuAnchor: null,
+  setMenuAnchor: vi.fn(),
+  onEdit: vi.fn(),
+  onDelete: vi.fn(),
+  menuId: "evt-admin-menu",
+}
+
+describe("EventAdminActions", () => {
+  it("renders a collapsed actions trigger when no anchor is set", () => {
+    render(<EventAdminActions {...baseProps} />)
+    const trigger = screen.getByRole("button", { name: "events:card.aria.actions" })
+    expect(trigger).toHaveAttribute("aria-expanded", "false")
+    expect(screen.queryByRole("button", { name: "common:buttons.edit" })).not.toBeInTheDocument()
+  })
+
+  it("opens the menu by setting the anchor when the trigger is clicked", async () => {
+    const user = userEvent.setup()
+    const setMenuAnchor = vi.fn()
+    render(<EventAdminActions {...baseProps} setMenuAnchor={setMenuAnchor} />)
+    await user.click(screen.getByRole("button", { name: "events:card.aria.actions" }))
+    expect(setMenuAnchor).toHaveBeenCalledOnce()
+  })
+
+  it("shows edit/delete and fires their callbacks when the menu is open", async () => {
+    const user = userEvent.setup()
+    const onEdit = vi.fn()
+    const onDelete = vi.fn()
+    const anchor = document.createElement("button")
+    render(
+      <EventAdminActions {...baseProps} menuAnchor={anchor} onEdit={onEdit} onDelete={onDelete} />
+    )
+    await user.click(screen.getByRole("button", { name: "common:buttons.edit" }))
+    expect(onEdit).toHaveBeenCalledOnce()
+    await user.click(screen.getByRole("button", { name: "common:buttons.delete" }))
+    expect(onDelete).toHaveBeenCalledOnce()
+  })
+})

--- a/frontend/src/components/events/EventCard/__tests__/EventMedia.test.tsx
+++ b/frontend/src/components/events/EventCard/__tests__/EventMedia.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, it, expect, vi } from "vitest"
+
+vi.mock("framer-motion", async () =>
+  (await import("@/tests/helpers/framerMotionMock")).framerMotionMock()
+)
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "en", changeLanguage: () => Promise.resolve() },
+  }),
+}))
+
+import { EventMedia } from "@/components/events/EventCard/EventMedia"
+
+const baseProps = {
+  imageUrl: "https://picsum.photos/seed/ue-event/640/360",
+  alt: "Event banner",
+  eventType: "Workshop",
+  timeStatus: { status: "none" as const },
+  isReady: true,
+  onReady: vi.fn(),
+  onImageClick: vi.fn(),
+}
+
+describe("EventMedia", () => {
+  it("renders the image button and the event type badge", () => {
+    render(<EventMedia {...baseProps} />)
+    expect(screen.getByText("Workshop")).toBeInTheDocument()
+    expect(screen.getByRole("button")).toBeEnabled()
+  })
+
+  it("shows the live status indicator", () => {
+    render(<EventMedia {...baseProps} timeStatus={{ status: "live" }} />)
+    expect(screen.getByText("common:statuses.live")).toBeInTheDocument()
+  })
+
+  it("shows the soon status indicator with the countdown text", () => {
+    render(<EventMedia {...baseProps} timeStatus={{ status: "soon", timeText: "15m" }} />)
+    expect(screen.getByText(/events:card.statuses.in/)).toBeInTheDocument()
+  })
+
+  it("fires onImageClick when the image is clicked", async () => {
+    const user = userEvent.setup()
+    const onImageClick = vi.fn()
+    render(<EventMedia {...baseProps} onImageClick={onImageClick} />)
+    await user.click(screen.getByRole("button"))
+    expect(onImageClick).toHaveBeenCalledOnce()
+  })
+})

--- a/frontend/src/components/events/__tests__/EventAboutEditor.test.tsx
+++ b/frontend/src/components/events/__tests__/EventAboutEditor.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, it, expect, vi } from "vitest"
+
+vi.mock("framer-motion", async () =>
+  (await import("@/tests/helpers/framerMotionMock")).framerMotionMock()
+)
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "en", changeLanguage: () => Promise.resolve() },
+  }),
+}))
+
+import { EventAboutEditor } from "@/components/events/EventAboutEditor"
+import type { Event } from "@/types/Event"
+
+const baseEvent: Event = {
+  id: "evt-1",
+  title: "React 19 Patterns Workshop",
+  title_en: "React 19 Patterns Workshop",
+  starts_at: "2026-06-15T14:00:00Z",
+  ends_at: "2026-06-15T16:00:00Z",
+  created_by: "admin-1",
+  created_at: "2026-05-01T10:00:00Z",
+  is_active: true,
+  image_url_optimized: null,
+  about: "Практический воркшоп по конкурентным возможностям React 19.",
+  about_en: "A hands-on workshop on React 19 concurrent features.",
+}
+
+const baseProps = {
+  event: baseEvent,
+  language: "en" as const,
+  canEdit: true,
+  onUpdate: vi.fn(() => Promise.resolve()),
+  onError: vi.fn(),
+  onSuccess: vi.fn(),
+}
+
+describe("EventAboutEditor", () => {
+  it("renders the heading and the language-aware about text", () => {
+    render(<EventAboutEditor {...baseProps} />)
+    expect(
+      screen.getByRole("heading", { name: "events:detail.sections.about.title" })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText("A hands-on workshop on React 19 concurrent features.")
+    ).toBeInTheDocument()
+  })
+
+  it("renders the Russian about text for the ru language", () => {
+    render(<EventAboutEditor {...baseProps} language="ru" />)
+    expect(
+      screen.getByText("Практический воркшоп по конкурентным возможностям React 19.")
+    ).toBeInTheDocument()
+  })
+
+  it("renders the empty placeholder when there is no about text", () => {
+    render(
+      <EventAboutEditor
+        {...baseProps}
+        event={{ ...baseEvent, about: "", about_en: "" }}
+        language="ru"
+      />
+    )
+    expect(screen.getByText("events:detail.sections.about.empty")).toBeInTheDocument()
+  })
+
+  it("enters edit mode and reverts on cancel", async () => {
+    const user = userEvent.setup()
+    render(<EventAboutEditor {...baseProps} />)
+    await user.click(screen.getByLabelText("events:detail.sections.about.editAria"))
+    const textarea = screen.getByRole("textbox")
+    expect(textarea).toBeInTheDocument()
+    await user.click(screen.getByRole("button", { name: "common:buttons.cancel" }))
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument()
+  })
+
+  it("does not show the edit affordance when canEdit is false", () => {
+    render(<EventAboutEditor {...baseProps} canEdit={false} />)
+    expect(screen.queryByLabelText("events:detail.sections.about.editAria")).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/events/__tests__/EventDetailEditDialog.test.tsx
+++ b/frontend/src/components/events/__tests__/EventDetailEditDialog.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { describe, it, expect, vi } from "vitest"
+
+vi.mock("framer-motion", async () =>
+  (await import("@/tests/helpers/framerMotionMock")).framerMotionMock()
+)
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "en", changeLanguage: () => Promise.resolve() },
+  }),
+}))
+vi.mock("@/api/events", () => ({ uploadEventImage: vi.fn(() => Promise.resolve("")) }))
+
+import { EventDetailEditDialog } from "@/components/events/EventDetailEditDialog"
+import type { Event } from "@/types/Event"
+
+const baseEvent: Event = {
+  id: "evt-1",
+  title: "React 19 Patterns Workshop",
+  title_en: "React 19 Patterns Workshop",
+  description: "A hands-on deep dive into React 19 concurrent features.",
+  location: "ГУК-305",
+  event_type: "workshop",
+  starts_at: "2026-06-15T14:00:00Z",
+  ends_at: "2026-06-15T16:00:00Z",
+  created_by: "u1",
+  created_at: "2026-05-01T10:00:00Z",
+  is_active: true,
+  speaker: "Dr. Ivanova",
+  image_url: "https://picsum.photos/seed/event-detail-edit/800/400",
+  image_url_optimized: null,
+}
+
+const baseProps = {
+  open: true,
+  onClose: vi.fn(),
+  event: baseEvent,
+  onSuccess: vi.fn(),
+  onError: vi.fn(),
+}
+
+function renderDialog(props = baseProps) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={client}>
+      <EventDetailEditDialog {...props} />
+    </QueryClientProvider>
+  )
+}
+
+describe("EventDetailEditDialog", () => {
+  it("renders the edit dialog when open", () => {
+    renderDialog()
+    const dialog = screen.getByRole("dialog")
+    expect(dialog).toBeInTheDocument()
+    expect(dialog.querySelectorAll("input,textarea").length).toBeGreaterThan(0)
+  })
+
+  it("does not render the dialog when closed", () => {
+    renderDialog({ ...baseProps, open: false })
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+  })
+
+  it("fires onClose when the cancel button is clicked", async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+    renderDialog({ ...baseProps, onClose })
+    await user.click(screen.getByRole("button", { name: "common:buttons.cancel" }))
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+})

--- a/frontend/src/components/events/__tests__/EventDetailHeader.test.tsx
+++ b/frontend/src/components/events/__tests__/EventDetailHeader.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, it, expect, vi } from "vitest"
+
+vi.mock("framer-motion", async () =>
+  (await import("@/tests/helpers/framerMotionMock")).framerMotionMock()
+)
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "en", changeLanguage: () => Promise.resolve() },
+  }),
+}))
+
+import { EventDetailHeader } from "@/components/events/EventDetailHeader"
+
+const baseProps = {
+  title: "AI Research Symposium 2026",
+  eventType: "conference",
+  participantCount: 248,
+  startsAt: "2026-06-15T14:00:00Z",
+  endsAt: "2026-06-15T18:00:00Z",
+  location: "Main Auditorium",
+  speaker: "Prof. A. Ivanova",
+  isRegistered: false,
+  isEnded: false,
+  isAdmin: false,
+  registering: false,
+  onShare: vi.fn(),
+  onRegister: vi.fn(),
+  onUnregister: vi.fn(),
+  onEditOpen: vi.fn(),
+  onDeleteOpen: vi.fn(),
+}
+
+describe("EventDetailHeader", () => {
+  it("renders title, meta pills, share and register actions", () => {
+    render(<EventDetailHeader {...baseProps} />)
+    expect(screen.getByRole("heading", { level: 1, name: baseProps.title })).toBeInTheDocument()
+    expect(screen.getByText("events:card.participants")).toBeInTheDocument()
+    expect(screen.getByText("Main Auditorium")).toBeInTheDocument()
+    expect(screen.getByText("Prof. A. Ivanova")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "events:detail.actions.share" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "events:card.actions.register" })).toBeInTheDocument()
+  })
+
+  it("shows unregister when the user is registered", () => {
+    render(<EventDetailHeader {...baseProps} isRegistered />)
+    expect(
+      screen.getByRole("button", { name: "events:card.actions.unregister" })
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: "events:card.actions.register" })
+    ).not.toBeInTheDocument()
+  })
+
+  it("hides register/unregister and shows admin actions for admins", () => {
+    render(<EventDetailHeader {...baseProps} isAdmin />)
+    expect(
+      screen.queryByRole("button", { name: "events:card.actions.register" })
+    ).not.toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "common:buttons.edit" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "common:buttons.delete" })).toBeInTheDocument()
+  })
+
+  it("fires share and register callbacks", async () => {
+    const user = userEvent.setup()
+    const onShare = vi.fn()
+    const onRegister = vi.fn()
+    render(<EventDetailHeader {...baseProps} onShare={onShare} onRegister={onRegister} />)
+    await user.click(screen.getByRole("button", { name: "events:detail.actions.share" }))
+    await user.click(screen.getByRole("button", { name: "events:card.actions.register" }))
+    expect(onShare).toHaveBeenCalledOnce()
+    expect(onRegister).toHaveBeenCalledOnce()
+  })
+})

--- a/frontend/src/components/events/__tests__/EventDetailHero.test.tsx
+++ b/frontend/src/components/events/__tests__/EventDetailHero.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, it, expect, vi } from "vitest"
+
+vi.mock("framer-motion", async () =>
+  (await import("@/tests/helpers/framerMotionMock")).framerMotionMock()
+)
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "en", changeLanguage: () => Promise.resolve() },
+  }),
+}))
+
+import { EventDetailHero } from "@/components/events/EventDetailHero"
+
+const baseProps = { imageUrl: "https://picsum.photos/seed/event-detail/1200/675" }
+
+describe("EventDetailHero", () => {
+  it("renders the hero image and a zoom button", () => {
+    render(<EventDetailHero {...baseProps} />)
+    expect(screen.getByRole("button", { name: "events:detail.actions.zoom" })).toBeInTheDocument()
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+  })
+
+  it("opens and closes the lightbox", async () => {
+    const user = userEvent.setup()
+    render(<EventDetailHero {...baseProps} />)
+    await user.click(screen.getByRole("button", { name: "events:detail.actions.zoom" }))
+    expect(screen.getByRole("dialog")).toBeInTheDocument()
+    await user.click(screen.getByRole("button", { name: "common:buttons.close" }))
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/events/__tests__/EventFileManager.test.tsx
+++ b/frontend/src/components/events/__tests__/EventFileManager.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from "@testing-library/react"
+import { describe, it, expect, vi } from "vitest"
+
+vi.mock("framer-motion", async () =>
+  (await import("@/tests/helpers/framerMotionMock")).framerMotionMock()
+)
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "en", changeLanguage: () => Promise.resolve() },
+  }),
+}))
+
+import { EventFileManager } from "@/components/events/EventFileManager"
+import type { Event } from "@/types/Event"
+
+const baseEvent: Event = {
+  id: "evt-1",
+  title: "React 19 Patterns Workshop",
+  title_en: "React 19 Patterns Workshop",
+  starts_at: "2026-06-15T14:00:00Z",
+  ends_at: "2026-06-15T16:00:00Z",
+  created_by: "admin-1",
+  created_at: "2026-05-01T10:00:00Z",
+  is_active: true,
+  image_url_optimized: null,
+  files: [
+    {
+      id: "f1",
+      event_id: "evt-1",
+      file_url: "/media/lecture-slides.pdf",
+      description: "Lecture slides.pdf",
+    },
+    {
+      id: "f2",
+      event_id: "evt-1",
+      file_url: "/media/reading-list.pdf",
+      description: "Reading list.pdf",
+    },
+  ],
+}
+
+const baseProps = {
+  event: baseEvent,
+  canEdit: true,
+  onUpdate: vi.fn(() => Promise.resolve()),
+  onError: vi.fn(),
+  onSuccess: vi.fn(),
+}
+
+describe("EventFileManager", () => {
+  it("renders the file list and upload form when editable", () => {
+    render(<EventFileManager {...baseProps} />)
+    expect(screen.getByText("events:detail.sections.files.title")).toBeInTheDocument()
+    expect(screen.getByText("Lecture slides.pdf")).toBeInTheDocument()
+    expect(screen.getByText("Reading list.pdf")).toBeInTheDocument()
+    expect(screen.getByText("events:detail.sections.files.pickFile")).toBeInTheDocument()
+    expect(screen.getAllByLabelText("events:detail.sections.files.deleteAria")).toHaveLength(2)
+  })
+
+  it("hides the upload form and delete buttons when not editable", () => {
+    render(<EventFileManager {...baseProps} canEdit={false} />)
+    expect(screen.queryByText("events:detail.sections.files.pickFile")).not.toBeInTheDocument()
+    expect(
+      screen.queryByLabelText("events:detail.sections.files.deleteAria")
+    ).not.toBeInTheDocument()
+    expect(screen.getByText("Lecture slides.pdf")).toBeInTheDocument()
+  })
+
+  it("renders the empty state when there are no files", () => {
+    render(<EventFileManager {...baseProps} event={{ ...baseEvent, files: [] }} />)
+    expect(screen.getByText("events:detail.sections.files.empty")).toBeInTheDocument()
+    expect(screen.queryByText("events:detail.sections.files.title")).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/events/__tests__/EventSearchBar.test.tsx
+++ b/frontend/src/components/events/__tests__/EventSearchBar.test.tsx
@@ -1,0 +1,69 @@
+import type { ReactNode } from "react"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+const { filterMock } = vi.hoisted(() => ({
+  filterMock: { referenceProps: {}, filtersActive: false, popoverNode: null } as {
+    referenceProps: Record<string, unknown>
+    filtersActive: boolean
+    popoverNode: ReactNode
+  },
+}))
+
+vi.mock("framer-motion", async () =>
+  (await import("@/tests/helpers/framerMotionMock")).framerMotionMock()
+)
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "en", changeLanguage: () => Promise.resolve() },
+  }),
+}))
+vi.mock("@/components/events/EventFilterPopover", () => ({
+  useEventFilterPopover: () => filterMock,
+}))
+
+import { EventSearchBar } from "@/components/events/EventSearchBar"
+import type { EventDateRange } from "@/features/events/types"
+
+const baseProps = {
+  search: "",
+  onSearchChange: vi.fn(),
+  dateRange: "" as EventDateRange,
+  onDateRangeChange: vi.fn(),
+  location: "",
+  onLocationChange: vi.fn(),
+}
+
+describe("EventSearchBar", () => {
+  beforeEach(() => {
+    filterMock.filtersActive = false
+  })
+
+  it("renders the search input and filter button", () => {
+    render(<EventSearchBar {...baseProps} />)
+    expect(screen.getByPlaceholderText("events:filters.search")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "events:aria.openFilters" })).toBeInTheDocument()
+  })
+
+  it("shows a clear button only when there is a query and clears it", async () => {
+    const user = userEvent.setup()
+    const onSearchChange = vi.fn()
+    const { rerender } = render(<EventSearchBar {...baseProps} onSearchChange={onSearchChange} />)
+    expect(
+      screen.queryByRole("button", { name: "events:aria.clearSearch" })
+    ).not.toBeInTheDocument()
+    rerender(<EventSearchBar {...baseProps} search="react" onSearchChange={onSearchChange} />)
+    await user.click(screen.getByRole("button", { name: "events:aria.clearSearch" }))
+    expect(onSearchChange).toHaveBeenCalledWith("")
+  })
+
+  it("forwards typed input to onSearchChange", async () => {
+    const user = userEvent.setup()
+    const onSearchChange = vi.fn()
+    render(<EventSearchBar {...baseProps} onSearchChange={onSearchChange} />)
+    await user.type(screen.getByPlaceholderText("events:filters.search"), "x")
+    expect(onSearchChange).toHaveBeenCalledWith("x")
+  })
+})

--- a/frontend/src/components/events/__tests__/RelatedEvents.test.tsx
+++ b/frontend/src/components/events/__tests__/RelatedEvents.test.tsx
@@ -1,0 +1,56 @@
+import { screen } from "@testing-library/react"
+import { describe, it, expect, vi } from "vitest"
+
+vi.mock("framer-motion", async () =>
+  (await import("@/tests/helpers/framerMotionMock")).framerMotionMock()
+)
+
+import { RelatedEvents } from "@/components/events/RelatedEvents"
+import type { Event } from "@/types/Event"
+import { renderWithRouter } from "@/tests/helpers/renderWithRouter"
+
+const ITEMS: Event[] = [
+  {
+    id: "e1",
+    title: "Воркшоп по React 19",
+    title_en: "React 19 Patterns Workshop",
+    event_type: "workshop",
+    starts_at: "2026-06-15T14:00:00Z",
+    ends_at: "2026-06-15T16:00:00Z",
+    created_by: "u1",
+    created_at: "2026-05-01T10:00:00Z",
+    is_active: true,
+    image_url: "https://picsum.photos/seed/related-e1/400/300",
+    image_url_optimized: null,
+  },
+  {
+    id: "e2",
+    title: "Лекция: ИИ в образовании",
+    title_en: "Lecture: AI in Education",
+    event_type: "lecture",
+    starts_at: "2026-06-18T11:00:00Z",
+    ends_at: "2026-06-18T12:30:00Z",
+    created_by: "u1",
+    created_at: "2026-05-01T10:00:00Z",
+    is_active: true,
+    image_url: null,
+    image_url_optimized: null,
+  },
+]
+
+const extraRoutes = [{ path: "/events/$id", Component: () => <div>Event detail</div> }]
+
+describe("RelatedEvents", () => {
+  it("renders one linked card per event", async () => {
+    await renderWithRouter({ ui: () => <RelatedEvents items={ITEMS} />, extraRoutes })
+    const links = screen.getAllByRole("link")
+    expect(links).toHaveLength(ITEMS.length)
+    expect(links[0]!.getAttribute("href")).toContain("/events/e1")
+    expect(links[1]!.getAttribute("href")).toContain("/events/e2")
+  })
+
+  it("renders nothing when there are no related events", async () => {
+    await renderWithRouter({ ui: () => <RelatedEvents items={[]} />, extraRoutes })
+    expect(screen.queryByRole("link")).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/map/__tests__/BuildingMarker.test.tsx
+++ b/frontend/src/components/map/__tests__/BuildingMarker.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, it, expect, vi } from "vitest"
+
+vi.mock("react-map-gl/maplibre", async () =>
+  (await import("@/tests/helpers/mapGlMock")).mapGlMock()
+)
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "en", changeLanguage: () => Promise.resolve() },
+  }),
+}))
+
+import { BuildingMarker } from "@/components/map/BuildingMarker"
+import type { CampusBuilding } from "@/data/campusBuildings"
+
+const BUILDING: CampusBuilding = {
+  letter: "ГУК",
+  structureId: "стр. 8",
+  name: "Главный учебный корпус",
+  description: "Главное здание университета.",
+  address: "Рязанский проспект, 99",
+  hours: { weekday: "08:00–22:00", saturday: "09:00–20:00", sunday: "Закрыто" },
+  amenities: ["Wi-Fi", "Буфет"],
+  tags: ["study"],
+  colorVar: "var(--color-blue-500)",
+  colorHex: "#3b82f6",
+  floorCount: 8,
+  floors: [{ floor: 1, rooms: [{ id: "ГУК-101", number: "101", type: "lecture" }] }],
+  geoCoords: [55.71, 37.81],
+}
+
+const baseProps = {
+  building: BUILDING,
+  isSelected: false,
+  isHighlighted: false,
+  onClick: vi.fn(),
+}
+
+describe("BuildingMarker", () => {
+  it("renders the building pin with an accessible label", () => {
+    render(<BuildingMarker {...baseProps} />)
+    expect(screen.getByRole("button", { name: "a11y.buildingSelected" })).toBeInTheDocument()
+  })
+
+  it("fires onClick with the building letter when the pin is clicked", async () => {
+    const user = userEvent.setup()
+    const onClick = vi.fn()
+    render(<BuildingMarker {...baseProps} onClick={onClick} />)
+    await user.click(screen.getByRole("button", { name: "a11y.buildingSelected" }))
+    expect(onClick).toHaveBeenCalledWith("ГУК")
+  })
+
+  it("renders the detail popup when the popup is open", () => {
+    render(<BuildingMarker {...baseProps} isPopupOpen />)
+    expect(screen.getByText("Главный учебный корпус")).toBeInTheDocument()
+    expect(screen.getByText("стр. 8")).toBeInTheDocument()
+  })
+
+  it("renders an event badge when eventCount is positive", () => {
+    render(<BuildingMarker {...baseProps} eventCount={3} />)
+    expect(screen.getByText("3")).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/map/__tests__/EventMarker.test.tsx
+++ b/frontend/src/components/map/__tests__/EventMarker.test.tsx
@@ -1,0 +1,58 @@
+import { createElement } from "react"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, it, expect, vi } from "vitest"
+
+vi.mock("react-map-gl/maplibre", async () =>
+  (await import("@/tests/helpers/mapGlMock")).mapGlMock()
+)
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "en", changeLanguage: () => Promise.resolve() },
+  }),
+}))
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({
+    children,
+    to,
+    params: _params,
+    ...rest
+  }: { children?: unknown; to?: unknown; params?: unknown } & Record<string, unknown>) =>
+    createElement("a", { href: typeof to === "string" ? to : "#", ...rest }, children as never),
+}))
+
+import { EventMarker } from "@/components/map/EventMarker"
+import type { MapEvent } from "@/hooks/useMapEvents"
+
+const EVENT = {
+  id: "e1",
+  title: "Hackathon 2026",
+  startsAt: "2026-06-15T18:00:00Z",
+  location: "ГУК-305",
+  geoCoords: [55.71, 37.81],
+  participantCount: 12,
+} as unknown as MapEvent
+
+const baseProps = { event: EVENT }
+
+describe("EventMarker", () => {
+  it("renders the event pin with an accessible label", () => {
+    render(<EventMarker {...baseProps} />)
+    expect(screen.getByRole("button", { name: "events.markerLabel" })).toBeInTheDocument()
+  })
+
+  it("fires onPopupOpen when the pin is clicked", async () => {
+    const user = userEvent.setup()
+    const onPopupOpen = vi.fn()
+    render(<EventMarker {...baseProps} onPopupOpen={onPopupOpen} />)
+    await user.click(screen.getByRole("button", { name: "events.markerLabel" }))
+    expect(onPopupOpen).toHaveBeenCalledOnce()
+  })
+
+  it("renders the popup with the event title and a details link when open", () => {
+    render(<EventMarker {...baseProps} isPopupOpen />)
+    expect(screen.getByText("Hackathon 2026")).toBeInTheDocument()
+    expect(screen.getByRole("link", { name: /events\.viewDetails/ })).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/map/__tests__/MapControls.test.tsx
+++ b/frontend/src/components/map/__tests__/MapControls.test.tsx
@@ -1,0 +1,47 @@
+import type { MutableRefObject } from "react"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, it, expect, vi } from "vitest"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "en", changeLanguage: () => Promise.resolve() },
+  }),
+}))
+vi.mock("@/hooks/useMediaQuery", () => ({ default: () => false }))
+
+import { MapControls } from "@/components/map/MapControls"
+import type { MapRef } from "react-map-gl/maplibre"
+
+const nullMapRef = { current: null } as MutableRefObject<MapRef | null>
+
+describe("MapControls", () => {
+  it("renders the full control panel of buttons", () => {
+    render(<MapControls mapRef={nullMapRef} />)
+    expect(screen.getByRole("group", { name: "zoom.ariaLabel" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "zoom.in" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "zoom.out" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "controls.compass" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "controls.pitchToggle" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "zoom.reset" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "controls.fullscreen" })).toBeInTheDocument()
+  })
+
+  it("handles zoom clicks without a live map (null-safe)", async () => {
+    const user = userEvent.setup()
+    render(<MapControls mapRef={nullMapRef} />)
+    await user.click(screen.getByRole("button", { name: "zoom.in" }))
+    await user.click(screen.getByRole("button", { name: "zoom.out" }))
+    expect(screen.getByRole("button", { name: "zoom.in" })).toBeInTheDocument()
+  })
+
+  it("toggles pitch, recenter, and fullscreen without crashing on a null map", async () => {
+    const user = userEvent.setup()
+    render(<MapControls mapRef={nullMapRef} />)
+    await user.click(screen.getByRole("button", { name: "controls.pitchToggle" }))
+    await user.click(screen.getByRole("button", { name: "zoom.reset" }))
+    await user.click(screen.getByRole("button", { name: "controls.fullscreen" }))
+    expect(screen.getByRole("button", { name: "controls.pitchToggle" })).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/map/__tests__/MapSearchBar.test.tsx
+++ b/frontend/src/components/map/__tests__/MapSearchBar.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, it, expect, vi } from "vitest"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "en", changeLanguage: () => Promise.resolve() },
+  }),
+}))
+
+import { MapSearchBar } from "@/components/map/MapSearchBar"
+import type { CampusBuilding } from "@/data/campusBuildings"
+
+const BUILDING: CampusBuilding = {
+  letter: "ГУК",
+  structureId: "стр. 8",
+  name: "Главный учебный корпус",
+  description: "Главное здание университета.",
+  address: "Рязанский проспект, 99",
+  hours: { weekday: "08:00–22:00", saturday: "09:00–20:00", sunday: "Закрыто" },
+  amenities: ["Wi-Fi"],
+  tags: ["study"],
+  colorVar: "var(--color-blue-500)",
+  colorHex: "#3b82f6",
+  floorCount: 1,
+  floors: [{ floor: 1, rooms: [{ id: "ГУК-101", number: "101", type: "lecture" }] }],
+  geoCoords: [55.71, 37.81],
+}
+
+const baseProps = {
+  buildings: [BUILDING],
+  onSelectBuilding: vi.fn(),
+  onSelectRoom: vi.fn(),
+}
+
+describe("MapSearchBar", () => {
+  it("renders the search combobox", () => {
+    render(<MapSearchBar {...baseProps} />)
+    expect(screen.getByRole("combobox")).toBeInTheDocument()
+  })
+
+  it("renders no dropdown for an empty query", () => {
+    render(<MapSearchBar {...baseProps} />)
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument()
+  })
+
+  it("opens a listbox with a matching building option when typing", async () => {
+    const user = userEvent.setup()
+    render(<MapSearchBar {...baseProps} />)
+    await user.type(screen.getByRole("combobox"), "Главный")
+    expect(screen.getByRole("listbox")).toBeInTheDocument()
+    expect(screen.getByRole("option", { name: /Главный учебный корпус/ })).toBeInTheDocument()
+  })
+
+  it("fires onSelectBuilding when a building option is clicked", async () => {
+    const user = userEvent.setup()
+    const onSelectBuilding = vi.fn()
+    render(<MapSearchBar {...baseProps} onSelectBuilding={onSelectBuilding} />)
+    await user.type(screen.getByRole("combobox"), "Главный")
+    await user.click(screen.getByRole("option", { name: /Главный учебный корпус/ }))
+    expect(onSelectBuilding).toHaveBeenCalledWith("ГУК")
+  })
+})

--- a/frontend/src/components/map/__tests__/MapShortcutsOverlay.test.tsx
+++ b/frontend/src/components/map/__tests__/MapShortcutsOverlay.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, it, expect, vi } from "vitest"
+
+vi.mock("framer-motion", async () =>
+  (await import("@/tests/helpers/framerMotionMock")).framerMotionMock()
+)
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "en", changeLanguage: () => Promise.resolve() },
+  }),
+}))
+vi.mock("@/hooks/useMediaQuery", () => ({ default: () => true }))
+
+import { MapShortcutsOverlay } from "@/components/map/MapShortcutsOverlay"
+
+const baseProps = { open: true, onClose: vi.fn() }
+
+describe("MapShortcutsOverlay", () => {
+  it("renders nothing when closed", () => {
+    render(<MapShortcutsOverlay {...baseProps} open={false} />)
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+  })
+
+  it("renders the shortcuts dialog with title and shortcut rows when open", () => {
+    render(<MapShortcutsOverlay {...baseProps} />)
+    expect(screen.getByRole("dialog", { name: "shortcuts.title" })).toBeInTheDocument()
+    expect(screen.getByRole("heading", { name: "shortcuts.title" })).toBeInTheDocument()
+    expect(screen.getByText("shortcuts.buildings")).toBeInTheDocument()
+    expect(screen.getByText("shortcuts.zoom")).toBeInTheDocument()
+    expect(screen.getByText("F")).toBeInTheDocument()
+  })
+
+  it("fires onClose from the close button", async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+    render(<MapShortcutsOverlay {...baseProps} onClose={onClose} />)
+    await user.click(screen.getByRole("button", { name: "sidebar.close" }))
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+})

--- a/frontend/src/components/map/__tests__/MapSidebar.test.tsx
+++ b/frontend/src/components/map/__tests__/MapSidebar.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, it, expect, vi } from "vitest"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "en", changeLanguage: () => Promise.resolve() },
+  }),
+}))
+vi.mock("@/contexts/AppShellContext", () => ({
+  useAppShell: () => ({ setOverlayState: vi.fn() }),
+}))
+
+import { MapSidebar } from "@/components/map/MapSidebar"
+import type { CampusBuilding, BuildingFloor } from "@/data/campusBuildings"
+
+const FLOOR_1: BuildingFloor = {
+  floor: 1,
+  rooms: [
+    { id: "ГУК-101", number: "101", type: "lecture", capacity: 120, name: "Большая аудитория" },
+  ],
+}
+const FLOOR_2: BuildingFloor = {
+  floor: 2,
+  rooms: [{ id: "ГУК-201", number: "201", type: "seminar" }],
+}
+
+const BUILDING: CampusBuilding = {
+  letter: "ГУК",
+  structureId: "стр. 8",
+  name: "Главный учебный корпус",
+  description: "Главное здание университета.",
+  address: "Рязанский проспект, 99",
+  hours: { weekday: "08:00–22:00", saturday: "09:00–20:00", sunday: "Закрыто" },
+  amenities: ["Wi-Fi", "Буфет"],
+  tags: ["study"],
+  colorVar: "var(--color-blue-500)",
+  colorHex: "#3b82f6",
+  floorCount: 2,
+  floors: [FLOOR_1, FLOOR_2],
+  geoCoords: [55.71, 37.81],
+}
+
+const baseProps = {
+  building: BUILDING,
+  floor: FLOOR_1,
+  selectedFloor: 1,
+  selectedRoom: null,
+  onFloorChange: vi.fn(),
+  onRoomClick: vi.fn(),
+  onClose: vi.fn(),
+  isMobile: false,
+}
+
+describe("MapSidebar", () => {
+  it("renders nothing when no building is selected", () => {
+    const { container } = render(
+      <MapSidebar {...baseProps} building={undefined} floor={undefined} />
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it("renders the building header, address, and description", () => {
+    render(<MapSidebar {...baseProps} />)
+    expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent("Главный учебный корпус")
+    expect(screen.getByText("Рязанский проспект, 99")).toBeInTheDocument()
+    expect(screen.getByText("Главное здание университета.")).toBeInTheDocument()
+  })
+
+  it("renders a floor selector radiogroup with one radio per floor", () => {
+    render(<MapSidebar {...baseProps} />)
+    expect(screen.getByRole("radiogroup")).toBeInTheDocument()
+    expect(screen.getAllByRole("radio")).toHaveLength(2)
+  })
+
+  it("fires onFloorChange when a floor radio is clicked", async () => {
+    const user = userEvent.setup()
+    const onFloorChange = vi.fn()
+    render(<MapSidebar {...baseProps} onFloorChange={onFloorChange} />)
+    await user.click(screen.getByRole("radio", { name: "2" }))
+    expect(onFloorChange).toHaveBeenCalledWith(2)
+  })
+
+  it("fires onRoomClick when a room button is clicked", async () => {
+    const user = userEvent.setup()
+    const onRoomClick = vi.fn()
+    render(<MapSidebar {...baseProps} onRoomClick={onRoomClick} />)
+    await user.click(screen.getByRole("button", { name: /ГУК-101/ }))
+    expect(onRoomClick).toHaveBeenCalledWith("ГУК-101")
+  })
+
+  it("fires onClose from the desktop close button", async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+    render(<MapSidebar {...baseProps} onClose={onClose} />)
+    await user.click(screen.getByRole("button", { name: "sidebar.close" }))
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+})

--- a/frontend/src/components/map/__tests__/MapWeatherPanel.test.tsx
+++ b/frontend/src/components/map/__tests__/MapWeatherPanel.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, it, expect, vi } from "vitest"
+
+vi.mock("framer-motion", async () =>
+  (await import("@/tests/helpers/framerMotionMock")).framerMotionMock()
+)
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "en", changeLanguage: () => Promise.resolve() },
+  }),
+}))
+vi.mock("@/hooks/useMediaQuery", () => ({ default: () => true }))
+
+import { MapWeatherPanel } from "@/components/map/MapWeatherPanel"
+import type { MapWeatherData } from "@/hooks/useMapWeather"
+
+const WEATHER: MapWeatherData = {
+  temperature: 5,
+  weatherCode: 1,
+  isDay: true,
+  condition: "clear",
+  feelsLike: 3,
+  windSpeed: 4,
+  humidity: 60,
+  uvIndex: 2,
+  hourlyForecast: [
+    { hour: 9, temperature: 4, condition: "clear" },
+    { hour: 10, temperature: 6, condition: "cloudy" },
+  ],
+}
+
+const baseProps = { data: WEATHER, open: true, onClose: vi.fn() }
+
+describe("MapWeatherPanel", () => {
+  it("renders nothing when closed", () => {
+    render(<MapWeatherPanel {...baseProps} open={false} />)
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+  })
+
+  it("renders the weather dialog with stat cards when open", () => {
+    render(<MapWeatherPanel {...baseProps} />)
+    expect(screen.getByRole("dialog", { name: "weather.hourlyForecast" })).toBeInTheDocument()
+    expect(screen.getByText("weather.feelsLike")).toBeInTheDocument()
+    expect(screen.getByText("weather.humidity")).toBeInTheDocument()
+    expect(screen.getByText("+3°")).toBeInTheDocument()
+    expect(screen.getByText("60%")).toBeInTheDocument()
+  })
+
+  it("renders the hourly forecast columns", () => {
+    render(<MapWeatherPanel {...baseProps} />)
+    expect(screen.getByText("weather.hourlyForecast")).toBeInTheDocument()
+    expect(screen.getByText("09")).toBeInTheDocument()
+    expect(screen.getByText("10")).toBeInTheDocument()
+  })
+
+  it("fires onClose from the close button", async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+    render(<MapWeatherPanel {...baseProps} onClose={onClose} />)
+    await user.click(screen.getByRole("button", { name: "common:buttons.close" }))
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+})

--- a/frontend/src/components/map/__tests__/POIMarker.test.tsx
+++ b/frontend/src/components/map/__tests__/POIMarker.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, it, expect, vi } from "vitest"
+
+vi.mock("react-map-gl/maplibre", async () =>
+  (await import("@/tests/helpers/mapGlMock")).mapGlMock()
+)
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "en", changeLanguage: () => Promise.resolve() },
+  }),
+}))
+
+import { POIMarker } from "@/components/map/POIMarker"
+import type { CampusPOI } from "@/data/campusPOI"
+
+const POI: CampusPOI = {
+  id: "cafe-1",
+  type: "food",
+  coords: [55.71, 37.81],
+  icon: "Coffee",
+  i18nKey: "cafe-1",
+}
+
+const baseProps = { poi: POI }
+
+describe("POIMarker", () => {
+  it("renders the POI pin with an accessible label", () => {
+    render(<POIMarker {...baseProps} />)
+    expect(screen.getByRole("button", { name: /poi\.items\.cafe-1\.name/ })).toBeInTheDocument()
+  })
+
+  it("fires onPopupOpen when the pin is clicked", async () => {
+    const user = userEvent.setup()
+    const onPopupOpen = vi.fn()
+    render(<POIMarker {...baseProps} onPopupOpen={onPopupOpen} />)
+    await user.click(screen.getByRole("button", { name: /poi\.items\.cafe-1\.name/ }))
+    expect(onPopupOpen).toHaveBeenCalledOnce()
+  })
+
+  it("renders the full popup with an external maps link when open", () => {
+    render(<POIMarker {...baseProps} isPopupOpen />)
+    expect(screen.getByText("poi.items.cafe-1.name")).toBeInTheDocument()
+    expect(screen.getByRole("link", { name: /poi\.openInMaps/ })).toHaveAttribute(
+      "href",
+      expect.stringContaining("yandex.ru/maps")
+    )
+  })
+})

--- a/frontend/src/components/news/__tests__/NewsCardEditDialog.test.tsx
+++ b/frontend/src/components/news/__tests__/NewsCardEditDialog.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, it, expect, vi } from "vitest"
+
+vi.mock("framer-motion", async () =>
+  (await import("@/tests/helpers/framerMotionMock")).framerMotionMock()
+)
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "en", changeLanguage: () => Promise.resolve() },
+  }),
+}))
+
+import { NewsCardEditDialog, type NewsEditData } from "@/components/news/NewsCardEditDialog"
+
+const initialData: NewsEditData = {
+  title: "Открыт набор в студенческий совет",
+  content: "Подавайте заявки до конца месяца.",
+  title_en: "Student council applications are open",
+  content_en: "Apply by the end of the month.",
+  image_url: "https://picsum.photos/seed/news-edit/640/360",
+}
+
+const baseProps = {
+  id: "news-1",
+  open: true,
+  onClose: vi.fn(),
+  initialData,
+  onSuccess: vi.fn(),
+}
+
+describe("NewsCardEditDialog", () => {
+  it("renders the dialog with prefilled fields when open", () => {
+    render(<NewsCardEditDialog {...baseProps} />)
+    expect(screen.getByText("news:dialogs.edit.title")).toBeInTheDocument()
+    expect(screen.getByDisplayValue(initialData.title)).toBeInTheDocument()
+    expect(screen.getByDisplayValue(initialData.content)).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "common:buttons.save" })).toBeInTheDocument()
+  })
+
+  it("does not render the dialog body when closed", () => {
+    render(<NewsCardEditDialog {...baseProps} open={false} />)
+    expect(screen.queryByText("news:dialogs.edit.title")).not.toBeInTheDocument()
+  })
+
+  it("fires onClose from the cancel button", async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+    render(<NewsCardEditDialog {...baseProps} onClose={onClose} />)
+    await user.click(screen.getByRole("button", { name: "common:buttons.cancel" }))
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+})

--- a/frontend/src/components/news/__tests__/NewsComments.test.tsx
+++ b/frontend/src/components/news/__tests__/NewsComments.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, it, expect, vi } from "vitest"
+
+vi.mock("framer-motion", async () =>
+  (await import("@/tests/helpers/framerMotionMock")).framerMotionMock()
+)
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "en", changeLanguage: () => Promise.resolve() },
+  }),
+}))
+
+import { NewsComments } from "@/components/news/NewsComments"
+import type { NewsComment } from "@/hooks/useNewsInteraction"
+import type { User } from "@/types/User"
+
+const SAMPLE_COMMENTS: NewsComment[] = [
+  {
+    id: "c1",
+    content: "Great write-up on the new research center.",
+    user_id: "u2",
+    user_name: "Anna Petrova",
+    created_at: "2026-05-20T09:30:00Z",
+  },
+  {
+    id: "c2",
+    content: "Any word on enrollment caps?",
+    user_id: "u3",
+    user_name: "Ivan Sokolov",
+    created_at: "2026-05-21T14:15:00Z",
+  },
+]
+
+const adminUser = { id: "u1", role: "admin" } as Pick<User, "id" | "role">
+
+const baseProps = {
+  comments: SAMPLE_COMMENTS,
+  user: adminUser,
+  isCommenting: false,
+  addComment: vi.fn(),
+  updateComment: vi.fn(),
+  deleteComment: vi.fn(),
+  t: (key: string) => key,
+  getMoscowDate: (date: string) => date,
+}
+
+describe("NewsComments", () => {
+  it("renders heading, count, and each comment", () => {
+    render(<NewsComments {...baseProps} />)
+    expect(screen.getByRole("heading", { name: "news:sections.comments" })).toBeInTheDocument()
+    expect(screen.getByText("2")).toBeInTheDocument()
+    expect(screen.getByText("Anna Petrova")).toBeInTheDocument()
+    expect(screen.getByText("Great write-up on the new research center.")).toBeInTheDocument()
+    expect(screen.getByText("Any word on enrollment caps?")).toBeInTheDocument()
+  })
+
+  it("shows the empty state when there are no comments", () => {
+    render(<NewsComments {...baseProps} comments={[]} />)
+    expect(screen.getByText("news:states.noComments")).toBeInTheDocument()
+  })
+
+  it("hides the comment form when there is no user", () => {
+    render(<NewsComments {...baseProps} user={null} />)
+    expect(screen.queryByLabelText("news:form.commentAriaLabel")).not.toBeInTheDocument()
+  })
+
+  it("posts a new comment", async () => {
+    const user = userEvent.setup()
+    const addComment = vi.fn()
+    render(<NewsComments {...baseProps} addComment={addComment} />)
+    const textarea = screen.getByLabelText("news:form.commentAriaLabel")
+    await user.type(textarea, "Looking forward to it!")
+    await user.click(screen.getByRole("button", { name: "news:actions.postComment" }))
+    expect(addComment).toHaveBeenCalledWith("Looking forward to it!")
+  })
+
+  it("enters inline edit mode and saves an update", async () => {
+    const user = userEvent.setup()
+    const updateComment = vi.fn()
+    render(<NewsComments {...baseProps} updateComment={updateComment} />)
+    await user.click(screen.getAllByLabelText("news:actions.editComment")[0]!)
+    const editBox = screen.getByLabelText("news:form.editCommentAriaLabel")
+    await user.type(editBox, " (edited)")
+    await user.click(screen.getByRole("button", { name: "common:buttons.save" }))
+    expect(updateComment).toHaveBeenCalledOnce()
+    expect(updateComment.mock.calls[0]![0]).toBe("c1")
+  })
+
+  it("confirms before deleting a comment", async () => {
+    const user = userEvent.setup()
+    const deleteComment = vi.fn()
+    render(<NewsComments {...baseProps} deleteComment={deleteComment} />)
+    await user.click(screen.getAllByLabelText("news:actions.deleteComment")[0]!)
+    const dialog = screen.getByRole("alertdialog")
+    await user.click(within(dialog).getByRole("button", { name: "common:buttons.delete" }))
+    expect(deleteComment).toHaveBeenCalledWith("c1")
+  })
+})

--- a/frontend/src/components/news/__tests__/NewsDetailBody.test.tsx
+++ b/frontend/src/components/news/__tests__/NewsDetailBody.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from "@testing-library/react"
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+const { mediaMock } = vi.hoisted(() => ({ mediaMock: vi.fn() }))
+
+vi.mock("framer-motion", async () =>
+  (await import("@/tests/helpers/framerMotionMock")).framerMotionMock()
+)
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "en", changeLanguage: () => Promise.resolve() },
+  }),
+}))
+vi.mock("@/hooks/useMediaQuery", () => ({ default: () => mediaMock() }))
+
+import { NewsDetailBody } from "@/components/news/NewsDetailBody"
+
+const MARKDOWN_WITH_TOC = `## Background
+
+The university opened a new interdisciplinary lab this spring.
+
+## Methodology
+
+We surveyed enrolment data across three faculties.
+
+## Key Findings
+
+Enrolment rose by a double-digit margin year over year.`
+
+const PLAIN_TEXT = `The new facility is the largest investment in a decade.
+
+It will host robotics, AI, and data-science tracks under one roof.`
+
+describe("NewsDetailBody", () => {
+  beforeEach(() => {
+    mediaMock.mockReset()
+    mediaMock.mockReturnValue(true) // desktop
+  })
+
+  it("renders markdown headings and the table of contents on desktop", () => {
+    render(<NewsDetailBody content={MARKDOWN_WITH_TOC} />)
+    expect(screen.getByRole("heading", { name: "Background" })).toBeInTheDocument()
+    expect(screen.getByText("news:toc.title")).toBeInTheDocument()
+  })
+
+  it("renders plain-text content as paragraphs", () => {
+    render(<NewsDetailBody content={PLAIN_TEXT} />)
+    expect(
+      screen.getByText("The new facility is the largest investment in a decade.")
+    ).toBeInTheDocument()
+    expect(screen.queryByText("news:toc.title")).not.toBeInTheDocument()
+  })
+
+  it("renders nothing in the body for empty content without throwing", () => {
+    expect(() => render(<NewsDetailBody content="" />)).not.toThrow()
+    expect(screen.queryByText("news:toc.title")).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/news/__tests__/NewsDetailEditDialog.test.tsx
+++ b/frontend/src/components/news/__tests__/NewsDetailEditDialog.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { describe, it, expect, vi } from "vitest"
+
+vi.mock("framer-motion", async () =>
+  (await import("@/tests/helpers/framerMotionMock")).framerMotionMock()
+)
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "en", changeLanguage: () => Promise.resolve() },
+  }),
+}))
+vi.mock("@/api/news", () => ({
+  updateNews: vi.fn(() => Promise.resolve({ data: {} })),
+  uploadNewsImage: vi.fn(() => Promise.resolve("")),
+}))
+
+import { NewsDetailEditDialog } from "@/components/news/NewsDetailEditDialog"
+
+const initialData = {
+  title: "Запуск новой кампусной экосистемы",
+  content: "Единая платформа: расписание, новости, события и мессенджер.",
+  title_en: "Launching the new campus ecosystem",
+  content_en: "A unified platform for schedule, news, events, and messenger.",
+  image_url: "https://picsum.photos/seed/news-detail-edit/800/400",
+}
+
+const baseProps = {
+  open: true,
+  onClose: vi.fn(),
+  newsId: "news-1",
+  language: "ru",
+  initialData,
+  onSuccess: vi.fn(),
+  onError: vi.fn(),
+}
+
+function renderDialog(props = baseProps) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={client}>
+      <NewsDetailEditDialog {...props} />
+    </QueryClientProvider>
+  )
+}
+
+describe("NewsDetailEditDialog", () => {
+  it("renders the form prefilled from initialData when open", () => {
+    renderDialog()
+    expect(screen.getByText("news:dialogs.edit.title")).toBeInTheDocument()
+    expect(screen.getByDisplayValue(initialData.title)).toBeInTheDocument()
+    expect(screen.getByDisplayValue(initialData.title_en)).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "common:buttons.save" })).toBeEnabled()
+  })
+
+  it("does not render the dialog body when closed", () => {
+    renderDialog({ ...baseProps, open: false })
+    expect(screen.queryByText("news:dialogs.edit.title")).not.toBeInTheDocument()
+  })
+
+  it("fires onClose when cancel is clicked", async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+    renderDialog({ ...baseProps, onClose })
+    await user.click(screen.getByRole("button", { name: "common:buttons.cancel" }))
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it("disables save when the title is cleared", async () => {
+    const user = userEvent.setup()
+    renderDialog()
+    await user.clear(screen.getByDisplayValue(initialData.title))
+    expect(screen.getByRole("button", { name: "common:buttons.save" })).toBeDisabled()
+  })
+})

--- a/frontend/src/components/news/__tests__/NewsDetailHeader.test.tsx
+++ b/frontend/src/components/news/__tests__/NewsDetailHeader.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, it, expect, vi } from "vitest"
+
+vi.mock("framer-motion", async () =>
+  (await import("@/tests/helpers/framerMotionMock")).framerMotionMock()
+)
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "en", changeLanguage: () => Promise.resolve() },
+  }),
+}))
+
+import { NewsDetailHeader } from "@/components/news/NewsDetailHeader"
+
+const baseProps = {
+  displayTitle: "University Announces New AI Research Center",
+  createdAt: "2026-05-20T09:00:00Z",
+  createdAtIso: "2026-05-20T09:00:00.000Z",
+  createdAtLabel: "20 MAY 2026",
+  readingTimeMinutes: 5,
+  isLiked: false,
+  likesCount: 42,
+  bookmarked: false,
+  isAdmin: false,
+  saving: false,
+  deleting: false,
+  sharing: false,
+  onShare: vi.fn(),
+  onToggleLike: vi.fn(),
+  onToggleBookmark: vi.fn(),
+  onEditOpen: vi.fn(),
+  onDeleteOpen: vi.fn(),
+}
+
+describe("NewsDetailHeader", () => {
+  it("renders title, meta pills, and primary actions", () => {
+    render(<NewsDetailHeader {...baseProps} />)
+    expect(
+      screen.getByRole("heading", { level: 1, name: baseProps.displayTitle })
+    ).toBeInTheDocument()
+    expect(screen.getByText("20 MAY 2026")).toBeInTheDocument()
+    expect(screen.getByText("news:meta.readingTime")).toBeInTheDocument()
+    expect(screen.getByText("news:actions.share")).toBeInTheDocument()
+    expect(screen.getByText("42")).toBeInTheDocument()
+    expect(screen.getByText("news:actions.bookmark")).toBeInTheDocument()
+  })
+
+  it("omits the reading-time pill when readingTimeMinutes is null", () => {
+    render(<NewsDetailHeader {...baseProps} readingTimeMinutes={null} createdAt={undefined} />)
+    expect(screen.queryByText("news:meta.readingTime")).not.toBeInTheDocument()
+    expect(screen.queryByText("20 MAY 2026")).not.toBeInTheDocument()
+  })
+
+  it("hides admin actions for non-admins", () => {
+    render(<NewsDetailHeader {...baseProps} />)
+    expect(screen.queryByLabelText("news:aria.editNews")).not.toBeInTheDocument()
+    expect(screen.queryByLabelText("news:aria.deleteNews")).not.toBeInTheDocument()
+  })
+
+  it("shows admin edit/delete and fires their callbacks", async () => {
+    const user = userEvent.setup()
+    const onEditOpen = vi.fn()
+    const onDeleteOpen = vi.fn()
+    render(
+      <NewsDetailHeader
+        {...baseProps}
+        isAdmin
+        onEditOpen={onEditOpen}
+        onDeleteOpen={onDeleteOpen}
+      />
+    )
+    await user.click(screen.getByLabelText("news:aria.editNews"))
+    await user.click(screen.getByLabelText("news:aria.deleteNews"))
+    expect(onEditOpen).toHaveBeenCalledOnce()
+    expect(onDeleteOpen).toHaveBeenCalledOnce()
+  })
+
+  it("reflects liked + bookmarked state and fires share/like/bookmark callbacks", async () => {
+    const user = userEvent.setup()
+    const onShare = vi.fn()
+    const onToggleLike = vi.fn()
+    const onToggleBookmark = vi.fn()
+    render(
+      <NewsDetailHeader
+        {...baseProps}
+        isLiked
+        bookmarked
+        likesCount={43}
+        onShare={onShare}
+        onToggleLike={onToggleLike}
+        onToggleBookmark={onToggleBookmark}
+      />
+    )
+    expect(screen.getByText("news:actions.saved")).toBeInTheDocument()
+    await user.click(screen.getByText("news:actions.share"))
+    await user.click(screen.getByText("news:actions.saved"))
+    await user.click(screen.getByText("43"))
+    expect(onShare).toHaveBeenCalledOnce()
+    expect(onToggleBookmark).toHaveBeenCalledOnce()
+    expect(onToggleLike).toHaveBeenCalledOnce()
+  })
+})

--- a/frontend/src/components/news/__tests__/NewsDetailHero.test.tsx
+++ b/frontend/src/components/news/__tests__/NewsDetailHero.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, it, expect, vi } from "vitest"
+
+vi.mock("framer-motion", async () =>
+  (await import("@/tests/helpers/framerMotionMock")).framerMotionMock()
+)
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "en", changeLanguage: () => Promise.resolve() },
+  }),
+}))
+
+import { NewsDetailHero } from "@/components/news/NewsDetailHero"
+
+const baseProps = {
+  imageUrl: "https://picsum.photos/seed/news-detail/1200/675",
+  displayTitle: "University Announces New AI Research Center",
+}
+
+describe("NewsDetailHero", () => {
+  it("renders the hero image and a zoom button", () => {
+    render(<NewsDetailHero {...baseProps} />)
+    expect(screen.getByRole("button", { name: "news:actions.zoomImage" })).toBeInTheDocument()
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+  })
+
+  it("renders a fallback figcaption when there is no display title", () => {
+    render(<NewsDetailHero {...baseProps} displayTitle="" />)
+    expect(screen.getByText("news:alt.heroFallback")).toBeInTheDocument()
+  })
+
+  it("opens and closes the lightbox", async () => {
+    const user = userEvent.setup()
+    render(<NewsDetailHero {...baseProps} />)
+    await user.click(screen.getByRole("button", { name: "news:actions.zoomImage" }))
+    const dialog = screen.getByRole("dialog")
+    expect(dialog).toBeInTheDocument()
+    await user.click(screen.getByRole("button", { name: "common:buttons.close" }))
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/news/__tests__/NewsTableOfContents.test.tsx
+++ b/frontend/src/components/news/__tests__/NewsTableOfContents.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+const { mediaMock } = vi.hoisted(() => ({ mediaMock: vi.fn() }))
+
+vi.mock("framer-motion", async () =>
+  (await import("@/tests/helpers/framerMotionMock")).framerMotionMock()
+)
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "en", changeLanguage: () => Promise.resolve() },
+  }),
+}))
+vi.mock("@/hooks/useMediaQuery", () => ({ default: () => mediaMock() }))
+
+import { NewsTableOfContents } from "@/components/news/NewsTableOfContents"
+import type { TocEntry } from "@/hooks/useArticleHeadings"
+
+const HEADINGS: TocEntry[] = [
+  { id: "background", text: "Background", level: 2 },
+  { id: "methodology", text: "Methodology", level: 2 },
+  { id: "data-pipeline", text: "Data Pipeline", level: 3 },
+  { id: "findings", text: "Key Findings", level: 2 },
+]
+
+describe("NewsTableOfContents", () => {
+  beforeEach(() => {
+    mediaMock.mockReset()
+    mediaMock.mockReturnValue(true) // desktop by default
+  })
+
+  it("renders nothing when there are fewer than 3 headings", () => {
+    const { container } = render(<NewsTableOfContents headings={HEADINGS.slice(0, 2)} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it("renders the nav, title, count, and all headings on desktop", () => {
+    render(<NewsTableOfContents headings={HEADINGS} />)
+    expect(screen.getByRole("navigation", { name: "news:toc.label" })).toBeInTheDocument()
+    expect(screen.getByText("news:toc.title")).toBeInTheDocument()
+    expect(screen.getByText("4")).toBeInTheDocument()
+    for (const h of HEADINGS) {
+      expect(screen.getByRole("button", { name: h.text })).toBeInTheDocument()
+    }
+  })
+
+  it("toggles the collapsed link list on mobile", async () => {
+    mediaMock.mockReturnValue(false) // mobile → collapsed initially
+    const user = userEvent.setup()
+    render(<NewsTableOfContents headings={HEADINGS} />)
+    expect(screen.queryByRole("button", { name: "Background" })).not.toBeInTheDocument()
+    await user.click(screen.getByText("news:toc.title"))
+    expect(screen.getByRole("button", { name: "Background" })).toBeInTheDocument()
+  })
+
+  it("scrolls to a heading when a link is clicked", async () => {
+    const target = document.createElement("h2")
+    target.id = "background"
+    target.scrollIntoView = vi.fn()
+    document.body.appendChild(target)
+    const user = userEvent.setup()
+    render(<NewsTableOfContents headings={HEADINGS} />)
+    await user.click(screen.getByRole("button", { name: "Background" }))
+    expect(target.scrollIntoView).toHaveBeenCalled()
+    document.body.removeChild(target)
+  })
+})

--- a/frontend/src/components/news/__tests__/RelatedNews.test.tsx
+++ b/frontend/src/components/news/__tests__/RelatedNews.test.tsx
@@ -1,0 +1,48 @@
+import { screen } from "@testing-library/react"
+import { describe, it, expect, vi } from "vitest"
+
+vi.mock("framer-motion", async () =>
+  (await import("@/tests/helpers/framerMotionMock")).framerMotionMock()
+)
+
+import { RelatedNews } from "@/components/news/RelatedNews"
+import type { NewsItem } from "@/api/news"
+import { renderWithRouter } from "@/tests/helpers/renderWithRouter"
+
+const ITEMS = [
+  {
+    id: "n1",
+    title: "Новая исследовательская лаборатория",
+    title_en: "New Interdisciplinary Research Lab",
+    content: "Lab opens this spring.",
+    created_at: "2026-05-20T09:00:00Z",
+    image_url: "https://picsum.photos/seed/related-n1/400/300",
+    image_url_optimized: null,
+  },
+  {
+    id: "n2",
+    title: "Старт набора в студсовет",
+    title_en: "Student council applications open",
+    content: "Apply by month end.",
+    created_at: "2026-05-18T09:00:00Z",
+    image_url: null,
+    image_url_optimized: null,
+  },
+] as unknown as NewsItem[]
+
+const extraRoutes = [{ path: "/news/$id", Component: () => <div>News detail</div> }]
+
+describe("RelatedNews", () => {
+  it("renders one linked card per item", async () => {
+    await renderWithRouter({ ui: () => <RelatedNews items={ITEMS} />, extraRoutes })
+    const links = screen.getAllByRole("link")
+    expect(links).toHaveLength(ITEMS.length)
+    expect(links[0]!.getAttribute("href")).toContain("/news/n1")
+    expect(links[1]!.getAttribute("href")).toContain("/news/n2")
+  })
+
+  it("renders nothing when there are no related items", async () => {
+    await renderWithRouter({ ui: () => <RelatedNews items={[]} />, extraRoutes })
+    expect(screen.queryByRole("link")).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/schedule/__tests__/DayColumn.test.tsx
+++ b/frontend/src/components/schedule/__tests__/DayColumn.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, it, expect, vi } from "vitest"
+
+vi.mock("framer-motion", async () =>
+  (await import("@/tests/helpers/framerMotionMock")).framerMotionMock()
+)
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "en", changeLanguage: () => Promise.resolve() },
+  }),
+}))
+
+import { DayColumn } from "@/components/schedule/DayColumn"
+import type { Lesson } from "@/components/schedule/scheduleUtils"
+
+const LESSONS: Lesson[] = [
+  {
+    id: "l1",
+    weekday: "monday",
+    parity: "both",
+    start_time: "09:00",
+    end_time: "10:30",
+    subject: "Linear Algebra",
+    teacher: "Dr. Ivanova",
+    room: "ГУК-305",
+    lesson_type: "lecture",
+    group_id: "g1",
+  },
+  {
+    id: "l2",
+    weekday: "monday",
+    parity: "both",
+    start_time: "10:45",
+    end_time: "12:15",
+    subject: "Discrete Mathematics",
+    teacher: "Prof. Petrov",
+    room: "ЛК-201",
+    lesson_type: "practice",
+    group_id: "g1",
+  },
+]
+
+const baseProps = {
+  day: "monday",
+  label: "Monday",
+  lessons: LESSONS,
+  isToday: false,
+  isOnline: true,
+  hasSchedule: true,
+  userRole: "student",
+  conflictedIds: new Set<string>(),
+  notesMap: new Map<string, boolean>(),
+  onAdd: vi.fn(),
+  onLessonDelete: vi.fn(),
+  onRetry: vi.fn(),
+  getLessonTypeColor: () => "#6366f1",
+  getLessonTypeLabel: (v?: string | null) => v ?? "Lesson",
+}
+
+describe("DayColumn", () => {
+  it("renders the day label, count badge, and lesson subjects", () => {
+    render(<DayColumn {...baseProps} />)
+    expect(screen.getByRole("heading", { name: "Monday" })).toBeInTheDocument()
+    expect(screen.getByText("2")).toBeInTheDocument()
+    expect(screen.getByText("Linear Algebra")).toBeInTheDocument()
+    expect(screen.getByText("Discrete Mathematics")).toBeInTheDocument()
+  })
+
+  it("renders the empty state when there are no lessons", () => {
+    render(<DayColumn {...baseProps} lessons={[]} />)
+    expect(screen.getByText("schedule:mobile.noLessons")).toBeInTheDocument()
+  })
+
+  it("renders an offline fallback when offline with no cached schedule", () => {
+    render(<DayColumn {...baseProps} lessons={[]} isOnline={false} hasSchedule={false} />)
+    expect(screen.queryByText("schedule:mobile.noLessons")).not.toBeInTheDocument()
+  })
+
+  it("shows an add button and fires onAdd for editors", async () => {
+    const user = userEvent.setup()
+    const onAdd = vi.fn()
+    render(<DayColumn {...baseProps} userRole="admin" onAdd={onAdd} />)
+    await user.click(screen.getByLabelText("schedule:aria.addLesson"))
+    expect(onAdd).toHaveBeenCalledOnce()
+  })
+
+  it("hides the add button for students", () => {
+    render(<DayColumn {...baseProps} />)
+    expect(screen.queryByLabelText("schedule:aria.addLesson")).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/schedule/__tests__/ExportDropdown.test.tsx
+++ b/frontend/src/components/schedule/__tests__/ExportDropdown.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, it, expect, vi } from "vitest"
+
+vi.mock("framer-motion", async () =>
+  (await import("@/tests/helpers/framerMotionMock")).framerMotionMock()
+)
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "en", changeLanguage: () => Promise.resolve() },
+  }),
+}))
+
+import { ExportDropdown } from "@/components/schedule/ExportDropdown"
+
+describe("ExportDropdown", () => {
+  it("renders the export trigger button", () => {
+    render(<ExportDropdown />)
+    expect(screen.getByRole("button", { name: /schedule:toolbar.export/ })).toBeInTheDocument()
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument()
+  })
+
+  it("opens the menu with PDF/PNG/Google Calendar items", async () => {
+    const user = userEvent.setup()
+    render(<ExportDropdown />)
+    await user.click(screen.getByRole("button", { name: /schedule:toolbar.export/ }))
+    expect(screen.getByRole("menu")).toBeInTheDocument()
+    expect(screen.getByRole("menuitem", { name: "schedule:export.pdf" })).toBeInTheDocument()
+    expect(screen.getByRole("menuitem", { name: "schedule:export.png" })).toBeInTheDocument()
+    expect(
+      screen.getByRole("menuitem", { name: "schedule:export.googleCalendar" })
+    ).toBeInTheDocument()
+  })
+
+  it("disables PDF/PNG export when there is no grid ref", async () => {
+    const user = userEvent.setup()
+    render(<ExportDropdown />)
+    await user.click(screen.getByRole("button", { name: /schedule:toolbar.export/ }))
+    expect(screen.getByRole("menuitem", { name: "schedule:export.pdf" })).toBeDisabled()
+    expect(screen.getByRole("menuitem", { name: "schedule:export.png" })).toBeDisabled()
+    expect(screen.getByRole("menuitem", { name: "schedule:export.googleCalendar" })).toBeEnabled()
+  })
+})

--- a/frontend/src/components/schedule/__tests__/ScheduleHeader.test.tsx
+++ b/frontend/src/components/schedule/__tests__/ScheduleHeader.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+const { mediaMock } = vi.hoisted(() => ({ mediaMock: vi.fn() }))
+
+vi.mock("framer-motion", async () =>
+  (await import("@/tests/helpers/framerMotionMock")).framerMotionMock()
+)
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "en", changeLanguage: () => Promise.resolve() },
+  }),
+}))
+vi.mock("@/hooks/useMediaQuery", () => ({ default: () => mediaMock() }))
+
+import { ScheduleHeader } from "@/components/schedule/ScheduleHeader"
+import type { Lesson } from "@/components/schedule/scheduleUtils"
+import type { User } from "@/types/User"
+
+const lesson = (over: Partial<Lesson>): Lesson => ({
+  id: "l1",
+  weekday: "monday",
+  parity: "both",
+  start_time: "09:00",
+  end_time: "10:30",
+  subject: "Linear Algebra",
+  teacher: "Dr. Ivanova",
+  room: "ГУК-305",
+  lesson_type: "lecture",
+  ...over,
+})
+
+const baseProps = {
+  user: { id: "1", email: "s@u.edu", full_name: "Test", role: "student" } as unknown as User,
+  groups: [{ id: "g1", name: "CS-2024" }],
+  selectedGroup: "g1",
+  setSelectedGroup: vi.fn(),
+  currentLesson: null,
+  nextLesson: null,
+  timeLeftText: "",
+  timeLeftShort: "",
+  currentProgress: 0,
+  todayLessons: [lesson({})],
+  nowTick: new Date("2026-06-15T10:00:00"),
+  onOpenSettings: vi.fn(),
+}
+
+describe("ScheduleHeader", () => {
+  beforeEach(() => {
+    mediaMock.mockReset()
+    mediaMock.mockReturnValue(false) // desktop
+  })
+
+  it("renders the student title and a current-lesson card", () => {
+    render(
+      <ScheduleHeader
+        {...baseProps}
+        currentLesson={lesson({ subject: "Active Lecture" })}
+        currentProgress={40}
+      />
+    )
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("schedule:title.student")
+    expect(screen.getByText("schedule:chips.current")).toBeInTheDocument()
+    expect(screen.getByText("Active Lecture")).toBeInTheDocument()
+  })
+
+  it("renders a next-lesson card when there is no current lesson", () => {
+    render(
+      <ScheduleHeader
+        {...baseProps}
+        nextLesson={lesson({ subject: "Upcoming Seminar", start_time: "15:00" })}
+      />
+    )
+    expect(screen.getByText("schedule:chips.next")).toBeInTheDocument()
+    expect(screen.getByText("Upcoming Seminar")).toBeInTheDocument()
+  })
+
+  it("shows a day-complete message when nothing is current or next", () => {
+    render(<ScheduleHeader {...baseProps} />)
+    expect(screen.getByText("schedule:dayComplete")).toBeInTheDocument()
+  })
+
+  it("fires onOpenSettings when the controls button is clicked", async () => {
+    const user = userEvent.setup()
+    const onOpenSettings = vi.fn()
+    render(<ScheduleHeader {...baseProps} onOpenSettings={onOpenSettings} />)
+    await user.click(screen.getByRole("button", { name: "schedule:toolbar.settings" }))
+    expect(onOpenSettings).toHaveBeenCalledOnce()
+  })
+
+  it("renders the group selector for teachers", () => {
+    render(
+      <ScheduleHeader
+        {...baseProps}
+        user={
+          { id: "1", email: "t@u.edu", full_name: "Teacher", role: "teacher" } as unknown as User
+        }
+      />
+    )
+    expect(screen.getByText("schedule:form.groupLabel")).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/schedule/__tests__/ScheduleListView.test.tsx
+++ b/frontend/src/components/schedule/__tests__/ScheduleListView.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen } from "@testing-library/react"
+import { describe, it, expect, vi } from "vitest"
+
+vi.mock("framer-motion", async () =>
+  (await import("@/tests/helpers/framerMotionMock")).framerMotionMock()
+)
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "en", changeLanguage: () => Promise.resolve() },
+  }),
+}))
+
+import { ScheduleListView } from "@/components/schedule/ScheduleListView"
+import { SchedulePageProvider } from "@/contexts/SchedulePageContext"
+import type { Lesson } from "@/components/schedule/scheduleUtils"
+
+const LESSONS: Lesson[] = [
+  {
+    id: "l1",
+    weekday: "monday",
+    parity: "both",
+    start_time: "09:00",
+    end_time: "10:30",
+    subject: "Linear Algebra",
+    teacher: "Dr. Ivanova",
+    room: "ГУК-305",
+    lesson_type: "lecture",
+    group_id: "g1",
+  },
+  {
+    id: "l2",
+    weekday: "tuesday",
+    parity: "both",
+    start_time: "10:45",
+    end_time: "12:15",
+    subject: "Discrete Mathematics",
+    teacher: "Prof. Petrov",
+    room: "ЛК-201",
+    lesson_type: "practice",
+    group_id: "g1",
+  },
+]
+
+const baseProps = {
+  schedule: LESSONS,
+  weekdayBackend: ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday"],
+  weekdayLabels: ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"],
+  hasToday: true,
+  todayIdx: 0,
+  rawSchedule: LESSONS,
+  refresh: vi.fn(),
+  user: null,
+  conflictedIds: new Set<string>(),
+  isOnline: true,
+  onDeleteLesson: vi.fn(),
+  getLessonTypeColor: () => "#6366f1",
+  getLessonTypeLabel: (v?: string | null) => v ?? "Lesson",
+  currentLesson: null,
+  currentProgress: 0,
+  notesMap: new Map<string, boolean>(),
+}
+
+function renderView(props = baseProps) {
+  return render(
+    <SchedulePageProvider>
+      <ScheduleListView {...props} />
+    </SchedulePageProvider>
+  )
+}
+
+describe("ScheduleListView", () => {
+  it("renders day headings and lesson subjects grouped by day", () => {
+    renderView()
+    expect(screen.getByRole("heading", { name: "Monday" })).toBeInTheDocument()
+    expect(screen.getByRole("heading", { name: "Tuesday" })).toBeInTheDocument()
+    expect(screen.getByText("Linear Algebra")).toBeInTheDocument()
+    expect(screen.getByText("Discrete Mathematics")).toBeInTheDocument()
+  })
+
+  it("renders the empty state when there are no lessons", () => {
+    renderView({ ...baseProps, schedule: [] })
+    expect(screen.getByText("schedule:list.noLessons")).toBeInTheDocument()
+  })
+
+  it("renders an offline fallback when offline with no cached schedule", () => {
+    renderView({ ...baseProps, schedule: [], rawSchedule: [], isOnline: false })
+    expect(screen.queryByText("schedule:list.noLessons")).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/schedule/__tests__/ScheduleMobileView.test.tsx
+++ b/frontend/src/components/schedule/__tests__/ScheduleMobileView.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, it, expect, vi } from "vitest"
+
+vi.mock("framer-motion", async () =>
+  (await import("@/tests/helpers/framerMotionMock")).framerMotionMock()
+)
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "en", changeLanguage: () => Promise.resolve() },
+  }),
+}))
+vi.mock("@/hooks/useMediaQuery", () => ({ default: () => true }))
+
+import { ScheduleMobileView } from "@/components/schedule/ScheduleMobileView"
+import { SchedulePageProvider } from "@/contexts/SchedulePageContext"
+import type { Lesson } from "@/components/schedule/scheduleUtils"
+
+const LESSONS: Lesson[] = [
+  {
+    id: "l1",
+    weekday: "monday",
+    parity: "both",
+    start_time: "09:00",
+    end_time: "10:30",
+    subject: "Linear Algebra",
+    teacher: "Dr. Ivanova",
+    room: "ГУК-305",
+    lesson_type: "lecture",
+    group_id: "g1",
+  },
+  {
+    id: "l2",
+    weekday: "tuesday",
+    parity: "both",
+    start_time: "10:45",
+    end_time: "12:15",
+    subject: "Discrete Mathematics",
+    teacher: "Prof. Petrov",
+    room: "ЛК-201",
+    lesson_type: "practice",
+    group_id: "g1",
+  },
+]
+
+const baseProps = {
+  schedule: LESSONS,
+  weekdayBackend: ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday"],
+  weekdayLabels: ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"],
+  weekdayShort: ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat"],
+  hasToday: true,
+  todayIdx: 0,
+  getDayLabel: (v: string) => v,
+  rawSchedule: LESSONS,
+  refresh: vi.fn(),
+  user: null,
+  conflictedIds: new Set<string>(),
+  isOnline: true,
+  onDeleteLesson: vi.fn(),
+  getLessonTypeColor: () => "#6366f1",
+  getLessonTypeLabel: (v?: string | null) => v ?? "Lesson",
+  currentLesson: null,
+  currentProgress: 0,
+  notesMap: new Map<string, boolean>(),
+}
+
+function renderView(props = baseProps) {
+  return render(
+    <SchedulePageProvider>
+      <ScheduleMobileView {...props} />
+    </SchedulePageProvider>
+  )
+}
+
+describe("ScheduleMobileView", () => {
+  it("renders a day tab per weekday", () => {
+    renderView()
+    expect(screen.getAllByRole("tab")).toHaveLength(baseProps.weekdayBackend.length)
+  })
+
+  it("renders the active day's lessons in the day column", () => {
+    renderView()
+    expect(screen.getByText("Linear Algebra")).toBeInTheDocument()
+  })
+
+  it("switches the active day when another tab is clicked", async () => {
+    const user = userEvent.setup()
+    renderView()
+    await user.click(screen.getByRole("tab", { name: /Tue/ }))
+    expect(screen.getByText("Discrete Mathematics")).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/schedule/__tests__/ScheduleSettingsPanel.test.tsx
+++ b/frontend/src/components/schedule/__tests__/ScheduleSettingsPanel.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, it, expect, vi } from "vitest"
+
+vi.mock("framer-motion", async () =>
+  (await import("@/tests/helpers/framerMotionMock")).framerMotionMock()
+)
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "en", changeLanguage: () => Promise.resolve() },
+  }),
+}))
+vi.mock("@/hooks/useMediaQuery", () => ({ default: () => true }))
+
+import { ScheduleSettingsPanel } from "@/components/schedule/ScheduleSettingsPanel"
+
+const baseProps = {
+  open: true,
+  onClose: vi.fn(),
+  weekdayLabels: ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"],
+  currentParity: "odd" as const,
+  setCurrentParity: vi.fn(),
+}
+
+describe("ScheduleSettingsPanel", () => {
+  it("renders nothing when closed", () => {
+    render(<ScheduleSettingsPanel {...baseProps} open={false} />)
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+  })
+
+  it("renders the settings dialog with title, parity, and weekday toggles when open", () => {
+    render(<ScheduleSettingsPanel {...baseProps} />)
+    expect(screen.getByRole("dialog", { name: "schedule:settings.title" })).toBeInTheDocument()
+    expect(screen.getByText("schedule:parity.odd")).toBeInTheDocument()
+    expect(screen.getByText("schedule:parity.even")).toBeInTheDocument()
+    expect(screen.getByText("Monday")).toBeInTheDocument()
+  })
+
+  it("fires onClose from the close button", async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+    render(<ScheduleSettingsPanel {...baseProps} onClose={onClose} />)
+    await user.click(screen.getByRole("button", { name: "common:buttons.close" }))
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it("fires setCurrentParity when the even parity button is clicked", async () => {
+    const user = userEvent.setup()
+    const setCurrentParity = vi.fn()
+    render(<ScheduleSettingsPanel {...baseProps} setCurrentParity={setCurrentParity} />)
+    await user.click(screen.getByText("schedule:parity.even"))
+    expect(setCurrentParity).toHaveBeenCalledWith("even")
+  })
+})

--- a/frontend/src/components/schedule/dialogs/__tests__/EditLessonDialog.test.tsx
+++ b/frontend/src/components/schedule/dialogs/__tests__/EditLessonDialog.test.tsx
@@ -1,0 +1,78 @@
+import { useEffect, type ReactNode } from "react"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, it, expect, vi } from "vitest"
+
+vi.mock("framer-motion", async () =>
+  (await import("@/tests/helpers/framerMotionMock")).framerMotionMock()
+)
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "en", changeLanguage: () => Promise.resolve() },
+  }),
+}))
+
+import { EditLessonDialog } from "@/components/schedule/dialogs/EditLessonDialog"
+import { SchedulePageProvider, useSchedulePage } from "@/contexts/SchedulePageContext"
+import type { Lesson } from "@/components/schedule/scheduleUtils"
+
+const SAMPLE: Lesson = {
+  id: "l1",
+  weekday: "monday",
+  parity: "both",
+  start_time: "09:00",
+  end_time: "10:30",
+  subject: "Линейная алгебра",
+  teacher: "Иванова Е.А.",
+  room: "ГУК-305",
+  lesson_type: "lecture",
+  group_id: "g1",
+}
+
+const baseProps = {
+  schedule: [SAMPLE],
+  lessonTypeOptions: [
+    { value: "lecture", label: "Лекция" },
+    { value: "practice", label: "Практика" },
+  ],
+  toBackendLessonType: (v?: string | null) => v ?? "lecture",
+  applyScheduleUpdate: vi.fn(),
+  refresh: vi.fn(),
+}
+
+function OpenEditHarness({ children }: { children: ReactNode }) {
+  const { openDialog } = useSchedulePage()
+  useEffect(() => {
+    openDialog("edit", SAMPLE)
+  }, [openDialog])
+  return <>{children}</>
+}
+
+function renderDialog(props = baseProps) {
+  return render(
+    <SchedulePageProvider>
+      <OpenEditHarness>
+        <EditLessonDialog {...props} />
+      </OpenEditHarness>
+    </SchedulePageProvider>
+  )
+}
+
+describe("EditLessonDialog", () => {
+  it("renders the edit form seeded from the selected lesson when open", () => {
+    renderDialog()
+    expect(screen.getByText("schedule:dialog.editTitle")).toBeInTheDocument()
+    expect(screen.getByDisplayValue("Линейная алгебра")).toBeInTheDocument()
+    expect(screen.getByDisplayValue("Иванова Е.А.")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "common:buttons.save" })).toBeInTheDocument()
+  })
+
+  it("closes the dialog when cancel is clicked", async () => {
+    const user = userEvent.setup()
+    renderDialog()
+    expect(screen.getByText("schedule:dialog.editTitle")).toBeInTheDocument()
+    await user.click(screen.getByRole("button", { name: "common:buttons.cancel" }))
+    expect(screen.queryByText("schedule:dialog.editTitle")).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/hooks/__tests__/useScheduleReminders.test.tsx
+++ b/frontend/src/hooks/__tests__/useScheduleReminders.test.tsx
@@ -1,0 +1,141 @@
+import { renderHook, act } from "@testing-library/react"
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+
+const { idbGet, idbSet } = vi.hoisted(() => ({ idbGet: vi.fn(), idbSet: vi.fn() }))
+vi.mock("idb-keyval", () => ({ get: idbGet, set: idbSet }))
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: "en" } }),
+}))
+
+import { useScheduleReminders, type ReminderPrefs } from "@/hooks/useScheduleReminders"
+import type { Lesson } from "@/components/schedule/scheduleUtils"
+
+const notifications: Array<{ title: string; options?: NotificationOptions }> = []
+let requestPermissionMock: ReturnType<typeof vi.fn>
+
+class MockNotification {
+  static permission: NotificationPermission = "default"
+  static requestPermission = (...args: unknown[]) => requestPermissionMock(...args)
+  title: string
+  options?: NotificationOptions
+  constructor(title: string, options?: NotificationOptions) {
+    this.title = title
+    this.options = options
+    notifications.push({ title, options })
+  }
+}
+
+const lesson = (over: Partial<Lesson> = {}): Lesson => ({
+  id: "l1",
+  weekday: "monday",
+  parity: "both",
+  start_time: "12:00",
+  end_time: "13:30",
+  subject: "Linear Algebra",
+  teacher: "Dr. Ivanova",
+  room: "ГУК-305",
+  lesson_type: "lecture",
+  ...over,
+})
+
+const flush = () =>
+  act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+
+beforeEach(() => {
+  idbGet.mockReset().mockResolvedValue(undefined)
+  idbSet.mockReset().mockResolvedValue(undefined)
+  notifications.length = 0
+  requestPermissionMock = vi.fn(async () => "granted" as NotificationPermission)
+  MockNotification.permission = "default"
+  vi.stubGlobal("Notification", MockNotification)
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+})
+
+describe("useScheduleReminders", () => {
+  it("defaults to 15-minutes-before and disabled when permission is default", async () => {
+    const { result } = renderHook(() => useScheduleReminders([]))
+    await flush()
+    expect(result.current.prefs.minutesBefore).toBe(15)
+    expect(result.current.permission).toBe("default")
+    expect(result.current.isEnabled).toBe(false)
+  })
+
+  it("loads stored prefs from IndexedDB on mount", async () => {
+    const stored: ReminderPrefs = { minutesBefore: 30, overrides: {} }
+    idbGet.mockImplementation((key: string) =>
+      Promise.resolve(key === "schedule:reminder-prefs" ? stored : undefined)
+    )
+    const { result } = renderHook(() => useScheduleReminders([]))
+    await flush()
+    expect(result.current.prefs.minutesBefore).toBe(30)
+  })
+
+  it("reflects granted permission from the Notification API", async () => {
+    MockNotification.permission = "granted"
+    const { result } = renderHook(() => useScheduleReminders([]))
+    await flush()
+    expect(result.current.permission).toBe("granted")
+    expect(result.current.isEnabled).toBe(true)
+  })
+
+  it("requestPermission returns true immediately when already granted", async () => {
+    MockNotification.permission = "granted"
+    const { result } = renderHook(() => useScheduleReminders([]))
+    await flush()
+    let granted: boolean | undefined
+    await act(async () => {
+      granted = await result.current.requestPermission()
+    })
+    expect(granted).toBe(true)
+    expect(requestPermissionMock).not.toHaveBeenCalled()
+  })
+
+  it("requestPermission asks the Notification API when permission is default", async () => {
+    const { result } = renderHook(() => useScheduleReminders([]))
+    await flush()
+    let granted: boolean | undefined
+    await act(async () => {
+      granted = await result.current.requestPermission()
+    })
+    expect(requestPermissionMock).toHaveBeenCalledOnce()
+    expect(granted).toBe(true)
+    expect(result.current.permission).toBe("granted")
+  })
+
+  it("setPrefs updates state and persists to IndexedDB", async () => {
+    const { result } = renderHook(() => useScheduleReminders([]))
+    await flush()
+    await act(async () => {
+      await result.current.setPrefs({ minutesBefore: 5 })
+    })
+    expect(result.current.prefs.minutesBefore).toBe(5)
+    expect(idbSet).toHaveBeenCalledWith(
+      "schedule:reminder-prefs",
+      expect.objectContaining({ minutesBefore: 5 })
+    )
+  })
+
+  it("schedules and fires a reminder notification for an upcoming lesson", async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-06-15T10:00:00"))
+    MockNotification.permission = "granted"
+    renderHook(() => useScheduleReminders([lesson({ start_time: "12:00" })]))
+    // Flush the mount effect (permission read + IDB loads) under fake timers
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+    // remindAt = 720 (12:00) - 15 = 705 min; now = 600 (10:00) → delay 105 min
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(105 * 60_000 + 100)
+    })
+    expect(notifications.length).toBeGreaterThanOrEqual(1)
+    expect(notifications[0]!.title).toBe("schedule:reminder.title")
+  })
+})

--- a/frontend/src/tests/helpers/framerMotionMock.ts
+++ b/frontend/src/tests/helpers/framerMotionMock.ts
@@ -1,0 +1,138 @@
+import { createElement, Fragment, type ElementType, type ReactNode } from "react"
+
+/**
+ * Shared framer-motion mock for jsdom render-tests (SESSION 13 sweep).
+ *
+ * Storybook stories prove a component renders in real Chromium, but a jsdom
+ * render-test still needs framer-motion stubbed out: `m.*` / `motion.*` become
+ * plain host elements (animation props stripped), `AnimatePresence` / `LazyMotion`
+ * / `MotionConfig` become passthroughs, and the motion-value hooks return inert
+ * stubs. Mirrors the inline mock in `NotificationsBell.test.tsx` but de-duplicated
+ * across the ~25 sweep files via an async `vi.mock` factory:
+ *
+ *   vi.mock("framer-motion", async () =>
+ *     (await import("@/tests/helpers/framerMotionMock")).framerMotionMock())
+ *
+ * (`vi.mock` is hoisted above imports, so the factory must be async + import the
+ * helper lazily rather than closing over a top-level import.)
+ */
+
+type MotionLikeProps = Record<string, unknown> & { children?: ReactNode }
+
+// framer-motion-only props that must NOT reach the DOM element.
+const MOTION_ONLY_PROPS = new Set<string>([
+  "initial",
+  "animate",
+  "exit",
+  "variants",
+  "transition",
+  "whileHover",
+  "whileTap",
+  "whileFocus",
+  "whileDrag",
+  "whileInView",
+  "whilePress",
+  "viewport",
+  "layout",
+  "layoutId",
+  "layoutScroll",
+  "layoutDependency",
+  "layoutRoot",
+  "drag",
+  "dragConstraints",
+  "dragElastic",
+  "dragMomentum",
+  "dragSnapToOrigin",
+  "dragTransition",
+  "dragControls",
+  "onAnimationStart",
+  "onAnimationComplete",
+  "onUpdate",
+  "onHoverStart",
+  "onHoverEnd",
+  "onTap",
+  "onTapStart",
+  "onTapCancel",
+  "onDrag",
+  "onDragStart",
+  "onDragEnd",
+  "onDirectionLock",
+  "custom",
+  "transformTemplate",
+  "transformValues",
+  "inherit",
+])
+
+const componentCache = new Map<string, ReturnType<typeof buildMotionComponent>>()
+
+function buildMotionComponent(tag: string) {
+  function MotionMock(props: MotionLikeProps) {
+    const cleaned: Record<string, unknown> = {}
+    for (const key of Object.keys(props)) {
+      if (key === "children") continue
+      if (MOTION_ONLY_PROPS.has(key)) continue
+      cleaned[key] = props[key]
+    }
+    return createElement(tag as ElementType, cleaned, props.children)
+  }
+  MotionMock.displayName = `motion.${tag}`
+  return MotionMock
+}
+
+const motionProxy = new Proxy(
+  {},
+  {
+    get(_target, key) {
+      if (typeof key !== "string") return undefined
+      let cached = componentCache.get(key)
+      if (!cached) {
+        cached = buildMotionComponent(key)
+        componentCache.set(key, cached)
+      }
+      return cached
+    },
+  }
+) as Record<string, ReturnType<typeof buildMotionComponent>>
+
+function motionValue(initial: unknown) {
+  return {
+    get: () => initial,
+    set: () => {},
+    on: () => () => {},
+    destroy: () => {},
+    clearListeners: () => {},
+  }
+}
+
+function Passthrough({ children }: { children?: ReactNode }) {
+  return createElement(Fragment, null, children)
+}
+
+export function framerMotionMock() {
+  return {
+    motion: motionProxy,
+    m: motionProxy,
+    AnimatePresence: Passthrough,
+    LazyMotion: Passthrough,
+    MotionConfig: Passthrough,
+    LayoutGroup: Passthrough,
+    domAnimation: {},
+    domMax: {},
+    useReducedMotion: () => true,
+    useMotionValue: (initial: unknown) => motionValue(initial),
+    useTransform: () => motionValue(0),
+    useSpring: (value: unknown) =>
+      value && typeof value === "object" ? value : motionValue(value),
+    useScroll: () => ({
+      scrollX: motionValue(0),
+      scrollY: motionValue(0),
+      scrollXProgress: motionValue(0),
+      scrollYProgress: motionValue(0),
+    }),
+    useVelocity: () => motionValue(0),
+    useMotionTemplate: () => "",
+    useInView: () => true,
+    useAnimation: () => ({ start: () => Promise.resolve(), stop: () => {}, set: () => {} }),
+    useAnimationControls: () => ({ start: () => Promise.resolve(), stop: () => {}, set: () => {} }),
+  }
+}

--- a/frontend/src/tests/helpers/mapGlMock.ts
+++ b/frontend/src/tests/helpers/mapGlMock.ts
@@ -1,0 +1,32 @@
+import { createElement, type ReactNode } from "react"
+
+type StubProps = { children?: ReactNode } & Record<string, unknown>
+
+/**
+ * Minimal jsdom-safe stub for `react-map-gl/maplibre` (Tier-3 STRETCH).
+ *
+ * Real maplibre-gl needs WebGL/canvas which jsdom lacks. Markers/popups render
+ * their children inside a plain <div>; the forwarded `ref` is intentionally NOT
+ * applied, so a marker's `markerRef.current` stays null and
+ * `useStripMaplibreMarkerChrome` early-returns (its 3 removeAttribute lines live
+ * in a separate file and stay uncovered — an acceptable trade).
+ *
+ * Usage:
+ *   vi.mock("react-map-gl/maplibre", async () =>
+ *     (await import("@/tests/helpers/mapGlMock")).mapGlMock())
+ */
+function MapGlStub({ children }: StubProps) {
+  return createElement("div", null, children)
+}
+MapGlStub.displayName = "MapGlStub"
+
+export function mapGlMock() {
+  return {
+    Map: MapGlStub,
+    Marker: MapGlStub,
+    Popup: MapGlStub,
+    Source: MapGlStub,
+    Layer: MapGlStub,
+    useMap: () => ({ current: null }),
+  }
+}

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -57,19 +57,21 @@ export default defineConfig({
         "src/utils/spotify.ts",
         "src/utils/workerChrome.ts",
       ],
-      // Ratchet floors at measured reality. After the session-12 batch
-      // (Select.tsx + useNotifications): statements 69.50 / branches 74.92 /
-      // functions 72.10 / lines 69.50. RAISED: statements 68→69 + lines 68→69
-      // (69.50 clears the +0.5 no-cushion buffer exactly; gate at 69 sits ~0.5
-      // below measured). branches HOLD 74 (74.92 < 75.5) + functions HOLD 71
-      // (72.10 < 72.5). NO-REGRESSION floors, NOT the target — raise
-      // incrementally (target 90; local == CI, so there is no integration
-      // cushion: keep ≥~0.5pp headroom before any raise).
+      // Ratchet floors at measured reality. SESSION-13 render-test sweep
+      // (37 files: News/Events/Schedule/Map-UI/Dashboard families +
+      // useScheduleReminders + Tier-3 maplibre markers/MapControls):
+      // statements 79.43 / branches 74.74 / functions 72.52 / lines 79.43 — a
+      // +9.93pp statement JUMP from the s12 floor (69.50). RAISED: statements
+      // 69→78 + lines 69→78 (78.93 floor after the 0.5 no-cushion buffer) +
+      // functions 71→72 (72.02 floor). branches HOLD 74 (74.74 < 75.5 — render-
+      // tests add statements, not new branch paths). NO-REGRESSION floors, NOT
+      // the target — raise incrementally (target 90; local == CI, so there is
+      // no integration cushion: keep ≥~0.5pp headroom before any raise).
       thresholds: {
-        statements: 69,
+        statements: 78,
         branches: 74,
-        functions: 71,
-        lines: 69,
+        functions: 72,
+        lines: 78,
       },
     },
   },

--- a/security/audit-allowlist.yaml
+++ b/security/audit-allowlist.yaml
@@ -253,10 +253,14 @@ npm:
     # range narrows. All 13 IDs come from the single source 1118053; npm
     # audit cascades each `via` reference into its own allowlist
     # requirement.
+    # SESSION-13 (2026-06-16) re-extended 2026-06-15 → 2026-09-16: still no
+    # clean @tanstack re-issue; installed @tanstack/history STILL 1.161.6
+    # (verified, predates 1.161.9/1.161.12) — not bundle-reachable as a real
+    # vuln. s13 added zero npm deps; this is the expired-entry revisit only.
     - id: "1118053"
       package: "@tanstack/history"
       owner: frontend@university.example
-      expires: 2026-06-15
+      expires: 2026-09-16
       reason: |
         @tanstack supply-chain advisory GHSA-rmmr-r34h-pfm5.
         Installed @tanstack/history@1.161.6 predates flagged malware
@@ -265,73 +269,73 @@ npm:
     - id: "@tanstack/history"
       package: "@tanstack/history"
       owner: frontend@university.example
-      expires: 2026-06-15
+      expires: 2026-09-16
       reason: |
         Transitive via reference cascade from advisory 1118053.
     - id: "@tanstack/react-router"
       package: "@tanstack/react-router"
       owner: frontend@university.example
-      expires: 2026-06-15
+      expires: 2026-09-16
       reason: |
         Transitive via reference cascade from advisory 1118053.
     - id: "@tanstack/react-start-client"
       package: "@tanstack/react-start-client"
       owner: frontend@university.example
-      expires: 2026-06-15
+      expires: 2026-09-16
       reason: |
         Transitive via reference cascade from advisory 1118053.
     - id: "@tanstack/react-start-rsc"
       package: "@tanstack/react-start-rsc"
       owner: frontend@university.example
-      expires: 2026-06-15
+      expires: 2026-09-16
       reason: |
         Transitive via reference cascade from advisory 1118053.
     - id: "@tanstack/react-start-server"
       package: "@tanstack/react-start-server"
       owner: frontend@university.example
-      expires: 2026-06-15
+      expires: 2026-09-16
       reason: |
         Transitive via reference cascade from advisory 1118053.
     - id: "@tanstack/router-core"
       package: "@tanstack/router-core"
       owner: frontend@university.example
-      expires: 2026-06-15
+      expires: 2026-09-16
       reason: |
         Transitive via reference cascade from advisory 1118053.
     - id: "@tanstack/router-generator"
       package: "@tanstack/router-generator"
       owner: frontend@university.example
-      expires: 2026-06-15
+      expires: 2026-09-16
       reason: |
         Transitive via reference cascade from advisory 1118053.
     - id: "@tanstack/router-plugin"
       package: "@tanstack/router-plugin"
       owner: frontend@university.example
-      expires: 2026-06-15
+      expires: 2026-09-16
       reason: |
         Transitive via reference cascade from advisory 1118053.
     - id: "@tanstack/start-client-core"
       package: "@tanstack/start-client-core"
       owner: frontend@university.example
-      expires: 2026-06-15
+      expires: 2026-09-16
       reason: |
         Transitive via reference cascade from advisory 1118053.
     - id: "@tanstack/start-plugin-core"
       package: "@tanstack/start-plugin-core"
       owner: frontend@university.example
-      expires: 2026-06-15
+      expires: 2026-09-16
       reason: |
         Transitive via reference cascade from advisory 1118053.
     - id: "@tanstack/start-server-core"
       package: "@tanstack/start-server-core"
       owner: frontend@university.example
-      expires: 2026-06-15
+      expires: 2026-09-16
       reason: |
         Transitive via reference cascade from advisory 1118053.
     - id: "@tanstack/start-storage-context"
       package: "@tanstack/start-storage-context"
       owner: frontend@university.example
-      expires: 2026-06-15
+      expires: 2026-09-16
       reason: |
         Transitive via reference cascade from advisory 1118053.
     # tmp Path Traversal advisory (GHSA-ph9p-34f9-6g65) — published during


### PR DESCRIPTION
## SESSION 13 — maximal frontend coverage JUMP

A render-test **sweep** reusing the W195–W200 Storybook fixtures (excluded from the vitest project → 0 coverage). Each test lifts a story's `args`+decorators and adds `expect()` — flipping 0%-files from uncovered to covered. Per `vitest.config.ts coverage.include: ["src/**/*"]`, every file is in the 41,041-stmt denominator, so mounting one moves the needle.

### Measured jump (gate = `npm run test:ci`, EXIT 0, 248 files / 1859 tests)
| dim | s12 floor | s13 | Δ |
|---|---|---|---|
| **statements** | 69.50 | **79.43** | **+9.93** |
| **lines** | 69.50 | **79.43** | **+9.93** |
| functions | 72.10 | 72.51 | +0.41 |
| branches | 74.93 | 74.74 | ~flat |

**+9.93 statement points** — top of the +8-10 target. Render-tests add statements + component-function coverage; they add few new branch paths (branches flat by design).

### Landed — 36 test files / 134 tests (+ 2 shared mock helpers), 8 commits
- **News-detail** ×8 (`315df820a`) — 30 tests + shared `framerMotionMock` helper
- **Events** ×10 (`ebdb28fcf`) — 33 tests
- **Schedule** ×7 (`4df827ca8`) — 25 tests
- **Map-UI** ×4 (`b9f134aab`) — 17 tests — MapSidebar / MapSearchBar / MapWeatherPanel / MapShortcutsOverlay
- **Dashboard** ×2 (`ad2953b2d`) — 9 tests — ScheduleTimeline / EventsCard
- **Tier-2** `useScheduleReminders` hook (`2fa67a575`) — 7 tests, 116 uncov, renderHook + fake-timer reminder fire
- **Tier-3 STRETCH unlocked** (`cf396cd16`) — 13 tests, NEW `mapGlMock` helper stubs `react-map-gl/maplibre`; BuildingMarker / POIMarker / EventMarker + MapControls (~456 uncov)
- **Ratchet** (`7ef7cfa61`) — statements/lines 69→78, functions 71→72, branches HOLD 74 (≥0.5pp headroom)

### Honesty
- **Test count**: the authoritative `it()`-grep is **134 tests / 36 test files**. The ratchet commit (`7ef7cfa61`) message body says "147 tests" — an arithmetic mis-sum of the per-family counts (30+33+25+17+9+7+13 = 134); the per-family numbers above are correct, only that one headline was off. Git history not rewritten; this PR description + the memory docs carry the corrected 134.
- **Deferred to s14**: secondary fronts (Go miniredis + backend 88→89) — the frontend jump fully met the maximal target and a frontend-only PR is lowest-risk; both carry hard bars ("hermetic ≥89", two-measure Go gate). Tier-3 MEDIUM targets (MapLibreMap 285 / MapFeature 206 / WeatherParticles 195 canvas) deferred per the "one focused attempt" rule — the HIGH-feasibility markers+MapControls subset landed; the reusable `mapGlMock` helper unblocks them next session.
- `branches` came in marginally below the s12-estimate baseline (74.74 vs 74.93) — render-tests add statements, not branch paths; treated as flat (HOLD 74).
- **Allowlist re-extension** (`352c4dd93`): this PR also re-extends the `@tanstack` GHSA-rmmr-r34h-pfm5 npm-audit allowlist entry (2026-06-15 → 2026-09-16). The prior window had lapsed, which would red the `Node.js Dependency Audit` gate; the installed `@tanstack/history@1.161.6` predates the flagged malware versions (1.161.9 / 1.161.12) and zero npm deps were added this session, so the re-extension is verified-safe (not a new advisory) — it rides in a test-coverage PR only because it was the lone CI-blocker on the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
