### PR TITLE
test(session14): +6.55pp frontend coverage jump (79.43% -> 85.98%)

### DIFF
--- a/frontend/src/app/__tests__/webVitals.test.ts
+++ b/frontend/src/app/__tests__/webVitals.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+
+vi.mock("web-vitals", () => ({
+  onCLS: vi.fn(),
+  onFCP: vi.fn(),
+  onFID: vi.fn(),
+  onINP: vi.fn(),
+  onLCP: vi.fn(),
+  onTTFB: vi.fn(),
+}))
+vi.mock("@/app/logger", () => ({ logDebug: vi.fn(), logError: vi.fn() }))
+
+import { onCLS, onFCP, onFID, onINP, onLCP, onTTFB } from "web-vitals"
+import { logDebug } from "@/app/logger"
+import { initWebVitals, reportBootstrapTTI, resetWebVitalsForTesting } from "@/app/webVitals"
+
+const PROD_BASE = { DEV: false, MODE: "production" } as unknown as ImportMetaEnv
+const enabledEnv = (extra: Record<string, unknown> = {}) =>
+  ({ ...PROD_BASE, VITE_ENABLE_WEB_VITALS: "true", ...extra }) as unknown as ImportMetaEnv & {
+    VITE_ENABLE_WEB_VITALS?: string
+    VITE_WEB_VITALS_ENDPOINT?: string
+  }
+
+const sampleMetric = (over: Record<string, unknown> = {}) => ({
+  name: "CLS",
+  value: 0.1,
+  delta: 0.1,
+  id: "v1-123",
+  rating: "good" as const,
+  navigationType: "navigate" as const,
+  entries: [],
+  ...over,
+})
+
+describe("webVitals", () => {
+  beforeEach(() => {
+    resetWebVitalsForTesting()
+    vi.clearAllMocks()
+  })
+  afterEach(() => {
+    resetWebVitalsForTesting()
+    vi.unstubAllGlobals()
+  })
+
+  it("returns false in DEV or test mode", () => {
+    expect(initWebVitals({ DEV: true, MODE: "development" } as unknown as ImportMetaEnv)).toBe(
+      false
+    )
+    expect(initWebVitals({ DEV: false, MODE: "test" } as unknown as ImportMetaEnv)).toBe(false)
+    expect(onCLS).not.toHaveBeenCalled()
+  })
+
+  it("returns false when the feature flag is not enabled", () => {
+    expect(initWebVitals(PROD_BASE)).toBe(false)
+    expect(initWebVitals({ ...PROD_BASE, VITE_ENABLE_WEB_VITALS: "nope" } as never)).toBe(false)
+  })
+
+  it("registers all six web-vital callbacks when enabled with an endpoint", () => {
+    const sendBeacon = vi.fn(() => true)
+    vi.stubGlobal("navigator", { ...navigator, sendBeacon })
+    expect(initWebVitals(enabledEnv({ VITE_WEB_VITALS_ENDPOINT: "https://metrics.test/v" }))).toBe(
+      true
+    )
+    for (const fn of [onCLS, onFCP, onFID, onINP, onLCP, onTTFB]) {
+      expect(fn).toHaveBeenCalledOnce()
+    }
+    const reporter = vi.mocked(onCLS).mock.calls[0]![0]
+    reporter(sampleMetric({ label: "main" }) as never)
+    expect(sendBeacon).toHaveBeenCalledWith("https://metrics.test/v", expect.any(Blob))
+  })
+
+  it("falls back to fetch when sendBeacon throws", () => {
+    const sendBeacon = vi.fn(() => {
+      throw new Error("beacon down")
+    })
+    const fetchMock = vi.fn(() => Promise.resolve(new Response(null, { status: 204 })))
+    vi.stubGlobal("navigator", { ...navigator, sendBeacon })
+    vi.stubGlobal("fetch", fetchMock)
+    initWebVitals(enabledEnv({ VITE_WEB_VITALS_ENDPOINT: "https://metrics.test/v" }))
+    const reporter = vi.mocked(onLCP).mock.calls[0]![0]
+    reporter(sampleMetric({ name: "LCP", value: 2400 }) as never)
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://metrics.test/v",
+      expect.objectContaining({ method: "POST" })
+    )
+  })
+
+  it("uses the console reporter when no endpoint is configured", () => {
+    expect(initWebVitals(enabledEnv())).toBe(true)
+    const reporter = vi.mocked(onFCP).mock.calls[0]![0]
+    reporter(sampleMetric({ name: "FCP", value: 1200 }) as never)
+    expect(logDebug).toHaveBeenCalledWith(
+      "[web-vitals] FCP",
+      expect.objectContaining({ value: 1200 })
+    )
+  })
+
+  it("is idempotent — a second init does not re-register", () => {
+    initWebVitals(enabledEnv({ VITE_WEB_VITALS_ENDPOINT: "https://metrics.test/v" }))
+    expect(initWebVitals(enabledEnv({ VITE_WEB_VITALS_ENDPOINT: "https://metrics.test/v" }))).toBe(
+      true
+    )
+    expect(onCLS).toHaveBeenCalledOnce()
+  })
+
+  it("reportBootstrapTTI returns false before init and reports rated metrics after", () => {
+    expect(reportBootstrapTTI(1000)).toBe(false)
+    initWebVitals(enabledEnv())
+    expect(reportBootstrapTTI(1000)).toBe(true)
+    expect(logDebug).toHaveBeenLastCalledWith(
+      "[web-vitals] APP_TTI",
+      expect.objectContaining({ rating: "good" })
+    )
+    reportBootstrapTTI(5000)
+    expect(logDebug).toHaveBeenLastCalledWith(
+      "[web-vitals] APP_TTI",
+      expect.objectContaining({ rating: "needs-improvement" })
+    )
+    reportBootstrapTTI(9000)
+    expect(logDebug).toHaveBeenLastCalledWith(
+      "[web-vitals] APP_TTI",
+      expect.objectContaining({ rating: "poor" })
+    )
+  })
+})

--- a/frontend/src/components/__tests__/InstallPrompt.branches.test.tsx
+++ b/frontend/src/components/__tests__/InstallPrompt.branches.test.tsx
@@ -1,0 +1,251 @@
+import { act, render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { type ReactNode } from "react"
+import InstallPrompt from "@/components/pwa/InstallPrompt"
+import { PWA_REFRESH_EVENT } from "@/app/pwaEvents"
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
+
+const mockUsePushPreferences = vi.fn()
+
+const lastNotify = { fn: null as ((toast: unknown) => void) | null }
+
+vi.mock("@/hooks/usePushPreferences", () => ({
+  usePushPreferences: (opts: { onNotify?: (toast: unknown) => void }) => {
+    lastNotify.fn = opts?.onNotify ?? null
+    return mockUsePushPreferences(opts)
+  },
+}))
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, string>) =>
+      opts?.appName ? `${key} ${opts.appName}` : key,
+  }),
+  Trans: ({ i18nKey }: { children?: ReactNode; i18nKey: string }) => <span>{i18nKey}</span>,
+}))
+
+const createPushPreferencesState = (overrides: Record<string, unknown> = {}) => ({
+  topicKeys: [],
+  topicState: {},
+  pushSupported: true,
+  notificationPermission: "default" as NotificationPermission,
+  notificationsEnabled: false,
+  pushBusy: false,
+  pushInitializing: false,
+  permissionText: "default",
+  selectedTopicsDescription: "",
+  enableNotifications: vi.fn(),
+  disableNotifications: vi.fn(),
+  handleTopicToggle: () => () => undefined,
+  safariIOS: false,
+  safariGuideUrl: "",
+  ...overrides,
+})
+
+interface MockBeforeInstallPromptEvent extends Event {
+  prompt: () => Promise<void>
+  userChoice: Promise<{ outcome: "accepted" | "dismissed" }>
+}
+
+const fireBeforeInstallPrompt = () => {
+  const event = new Event("beforeinstallprompt") as MockBeforeInstallPromptEvent
+  event.prompt = vi.fn().mockResolvedValue(undefined)
+  event.userChoice = Promise.resolve({ outcome: "dismissed" })
+  act(() => {
+    window.dispatchEvent(event)
+  })
+}
+
+beforeAll(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+})
+
+beforeEach(() => {
+  localStorage.clear()
+  lastNotify.fn = null
+  mockUsePushPreferences.mockReturnValue(createPushPreferencesState())
+})
+
+describe("InstallPrompt — branches", () => {
+  it("clears the install suppress when the app is installed", async () => {
+    render(<InstallPrompt />)
+    fireBeforeInstallPrompt()
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("system:installPrompt.installTitle navigation:brandName")
+      ).toBeInTheDocument()
+    })
+
+    act(() => {
+      window.dispatchEvent(new Event("appinstalled"))
+    })
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText("system:installPrompt.installTitle navigation:brandName")
+      ).not.toBeInTheDocument()
+    })
+  })
+
+  it("renders the unsupported warning when push is not supported", async () => {
+    mockUsePushPreferences.mockReturnValue(createPushPreferencesState({ pushSupported: false }))
+    render(<InstallPrompt />)
+
+    await waitFor(() => {
+      expect(screen.getByText("system:installPrompt.manageNotifications")).toBeInTheDocument()
+    })
+    expect(screen.getByText("system:installPrompt.unsupported")).toBeInTheDocument()
+  })
+
+  it("renders the blocked state when permission is denied", async () => {
+    mockUsePushPreferences.mockReturnValue(
+      createPushPreferencesState({ notificationPermission: "denied" })
+    )
+    render(<InstallPrompt />)
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("system:installPrompt.blocked navigation:brandName")
+      ).toBeInTheDocument()
+    })
+    expect(screen.getByText("system:installPrompt.check")).toBeInTheDocument()
+  })
+
+  it("shows the Safari iOS guide in the denied state", async () => {
+    mockUsePushPreferences.mockReturnValue(
+      createPushPreferencesState({
+        notificationPermission: "denied",
+        safariIOS: true,
+        safariGuideUrl: "https://example.com/guide",
+      })
+    )
+    render(<InstallPrompt />)
+
+    await waitFor(() => {
+      expect(screen.getByText("system:installPrompt.safariGuide")).toBeInTheDocument()
+    })
+  })
+
+  it("invokes enableNotifications from the denied state check button", async () => {
+    const enableNotifications = vi.fn()
+    mockUsePushPreferences.mockReturnValue(
+      createPushPreferencesState({ notificationPermission: "denied", enableNotifications })
+    )
+    render(<InstallPrompt />)
+
+    const user = userEvent.setup()
+    const checkButton = await screen.findByText("system:installPrompt.check")
+    await user.click(checkButton)
+
+    expect(enableNotifications).toHaveBeenCalledTimes(1)
+  })
+
+  it("invokes enableNotifications from the default-permission allow button", async () => {
+    const enableNotifications = vi.fn()
+    mockUsePushPreferences.mockReturnValue(
+      createPushPreferencesState({ notificationPermission: "default", enableNotifications })
+    )
+    render(<InstallPrompt />)
+
+    const user = userEvent.setup()
+    const allowButton = await screen.findByText("system:installPrompt.allow")
+    await user.click(allowButton)
+
+    expect(enableNotifications).toHaveBeenCalledTimes(1)
+  })
+
+  it("surfaces a feedback toast via the onNotify callback", async () => {
+    render(<InstallPrompt />)
+
+    await waitFor(() => {
+      expect(lastNotify.fn).toBeTypeOf("function")
+    })
+
+    act(() => {
+      lastNotify.fn?.({ text: "saved", severity: "success" })
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText("saved")).toBeInTheDocument()
+    })
+
+    const user = userEvent.setup()
+    await user.click(screen.getByText("saved").closest("div")!.querySelector("button")!)
+
+    await waitFor(() => {
+      expect(screen.queryByText("saved")).not.toBeInTheDocument()
+    })
+  })
+
+  it("renders an error-severity feedback toast", async () => {
+    render(<InstallPrompt />)
+
+    await waitFor(() => {
+      expect(lastNotify.fn).toBeTypeOf("function")
+    })
+
+    act(() => {
+      lastNotify.fn?.({ text: "boom", severity: "error" })
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText("boom")).toBeInTheDocument()
+    })
+  })
+
+  it("runs the SW update toast lifecycle and triggers reload", async () => {
+    const update = vi.fn().mockResolvedValue(undefined)
+    render(<InstallPrompt />)
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent(PWA_REFRESH_EVENT, { detail: { update } }))
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText("system:installPrompt.updateAvailable")).toBeInTheDocument()
+    })
+
+    const user = userEvent.setup()
+    await user.click(screen.getByText("system:installPrompt.reload"))
+
+    expect(update).toHaveBeenCalledTimes(1)
+    await waitFor(() => {
+      expect(screen.queryByText("system:installPrompt.updateAvailable")).not.toBeInTheDocument()
+    })
+  })
+
+  it("closes the SW update toast without reloading", async () => {
+    const update = vi.fn().mockResolvedValue(undefined)
+    render(<InstallPrompt />)
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent(PWA_REFRESH_EVENT, { detail: { update } }))
+    })
+
+    const toast = await screen.findByText("system:installPrompt.updateAvailable")
+    const closeButton = toast
+      .closest("div")!
+      .parentElement!.querySelector("button:last-of-type") as HTMLButtonElement
+
+    const user = userEvent.setup()
+    await user.click(closeButton)
+
+    expect(update).not.toHaveBeenCalled()
+    await waitFor(() => {
+      expect(screen.queryByText("system:installPrompt.updateAvailable")).not.toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/components/dashboard/__tests__/DashboardSectionSkeleton.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/DashboardSectionSkeleton.test.tsx
@@ -1,0 +1,46 @@
+import { render } from "@testing-library/react"
+import { describe, it, expect } from "vitest"
+import { DashboardSectionSkeleton } from "@/components/dashboard/DashboardSectionSkeleton"
+
+describe("DashboardSectionSkeleton", () => {
+  it("renders the schedule variant with 3 list rows", () => {
+    const { container } = render(<DashboardSectionSkeleton type="schedule" />)
+    const card = container.querySelector(".card-matte")
+    expect(card).toBeInTheDocument()
+    expect(card).toHaveClass("glass-noise")
+    // 3 schedule rows, each with bg-(--bg-matte-list)
+    const rows = container.querySelectorAll('[class*="bg-(--bg-matte-list)"]')
+    expect(rows.length).toBe(3)
+  })
+
+  it("renders the news variant with 2 list rows", () => {
+    const { container } = render(<DashboardSectionSkeleton type="news" />)
+    const card = container.querySelector(".card-matte")
+    expect(card).toBeInTheDocument()
+    const rows = container.querySelectorAll('[class*="bg-(--bg-matte-list)"]')
+    expect(rows.length).toBe(2)
+  })
+
+  it("renders the events variant with 3 list rows", () => {
+    const { container } = render(<DashboardSectionSkeleton type="events" />)
+    expect(container.querySelector(".card-matte")).toBeInTheDocument()
+    const rows = container.querySelectorAll('[class*="bg-(--bg-matte-list)"]')
+    expect(rows.length).toBe(3)
+  })
+
+  it("forwards a custom className onto the Card", () => {
+    const { container } = render(
+      <DashboardSectionSkeleton type="schedule" className="custom-test-class" />
+    )
+    const card = container.querySelector(".card-matte")
+    expect(card).toHaveClass("custom-test-class")
+    expect(card).toHaveClass("p-6", "h-full")
+  })
+
+  it("always renders the heading skeleton regardless of variant", () => {
+    const { container } = render(<DashboardSectionSkeleton type="news" />)
+    // The heading Skeleton has mb-5; at least one skeleton element should exist
+    const skeletons = container.querySelectorAll(".mb-5")
+    expect(skeletons.length).toBeGreaterThan(0)
+  })
+})

--- a/frontend/src/components/error/__tests__/PageErrorBoundary.test.tsx
+++ b/frontend/src/components/error/__tests__/PageErrorBoundary.test.tsx
@@ -1,0 +1,113 @@
+import { render, screen, fireEvent } from "@testing-library/react"
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+
+const { routeState, navigateMock } = vi.hoisted(() => ({
+  routeState: { current: "/start" },
+  navigateMock: vi.fn(),
+}))
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    ready: true,
+    i18n: { language: "en", changeLanguage: () => Promise.resolve() },
+  }),
+}))
+vi.mock("@tanstack/react-router", () => ({
+  useRouterState: (opts?: { select?: (s: unknown) => unknown }) =>
+    opts?.select ? opts.select({ location: { pathname: routeState.current } }) : routeState.current,
+  useNavigate: () => navigateMock,
+}))
+vi.mock("@sentry/react", () => ({ captureException: vi.fn() }))
+vi.mock("@/app/logger", () => ({ logError: vi.fn(), logDebug: vi.fn() }))
+
+import * as Sentry from "@sentry/react"
+import { PageErrorBoundary } from "@/components/error/PageErrorBoundary"
+
+function Boom(): never {
+  throw new Error("kaboom")
+}
+
+describe("PageErrorBoundary", () => {
+  beforeEach(() => {
+    routeState.current = "/start"
+    vi.clearAllMocks()
+    // React logs caught errors via console.error — silence to keep output clean.
+    vi.spyOn(console, "error").mockImplementation(() => {})
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("renders children when there is no error", () => {
+    render(
+      <PageErrorBoundary>
+        <div>safe content</div>
+      </PageErrorBoundary>
+    )
+    expect(screen.getByText("safe content")).toBeInTheDocument()
+  })
+
+  it("renders the fallback alert + reports to Sentry when a child throws", () => {
+    render(
+      <PageErrorBoundary pageName="events">
+        <Boom />
+      </PageErrorBoundary>
+    )
+    expect(screen.getByRole("alert")).toBeInTheDocument()
+    expect(screen.getByText("system:pageError.title")).toBeInTheDocument()
+    // DEV error details branch (import.meta.env.DEV is true under vitest)
+    expect(screen.getByText("Non-API Error")).toBeInTheDocument()
+    expect(Sentry.captureException).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({ contexts: expect.objectContaining({ page: { name: "events" } }) })
+    )
+  })
+
+  it("renders a custom fallback when provided", () => {
+    render(
+      <PageErrorBoundary fallback={<div>custom fallback</div>}>
+        <Boom />
+      </PageErrorBoundary>
+    )
+    expect(screen.getByText("custom fallback")).toBeInTheDocument()
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument()
+  })
+
+  it("navigates home from the fallback", () => {
+    render(
+      <PageErrorBoundary>
+        <Boom />
+      </PageErrorBoundary>
+    )
+    fireEvent.click(screen.getByText("system:pageError.home"))
+    expect(navigateMock).toHaveBeenCalledWith({ to: "/" })
+  })
+
+  it("retry re-renders children (which throw again → fallback persists)", () => {
+    render(
+      <PageErrorBoundary>
+        <Boom />
+      </PageErrorBoundary>
+    )
+    fireEvent.click(screen.getByText("system:pageError.retry"))
+    expect(screen.getByRole("alert")).toBeInTheDocument()
+  })
+
+  it("resets on route change", () => {
+    const { rerender } = render(
+      <PageErrorBoundary>
+        <Boom />
+      </PageErrorBoundary>
+    )
+    expect(screen.getByRole("alert")).toBeInTheDocument()
+    routeState.current = "/other"
+    rerender(
+      <PageErrorBoundary>
+        <div>recovered view</div>
+      </PageErrorBoundary>
+    )
+    expect(screen.getByText("recovered view")).toBeInTheDocument()
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/events/EventCard/__tests__/EventInfo.test.tsx
+++ b/frontend/src/components/events/EventCard/__tests__/EventInfo.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from "@testing-library/react"
+import { describe, it, expect, vi } from "vitest"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "en", changeLanguage: () => Promise.resolve() },
+  }),
+}))
+
+import { EventInfo } from "@/components/events/EventCard/EventInfo"
+
+const baseProps = {
+  title: "Annual Tech Conference",
+  startsAt: "2026-06-01T10:00:00Z",
+  endsAt: "2026-06-01T18:00:00Z",
+  location: "Main Auditorium",
+  description: "A full-day conference covering the latest technology trends.",
+}
+
+describe("EventInfo", () => {
+  it("renders title, location and description", () => {
+    render(<EventInfo {...baseProps} />)
+    expect(screen.getByRole("heading", { name: "Annual Tech Conference" })).toBeInTheDocument()
+    expect(screen.getByText("Main Auditorium")).toBeInTheDocument()
+    expect(
+      screen.getByText("A full-day conference covering the latest technology trends.")
+    ).toBeInTheDocument()
+  })
+
+  it("applies the titleId to the heading when provided", () => {
+    render(<EventInfo {...baseProps} titleId="event-heading-1" />)
+    expect(screen.getByRole("heading", { name: "Annual Tech Conference" })).toHaveAttribute(
+      "id",
+      "event-heading-1"
+    )
+  })
+
+  it("renders the speaker line when speaker is provided", () => {
+    render(<EventInfo {...baseProps} speaker="Dr. Jane Doe" />)
+    expect(screen.getByText("events:form.speaker: Dr. Jane Doe")).toBeInTheDocument()
+  })
+
+  it("omits the speaker line when speaker is absent", () => {
+    render(<EventInfo {...baseProps} />)
+    expect(screen.queryByText(/events:form\.speaker/)).not.toBeInTheDocument()
+  })
+
+  it("renders the date and location tooltip labels via i18n keys", () => {
+    const { container } = render(<EventInfo {...baseProps} />)
+    expect(container.querySelector('[title="events:form.dates"]')).toBeInTheDocument()
+    expect(container.querySelector('[title="events:form.location"]')).toBeInTheDocument()
+    expect(container.querySelector('[data-tooltip="events:form.dates"]')).toBeInTheDocument()
+    expect(container.querySelector('[data-tooltip="events:form.location"]')).toBeInTheDocument()
+  })
+
+  it("renders both start and end timestamps as <time> elements", () => {
+    const { container } = render(<EventInfo {...baseProps} />)
+    expect(container.querySelector('time[datetime="2026-06-01T10:00:00Z"]')).toBeInTheDocument()
+    expect(container.querySelector('time[datetime="2026-06-01T18:00:00Z"]')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/events/__tests__/EventDetailNavigation.test.tsx
+++ b/frontend/src/components/events/__tests__/EventDetailNavigation.test.tsx
@@ -1,0 +1,101 @@
+import type { ReactNode } from "react"
+import { render, screen } from "@testing-library/react"
+import { describe, it, expect, vi } from "vitest"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "en", changeLanguage: () => Promise.resolve() },
+  }),
+}))
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({
+    children,
+    to,
+    params,
+    ...rest
+  }: { children?: ReactNode; to?: string; params?: { id?: string } } & Record<string, unknown>) => (
+    <a href={`${to}/${params?.id ?? ""}`} {...rest}>
+      {children}
+    </a>
+  ),
+}))
+
+import { EventDetailNavigation } from "@/components/events/EventDetailNavigation"
+
+const baseProps = {
+  prevId: "prev-1",
+  nextId: "next-1",
+  prevTitle: "Previous Event Title",
+  nextTitle: "Next Event Title",
+}
+
+describe("EventDetailNavigation", () => {
+  it("renders nothing when neither prevId nor nextId is set", () => {
+    const { container } = render(
+      <EventDetailNavigation prevId={null} nextId={null} prevTitle={null} nextTitle={null} />
+    )
+    expect(container).toBeEmptyDOMElement()
+    expect(screen.queryByRole("navigation")).not.toBeInTheDocument()
+  })
+
+  it("renders both prev and next links when both ids are set", () => {
+    render(<EventDetailNavigation {...baseProps} />)
+    expect(screen.getByRole("navigation", { name: "events:detail.nav.label" })).toBeInTheDocument()
+    expect(screen.getByText("events:detail.nav.prev")).toBeInTheDocument()
+    expect(screen.getByText("events:detail.nav.next")).toBeInTheDocument()
+    expect(screen.getByText("Previous Event Title")).toBeInTheDocument()
+    expect(screen.getByText("Next Event Title")).toBeInTheDocument()
+    const links = screen.getAllByRole("link")
+    expect(links).toHaveLength(2)
+    expect(links[0]!).toHaveAttribute("href", "/events/$id/prev-1")
+    expect(links[1]!).toHaveAttribute("href", "/events/$id/next-1")
+  })
+
+  it("renders only the prev link when nextId is null", () => {
+    render(
+      <EventDetailNavigation
+        prevId="prev-1"
+        nextId={null}
+        prevTitle="Previous Event Title"
+        nextTitle={null}
+      />
+    )
+    expect(screen.getByText("events:detail.nav.prev")).toBeInTheDocument()
+    expect(screen.queryByText("events:detail.nav.next")).not.toBeInTheDocument()
+    const links = screen.getAllByRole("link")
+    expect(links).toHaveLength(1)
+    expect(links[0]!).toHaveAttribute("href", "/events/$id/prev-1")
+  })
+
+  it("renders only the next link when prevId is null", () => {
+    render(
+      <EventDetailNavigation
+        prevId={null}
+        nextId="next-1"
+        prevTitle={null}
+        nextTitle="Next Event Title"
+      />
+    )
+    expect(screen.getByText("events:detail.nav.next")).toBeInTheDocument()
+    expect(screen.queryByText("events:detail.nav.prev")).not.toBeInTheDocument()
+    const links = screen.getAllByRole("link")
+    expect(links).toHaveLength(1)
+    expect(links[0]!).toHaveAttribute("href", "/events/$id/next-1")
+  })
+
+  it("renders the nav with a placeholder spacer when only one link is present", () => {
+    render(
+      <EventDetailNavigation
+        prevId="prev-1"
+        nextId={null}
+        prevTitle="Previous Event Title"
+        nextTitle={null}
+      />
+    )
+    const nav = screen.getByRole("navigation", { name: "events:detail.nav.label" })
+    expect(nav).toBeInTheDocument()
+    // the empty next slot is a flex-1 spacer div, not a link
+    expect(nav.querySelectorAll("div.flex-1")).toHaveLength(1)
+  })
+})

--- a/frontend/src/components/events/__tests__/EventFileManager.branches.test.tsx
+++ b/frontend/src/components/events/__tests__/EventFileManager.branches.test.tsx
@@ -1,0 +1,241 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  post: vi.fn(() => Promise.resolve({ data: {} })),
+  del: vi.fn(() => Promise.resolve({ data: {} })),
+}))
+
+vi.mock("@/api/client", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return {
+    ...actual,
+    default: { post: mocks.post, delete: mocks.del },
+  }
+})
+vi.mock("@/app/logger", () => ({ logError: vi.fn() }))
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "en", changeLanguage: () => Promise.resolve() },
+  }),
+}))
+
+import { EventFileManager } from "@/components/events/EventFileManager"
+import type { Event, EventFile } from "@/types/Event"
+
+const baseEvent: Event = {
+  id: "evt-1",
+  title: "React 19 Patterns Workshop",
+  title_en: "React 19 Patterns Workshop",
+  starts_at: "2026-06-15T14:00:00Z",
+  ends_at: "2026-06-15T16:00:00Z",
+  created_by: "admin-1",
+  created_at: "2026-05-01T10:00:00Z",
+  is_active: true,
+  image_url_optimized: null,
+  files: [
+    {
+      id: "f1",
+      event_id: "evt-1",
+      file_url: "/media/lecture-slides.pdf",
+      description: "Lecture slides.pdf",
+    },
+    {
+      id: "f2",
+      event_id: "evt-1",
+      file_url: "/media/reading-list.pdf",
+      description: "Reading list.pdf",
+    },
+  ],
+}
+
+type Props = React.ComponentProps<typeof EventFileManager>
+
+const makeProps = (overrides: Partial<Props> = {}): Props => ({
+  event: baseEvent,
+  canEdit: true,
+  onUpdate: vi.fn(() => Promise.resolve()),
+  onError: vi.fn(),
+  onSuccess: vi.fn(),
+  ...overrides,
+})
+
+const getFileInput = (): HTMLInputElement => {
+  const inputs = document.querySelectorAll<HTMLInputElement>("input[type='file']")
+  expect(inputs.length).toBeGreaterThan(0)
+  return inputs[0]!
+}
+
+const makeFile = (name = "notes.pdf"): File =>
+  new File(["binary-content"], name, { type: "application/pdf" })
+
+// jsdom's file input is read-only and fireEvent.change cannot attach a real
+// File for FormData to pick up on submit. Define a FileList-shaped value on the
+// input so React's form action constructs FormData with the real File.
+const selectFileViaInput = (file: File): void => {
+  const input = getFileInput()
+  const fileList = {
+    0: file,
+    length: 1,
+    item: (i: number) => (i === 0 ? file : null),
+    [Symbol.iterator]: function* () {
+      yield file
+    },
+  }
+  Object.defineProperty(input, "files", { value: fileList, configurable: true })
+  fireEvent.change(input)
+}
+
+// React 19 form actions intercept the native submit event; jsdom does not run
+// requestSubmit() on fireEvent.click, so submit the <form> directly.
+const submitForm = (): void => {
+  const form = document.querySelector("form")
+  expect(form).not.toBeNull()
+  fireEvent.submit(form!)
+}
+
+describe("EventFileManager branches", () => {
+  beforeEach(() => {
+    mocks.post.mockReset()
+    mocks.post.mockResolvedValue({ data: {} })
+    mocks.del.mockReset()
+    mocks.del.mockResolvedValue({ data: {} })
+  })
+
+  it("disables the submit button until a file is selected", () => {
+    render(<EventFileManager {...makeProps()} />)
+    const submit = screen.getByRole("button", { name: "events:detail.upload.submit.label" })
+    expect(submit).toBeDisabled()
+  })
+
+  it("selecting a file enables submit and shows the file name", () => {
+    render(<EventFileManager {...makeProps()} />)
+    selectFileViaInput(makeFile("syllabus.pdf"))
+    expect(screen.getByText("syllabus.pdf")).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "events:detail.upload.submit.label" })
+    ).not.toBeDisabled()
+  })
+
+  // NOTE: the api.post success/error paths require a non-empty File to survive
+  // React 19's form-action FormData reconstruction. jsdom rebuilds FormData from
+  // the DOM and serializes <input type=file> to a 0-byte File (verified via a
+  // userEvent.upload + requestSubmit probe), so the upload happy/error network
+  // paths are not exercisable in jsdom. We instead drive the empty-file error
+  // branch (uploadState.status === "error") and the __upload_reset__ branch.
+  it("submitting with no usable file shows the inline noFile error branch", async () => {
+    const props = makeProps()
+    render(<EventFileManager {...props} />)
+
+    submitForm()
+
+    await waitFor(() =>
+      expect(screen.getByText("events:detail.upload.errors.noFile")).toBeInTheDocument()
+    )
+    expect(mocks.post).not.toHaveBeenCalled()
+    expect(props.onUpdate).not.toHaveBeenCalled()
+  })
+
+  it("re-selecting a file after an error resets the inline error message", async () => {
+    render(<EventFileManager {...makeProps()} />)
+    submitForm()
+
+    await waitFor(() =>
+      expect(screen.getByText("events:detail.upload.errors.noFile")).toBeInTheDocument()
+    )
+
+    // Re-select triggers the __upload_reset__ branch in handleFileChange,
+    // dispatching the reset action that returns { status: "idle" }.
+    selectFileViaInput(makeFile("second.pdf"))
+    await waitFor(() =>
+      expect(screen.queryByText("events:detail.upload.errors.noFile")).not.toBeInTheDocument()
+    )
+  })
+
+  it("deletes a file: calls api.delete, onSuccess and onUpdate", async () => {
+    const props = makeProps()
+    render(<EventFileManager {...props} />)
+    const deleteButtons = screen.getAllByRole("button", {
+      name: "events:detail.sections.files.deleteAria",
+    })
+    fireEvent.click(deleteButtons[0]!)
+
+    await waitFor(() => expect(mocks.del).toHaveBeenCalledTimes(1))
+    expect(mocks.del).toHaveBeenCalledWith("/events/file/f1")
+    await waitFor(() =>
+      expect(props.onSuccess).toHaveBeenCalledWith("events:detail.messages.fileDeleted")
+    )
+    await waitFor(() => expect(props.onUpdate).toHaveBeenCalled())
+  })
+
+  it("delete failure: calls onError and still calls onUpdate in finally", async () => {
+    mocks.del.mockRejectedValueOnce(new Error("delete failed"))
+    const props = makeProps()
+    render(<EventFileManager {...props} />)
+    const deleteButtons = screen.getAllByRole("button", {
+      name: "events:detail.sections.files.deleteAria",
+    })
+    fireEvent.click(deleteButtons[0]!)
+
+    await waitFor(() =>
+      expect(props.onError).toHaveBeenCalledWith("events:detail.messages.fileDeleteFailed")
+    )
+    await waitFor(() => expect(props.onUpdate).toHaveBeenCalled())
+  })
+
+  it("renders a pending file as plain text with a disabled delete button", () => {
+    const pendingEvent: Event = {
+      ...baseEvent,
+      files: [
+        {
+          id: "pending-123",
+          event_id: "evt-1",
+          file_url: "",
+          description: "uploading.pdf",
+        },
+      ],
+    }
+    render(<EventFileManager {...makeProps({ event: pendingEvent })} />)
+    // pending file renders as a <span>, not a download <a>
+    expect(screen.getByText("uploading.pdf")).toBeInTheDocument()
+    expect(screen.queryByRole("link")).not.toBeInTheDocument()
+    const deleteButton = screen.getByRole("button", {
+      name: "events:detail.sections.files.deleteAria",
+    })
+    expect(deleteButton).toBeDisabled()
+  })
+
+  it("renders the explicit pending label when a pending file has no description", () => {
+    const pendingFile: EventFile & { pending?: boolean } = {
+      id: "f9",
+      event_id: "evt-1",
+      file_url: "",
+      description: null,
+      pending: true,
+    }
+    const pendingEvent: Event = { ...baseEvent, files: [pendingFile] }
+    render(<EventFileManager {...makeProps({ event: pendingEvent })} />)
+    expect(screen.getByText("events:detail.sections.files.pending")).toBeInTheDocument()
+  })
+
+  it("clicking a disabled pending delete does not call api.delete", () => {
+    const pendingEvent: Event = {
+      ...baseEvent,
+      files: [
+        {
+          id: "pending-xyz",
+          event_id: "evt-1",
+          file_url: "",
+          description: "still-uploading.pdf",
+        },
+      ],
+    }
+    render(<EventFileManager {...makeProps({ event: pendingEvent })} />)
+    const deleteButton = screen.getByRole("button", {
+      name: "events:detail.sections.files.deleteAria",
+    })
+    fireEvent.click(deleteButton)
+    expect(mocks.del).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/feedback/__tests__/OfflineIndicator.test.tsx
+++ b/frontend/src/components/feedback/__tests__/OfflineIndicator.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen, act } from "@testing-library/react"
+import { describe, it, expect, vi, afterEach } from "vitest"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "en", changeLanguage: () => Promise.resolve() },
+  }),
+}))
+
+import { OfflineIndicator } from "@/components/feedback/OfflineIndicator"
+import { TIMEOUTS } from "@/config/timeouts"
+
+function setOnline(value: boolean) {
+  Object.defineProperty(navigator, "onLine", { configurable: true, writable: true, value })
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+  setOnline(true)
+})
+
+describe("OfflineIndicator", () => {
+  it("renders nothing while online", () => {
+    setOnline(true)
+    render(<OfflineIndicator />)
+    expect(screen.queryByRole("status")).not.toBeInTheDocument()
+  })
+
+  it("shows the offline toast when navigator starts offline", () => {
+    setOnline(false)
+    render(<OfflineIndicator />)
+    expect(screen.getByRole("status")).toBeInTheDocument()
+    expect(screen.getByText("offlineIndicator.offline")).toBeInTheDocument()
+  })
+
+  it("reacts to offline → online events and auto-hides the back-online toast", () => {
+    vi.useFakeTimers()
+    setOnline(true)
+    render(<OfflineIndicator />)
+    expect(screen.queryByRole("status")).not.toBeInTheDocument()
+
+    setOnline(false)
+    act(() => {
+      window.dispatchEvent(new Event("offline"))
+    })
+    expect(screen.getByText("offlineIndicator.offline")).toBeInTheDocument()
+
+    setOnline(true)
+    act(() => {
+      window.dispatchEvent(new Event("online"))
+    })
+    expect(screen.getByText("offlineIndicator.online")).toBeInTheDocument()
+
+    act(() => {
+      vi.advanceTimersByTime(TIMEOUTS.OFFLINE_INDICATOR + 100)
+    })
+    expect(screen.queryByRole("status")).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/feedback/__tests__/SyncStatus.test.tsx
+++ b/frontend/src/components/feedback/__tests__/SyncStatus.test.tsx
@@ -1,0 +1,165 @@
+import { act, render, screen } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("framer-motion", async () =>
+  (await import("@/tests/helpers/framerMotionMock")).framerMotionMock()
+)
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "en", changeLanguage: () => Promise.resolve() },
+  }),
+}))
+
+import { SyncStatus } from "@/components/feedback/SyncStatus"
+
+const CLICK_DB_NAME = "notification-interactions"
+const CLICK_DB_VERSION = 3
+const NEWS_INTERACTION_STORE = "pending-news-interactions"
+
+function setOnline(value: boolean) {
+  Object.defineProperty(navigator, "onLine", { configurable: true, value })
+}
+
+/** Flush the queued IDB async work (DB open + count) and the component re-render. */
+async function flushQueue() {
+  await act(async () => {
+    // Let the immediate checkQueue() promise chain (open → count) settle, then
+    // give React a tick to apply the resulting setPendingCount.
+    await Promise.resolve()
+    await new Promise((r) => setTimeout(r, 0))
+    await Promise.resolve()
+  })
+}
+
+/** Seed the news-interaction store so checkQueue counts > 0. */
+async function seedPendingInteractions(rows: number) {
+  await new Promise<void>((resolve, reject) => {
+    const request = indexedDB.open(CLICK_DB_NAME, CLICK_DB_VERSION)
+    request.onupgradeneeded = () => {
+      const database = request.result
+      if (!database.objectStoreNames.contains(NEWS_INTERACTION_STORE)) {
+        database.createObjectStore(NEWS_INTERACTION_STORE, { keyPath: "id", autoIncrement: true })
+      }
+    }
+    request.onsuccess = () => {
+      const db = request.result
+      if (rows === 0) {
+        db.close()
+        resolve()
+        return
+      }
+      const tx = db.transaction(NEWS_INTERACTION_STORE, "readwrite")
+      const store = tx.objectStore(NEWS_INTERACTION_STORE)
+      for (let i = 0; i < rows; i++) store.add({ payload: `pending-${i}` })
+      tx.oncomplete = () => {
+        db.close()
+        resolve()
+      }
+      tx.onerror = () => reject(tx.error)
+    }
+    request.onerror = () => reject(request.error)
+  })
+}
+
+async function deleteDb() {
+  await new Promise<void>((resolve) => {
+    const req = indexedDB.deleteDatabase(CLICK_DB_NAME)
+    req.onsuccess = () => resolve()
+    req.onerror = () => resolve()
+    req.onblocked = () => resolve()
+  })
+}
+
+describe("SyncStatus", () => {
+  beforeEach(() => {
+    setOnline(true)
+  })
+
+  afterEach(async () => {
+    // Restore real timers FIRST — fake-indexeddb drives its own async scheduler
+    // off real microtasks/timers, so deleteDb() would hang under fake timers.
+    vi.useRealTimers()
+    setOnline(true)
+    await deleteDb()
+  })
+
+  it("renders the online status badge when online (Cloud icon, no count)", async () => {
+    setOnline(true)
+    render(<SyncStatus />)
+    await flushQueue()
+
+    const status = screen.getByRole("status")
+    expect(status).toBeInTheDocument()
+    expect(status).toHaveAttribute("title", "common:sync.online")
+    // No pending count badge when the queue is empty.
+    expect(screen.queryByText("0")).not.toBeInTheDocument()
+  })
+
+  it("renders nothing when offline with an empty queue", async () => {
+    setOnline(false)
+    render(<SyncStatus />)
+    await flushQueue()
+
+    expect(screen.queryByRole("status")).not.toBeInTheDocument()
+  })
+
+  it("renders the offline badge with a pending count when offline + queued items", async () => {
+    await seedPendingInteractions(3)
+    setOnline(false)
+    render(<SyncStatus />)
+    await flushQueue()
+
+    const status = screen.getByRole("status")
+    expect(status).toBeInTheDocument()
+    expect(status).toHaveAttribute("title", "common:sync.offline")
+    expect(screen.getByText("3")).toBeInTheDocument()
+  })
+
+  it("renders the online badge with a pending count when online + queued items", async () => {
+    await seedPendingInteractions(2)
+    setOnline(true)
+    render(<SyncStatus />)
+    await flushQueue()
+
+    const status = screen.getByRole("status")
+    expect(status).toHaveAttribute("title", "common:sync.online")
+    expect(screen.getByText("2")).toBeInTheDocument()
+  })
+
+  it("re-evaluates the queue on the 3s interval and reflects newly-seeded items", async () => {
+    // Real timers: fake-indexeddb runs its async work off real microtasks/timers,
+    // which vi.advanceTimersByTimeAsync does not drive reliably.
+    setOnline(true)
+    render(<SyncStatus />)
+    await flushQueue()
+    // Initial empty queue → online badge, no count.
+    expect(screen.getByRole("status")).toHaveAttribute("title", "common:sync.online")
+    expect(screen.queryByText("1")).not.toBeInTheDocument()
+
+    // Seed an item, then wait past the 3s interval for the scheduled re-check.
+    await seedPendingInteractions(1)
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 3200))
+    })
+
+    expect(screen.getByText("1")).toBeInTheDocument()
+  }, 10000)
+
+  it("reacts to the window offline event (hides when the queue is empty)", async () => {
+    setOnline(true)
+    render(<SyncStatus />)
+    await flushQueue()
+    expect(screen.getByRole("status")).toBeInTheDocument()
+
+    await act(async () => {
+      setOnline(false)
+      window.dispatchEvent(new Event("offline"))
+      await Promise.resolve()
+    })
+
+    // Offline + empty queue → component returns null (exercises the offline
+    // listener wiring + the early-return branch via a runtime state transition).
+    expect(screen.queryByRole("status")).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/map/__tests__/MapBackdrop.test.tsx
+++ b/frontend/src/components/map/__tests__/MapBackdrop.test.tsx
@@ -1,0 +1,56 @@
+import { render } from "@testing-library/react"
+import { describe, it, expect } from "vitest"
+import { MapBackdrop } from "@/components/map/MapBackdrop"
+
+describe("MapBackdrop", () => {
+  it("renders the decorative aria-hidden container", () => {
+    const { container } = render(<MapBackdrop isNarrow={false} prefersReducedMotion={false} />)
+    const root = container.firstChild as HTMLElement
+    expect(root).not.toBeNull()
+    expect(root).toHaveAttribute("aria-hidden", "true")
+    expect(root.className).toContain("pointer-events-none")
+    expect(root.className).toContain("overflow-hidden")
+  })
+
+  it("renders all four orbs when wide and motion enabled", () => {
+    const { container } = render(<MapBackdrop isNarrow={false} prefersReducedMotion={false} />)
+    const root = container.firstChild as HTMLElement
+    // hero + highlight + conic + bottom = 4 child orb divs
+    expect(root.children).toHaveLength(4)
+  })
+
+  it("omits the highlight and conic orbs when narrow", () => {
+    const { container } = render(<MapBackdrop isNarrow={true} prefersReducedMotion={false} />)
+    const root = container.firstChild as HTMLElement
+    // hero + bottom only (highlight + conic both gated by !isNarrow)
+    expect(root.children).toHaveLength(2)
+  })
+
+  it("omits the drifting conic orb when reduced motion is preferred", () => {
+    const { container } = render(<MapBackdrop isNarrow={false} prefersReducedMotion={true} />)
+    const root = container.firstChild as HTMLElement
+    // hero + highlight + bottom = 3 (conic gated by !prefersReducedMotion)
+    expect(root.children).toHaveLength(3)
+    // no element should carry the orb-drift animation
+    const drifting = Array.from(root.children).find((el) =>
+      (el as HTMLElement).style.animation.includes("orb-drift")
+    )
+    expect(drifting).toBeUndefined()
+  })
+
+  it("applies the orb-drift animation to the conic orb only when wide + motion", () => {
+    const { container } = render(<MapBackdrop isNarrow={false} prefersReducedMotion={false} />)
+    const root = container.firstChild as HTMLElement
+    const drifting = Array.from(root.children).find((el) =>
+      (el as HTMLElement).style.animation.includes("orb-drift")
+    )
+    expect(drifting).toBeDefined()
+  })
+
+  it("renders nothing extra when narrow + reduced motion (minimal orbs)", () => {
+    const { container } = render(<MapBackdrop isNarrow={true} prefersReducedMotion={true} />)
+    const root = container.firstChild as HTMLElement
+    // only hero + bottom survive both gates
+    expect(root.children).toHaveLength(2)
+  })
+})

--- a/frontend/src/components/map/__tests__/MapLibreMap.test.tsx
+++ b/frontend/src/components/map/__tests__/MapLibreMap.test.tsx
@@ -1,0 +1,149 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import { describe, it, expect, vi } from "vitest"
+import type { MapRef } from "react-map-gl/maplibre"
+
+vi.mock("react-map-gl/maplibre", async () =>
+  (await import("@/tests/helpers/mapGlMock")).mapGlMock()
+)
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "en", resolvedLanguage: "en", changeLanguage: () => Promise.resolve() },
+  }),
+}))
+// Stub the heavy child components so this test isolates MapLibreMap's own logic
+// (rAF poll, cinematic intro, easeTo, sky-update). Their internals are covered
+// by their own tests.
+vi.mock("@/components/map/BuildingMarker", () => ({ BuildingMarker: () => null }))
+vi.mock("@/components/map/POIMarker", () => ({ POIMarker: () => null }))
+vi.mock("@/components/map/EventMarker", () => ({ EventMarker: () => null }))
+vi.mock("@/components/map/MapControls", () => ({ MapControls: () => null }))
+vi.mock("@/components/map/WeatherParticles", () => ({ WeatherParticles: () => null }))
+
+import { MapLibreMapComponent } from "@/components/map/MapLibreMap"
+
+type MockMap = {
+  loaded: ReturnType<typeof vi.fn>
+  resize: ReturnType<typeof vi.fn>
+  setSky: ReturnType<typeof vi.fn>
+  jumpTo: ReturnType<typeof vi.fn>
+  flyTo: ReturnType<typeof vi.fn>
+  getCenter: ReturnType<typeof vi.fn>
+  getZoom: ReturnType<typeof vi.fn>
+  getPitch: ReturnType<typeof vi.fn>
+  getBearing: ReturnType<typeof vi.fn>
+}
+
+function makeMap(): MockMap {
+  return {
+    loaded: vi.fn(() => true),
+    resize: vi.fn(),
+    setSky: vi.fn(),
+    jumpTo: vi.fn(),
+    flyTo: vi.fn(),
+    getCenter: vi.fn(() => ({ lat: 55.7, lng: 37.8 })),
+    getZoom: vi.fn(() => 16),
+    getPitch: vi.fn(() => 45),
+    getBearing: vi.fn(() => 0),
+  }
+}
+
+function makeRef(map: MockMap) {
+  return { current: { getMap: () => map, easeTo: vi.fn() } as unknown as MapRef }
+}
+
+const baseProps = {
+  selectedBuilding: null,
+  activeCategory: "all" as const,
+  highlightedBuilding: null,
+  onSelectBuilding: vi.fn(),
+  onDeselectBuilding: vi.fn(),
+}
+
+describe("MapLibreMap", () => {
+  it("renders the map application container with the a11y keyboard hint", () => {
+    render(<MapLibreMapComponent {...baseProps} mapRef={makeRef(makeMap())} />)
+    expect(screen.getByRole("application", { name: "a11y.mapContainer" })).toBeInTheDocument()
+    expect(screen.getByText("a11y.mapKeyboardHint")).toBeInTheDocument()
+  })
+
+  it("on map-ready resizes, sets the sky, and runs the cinematic flyTo intro", async () => {
+    const map = makeMap()
+    render(<MapLibreMapComponent {...baseProps} mapRef={makeRef(map)} isDark={false} />)
+    await waitFor(() => expect(map.resize).toHaveBeenCalled())
+    expect(map.setSky).toHaveBeenCalled()
+    await waitFor(() => expect(map.flyTo).toHaveBeenCalled(), { timeout: 1500 })
+  })
+
+  it("jumps straight to a restored URL viewport instead of the intro", async () => {
+    const map = makeMap()
+    render(
+      <MapLibreMapComponent
+        {...baseProps}
+        mapRef={makeRef(map)}
+        urlInitialViewport={{ longitude: 37.8, latitude: 55.7, zoom: 17, pitch: 30, bearing: 90 }}
+      />
+    )
+    await waitFor(() =>
+      expect(map.jumpTo).toHaveBeenCalledWith(
+        expect.objectContaining({ zoom: 17, pitch: 30, bearing: 90 })
+      )
+    )
+    expect(map.flyTo).not.toHaveBeenCalled()
+  })
+
+  it("jumps (no animation) when the user prefers reduced motion", async () => {
+    const map = makeMap()
+    // Scoped spy + mockRestore — restoreAllMocks would wipe the global
+    // setupTests matchMedia vi.fn() implementation for later tests.
+    const mm = vi.spyOn(window, "matchMedia").mockReturnValue({
+      matches: true,
+      media: "(prefers-reduced-motion: reduce)",
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    } as unknown as MediaQueryList)
+    try {
+      render(<MapLibreMapComponent {...baseProps} mapRef={makeRef(map)} />)
+      await waitFor(() => expect(map.jumpTo).toHaveBeenCalled())
+      expect(map.flyTo).not.toHaveBeenCalled()
+    } finally {
+      mm.mockRestore()
+    }
+  })
+
+  it("eases to the selected building when one is chosen", async () => {
+    const map = makeMap()
+    const ref = makeRef(map)
+    const easeTo = (ref.current as unknown as { easeTo: ReturnType<typeof vi.fn> }).easeTo
+    render(<MapLibreMapComponent {...baseProps} mapRef={ref} selectedBuilding="ГУК" />)
+    await waitFor(() =>
+      expect(easeTo).toHaveBeenCalledWith(expect.objectContaining({ duration: 600 }))
+    )
+  })
+
+  it("re-applies the sky on theme change", async () => {
+    const map = makeMap()
+    const ref = makeRef(map)
+    const { rerender } = render(<MapLibreMapComponent {...baseProps} mapRef={ref} isDark={false} />)
+    await waitFor(() => expect(map.setSky).toHaveBeenCalled())
+    map.setSky.mockClear()
+    rerender(<MapLibreMapComponent {...baseProps} mapRef={ref} isDark={true} />)
+    await waitFor(() => expect(map.setSky).toHaveBeenCalled())
+  })
+
+  it("filters building markers by the active category without crashing", () => {
+    render(
+      <MapLibreMapComponent
+        {...baseProps}
+        mapRef={makeRef(makeMap())}
+        activeCategory={"study" as typeof baseProps.activeCategory}
+        mapEvents={[{ id: "e1", buildingId: "ГУК" } as never]}
+      />
+    )
+    expect(screen.getByRole("application")).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/map/__tests__/MapSidebar.branches.test.tsx
+++ b/frontend/src/components/map/__tests__/MapSidebar.branches.test.tsx
@@ -1,0 +1,150 @@
+import { render, screen, act } from "@testing-library/react"
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) =>
+      opts && Object.keys(opts).length ? `${key}:${JSON.stringify(opts)}` : key,
+    i18n: { language: "en", changeLanguage: () => Promise.resolve() },
+  }),
+}))
+vi.mock("@/contexts/AppShellContext", () => ({
+  useAppShell: () => ({ setOverlayState: vi.fn() }),
+}))
+
+const hooks = vi.hoisted(() => ({
+  open: true,
+  roomStatus: null as { status: "free" | "busy"; busyUntil?: string } | null,
+}))
+
+vi.mock("@/utils/buildingHours", () => ({
+  isOpenNow: () => hooks.open,
+}))
+vi.mock("@/utils/roomStatus", () => ({
+  getRoomStatus: () => hooks.roomStatus,
+}))
+
+import { MapSidebar } from "@/components/map/MapSidebar"
+import type { CampusBuilding, BuildingFloor } from "@/data/campusBuildings"
+
+const FLOOR_1: BuildingFloor = {
+  floor: 1,
+  rooms: [
+    { id: "ГУК-101", number: "101", type: "lecture", capacity: 120, name: "Большая аудитория" },
+  ],
+}
+const FLOOR_2: BuildingFloor = {
+  floor: 2,
+  rooms: [{ id: "ГУК-201", number: "201", type: "seminar" }],
+}
+
+const BUILDING: CampusBuilding = {
+  letter: "ГУК",
+  structureId: "стр. 8",
+  name: "Главный учебный корпус",
+  description: "Главное здание университета.",
+  address: "Рязанский проспект, 99",
+  hours: { weekday: "08:00–22:00", saturday: "09:00–20:00", sunday: "Закрыто" },
+  amenities: ["Wi-Fi", "Буфет"],
+  tags: ["study"],
+  colorVar: "var(--color-blue-500)",
+  colorHex: "#3b82f6",
+  floorCount: 2,
+  floors: [FLOOR_1, FLOOR_2],
+  geoCoords: [55.71, 37.81],
+}
+
+const baseProps = {
+  building: BUILDING,
+  floor: FLOOR_1,
+  selectedFloor: 1,
+  selectedRoom: null,
+  onFloorChange: vi.fn(),
+  onRoomClick: vi.fn(),
+  onClose: vi.fn(),
+  isMobile: false,
+}
+
+describe("MapSidebar branches", () => {
+  beforeEach(() => {
+    hooks.open = true
+    hooks.roomStatus = null
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.runOnlyPendingTimers()
+    vi.useRealTimers()
+    vi.clearAllMocks()
+  })
+
+  it("renders the mobile bottom sheet branch (role=dialog, drag handle, sheetReady timer)", () => {
+    render(<MapSidebar {...baseProps} isMobile />)
+    const dialog = screen.getByRole("dialog")
+    expect(dialog).toHaveAttribute("aria-modal", "true")
+    expect(dialog).toHaveAttribute("aria-label", "Главный учебный корпус")
+    expect(screen.getByLabelText("sidebar.dragToResize")).toBeInTheDocument()
+    // No desktop close button in the mobile branch
+    expect(screen.queryByRole("button", { name: "sidebar.close" })).not.toBeInTheDocument()
+    // Advance past the 260ms sheetReady entrance timer (overflow-hidden → overflow-y-auto)
+    act(() => {
+      vi.advanceTimersByTime(300)
+    })
+  })
+
+  it("renders the amenities section when building.amenities is non-empty", () => {
+    render(<MapSidebar {...baseProps} />)
+    expect(screen.getByText("sidebar.amenities")).toBeInTheDocument()
+    expect(screen.getByText("Wi-Fi")).toBeInTheDocument()
+    expect(screen.getByText("Буфет")).toBeInTheDocument()
+  })
+
+  it("omits the amenities section when building.amenities is empty", () => {
+    render(<MapSidebar {...baseProps} building={{ ...BUILDING, amenities: [] }} />)
+    expect(screen.queryByText("sidebar.amenities")).not.toBeInTheDocument()
+  })
+
+  it("renders the selected-room detail panel with type and capacity", () => {
+    render(<MapSidebar {...baseProps} selectedRoom="ГУК-101" />)
+    // roomTypes.<type> label rendered from the detail panel
+    expect(screen.getByText("roomTypes.lecture")).toBeInTheDocument()
+    // capacity value (120) shown alongside Users icon
+    expect(screen.getByText("120")).toBeInTheDocument()
+    // room name appears in both the list item and the detail panel
+    expect(screen.getAllByText("Большая аудитория").length).toBeGreaterThan(0)
+  })
+
+  it("renders a free room-status badge when getRoomStatus returns free", () => {
+    hooks.roomStatus = { status: "free" }
+    render(<MapSidebar {...baseProps} todayLessons={[{ room: "101", start_time: "10:00" }]} />)
+    expect(screen.getByText("sidebar.roomFree")).toBeInTheDocument()
+  })
+
+  it("renders a busy room-status badge with interpolated time when getRoomStatus returns busy", () => {
+    hooks.roomStatus = { status: "busy", busyUntil: "11:30" }
+    render(<MapSidebar {...baseProps} todayLessons={[{ room: "101", start_time: "10:00" }]} />)
+    expect(screen.getByText(/sidebar\.roomBusy/)).toBeInTheDocument()
+  })
+
+  it("renders the building photo as an img when building.photo is present", () => {
+    render(<MapSidebar {...baseProps} building={{ ...BUILDING, photo: "https://x/photo.jpg" }} />)
+    const img = screen.getByRole("img", { name: "Главный учебный корпус" })
+    expect(img).toHaveAttribute("src", "https://x/photo.jpg")
+  })
+
+  it("renders the gradient placeholder (no img) when building.photo is absent", () => {
+    render(<MapSidebar {...baseProps} />)
+    expect(screen.queryByRole("img", { name: "Главный учебный корпус" })).not.toBeInTheDocument()
+  })
+
+  it("renders the open-now hours badge when isOpenNow is true", () => {
+    hooks.open = true
+    render(<MapSidebar {...baseProps} />)
+    expect(screen.getByText("hours.openNow")).toBeInTheDocument()
+  })
+
+  it("renders the closed-now hours badge when isOpenNow is false", () => {
+    hooks.open = false
+    render(<MapSidebar {...baseProps} />)
+    expect(screen.getByText("hours.closedNow")).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/map/__tests__/WeatherParticles.test.tsx
+++ b/frontend/src/components/map/__tests__/WeatherParticles.test.tsx
@@ -1,0 +1,98 @@
+import { render } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const hoisted = vi.hoisted(() => ({ reducedMotion: false }))
+
+vi.mock("@/hooks/useMediaQuery", () => ({ default: () => hoisted.reducedMotion }))
+
+import { WeatherParticles } from "@/components/map/WeatherParticles"
+
+const DRAWING_CONDITIONS = ["rain", "snow", "storm", "fog"] as const
+
+describe("WeatherParticles", () => {
+  beforeEach(() => {
+    hoisted.reducedMotion = false
+    let n = 0
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((cb) => {
+      if (n++ < 2) {
+        cb(16)
+      }
+      return 1
+    })
+    vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("renders null for the clear condition", () => {
+    const { container } = render(<WeatherParticles condition="clear" isDark={false} />)
+    expect(container.querySelector("canvas")).toBeNull()
+  })
+
+  it("renders null for the cloudy condition", () => {
+    const { container } = render(<WeatherParticles condition="cloudy" isDark={false} />)
+    expect(container.querySelector("canvas")).toBeNull()
+  })
+
+  it("renders null when prefers-reduced-motion is enabled", () => {
+    hoisted.reducedMotion = true
+    const { container } = render(<WeatherParticles condition="rain" isDark={false} />)
+    expect(container.querySelector("canvas")).toBeNull()
+  })
+
+  it.each(DRAWING_CONDITIONS)("draws a canvas for the %s condition (light)", (condition) => {
+    const { container } = render(<WeatherParticles condition={condition} isDark={false} />)
+    expect(container.querySelector("canvas")).not.toBeNull()
+    const wrapper = container.querySelector("[aria-hidden='true']")
+    expect(wrapper).not.toBeNull()
+  })
+
+  it.each(DRAWING_CONDITIONS)("draws a canvas for the %s condition (dark)", (condition) => {
+    const { container } = render(<WeatherParticles condition={condition} isDark={true} />)
+    expect(container.querySelector("canvas")).not.toBeNull()
+  })
+
+  it("exercises the particle-recycle branches when particles fall out of bounds", () => {
+    // Force particles to spawn near the bottom edge so the y-update pushes them
+    // out of bounds, hitting recycleParticle (rain/snow/storm) and the fog
+    // horizontal-recycle branch on the second animation frame.
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0.999)
+    try {
+      for (const condition of DRAWING_CONDITIONS) {
+        const { container } = render(<WeatherParticles condition={condition} isDark={false} />)
+        expect(container.querySelector("canvas")).not.toBeNull()
+      }
+    } finally {
+      randomSpy.mockRestore()
+    }
+  })
+
+  it("walks the storm flash scheduling branch", () => {
+    // Low Math.random pushes the flash schedule toward its minimum window; this
+    // still walks the storm flash scheduling + fade arithmetic.
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0.001)
+    try {
+      const { container } = render(<WeatherParticles condition="storm" isDark={true} />)
+      expect(container.querySelector("canvas")).not.toBeNull()
+    } finally {
+      randomSpy.mockRestore()
+    }
+  })
+
+  it("cleans up on unmount without throwing", () => {
+    const { container, unmount } = render(<WeatherParticles condition="rain" isDark={false} />)
+    expect(container.querySelector("canvas")).not.toBeNull()
+    expect(() => unmount()).not.toThrow()
+  })
+
+  it("re-runs the effect when the condition prop changes", () => {
+    const { container, rerender } = render(<WeatherParticles condition="rain" isDark={false} />)
+    expect(container.querySelector("canvas")).not.toBeNull()
+    rerender(<WeatherParticles condition="snow" isDark={false} />)
+    expect(container.querySelector("canvas")).not.toBeNull()
+    rerender(<WeatherParticles condition="clear" isDark={false} />)
+    expect(container.querySelector("canvas")).toBeNull()
+  })
+})

--- a/frontend/src/components/messenger/ChatWindow.branches.test.tsx
+++ b/frontend/src/components/messenger/ChatWindow.branches.test.tsx
@@ -1,0 +1,420 @@
+import { render, screen, fireEvent, act } from "@testing-library/react"
+import { describe, it, expect, vi, afterEach } from "vitest"
+import type { ReactNode } from "react"
+
+import { ChatWindow } from "@/components/messenger/ChatWindow"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import type { Message } from "@/components/messenger/types"
+
+/**
+ * Sibling branch-coverage test for ChatWindow (do NOT touch ChatWindow.test.tsx).
+ *
+ * The existing test covers loading/error/search-empty/no-messages-yet, the
+ * edit/delete/tombstone/inline-editor, reactions pills + picker, seen marker,
+ * and date dividers + sender grouping. This file fills the remaining uncovered
+ * branches of the normal-bubble render path:
+ *  - reply affordance (onStartReply) on ALL bubbles
+ *  - forward affordance (onForward) on ALL bubbles
+ *  - "Forwarded from X" chip (W211)
+ *  - reply/quote chip — "You" vs sender name + deleted-original placeholder (W207)
+ *  - attachments — image (with/without sanitizable url) + file types (W205)
+ *  - jump-to-bottom FAB + scroll handler (W208 SW4)
+ *  - reactions picker outside-click / Escape close (W206)
+ *
+ * Mocks mirror ChatWindow.test.tsx exactly so the i18n key echoes line up.
+ */
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) =>
+      opts ? `${key}|${JSON.stringify(opts)}` : key,
+  }),
+}))
+
+vi.mock("@/components/media/SmartImage", () => ({
+  default: ({ alt, className }: { alt?: string; className?: string }) => (
+    <img alt={alt} className={className} />
+  ),
+}))
+
+// Pass-through debounce so search filtering applies immediately (no fake timers).
+vi.mock("@/hooks/useDebounced", () => ({
+  useDebounced: <T,>(value: T) => value,
+}))
+
+// Render all rows: jsdom has scrollHeight=0 so the real virtualizer yields no
+// rows → message bubbles never mount. The mock renders one row per message.
+vi.mock("@tanstack/react-virtual", () => ({
+  useVirtualizer: ({ count }: { count: number }) => ({
+    getVirtualItems: () =>
+      Array.from({ length: count }, (_, idx) => ({
+        key: idx,
+        index: idx,
+        start: idx * 80,
+        end: (idx + 1) * 80,
+        size: 80,
+        lane: 0,
+      })),
+    getTotalSize: () => count * 80,
+    measureElement: () => {},
+    scrollToIndex: () => {},
+  }),
+}))
+
+const queryClient = new QueryClient()
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+)
+
+const makeMessage = (overrides: Partial<Message> & Pick<Message, "id" | "text">): Message => ({
+  senderId: "user-1",
+  senderName: "Alice",
+  senderAvatar: "",
+  timestamp: "12:00",
+  isMe: false,
+  ...overrides,
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe("ChatWindow — reply / forward affordances (all bubbles)", () => {
+  it("renders the reply affordance and fires onStartReply(id) for a received message", () => {
+    const onStartReply = vi.fn()
+    render(
+      <ChatWindow
+        messages={[makeMessage({ id: "r1", text: "theirs", isMe: false })]}
+        onStartReply={onStartReply}
+      />,
+      { wrapper }
+    )
+    const btn = screen.getByRole("button", { name: "messenger:reply" })
+    fireEvent.click(btn)
+    expect(onStartReply).toHaveBeenCalledWith("r1")
+  })
+
+  it("renders the forward affordance and fires onForward(id) for a received message", () => {
+    const onForward = vi.fn()
+    render(
+      <ChatWindow
+        messages={[makeMessage({ id: "f1", text: "theirs", isMe: false })]}
+        onForward={onForward}
+      />,
+      { wrapper }
+    )
+    const btn = screen.getByRole("button", { name: "messenger:forward" })
+    fireEvent.click(btn)
+    expect(onForward).toHaveBeenCalledWith("f1")
+  })
+
+  it("renders reply + forward + edit + delete together on an own message", () => {
+    render(
+      <ChatWindow
+        messages={[makeMessage({ id: "o1", text: "mine", isMe: true })]}
+        onStartReply={() => {}}
+        onForward={() => {}}
+      />,
+      { wrapper }
+    )
+    expect(screen.getByRole("button", { name: "messenger:reply" })).toBeTruthy()
+    expect(screen.getByRole("button", { name: "messenger:forward" })).toBeTruthy()
+    expect(screen.getByRole("button", { name: "messenger:editMessage" })).toBeTruthy()
+    expect(screen.getByRole("button", { name: "messenger:deleteMessage" })).toBeTruthy()
+  })
+
+  it("renders the empty placeholder span when no affordance applies (received, no handlers)", () => {
+    render(<ChatWindow messages={[makeMessage({ id: "p1", text: "theirs", isMe: false })]} />, {
+      wrapper,
+    })
+    // No reply/forward/edit/delete buttons → falls into the <span aria-hidden> branch.
+    expect(screen.queryByRole("button", { name: "messenger:reply" })).toBeFalsy()
+    expect(screen.queryByRole("button", { name: "messenger:forward" })).toBeFalsy()
+    expect(screen.queryByRole("button", { name: "messenger:editMessage" })).toBeFalsy()
+  })
+})
+
+describe("ChatWindow — forwarded-from chip (W211)", () => {
+  it("renders the 'Forwarded from {name}' chip when forwardedFromName is set", () => {
+    render(
+      <ChatWindow
+        messages={[makeMessage({ id: "fw1", text: "passed along", forwardedFromName: "Анна" })]}
+      />,
+      { wrapper }
+    )
+    expect(screen.getByText('messenger:forwardedFrom|{"name":"Анна"}')).toBeTruthy()
+  })
+
+  it("does NOT render the forwarded chip when forwardedFromName is absent", () => {
+    render(<ChatWindow messages={[makeMessage({ id: "fw2", text: "normal" })]} />, { wrapper })
+    expect(screen.queryByText(/^messenger:forwardedFrom/)).toBeFalsy()
+  })
+})
+
+describe("ChatWindow — reply/quote chip (W207)", () => {
+  it("renders the quoted preview with sender name + snippet for a non-mine quote", () => {
+    render(
+      <ChatWindow
+        messages={[
+          makeMessage({
+            id: "q1",
+            text: "answer",
+            replyTo: {
+              id: "src",
+              senderName: "Bob",
+              isMe: false,
+              text: "original question",
+              deletedAt: null,
+            },
+          }),
+        ]}
+      />,
+      { wrapper }
+    )
+    expect(screen.getByText("Bob")).toBeTruthy()
+    expect(screen.getByText("original question")).toBeTruthy()
+  })
+
+  it("renders 'You' as the author when the quoted message isMe", () => {
+    render(
+      <ChatWindow
+        messages={[
+          makeMessage({
+            id: "q2",
+            text: "reply to my own",
+            replyTo: { id: "src", senderName: "Me", isMe: true, text: "self", deletedAt: null },
+          }),
+        ]}
+      />,
+      { wrapper }
+    )
+    expect(screen.getByText("messenger:replyTo.you")).toBeTruthy()
+  })
+
+  it("renders the unknown-sender label when the quote senderName is null", () => {
+    render(
+      <ChatWindow
+        messages={[
+          makeMessage({
+            id: "q3",
+            text: "reply",
+            replyTo: { id: "src", senderName: null, isMe: false, text: "anon", deletedAt: null },
+          }),
+        ]}
+      />,
+      { wrapper }
+    )
+    expect(screen.getByText("messenger:replyTo.unknownSender")).toBeTruthy()
+  })
+
+  it("renders the 'original deleted' placeholder when the quoted message was soft-deleted", () => {
+    render(
+      <ChatWindow
+        messages={[
+          makeMessage({
+            id: "q4",
+            text: "reply",
+            replyTo: {
+              id: "src",
+              senderName: "Bob",
+              isMe: false,
+              text: "gone text",
+              deletedAt: "2026-05-31T10:00:00+00:00",
+            },
+          }),
+        ]}
+      />,
+      { wrapper }
+    )
+    expect(screen.getByText("messenger:replyTo.deletedOriginal")).toBeTruthy()
+    expect(screen.queryByText("gone text")).toBeFalsy()
+  })
+})
+
+describe("ChatWindow — attachments (W205)", () => {
+  it("renders an image attachment (sanitizable url) as an <img>", () => {
+    render(
+      <ChatWindow
+        messages={[
+          makeMessage({
+            id: "a1",
+            text: "photo",
+            attachments: [
+              {
+                id: "att-1",
+                url: "https://example.com/pic.png",
+                type: "image",
+                name: "pic.png",
+                size: 2048,
+              },
+            ],
+          }),
+        ]}
+      />,
+      { wrapper }
+    )
+    expect(screen.getByAltText("pic.png")).toBeTruthy()
+  })
+
+  it("renders a file attachment as a link with name + size", () => {
+    render(
+      <ChatWindow
+        messages={[
+          makeMessage({
+            id: "a2",
+            text: "doc",
+            attachments: [
+              {
+                id: "att-2",
+                url: "https://example.com/report.pdf",
+                type: "file",
+                name: "report.pdf",
+                size: 4096,
+              },
+            ],
+          }),
+        ]}
+      />,
+      { wrapper }
+    )
+    const link = screen.getByRole("link", { name: /report\.pdf/ })
+    expect(link.getAttribute("href")).toBe("https://example.com/report.pdf")
+    // size rendered as KB → 4096 / 1024 = 4.0
+    expect(screen.getByText("4.0 KB")).toBeTruthy()
+  })
+
+  it("renders an image attachment with a non-sanitizable url as null (no img)", () => {
+    render(
+      <ChatWindow
+        messages={[
+          makeMessage({
+            id: "a3",
+            text: "bad",
+            attachments: [
+              {
+                id: "att-3",
+                url: "javascript:alert(1)",
+                type: "image",
+                name: "evil.png",
+                size: 1024,
+              },
+            ],
+          }),
+        ]}
+      />,
+      { wrapper }
+    )
+    expect(screen.queryByAltText("evil.png")).toBeFalsy()
+  })
+})
+
+describe("ChatWindow — jump-to-bottom FAB (W208 SW4)", () => {
+  it("shows the FAB after scrolling up past the threshold, hides it after scrolling back", () => {
+    const { container } = render(
+      <ChatWindow messages={[makeMessage({ id: "j1", text: "msg" })]} />,
+      { wrapper }
+    )
+    const log = container.querySelector('[role="log"]') as HTMLDivElement
+    expect(log).toBeTruthy()
+
+    // Stub scroll metrics so distanceFromBottom > SCROLL_FAB_THRESHOLD (240).
+    Object.defineProperty(log, "scrollHeight", { value: 1000, configurable: true })
+    Object.defineProperty(log, "clientHeight", { value: 300, configurable: true })
+    Object.defineProperty(log, "scrollTop", { value: 100, configurable: true })
+    // distanceFromBottom = 1000 - 100 - 300 = 600 > 240 → FAB visible.
+    act(() => {
+      fireEvent.scroll(log)
+    })
+    expect(screen.getByRole("button", { name: "messenger:aria.jumpToLatest" })).toBeTruthy()
+
+    // Scroll back to bottom → distanceFromBottom = 1000 - 700 - 300 = 0 → hide.
+    Object.defineProperty(log, "scrollTop", { value: 700, configurable: true })
+    act(() => {
+      fireEvent.scroll(log)
+    })
+    expect(screen.queryByRole("button", { name: "messenger:aria.jumpToLatest" })).toBeFalsy()
+  })
+
+  it("clicking the FAB does not throw (scrollToIndex mocked)", () => {
+    const { container } = render(
+      <ChatWindow messages={[makeMessage({ id: "j2", text: "msg" })]} />,
+      { wrapper }
+    )
+    const log = container.querySelector('[role="log"]') as HTMLDivElement
+    Object.defineProperty(log, "scrollHeight", { value: 1000, configurable: true })
+    Object.defineProperty(log, "clientHeight", { value: 300, configurable: true })
+    Object.defineProperty(log, "scrollTop", { value: 100, configurable: true })
+    act(() => {
+      fireEvent.scroll(log)
+    })
+    const fab = screen.getByRole("button", { name: "messenger:aria.jumpToLatest" })
+    expect(() => fireEvent.click(fab)).not.toThrow()
+  })
+})
+
+describe("ChatWindow — reactions picker outside-click / Escape close (W206)", () => {
+  it("closes the open picker on an outside mousedown", () => {
+    render(
+      <ChatWindow
+        messages={[makeMessage({ id: "rx1", text: "react", reactions: [] })]}
+        onToggleReaction={() => {}}
+      />,
+      { wrapper }
+    )
+    const pickerEmoji = 'messenger:reactions.react|{"emoji":"👍"}'
+    expect(screen.queryByRole("button", { name: pickerEmoji })).toBeFalsy()
+    fireEvent.click(screen.getByRole("button", { name: "messenger:reactions.add" }))
+    expect(screen.getByRole("button", { name: pickerEmoji })).toBeTruthy()
+    // outside mousedown closes
+    fireEvent.mouseDown(document.body)
+    expect(screen.queryByRole("button", { name: pickerEmoji })).toBeFalsy()
+  })
+
+  it("closes the open picker on Escape", () => {
+    render(
+      <ChatWindow
+        messages={[makeMessage({ id: "rx2", text: "react", reactions: [] })]}
+        onToggleReaction={() => {}}
+      />,
+      { wrapper }
+    )
+    const pickerEmoji = 'messenger:reactions.react|{"emoji":"👍"}'
+    fireEvent.click(screen.getByRole("button", { name: "messenger:reactions.add" }))
+    expect(screen.getByRole("button", { name: pickerEmoji })).toBeTruthy()
+    fireEvent.keyDown(document, { key: "Escape" })
+    expect(screen.queryByRole("button", { name: pickerEmoji })).toBeFalsy()
+  })
+
+  it("keeps the picker open on an inside (data-reaction-ui) mousedown", () => {
+    render(
+      <ChatWindow
+        messages={[makeMessage({ id: "rx3", text: "react", reactions: [] })]}
+        onToggleReaction={() => {}}
+      />,
+      { wrapper }
+    )
+    const pickerEmoji = 'messenger:reactions.react|{"emoji":"👍"}'
+    fireEvent.click(screen.getByRole("button", { name: "messenger:reactions.add" }))
+    const insideBtn = screen.getByRole("button", { name: pickerEmoji })
+    // mousedown on a [data-reaction-ui] element is exempt → picker stays open
+    fireEvent.mouseDown(insideBtn)
+    expect(screen.getByRole("button", { name: pickerEmoji })).toBeTruthy()
+  })
+
+  it("toggles the picker closed when +react is clicked twice", () => {
+    render(
+      <ChatWindow
+        messages={[makeMessage({ id: "rx4", text: "react", reactions: [] })]}
+        onToggleReaction={() => {}}
+      />,
+      { wrapper }
+    )
+    const pickerEmoji = 'messenger:reactions.react|{"emoji":"👍"}'
+    const addBtn = screen.getByRole("button", { name: "messenger:reactions.add" })
+    fireEvent.click(addBtn)
+    expect(screen.getByRole("button", { name: pickerEmoji })).toBeTruthy()
+    fireEvent.click(addBtn)
+    expect(screen.queryByRole("button", { name: pickerEmoji })).toBeFalsy()
+  })
+})

--- a/frontend/src/components/motion/__tests__/PageTransition.test.tsx
+++ b/frontend/src/components/motion/__tests__/PageTransition.test.tsx
@@ -1,0 +1,122 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+// The animated branch only commits after the async `import("framer-motion")` →
+// setState chain resolves. waitFor polls inside act(), absorbing the
+// module-level motionModulePromise cache timing variance across tests.
+const WILL_CHANGE = ".will-change-\\[transform\\,opacity\\,filter\\]"
+
+const expectAnimatedChild = async (text: string) =>
+  waitFor(() => {
+    const node = screen.getByText(text)
+    // animated branch (LazyMotion + m.div) attaches the will-change wrapper;
+    // the reduced-motion fallback does not — so this asserts the animated commit
+    expect(node.closest(WILL_CHANGE)).toBeInTheDocument()
+    return node
+  })
+
+vi.mock("framer-motion", async () =>
+  (await import("@/tests/helpers/framerMotionMock")).framerMotionMock()
+)
+
+import PageTransition from "@/components/motion/PageTransition"
+
+const setReduceMotion = (matches: boolean) => {
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+}
+
+describe("PageTransition", () => {
+  beforeEach(() => {
+    setReduceMotion(false)
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("renders the reduced-motion fallback wrapper (no framer-motion)", () => {
+    setReduceMotion(true)
+    const { container } = render(
+      <PageTransition>
+        <div>Hello reduced</div>
+      </PageTransition>
+    )
+    expect(screen.getByText("Hello reduced")).toBeInTheDocument()
+    // simple fallback wrapper carries the bg-page class
+    expect(container.querySelector(".bg-page")).toBeInTheDocument()
+  })
+
+  it("renders children through the animated framer-motion path", async () => {
+    render(
+      <PageTransition>
+        <div>Hello animated</div>
+      </PageTransition>
+    )
+    // motion module loads asynchronously via useEffect — poll until it commits
+    await expectAnimatedChild("Hello animated")
+    expect(screen.getByText("Hello animated")).toBeInTheDocument()
+  })
+
+  it("keeps children visible after the painted->animated transition", async () => {
+    // first render flips the module-level didPaint flag + loads motion module
+    const first = render(
+      <PageTransition>
+        <div>First paint child</div>
+      </PageTransition>
+    )
+    await expectAnimatedChild("First paint child")
+    first.unmount()
+
+    // a subsequent independent render now starts with didPaint=true (hasPainted),
+    // exercising the `initial = { opacity: 0, ... }` branch instead of `false`
+    render(
+      <PageTransition>
+        <div>Second paint child</div>
+      </PageTransition>
+    )
+    await expectAnimatedChild("Second paint child")
+    expect(screen.getByText("Second paint child")).toBeInTheDocument()
+  })
+
+  it("responds to a reduced-motion preference change after mount", async () => {
+    let changeHandler: ((event: MediaQueryListEvent) => void) | null = null
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn((_evt: string, handler: (event: MediaQueryListEvent) => void) => {
+          changeHandler = handler
+        }),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    })
+
+    render(
+      <PageTransition>
+        <div>Toggle child</div>
+      </PageTransition>
+    )
+    await expectAnimatedChild("Toggle child")
+    // the media-change listener was registered (covers the addEventListener branch)
+    expect(changeHandler).toBeTypeOf("function")
+  })
+})

--- a/frontend/src/components/profile/__tests__/ProfileEditor.test.tsx
+++ b/frontend/src/components/profile/__tests__/ProfileEditor.test.tsx
@@ -1,0 +1,126 @@
+import { render, screen, fireEvent } from "@testing-library/react"
+import { describe, it, expect, vi } from "vitest"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "en", changeLanguage: () => Promise.resolve() },
+  }),
+}))
+
+import { ProfileEditor } from "@/components/profile/ProfileEditor"
+import type { User } from "@/types/User"
+
+function makeProps(overrides: Record<string, unknown> = {}) {
+  return {
+    user: null as User | null,
+    fullName: "Ada Lovelace",
+    setFullName: vi.fn(),
+    email: "ada@example.com",
+    setEmail: vi.fn(),
+    telegram: "@ada",
+    setTelegram: vi.fn(),
+    about: "about",
+    setAbout: vi.fn(),
+    recordBookNumber: "123",
+    setRecordBookNumber: vi.fn(),
+    status: "active",
+    setStatus: vi.fn(),
+    institute: "ITM",
+    setInstitute: vi.fn(),
+    course: "2",
+    setCourse: vi.fn(),
+    educationLevel: "bachelor",
+    setEducationLevel: vi.fn(),
+    track: "track",
+    setTrack: vi.fn(),
+    program: "program",
+    setProgram: vi.fn(),
+    achievements: "achievements",
+    setAchievements: vi.fn(),
+    department: "CS",
+    setDepartment: vi.fn(),
+    position: "prof",
+    setPosition: vi.fn(),
+    saving: false,
+    onSave: vi.fn(),
+    onCancel: vi.fn(),
+    ...overrides,
+  }
+}
+
+const teacher = { role: "teacher" } as unknown as User
+const student = { role: "student" } as unknown as User
+
+describe("ProfileEditor", () => {
+  it("renders base fields and action buttons with no user role", () => {
+    render(<ProfileEditor {...makeProps()} />)
+    expect(screen.getByText("profile:form.name")).toBeInTheDocument()
+    expect(screen.getByText("profile:form.email")).toBeInTheDocument()
+    expect(screen.getByText("profile:form.telegram")).toBeInTheDocument()
+    expect(screen.getByText("profile:form.save")).toBeInTheDocument()
+    expect(screen.getByText("profile:form.cancel")).toBeInTheDocument()
+    // role-specific fields hidden when no user
+    expect(screen.queryByText("profile:form.department")).not.toBeInTheDocument()
+    expect(screen.queryByText("profile:form.about")).not.toBeInTheDocument()
+    // 3 base textboxes (name, email, telegram)
+    expect(screen.getAllByRole("textbox")).toHaveLength(3)
+  })
+
+  it("fires the base-field setters and the action callbacks", () => {
+    const props = makeProps()
+    render(<ProfileEditor {...props} />)
+    const boxes = screen.getAllByRole("textbox")
+    fireEvent.change(boxes[0]!, { target: { value: "Grace" } })
+    fireEvent.change(boxes[1]!, { target: { value: "grace@example.com" } })
+    fireEvent.change(boxes[2]!, { target: { value: "@grace" } })
+    expect(props.setFullName).toHaveBeenCalledWith("Grace")
+    expect(props.setEmail).toHaveBeenCalledWith("grace@example.com")
+    expect(props.setTelegram).toHaveBeenCalledWith("@grace")
+    fireEvent.click(screen.getByText("profile:form.save"))
+    fireEvent.click(screen.getByText("profile:form.cancel"))
+    expect(props.onSave).toHaveBeenCalledOnce()
+    expect(props.onCancel).toHaveBeenCalledOnce()
+  })
+
+  it("renders teacher fields and wires their setters", () => {
+    const props = makeProps({ user: teacher })
+    render(<ProfileEditor {...props} />)
+    expect(screen.getByText("profile:form.department")).toBeInTheDocument()
+    expect(screen.getByText("profile:form.position")).toBeInTheDocument()
+    const boxes = screen.getAllByRole("textbox")
+    boxes.forEach((box, i) => fireEvent.change(box, { target: { value: `v${i}` } }))
+    expect(props.setDepartment).toHaveBeenCalled()
+    expect(props.setPosition).toHaveBeenCalled()
+  })
+
+  it("renders the full student field set and wires every setter", () => {
+    const props = makeProps({ user: student })
+    render(<ProfileEditor {...props} />)
+    for (const key of [
+      "profile:form.about",
+      "profile:form.recordBookNumber",
+      "profile:form.status",
+      "profile:form.institute",
+      "profile:form.course",
+      "profile:form.educationLevel",
+      "profile:form.track",
+      "profile:form.program",
+      "profile:form.achievements",
+    ]) {
+      expect(screen.getByText(key)).toBeInTheDocument()
+    }
+    const boxes = screen.getAllByRole("textbox")
+    boxes.forEach((box, i) => fireEvent.change(box, { target: { value: `s${i}` } }))
+    expect(props.setAbout).toHaveBeenCalled()
+    expect(props.setProgram).toHaveBeenCalled()
+    expect(props.setAchievements).toHaveBeenCalled()
+  })
+
+  it("shows the saving label and disables save while saving", () => {
+    render(<ProfileEditor {...makeProps({ saving: true })} />)
+    const save = screen.getByText("profile:form.saving")
+    expect(save).toBeInTheDocument()
+    expect(save).toBeDisabled()
+  })
+})

--- a/frontend/src/components/schedule/__tests__/FlipCountdown.test.tsx
+++ b/frontend/src/components/schedule/__tests__/FlipCountdown.test.tsx
@@ -1,0 +1,98 @@
+import { act, render, screen } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) =>
+      opts && "mins" in opts && "secs" in opts ? `${key}:${opts.mins}:${opts.secs}` : key,
+    i18n: { language: "en", changeLanguage: () => Promise.resolve() },
+  }),
+}))
+
+import { FlipCountdown } from "@/components/schedule/FlipCountdown"
+
+describe("FlipCountdown", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    // Pin "now" to a deterministic wall-clock so secondsLeft is computable.
+    // 09:59:55 → 35995s since midnight; target 600 min (10:00) = 36000s → 5s left.
+    vi.setSystemTime(new Date(2026, 5, 16, 9, 59, 55))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("renders the timer region with MM:SS flip digits and aria-label", () => {
+    render(<FlipCountdown targetMinutes={600} />)
+    const timer = screen.getByRole("timer")
+    expect(timer).toBeInTheDocument()
+    expect(timer).toHaveAttribute("aria-live", "polite")
+    // ariaLabel key receives interpolated mins/secs (5s left → 0 min 5 sec)
+    expect(timer).toHaveAttribute("aria-label", "schedule:countdown.ariaLabel:0:5")
+    // 4 flip digit groups (MM:SS) — each FlipDigit emits an aria-label "<value> <label>"
+    expect(screen.getByLabelText("0 schedule:countdown.tensOfMinutes")).toBeInTheDocument()
+    expect(screen.getByLabelText("0 schedule:countdown.unitMinutes")).toBeInTheDocument()
+    // tens-of-seconds digit = "0", units-of-seconds digit = "5"
+    expect(screen.getByLabelText("0 schedule:countdown.tensOfSeconds")).toBeInTheDocument()
+    expect(screen.getByLabelText("5 schedule:countdown.unitSeconds")).toBeInTheDocument()
+    expect(screen.getByText(":")).toBeInTheDocument()
+  })
+
+  it("marks the timer urgent within the last 5 minutes", () => {
+    // 5s left ≤ 300 → urgent branch
+    render(<FlipCountdown targetMinutes={600} />)
+    expect(screen.getByRole("timer")).toHaveAttribute("data-urgent", "true")
+  })
+
+  it("is not urgent when more than 5 minutes remain", () => {
+    // target 700 min (11:40) vs 09:59:55 → 6005s left (> 300) → no urgent flag
+    render(<FlipCountdown targetMinutes={700} />)
+    expect(screen.getByRole("timer")).not.toHaveAttribute("data-urgent")
+  })
+
+  it("ticks down each second and flips a digit on change", () => {
+    render(<FlipCountdown targetMinutes={600} />)
+    // starts at 5s → units digit "5"
+    expect(screen.getByLabelText("5 schedule:countdown.unitSeconds")).toBeInTheDocument()
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+    // now 4s → units digit "4", flip flap shows previous "5"
+    expect(screen.getByLabelText("4 schedule:countdown.unitSeconds")).toBeInTheDocument()
+  })
+
+  it("fires onComplete when the countdown reaches zero", () => {
+    const onComplete = vi.fn()
+    // 1s left so a single tick hits zero deterministically.
+    vi.setSystemTime(new Date(2026, 5, 16, 9, 59, 59))
+    render(<FlipCountdown targetMinutes={600} onComplete={onComplete} />)
+    expect(onComplete).not.toHaveBeenCalled()
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+    expect(onComplete).toHaveBeenCalledTimes(1)
+    expect(screen.getByRole("timer")).toHaveAttribute(
+      "aria-label",
+      "schedule:countdown.ariaLabel:0:0"
+    )
+    // 0s is no longer urgent (isUrgent requires secondsLeft > 0)
+    expect(screen.getByRole("timer")).not.toHaveAttribute("data-urgent")
+  })
+
+  it("pauses ticking while the tab is hidden", () => {
+    render(<FlipCountdown targetMinutes={600} />)
+    Object.defineProperty(document, "visibilityState", { configurable: true, value: "hidden" })
+    act(() => {
+      vi.advanceTimersByTime(3000)
+    })
+    // Still 5s left — interval body early-returns when hidden
+    expect(screen.getByLabelText("5 schedule:countdown.unitSeconds")).toBeInTheDocument()
+    Object.defineProperty(document, "visibilityState", { configurable: true, value: "visible" })
+  })
+
+  it("applies a custom className to the timer container", () => {
+    render(<FlipCountdown targetMinutes={600} className="my-custom-countdown" />)
+    expect(screen.getByRole("timer")).toHaveClass("my-custom-countdown")
+  })
+})

--- a/frontend/src/components/schedule/__tests__/ScheduleShortcutsOverlay.test.tsx
+++ b/frontend/src/components/schedule/__tests__/ScheduleShortcutsOverlay.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen, fireEvent } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, it, expect, vi } from "vitest"
+
+vi.mock("framer-motion", async () =>
+  (await import("@/tests/helpers/framerMotionMock")).framerMotionMock()
+)
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "en", changeLanguage: () => Promise.resolve() },
+  }),
+}))
+vi.mock("@/hooks/useMediaQuery", () => ({ default: () => true }))
+
+import { ScheduleShortcutsOverlay } from "@/components/schedule/ScheduleShortcutsOverlay"
+
+const baseProps = { open: true, onClose: vi.fn() }
+
+describe("ScheduleShortcutsOverlay", () => {
+  it("renders nothing when closed", () => {
+    render(<ScheduleShortcutsOverlay {...baseProps} open={false} />)
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+  })
+
+  it("renders the dialog with title and shortcut rows when open", () => {
+    render(<ScheduleShortcutsOverlay {...baseProps} />)
+    expect(screen.getByRole("dialog", { name: "schedule:shortcuts.title" })).toBeInTheDocument()
+    expect(screen.getByRole("heading", { name: "schedule:shortcuts.title" })).toBeInTheDocument()
+    expect(screen.getByText("schedule:shortcuts.arrowNav")).toBeInTheDocument()
+    expect(screen.getByText("schedule:shortcuts.today")).toBeInTheDocument()
+    expect(screen.getByText("Enter")).toBeInTheDocument()
+    expect(screen.getByText("Esc")).toBeInTheDocument()
+  })
+
+  it("fires onClose from the close button", async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+    render(<ScheduleShortcutsOverlay {...baseProps} onClose={onClose} />)
+    await user.click(screen.getByRole("button", { name: "common:buttons.close" }))
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it("fires onClose when the backdrop is clicked", () => {
+    const onClose = vi.fn()
+    const { container } = render(<ScheduleShortcutsOverlay {...baseProps} onClose={onClose} />)
+    const backdrop = container.querySelector('div[aria-hidden="true"]')
+    expect(backdrop).not.toBeNull()
+    fireEvent.click(backdrop!)
+    expect(onClose).toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/search/__tests__/SearchDialog.test.tsx
+++ b/frontend/src/components/search/__tests__/SearchDialog.test.tsx
@@ -1,0 +1,158 @@
+import { act, fireEvent, render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("framer-motion", async () =>
+  (await import("@/tests/helpers/framerMotionMock")).framerMotionMock()
+)
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "en", changeLanguage: () => Promise.resolve() },
+  }),
+}))
+
+const navigateMock = vi.fn()
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => navigateMock,
+}))
+
+vi.mock("@/hooks/useDebounced", () => ({
+  useDebounced: (value: unknown) => value,
+}))
+
+vi.mock("@/api/client", () => ({ default: { get: vi.fn() } }))
+
+const queryState = vi.hoisted(() => ({
+  data: undefined as unknown,
+  isLoading: false,
+}))
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: () => ({ data: queryState.data, isLoading: queryState.isLoading }),
+}))
+
+import { SearchDialog } from "@/components/search/SearchDialog"
+
+const RECENT_SEARCHES_KEY = "ue:recent-searches"
+
+function openDialog() {
+  act(() => {
+    fireEvent.keyDown(document, { key: "k", ctrlKey: true })
+  })
+}
+
+describe("SearchDialog", () => {
+  beforeEach(() => {
+    queryState.data = undefined
+    queryState.isLoading = false
+    navigateMock.mockClear()
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  it("renders nothing until the Cmd/Ctrl+K shortcut opens it", () => {
+    const { container } = render(<SearchDialog />)
+    expect(container.firstChild).toBeNull()
+
+    openDialog()
+    expect(screen.getByRole("dialog", { name: "common:search.title" })).toBeInTheDocument()
+    expect(screen.getByPlaceholderText("common:search.placeholder")).toBeInTheDocument()
+  })
+
+  it("shows the empty-state hint when no query and no recent searches", () => {
+    render(<SearchDialog />)
+    openDialog()
+    expect(screen.getByText("common:search.hint")).toBeInTheDocument()
+  })
+
+  it("shows recent searches from localStorage when present and no query", () => {
+    localStorage.setItem(RECENT_SEARCHES_KEY, JSON.stringify(["calculus", "lab report"]))
+    render(<SearchDialog />)
+    openDialog()
+    expect(screen.getByText("common:search.recent")).toBeInTheDocument()
+    expect(screen.getByText("calculus")).toBeInTheDocument()
+    expect(screen.getByText("lab report")).toBeInTheDocument()
+  })
+
+  it("renders the loading spinner branch while a 2+ char query is in flight", async () => {
+    queryState.isLoading = true
+    const user = userEvent.setup()
+    render(<SearchDialog />)
+    openDialog()
+    const input = screen.getByPlaceholderText("common:search.placeholder")
+    await user.type(input, "ph")
+    // Spinner has no text/role; assert the no-results / hint copy is NOT shown while loading
+    expect(screen.queryByText("common:search.noResults")).not.toBeInTheDocument()
+    expect(screen.queryByText("common:search.hint")).not.toBeInTheDocument()
+  })
+
+  it("renders grouped results and navigates on click", async () => {
+    queryState.data = {
+      query: "phys",
+      results: {
+        news: [
+          {
+            id: "n1",
+            type: "news",
+            title: "Physics News",
+            summary: "About physics",
+            score: 0.9,
+            url: "/news/n1",
+          },
+        ],
+        events: [
+          {
+            id: "e1",
+            type: "events",
+            title: "Physics Event",
+            summary: "",
+            score: 0.7,
+            url: "/events/e1",
+          },
+        ],
+      },
+    }
+    const user = userEvent.setup()
+    render(<SearchDialog />)
+    openDialog()
+    const input = screen.getByPlaceholderText("common:search.placeholder")
+    await user.type(input, "phys")
+
+    const newsResult = screen.getByText("Physics News")
+    expect(newsResult).toBeInTheDocument()
+    expect(screen.getByText("Physics Event")).toBeInTheDocument()
+    expect(screen.getByText("About physics")).toBeInTheDocument()
+
+    await user.click(newsResult)
+    expect(navigateMock).toHaveBeenCalledWith({ to: "/news/n1" })
+  })
+
+  it("shows the no-results state when the query returns nothing", async () => {
+    queryState.data = { query: "zzz", results: {} }
+    const user = userEvent.setup()
+    render(<SearchDialog />)
+    openDialog()
+    const input = screen.getByPlaceholderText("common:search.placeholder")
+    await user.type(input, "zzz")
+    expect(screen.getByText("common:search.noResults")).toBeInTheDocument()
+  })
+
+  it("clears the query via the clear button and exposes nav/select footer hints", async () => {
+    const user = userEvent.setup()
+    render(<SearchDialog />)
+    openDialog()
+    const input = screen.getByPlaceholderText<HTMLInputElement>("common:search.placeholder")
+    await user.type(input, "ab")
+    expect(input.value).toBe("ab")
+
+    await user.click(screen.getByRole("button", { name: "common:search.clear" }))
+    expect(input.value).toBe("")
+
+    expect(screen.getByText("common:search.navigate")).toBeInTheDocument()
+    expect(screen.getByText("common:search.select")).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/ui/__tests__/SpotifyConnect.test.tsx
+++ b/frontend/src/components/ui/__tests__/SpotifyConnect.test.tsx
@@ -1,0 +1,131 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+const mockState = vi.hoisted(() => ({
+  user: null as Record<string, unknown> | null,
+  nowPlaying: null as Record<string, unknown> | null,
+  isFetching: false,
+  refetch: vi.fn(() => Promise.resolve({ data: null })),
+  setUser: vi.fn(),
+  invalidateQueries: vi.fn(() => Promise.resolve()),
+  apiGet: vi.fn((..._args: unknown[]) =>
+    Promise.resolve({ data: { url: "https://accounts.spotify.com/authorize?x=1" } })
+  ),
+  apiPost: vi.fn((..._args: unknown[]) => Promise.resolve({ data: {} })),
+}))
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "en", changeLanguage: () => Promise.resolve() },
+  }),
+}))
+
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => ({ user: mockState.user, setUser: mockState.setUser }),
+  currentUserQueryKey: ["users", "me"],
+}))
+
+vi.mock("@/hooks/useNowPlaying", () => ({
+  nowPlayingQueryKey: ["spotify", "now-playing"],
+  useNowPlaying: () => ({
+    data: mockState.nowPlaying,
+    isFetching: mockState.isFetching,
+    refetch: mockState.refetch,
+  }),
+}))
+
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({ invalidateQueries: mockState.invalidateQueries }),
+}))
+
+vi.mock("@/api/client", () => ({
+  default: {
+    get: (...args: unknown[]) => mockState.apiGet(...args),
+    post: (...args: unknown[]) => mockState.apiPost(...args),
+  },
+}))
+
+vi.mock("@/utils/spotify", () => ({
+  sanitizeSpotifyAuthorizeUrl: (url?: string) => url ?? null,
+}))
+
+import SpotifyConnect from "@/components/ui/SpotifyConnect"
+
+describe("SpotifyConnect", () => {
+  beforeEach(() => {
+    mockState.user = null
+    mockState.nowPlaying = null
+    mockState.isFetching = false
+    mockState.refetch.mockClear()
+    mockState.setUser.mockClear()
+    mockState.invalidateQueries.mockClear()
+    mockState.apiGet.mockClear()
+    mockState.apiPost.mockClear()
+  })
+
+  it("renders nothing when there is no user", () => {
+    const { container } = render(<SpotifyConnect />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it("shows the connect button when Spotify is not connected", () => {
+    mockState.user = { spotify_connected: false }
+    render(<SpotifyConnect />)
+    expect(screen.getByText("settings:integrations.spotify.title")).toBeInTheDocument()
+    expect(screen.getByText("settings:integrations.spotify.connect")).toBeInTheDocument()
+  })
+
+  it("shows the connected controls + display name when connected", () => {
+    mockState.user = { spotify_connected: true, spotify_display_name: "Egor's Spotify" }
+    render(<SpotifyConnect />)
+    expect(screen.getByText("Egor's Spotify")).toBeInTheDocument()
+    expect(screen.getByText("common:buttons.refresh")).toBeInTheDocument()
+    expect(screen.getByText("settings:integrations.spotify.disconnect")).toBeInTheDocument()
+    expect(screen.queryByText("settings:integrations.spotify.connect")).not.toBeInTheDocument()
+  })
+
+  it("falls back to the status label when connected without a display name", () => {
+    mockState.user = { spotify_is_connected: true }
+    render(<SpotifyConnect />)
+    expect(
+      screen.getByText("settings:integrations.spotify.status.connectedFallback")
+    ).toBeInTheDocument()
+  })
+
+  it("renders the now-playing card with track, album and external link", () => {
+    mockState.user = { spotify_connected: true, spotify_display_name: "Egor's Spotify" }
+    mockState.nowPlaying = {
+      track_name: "Track One",
+      artists: ["Artist A", "Artist B"],
+      album_name: "Album X",
+      track_url: "https://open.spotify.com/track/1",
+    }
+    render(<SpotifyConnect />)
+    expect(screen.getByText("Track One")).toBeInTheDocument()
+    expect(screen.getByText("Artist A, Artist B")).toBeInTheDocument()
+    expect(screen.getByText("Album X")).toBeInTheDocument()
+    const link = screen.getByRole("link")
+    expect(link).toHaveAttribute("href", "https://open.spotify.com/track/1")
+  })
+
+  it("disconnects via the disconnect button, calling api + setUser + invalidateQueries", async () => {
+    const user = userEvent.setup()
+    mockState.user = { spotify_connected: true, spotify_display_name: "Egor's Spotify" }
+    render(<SpotifyConnect />)
+    await user.click(screen.getByText("settings:integrations.spotify.disconnect"))
+    expect(mockState.apiPost).toHaveBeenCalledWith("/spotify/disconnect")
+    expect(mockState.setUser).toHaveBeenCalled()
+    expect(mockState.invalidateQueries).toHaveBeenCalled()
+  })
+
+  it("refreshes now-playing via the refresh button", async () => {
+    const user = userEvent.setup()
+    mockState.user = { spotify_connected: true, spotify_display_name: "Egor's Spotify" }
+    render(<SpotifyConnect />)
+    mockState.refetch.mockClear()
+    await user.click(screen.getByText("common:buttons.refresh"))
+    expect(mockState.refetch).toHaveBeenCalled()
+  })
+})

--- a/frontend/src/data/__tests__/campusPOI.test.ts
+++ b/frontend/src/data/__tests__/campusPOI.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest"
+
+import { CAMPUS_POIS, POI_CATEGORY_COLORS, type POICategory } from "@/data/campusPOI"
+
+const CATEGORIES: POICategory[] = ["transport", "food", "shop", "service", "campus"]
+const ICONS = new Set([
+  "TrainFront",
+  "Bus",
+  "UtensilsCrossed",
+  "Coffee",
+  "ShoppingCart",
+  "ShoppingBag",
+  "Pill",
+  "Landmark",
+  "ParkingCircle",
+  "MapPin",
+  "BookOpen",
+])
+
+describe("campusPOI data", () => {
+  it("exposes the verified set of campus POIs", () => {
+    expect(Array.isArray(CAMPUS_POIS)).toBe(true)
+    expect(CAMPUS_POIS).toHaveLength(11)
+  })
+
+  it("gives every POI a unique id", () => {
+    const ids = CAMPUS_POIS.map((p) => p.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it("keeps every POI well-formed (type, coords, icon, i18nKey)", () => {
+    for (const poi of CAMPUS_POIS) {
+      expect(typeof poi.id).toBe("string")
+      expect(CATEGORIES).toContain(poi.type)
+      expect(poi.coords).toHaveLength(2)
+      expect(typeof poi.coords[0]).toBe("number")
+      expect(typeof poi.coords[1]).toBe("number")
+      expect(ICONS.has(poi.icon)).toBe(true)
+      expect(typeof poi.i18nKey).toBe("string")
+      expect(poi.i18nKey.length).toBeGreaterThan(0)
+    }
+  })
+
+  it("maps every category to a map-poi CSS variable colour", () => {
+    expect(Object.keys(POI_CATEGORY_COLORS)).toHaveLength(5)
+    for (const category of CATEGORIES) {
+      expect(POI_CATEGORY_COLORS[category]).toBe(`var(--map-poi-${category})`)
+    }
+  })
+
+  it("only uses categories that have a colour mapping", () => {
+    for (const poi of CAMPUS_POIS) {
+      expect(POI_CATEGORY_COLORS[poi.type]).toBeDefined()
+    }
+  })
+})

--- a/frontend/src/features/activity/components/__tests__/ActivityExportButton.test.tsx
+++ b/frontend/src/features/activity/components/__tests__/ActivityExportButton.test.tsx
@@ -1,0 +1,115 @@
+import { render, screen, waitFor, act } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+
+const { exportMock } = vi.hoisted(() => ({
+  exportMock: { pdf: vi.fn(), png: vi.fn() },
+}))
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "en", changeLanguage: () => Promise.resolve() },
+  }),
+}))
+vi.mock("@/utils/activityExport", () => ({
+  exportActivityAsPdf: (...args: unknown[]) => exportMock.pdf(...args),
+  exportActivityAsPng: (...args: unknown[]) => exportMock.png(...args),
+}))
+
+import { ActivityExportButton } from "@/features/activity/components/ActivityExportButton"
+
+function renderButton() {
+  const contentRef = { current: document.createElement("div") }
+  return render(<ActivityExportButton contentRef={contentRef} />)
+}
+
+describe("ActivityExportButton", () => {
+  beforeEach(() => {
+    exportMock.pdf.mockResolvedValue({ success: true })
+    exportMock.png.mockResolvedValue({ success: true })
+  })
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("renders the trigger collapsed", () => {
+    renderButton()
+    const trigger = screen.getByRole("button", { name: "activity:export.title" })
+    expect(trigger).toHaveAttribute("aria-expanded", "false")
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument()
+  })
+
+  it("opens the menu with PDF + PNG items", async () => {
+    const user = userEvent.setup()
+    renderButton()
+    await user.click(screen.getByRole("button", { name: "activity:export.title" }))
+    expect(screen.getByRole("menu")).toBeInTheDocument()
+    expect(screen.getByText("activity:export.pdf")).toBeInTheDocument()
+    expect(screen.getByText("activity:export.png")).toBeInTheDocument()
+  })
+
+  it("exports as PDF and shows success feedback", async () => {
+    const user = userEvent.setup()
+    renderButton()
+    await user.click(screen.getByRole("button", { name: "activity:export.title" }))
+    await user.click(screen.getByText("activity:export.pdf"))
+    expect(exportMock.pdf).toHaveBeenCalledWith(expect.any(HTMLDivElement), "activity:title")
+    await waitFor(() => expect(screen.getByText("activity:export.success")).toBeInTheDocument())
+  })
+
+  it("exports as PNG", async () => {
+    const user = userEvent.setup()
+    renderButton()
+    await user.click(screen.getByRole("button", { name: "activity:export.title" }))
+    await user.click(screen.getByText("activity:export.png"))
+    expect(exportMock.png).toHaveBeenCalledOnce()
+  })
+
+  it("shows error feedback when the export rejects", async () => {
+    exportMock.pdf.mockRejectedValueOnce(new Error("boom"))
+    const user = userEvent.setup()
+    renderButton()
+    await user.click(screen.getByRole("button", { name: "activity:export.title" }))
+    await user.click(screen.getByText("activity:export.pdf"))
+    await waitFor(() => expect(screen.getByText("activity:export.error")).toBeInTheDocument())
+  })
+
+  it("shows the exporting state while a slow export is pending", async () => {
+    let resolveExport: (v: { success: boolean }) => void = () => {}
+    exportMock.pdf.mockReturnValueOnce(
+      new Promise<{ success: boolean }>((resolve) => {
+        resolveExport = resolve
+      })
+    )
+    const user = userEvent.setup()
+    renderButton()
+    await user.click(screen.getByRole("button", { name: "activity:export.title" }))
+    await user.click(screen.getByText("activity:export.pdf"))
+    expect(screen.getByText("activity:export.exporting")).toBeInTheDocument()
+    const trigger = screen.getByRole("button", { name: "activity:export.title" })
+    expect(trigger).toBeDisabled()
+    await act(async () => {
+      resolveExport({ success: true })
+    })
+    await waitFor(() => expect(screen.getByText("activity:export.success")).toBeInTheDocument())
+  })
+
+  it("closes the menu on Escape and on outside click", async () => {
+    const user = userEvent.setup()
+    renderButton()
+    await user.click(screen.getByRole("button", { name: "activity:export.title" }))
+    expect(screen.getByRole("menu")).toBeInTheDocument()
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }))
+    })
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: "activity:export.title" }))
+    expect(screen.getByRole("menu")).toBeInTheDocument()
+    act(() => {
+      document.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }))
+    })
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/features/map/__tests__/MapFeature.test.tsx
+++ b/frontend/src/features/map/__tests__/MapFeature.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen } from "@testing-library/react"
+import type { ComponentType } from "react"
+import { Suspense } from "react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("framer-motion", async () =>
+  (await import("@/tests/helpers/framerMotionMock")).framerMotionMock()
+)
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "en", resolvedLanguage: "en", changeLanguage: () => Promise.resolve() },
+  }),
+  // WidgetErrorBoundary's barrel transitively imports ErrorBoundary,
+  // which wraps with withTranslation() at module-eval time.
+  withTranslation: () => (Component: ComponentType) => Component,
+  Trans: ({ children }: { children?: React.ReactNode }) => children,
+}))
+
+const mq = vi.hoisted(() => ({ value: false }))
+vi.mock("@/hooks/useMediaQuery", () => ({ default: () => mq.value }))
+
+/* Sidestep the entire maplibre stack — the lazy child is replaced with null. */
+vi.mock("@/components/map/MapLibreMap", () => ({ default: () => null }))
+
+/* Module-mock every data/router hook MapFeature reaches. */
+vi.mock("@/hooks/useURLState", () => ({
+  useURLState: () => ({ params: {}, setParam: vi.fn(), setParams: vi.fn() }),
+}))
+vi.mock("@/hooks/useTimeOfDay", () => ({ useTimeOfDay: () => "afternoon" }))
+vi.mock("@/hooks/useSeason", () => ({ useSeason: () => "spring" }))
+vi.mock("@/hooks/useNextLesson", () => ({ useNextLesson: () => null }))
+vi.mock("@/hooks/useScheduleData", () => ({ useScheduleData: () => ({ todayLessons: [] }) }))
+vi.mock("@/hooks/useMapEvents", () => ({ useMapEvents: () => ({ events: [], isLoading: false }) }))
+vi.mock("@/hooks/useMapWeather", () => ({
+  useMapWeather: () => ({ data: undefined, isLoading: false }),
+}))
+vi.mock("@/hooks/useMapKeyboardShortcuts", () => ({ useMapKeyboardShortcuts: () => undefined }))
+
+import { MapFeature } from "@/features/map/MapFeature"
+
+function renderFeature() {
+  return render(
+    <Suspense fallback={null}>
+      <MapFeature />
+    </Suspense>
+  )
+}
+
+describe("MapFeature", () => {
+  afterEach(() => {
+    mq.value = false
+  })
+
+  it("renders the feature shell with header, search bar, and category filter (wide)", () => {
+    const { container } = renderFeature()
+    // Page title + badge from MapHeader
+    expect(screen.getByRole("heading", { name: /page\.title/ })).toBeInTheDocument()
+    // Search combobox from MapSearchBar
+    expect(screen.getByRole("combobox", { name: "search.ariaLabel" })).toBeInTheDocument()
+    // Category radiogroup from MapCategoryFilter
+    expect(screen.getByRole("radiogroup", { name: "categories.filterLabel" })).toBeInTheDocument()
+    // Themed root with data attributes from useTimeOfDay / useSeason
+    const root = container.querySelector(".map-theme")
+    expect(root).not.toBeNull()
+    expect(root).toHaveAttribute("data-time-period", "afternoon")
+    expect(root).toHaveAttribute("data-season", "spring")
+  })
+
+  it("does not render the building sidebar when no building is selected", () => {
+    renderFeature()
+    // Sidebar only mounts when currentBuilding is truthy (none selected on mount)
+    expect(screen.queryByText("sidebar.close")).not.toBeInTheDocument()
+  })
+
+  it("renders the all-categories filter with the 'all' radio active by default", () => {
+    renderFeature()
+    const radios = screen.getAllByRole("radio")
+    expect(radios.length).toBeGreaterThan(0)
+    const allRadio = radios[0]!
+    expect(allRadio).toHaveAttribute("aria-checked", "true")
+  })
+
+  it("renders the narrow-viewport branch (useMediaQuery true)", () => {
+    mq.value = true
+    const { container } = renderFeature()
+    expect(screen.getByRole("heading", { name: /page\.title/ })).toBeInTheDocument()
+    expect(container.querySelector(".map-theme")).not.toBeNull()
+  })
+})

--- a/frontend/src/hooks/__tests__/index.test.ts
+++ b/frontend/src/hooks/__tests__/index.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest"
+
+import * as hooks from "@/hooks"
+
+/**
+ * Barrel smoke test — importing `@/hooks` executes every re-export line, which
+ * pulls in each top-level shared hook module. The assertions below spot-check a
+ * representative slice (incl. all four `export { default as ... }` re-exports)
+ * so the test fails loudly if a re-export goes stale, while the `import *`
+ * itself credits the barrel's export statements.
+ */
+describe("hooks barrel (@/hooks)", () => {
+  it("re-exports the four default-exported hooks as functions", () => {
+    expect(typeof hooks.useActivityData).toBe("function")
+    expect(typeof hooks.useFocusTrap).toBe("function")
+    expect(typeof hooks.useMediaQuery).toBe("function")
+    expect(typeof hooks.useScrollRestoration).toBe("function")
+  })
+
+  it("re-exports a representative slice of named hooks as functions", () => {
+    const named = [
+      "useDebounced",
+      "useURLState",
+      "useClock",
+      "useSwipe",
+      "useBookmarks",
+      "useShare",
+      "useTilt",
+      "useSeason",
+      "useTimeOfDay",
+      "useWeather",
+      "useLocalStorage",
+      "useOnlineStatus",
+      "useScheduleData",
+      "useScheduleKeyboardNav",
+      "useNextLesson",
+      "useMapEvents",
+      "useMapWeather",
+    ] as const
+    for (const name of named) {
+      expect(typeof (hooks as Record<string, unknown>)[name]).toBe("function")
+    }
+  })
+})

--- a/frontend/src/hooks/__tests__/useScheduleKeyboardNav.test.ts
+++ b/frontend/src/hooks/__tests__/useScheduleKeyboardNav.test.ts
@@ -1,0 +1,113 @@
+import { renderHook, act } from "@testing-library/react"
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+import { useScheduleKeyboardNav } from "@/hooks/useScheduleKeyboardNav"
+
+function makeOpts(over: Record<string, unknown> = {}) {
+  return {
+    colCount: 5,
+    rowCount: 7,
+    todayColIdx: 2,
+    onSelect: vi.fn(),
+    onOpen: vi.fn(),
+    onEdit: vi.fn(),
+    onDelete: vi.fn(),
+    onToggleShortcuts: vi.fn(),
+    enabled: true,
+    ...over,
+  }
+}
+
+function press(key: string, init: KeyboardEventInit = {}) {
+  act(() => {
+    document.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true, ...init }))
+  })
+}
+
+describe("useScheduleKeyboardNav", () => {
+  beforeEach(() => {
+    document.body.innerHTML = ""
+  })
+
+  it("moves the active cell with arrow keys and fires onSelect (clamped to bounds)", () => {
+    const opts = makeOpts()
+    const { result } = renderHook(() => useScheduleKeyboardNav(opts))
+    press("ArrowRight")
+    expect(result.current.activeCell).toEqual({ row: 0, col: 1 })
+    expect(opts.onSelect).toHaveBeenLastCalledWith(0, 1)
+    press("ArrowDown")
+    expect(result.current.activeCell).toEqual({ row: 1, col: 1 })
+    // clamp: ArrowLeft past col 0 from (1,1)->(1,0); again stays at 0
+    press("ArrowLeft")
+    press("ArrowLeft")
+    expect(result.current.activeCell).toEqual({ row: 1, col: 0 })
+    // clamp: ArrowUp past row 0
+    press("ArrowUp")
+    press("ArrowUp")
+    expect(result.current.activeCell).toEqual({ row: 0, col: 0 })
+  })
+
+  it("fires the action callbacks for Enter / E / Delete / ? and jumps to today on T", () => {
+    const opts = makeOpts()
+    renderHook(() => useScheduleKeyboardNav(opts))
+    press("Enter")
+    expect(opts.onOpen).toHaveBeenCalledOnce()
+    press("e")
+    expect(opts.onEdit).toHaveBeenCalledOnce()
+    press("Delete")
+    expect(opts.onDelete).toHaveBeenCalledOnce()
+    press("Backspace")
+    expect(opts.onDelete).toHaveBeenCalledTimes(2)
+    press("?")
+    expect(opts.onToggleShortcuts).toHaveBeenCalledOnce()
+    press("t")
+    expect(opts.onSelect).toHaveBeenLastCalledWith(0, 2)
+  })
+
+  it("respects the ctrl/meta modifier guard on E / Delete / T", () => {
+    const opts = makeOpts()
+    renderHook(() => useScheduleKeyboardNav(opts))
+    press("e", { ctrlKey: true })
+    press("Delete", { metaKey: true })
+    press("t", { ctrlKey: true })
+    expect(opts.onEdit).not.toHaveBeenCalled()
+    expect(opts.onDelete).not.toHaveBeenCalled()
+  })
+
+  it("clears the active cell on Escape and clearSelection()", () => {
+    const opts = makeOpts()
+    const { result } = renderHook(() => useScheduleKeyboardNav(opts))
+    press("ArrowRight")
+    expect(result.current.activeCell).not.toBeNull()
+    press("Escape")
+    expect(result.current.activeCell).toBeNull()
+    press("ArrowRight")
+    act(() => result.current.clearSelection())
+    expect(result.current.activeCell).toBeNull()
+  })
+
+  it("ignores keys when typing in an input and when disabled or empty", () => {
+    const opts = makeOpts()
+    const { rerender } = renderHook(({ o }) => useScheduleKeyboardNav(o), {
+      initialProps: { o: opts },
+    })
+    const input = document.createElement("input")
+    document.body.appendChild(input)
+    act(() => {
+      input.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }))
+    })
+    expect(opts.onSelect).not.toHaveBeenCalled()
+
+    // disabled → listener not attached
+    const disabled = makeOpts({ enabled: false })
+    rerender({ o: disabled })
+    press("ArrowRight")
+    expect(disabled.onSelect).not.toHaveBeenCalled()
+
+    // empty grid → early return
+    const empty = makeOpts({ rowCount: 0 })
+    rerender({ o: empty })
+    press("ArrowRight")
+    expect(empty.onSelect).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -58,7 +58,7 @@ export default defineConfig({
         "src/utils/workerChrome.ts",
       ],
       // Ratchet floors at measured reality. SESSION-14 multi-lane sweep
-      // (31 files: Lane B fresh render/data/barrel + Lane C LOW-% partials &
+      // (25 files / +171 runtime tests: Lane B fresh render/data/barrel + Lane C LOW-% partials &
       // branch top-ups + Lane A Tier-3 map internals — WeatherParticles 0→88%,
       // MapFeature 0→81%, MapLibreMap fresh): statements 85.98 / branches 76.1 /
       // functions 75.17 / lines 85.98 — a +6.55pp statement JUMP from the s13

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -57,21 +57,24 @@ export default defineConfig({
         "src/utils/spotify.ts",
         "src/utils/workerChrome.ts",
       ],
-      // Ratchet floors at measured reality. SESSION-13 render-test sweep
-      // (37 files: News/Events/Schedule/Map-UI/Dashboard families +
-      // useScheduleReminders + Tier-3 maplibre markers/MapControls):
-      // statements 79.43 / branches 74.74 / functions 72.52 / lines 79.43 — a
-      // +9.93pp statement JUMP from the s12 floor (69.50). RAISED: statements
-      // 69→78 + lines 69→78 (78.93 floor after the 0.5 no-cushion buffer) +
-      // functions 71→72 (72.02 floor). branches HOLD 74 (74.74 < 75.5 — render-
-      // tests add statements, not new branch paths). NO-REGRESSION floors, NOT
-      // the target — raise incrementally (target 90; local == CI, so there is
-      // no integration cushion: keep ≥~0.5pp headroom before any raise).
+      // Ratchet floors at measured reality. SESSION-14 multi-lane sweep
+      // (31 files: Lane B fresh render/data/barrel + Lane C LOW-% partials &
+      // branch top-ups + Lane A Tier-3 map internals — WeatherParticles 0→88%,
+      // MapFeature 0→81%, MapLibreMap fresh): statements 85.98 / branches 76.1 /
+      // functions 75.17 / lines 85.98 — a +6.55pp statement JUMP from the s13
+      // floor (79.43). RAISED: statements 78→85 + lines 78→85 (85.48 floor after
+      // the 0.5 no-cushion buffer) + functions 72→74 (74.67 floor) + branches
+      // 74→75 (75.6 floor — render+partial tests finally moved branch coverage).
+      // NO-REGRESSION floors, NOT the target — raise incrementally (target 90;
+      // local == CI, so there is no integration cushion: keep ≥~0.5pp headroom
+      // before any raise). DEFERRED to s15 (subagent session limit): Lane D
+      // logic-hooks (useChatWebSocket un-skip — needs a /ws/ticket test handler
+      // not currently in mocks/server.ts; useProfileSync hook + useMessengerController).
       thresholds: {
-        statements: 78,
-        branches: 74,
-        functions: 72,
-        lines: 78,
+        statements: 85,
+        branches: 75,
+        functions: 74,
+        lines: 85,
       },
     },
   },


### PR DESCRIPTION
## Session 14 — multi-lane coverage push

Statements **79.43% → 85.98% (+6.55pp)**, branches 74.74→76.14, functions 72.51→75.17, lines →85.98. **273 test files pass / 2030 tests** (1 skipped = the W113 useChatWebSocket). 25 new test files (+171 runtime tests; the static `it()`-grep is 163 — `it.each` expands at runtime).

### Lanes
- **Lane B (12 files / 65 tests)** — fresh render/data/barrel tests: ProfileEditor (0→90%), SearchDialog, SpotifyConnect, SyncStatus, FlipCountdown, PageTransition, DashboardSectionSkeleton, EventDetailNavigation, MapBackdrop, EventInfo, campusPOI (data), hooks/index (barrel).
- **Lane C fresh (6 / 32)** — LOW-% partials: PageErrorBoundary (11%→), webVitals (30%→), OfflineIndicator (12%→), useScheduleKeyboardNav (38%→), ScheduleShortcutsOverlay (34%→), ActivityExportButton (43%→).
- **Lane A (3 / 26)** — Tier-3 map internals: WeatherParticles **0→88%**, MapFeature **0→81%**, MapLibreMap (mapGlMock + hand-built getMap mock + real-rAF/waitFor).
- **Lane C add-branches (4 / 48)** — isolated `.branches.test.tsx` siblings: InstallPrompt, ChatWindow, MapSidebar, EventFileManager (existing tests untouched).

### Gate ratchet (`frontend/vitest.config.ts`)
`floor = ⌊measured − 0.5⌋`: statements 78→85, lines 78→85, functions 72→74, branches 74→75.

### Deferred to s15
Lane D logic-hooks (useChatWebSocket un-skip — needs a `/ws/ticket` test handler not currently in `mocks/server.ts`; useProfileSync hook + useMessengerController) — the parallel fan-out hit a subagent session limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
