### PR TITLE
test(session16): multi-front coverage — Go services +15/+7/+4pp + frontend long-tail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -376,10 +376,11 @@ jobs:
             # pkg 41.4→84.7, cmd 33→44.4. RAISED 50→65: floor(67.4) − 2 = 65.
             coverage-threshold: 65
           - service: services/ws-hub
-            # Measured 68.8% unit-only ×2 (s12 Invalidate + CanJoinRoom invalid-UUID
-            # guard arms on top of s11 validateHMAC/handleRegister). HOLD 66:
-            # floor(68.8) − 2 = 66 (next floor 67 needs ≥ 69).
-            coverage-threshold: 66
+            # Measured 72.7% unit-only (s16: miniredis L2 in CanJoinRoom 59.5→89.2
+            # + Invalidate 73.7→100; root main.go initLogger/initRedis 0→100;
+            # NATS handler ctx-done + notif full-channel branches). pkg/hub
+            # 77.7→80.8, root 0→10.4. RAISED 66→70: floor(72.7) − 2 = 70.
+            coverage-threshold: 70
           - service: services/cmd/uni-cli
             coverage-threshold: 80
     needs: pre-commit-check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,10 +363,11 @@ jobs:
         # file-processor validateProcessFileRequest rejection arms.
         include:
           - service: services/gateway
-            # Measured 68.9% unit-only ×2 (s12 checkL1Cache miss/hit/probabilistic-
-            # refresh + NewRateLimiter bad-URL + GetClient white-box). RAISED 65→66:
-            # Floor 66 = floor(68.9) − 2.
-            coverage-threshold: 66
+            # Measured 75.8% unit-only (s16: miniredis pub/sub revocation listener
+            # ListenForRevocations 9.5→90.5 + listenOnce 0→80; NewRateLimiter
+            # Ping-OK 30→90 + Middleware 53.8→100 via redis_rate GCRA on miniredis
+            # Lua). middleware 76.5→87.8. RAISED 66→73: floor(75.8) − 2 = 73.
+            coverage-threshold: 73
           - service: services/file-processor
             # Measured 67.4% unit-only (s16: workflow activities via httptest
             # fake-S3 — ResizeImageActivity/downloadAndDecodeImage default-run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -368,10 +368,12 @@ jobs:
             # Floor 66 = floor(68.9) − 2.
             coverage-threshold: 66
           - service: services/file-processor
-            # Measured 52.3% unit-only ×2 (s9 + s10 validateProcessFileRequest
-            # empty-id/unsupported-type/empty-keys/options-limit/oversized-opt).
-            # Floor 50.
-            coverage-threshold: 50
+            # Measured 67.4% unit-only (s16: workflow activities via httptest
+            # fake-S3 — ResizeImageActivity/downloadAndDecodeImage default-run
+            # coverage, was integration-tag-only; + cmd initLogger/initSentry/
+            # initTracer/stream-auth-error/authedServerStream.Context). Workflow
+            # pkg 41.4→84.7, cmd 33→44.4. RAISED 50→65: floor(67.4) − 2 = 65.
+            coverage-threshold: 65
           - service: services/ws-hub
             # Measured 68.8% unit-only ×2 (s12 Invalidate + CanJoinRoom invalid-UUID
             # guard arms on top of s11 validateHMAC/handleRegister). HOLD 66:

--- a/frontend/src/api/__tests__/client.retry.test.ts
+++ b/frontend/src/api/__tests__/client.retry.test.ts
@@ -1,0 +1,220 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { AxiosHeaders } from "axios"
+import type { AxiosResponse, InternalAxiosRequestConfig } from "axios"
+
+// Stable module-level mock for the trace-context sink. The traceContext
+// interceptor imports setTraceContext as a direct binding, so we must mock the
+// module (a namespace spy wouldn't intercept the live ESM binding). The spy is
+// hoisted + stable across vi.resetModules() so re-imported client graphs share it.
+const setTraceContextMock = vi.hoisted(() => vi.fn((..._a: unknown[]) => undefined))
+vi.mock("@/app/logger", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/app/logger")>()
+  return { ...actual, setTraceContext: setTraceContextMock }
+})
+
+/**
+ * Build a 429 error matching what axios surfaces to the response interceptor.
+ */
+const make429 = (config: InternalAxiosRequestConfig, headers: Record<string, string> = {}) =>
+  Object.assign(new Error("Too Many Requests"), {
+    config,
+    response: {
+      status: 429,
+      statusText: "Too Many Requests",
+      headers: AxiosHeaders.from(headers),
+      data: { detail: "slow down" },
+      config,
+    },
+  })
+
+describe("API client 429 retry loop", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.resetModules()
+    vi.unstubAllEnvs()
+    // Generous client-side queue so the queue logic never interferes with the
+    // server-side 429 retry path we are exercising here.
+    vi.stubEnv("VITE_API_RATE_LIMIT_PER_MINUTE", "100")
+    vi.stubEnv("VITE_API_RATE_LIMIT_MAX_CONCURRENT", "10")
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.useRealTimers()
+  })
+
+  it("retries after a 429 and resolves once the backoff window elapses and a 200 returns", async () => {
+    const { default: api } = await import("@/api/client")
+
+    let calls = 0
+    const adapter = vi.fn(async (config): Promise<AxiosResponse> => {
+      calls += 1
+      if (calls === 1) {
+        // First attempt: 429 with a 1s retry-after window.
+        throw make429(config, { "retry-after": "1" })
+      }
+      return {
+        config,
+        data: { ok: true },
+        status: 200,
+        statusText: "OK",
+        headers: new AxiosHeaders(),
+        request: {},
+      } as AxiosResponse
+    })
+    api.defaults.adapter = adapter
+
+    const pending = api.get("/news")
+
+    // Let the first attempt run + reject, scheduling the rate-limit window.
+    await vi.advanceTimersByTimeAsync(0)
+    // Retry-after "1" => 1000ms backoff. Advance past it to release the wait.
+    await vi.advanceTimersByTimeAsync(1000)
+    await vi.advanceTimersByTimeAsync(0)
+
+    await expect(pending).resolves.toMatchObject({ status: 200, data: { ok: true } })
+    expect(adapter).toHaveBeenCalledTimes(2)
+  })
+
+  it("rejects with the 429 once the retry count reaches RATE_LIMIT_MAX_RETRY", async () => {
+    const { default: api } = await import("@/api/client")
+    const { RATE_LIMIT_MAX_RETRY } = await import("@/api/interceptors/rateLimit")
+
+    const adapter = vi.fn(async (config): Promise<AxiosResponse> => {
+      // Always 429 — the loop should give up after MAX_RETRY retries.
+      throw make429(config, { "retry-after": "1" })
+    })
+    api.defaults.adapter = adapter
+
+    const pending = api.get("/news")
+    // Surface as a rejection rather than an unhandled rejection.
+    const settled = pending.catch((e: unknown) => e)
+
+    // Drive the backoff windows: initial attempt + RATE_LIMIT_MAX_RETRY retries.
+    for (let i = 0; i <= RATE_LIMIT_MAX_RETRY + 1; i += 1) {
+      await vi.advanceTimersByTimeAsync(1000)
+      await vi.advanceTimersByTimeAsync(0)
+    }
+
+    const result = await settled
+    expect(result).toMatchObject({ response: { status: 429 } })
+    // 1 initial attempt + RATE_LIMIT_MAX_RETRY retries.
+    expect(adapter).toHaveBeenCalledTimes(RATE_LIMIT_MAX_RETRY + 1)
+  })
+
+  it("aborts during the rate-limit backoff wait and rejects with an AbortError", async () => {
+    const { default: api } = await import("@/api/client")
+
+    const controller = new AbortController()
+    const adapter = vi.fn(async (config): Promise<AxiosResponse> => {
+      // Always 429 with a long backoff so the abort wins the race.
+      throw make429(config, { "retry-after": "30" })
+    })
+    api.defaults.adapter = adapter
+
+    const pending = api.get("/news", { signal: controller.signal } as never)
+    const settled = pending.catch((e: unknown) => e)
+
+    // Let the first attempt run + reject, entering waitForRateLimitWindow.
+    await vi.advanceTimersByTimeAsync(0)
+    // Abort mid-wait — waitForRateLimitWindow's abort listener rejects.
+    controller.abort()
+    await vi.advanceTimersByTimeAsync(0)
+
+    const result = await settled
+    expect(result).toBeInstanceOf(DOMException)
+    expect((result as DOMException).name).toBe("AbortError")
+    // Only the initial attempt fired; the retry never reissued the request.
+    expect(adapter).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not retry a 429 when skipRateLimitQueue bypasses the queue", async () => {
+    const { default: api } = await import("@/api/client")
+
+    const adapter = vi.fn(async (config): Promise<AxiosResponse> => {
+      throw make429(config, { "retry-after": "1" })
+    })
+    api.defaults.adapter = adapter
+
+    // /users/me is on the rate-limit skip allowlist, so skipRateLimitQueue stays true
+    // and the 429 retry branch (gated on !config.skipRateLimitQueue) is skipped.
+    const pending = api.get("/users/me", { skipRateLimitQueue: true } as never)
+    const settled = pending.catch((e: unknown) => e)
+
+    await vi.advanceTimersByTimeAsync(0)
+    await vi.advanceTimersByTimeAsync(2000)
+    await vi.advanceTimersByTimeAsync(0)
+
+    const result = await settled
+    expect(result).toMatchObject({ response: { status: 429 } })
+    expect(adapter).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe("API client trace-context response interceptor", () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.unstubAllEnvs()
+    setTraceContextMock.mockClear()
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it("forwards the x-trace-id response header into setTraceContext on success", async () => {
+    const { default: api } = await import("@/api/client")
+
+    api.defaults.adapter = async (config): Promise<AxiosResponse> =>
+      ({
+        config,
+        data: { ok: true },
+        status: 200,
+        statusText: "OK",
+        headers: AxiosHeaders.from({ "x-trace-id": "trace-abc-123" }),
+        request: {},
+      }) as AxiosResponse
+
+    await api.get("/news")
+
+    expect(setTraceContextMock).toHaveBeenCalledWith("trace-abc-123")
+  })
+
+  it("clears the trace context (null) when the response carries no trace header", async () => {
+    const { default: api } = await import("@/api/client")
+
+    api.defaults.adapter = async (config): Promise<AxiosResponse> =>
+      ({
+        config,
+        data: { ok: true },
+        status: 200,
+        statusText: "OK",
+        headers: AxiosHeaders.from({ "content-type": "application/json" }),
+        request: {},
+      }) as AxiosResponse
+
+    await api.get("/news")
+
+    expect(setTraceContextMock).toHaveBeenCalledWith(null)
+  })
+
+  it("forwards the trace header from an error response too", async () => {
+    const { default: api } = await import("@/api/client")
+
+    api.defaults.adapter = async (config): Promise<AxiosResponse> => {
+      throw Object.assign(new Error("Server error"), {
+        config,
+        response: {
+          status: 500,
+          statusText: "Internal Server Error",
+          headers: AxiosHeaders.from({ "x-trace-id": "trace-err-999" }),
+          data: { detail: "boom" },
+          config,
+        },
+      })
+    }
+
+    await expect(api.get("/news")).rejects.toMatchObject({ response: { status: 500 } })
+    expect(setTraceContextMock).toHaveBeenCalledWith("trace-err-999")
+  })
+})

--- a/frontend/src/api/interceptors/__tests__/etagCache.test.ts
+++ b/frontend/src/api/interceptors/__tests__/etagCache.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { AxiosHeaders } from "axios"
 import type { AxiosResponse, InternalAxiosRequestConfig } from "axios"
 
@@ -229,5 +229,225 @@ describe("etagCache — handleEtagResponse", () => {
     // A logout clears the response cache + bumps the epoch.
     clearCachesOnLogout()
     expect(responseCache.get("epoch:key")).toBeUndefined()
+  })
+
+  it("discards the result when the session epoch changes DURING the async HMAC", async () => {
+    // Bump the epoch from inside crypto.subtle.sign — this fires after the
+    // epochSnapshot is captured but before the post-HMAC re-check, so the
+    // computed entry must be thrown away (RED-02 stale-result guard).
+    const realSign = crypto.subtle.sign.bind(crypto.subtle)
+    const signSpy = vi
+      .spyOn(crypto.subtle, "sign")
+      .mockImplementation(async (...args: Parameters<typeof realSign>) => {
+        incrementSessionEpoch()
+        return realSign(...args)
+      })
+
+    const response = makeResponse(
+      200,
+      { etag: '"epoch-race"', "content-type": "application/json" },
+      { v: 99 }
+    )
+    await handleEtagResponse(response, "epoch:race")
+
+    // The etag tag is still written (it happens before the async HMAC) but the
+    // signed payload is discarded because the epoch moved mid-flight.
+    expect(etagCache.get("epoch:race")).toBe('"epoch-race"')
+    expect(responseCache.get("epoch:race")).toBeUndefined()
+
+    signSpy.mockRestore()
+  })
+
+  it("evicts both caches on 304 when the stored HMAC does not verify", async () => {
+    // Cache a valid signed 200 first.
+    const data = { items: ["x"] }
+    const first = makeResponse(
+      200,
+      { etag: '"etag-bad-hmac"', "content-type": "application/json" },
+      data
+    )
+    await handleEtagResponse(first, "bad:hmac")
+    expect(responseCache.get("bad:hmac")).toBeDefined()
+
+    // Corrupt the stored HMAC so the 304 restore-time verification fails.
+    const corrupted = responseCache.get("bad:hmac")!
+    responseCache.set("bad:hmac", { ...corrupted, hmac: "00".repeat(32) })
+
+    const notModified = makeResponse(304, { etag: '"etag-bad-hmac"' }, null)
+    await handleEtagResponse(notModified, "bad:hmac")
+
+    // Mismatch path: status stays 304, both caches evicted.
+    expect(notModified.status).toBe(304)
+    expect(notModified.data).toBeNull()
+    expect(etagCache.get("bad:hmac")).toBeUndefined()
+    expect(responseCache.get("bad:hmac")).toBeUndefined()
+  })
+
+  it("evicts both caches on 304 when there is no signing key", async () => {
+    // Seed a response cache entry, then drop the signing key before the 304.
+    const data = { a: 1 }
+    const first = makeResponse(
+      200,
+      { etag: '"etag-nokey-304"', "content-type": "application/json" },
+      data
+    )
+    await handleEtagResponse(first, "nokey:304")
+    expect(responseCache.get("nokey:304")).toBeDefined()
+
+    registerSigningKeyAccessor(() => null)
+    const notModified = makeResponse(304, { etag: '"etag-nokey-304"' }, null)
+    await handleEtagResponse(notModified, "nokey:304")
+
+    expect(notModified.status).toBe(304)
+    expect(etagCache.get("nokey:304")).toBeUndefined()
+    expect(responseCache.get("nokey:304")).toBeUndefined()
+  })
+})
+
+describe("etagCache — debounced flush + visibilitychange", () => {
+  beforeEach(() => {
+    etagCache.clear()
+    responseCache.clear()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+    // Reset the visibilityState override back to the jsdom default so other
+    // suites are not left with a "hidden" tab (which would auto-flush).
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => "visible",
+    })
+  })
+
+  it("debounced set persists to localStorage only after the 30s flush timer fires", () => {
+    vi.useFakeTimers()
+    const setItemSpy = vi.spyOn(Storage.prototype, "setItem")
+
+    etagCache.set("flush:k1", '"tag-flush"')
+    // Nothing persisted synchronously — flush is debounced.
+    const beforeCalls = setItemSpy.mock.calls.filter(([k]) => k.startsWith("ue:etag-cache"))
+    expect(beforeCalls.length).toBe(0)
+
+    vi.advanceTimersByTime(30_000)
+
+    const afterCalls = setItemSpy.mock.calls.filter(([k]) => k.startsWith("ue:etag-cache"))
+    expect(afterCalls.length).toBeGreaterThanOrEqual(1)
+    const persisted = afterCalls[afterCalls.length - 1]![1]
+    expect(persisted).toContain("flush:k1")
+  })
+
+  it("a second set within the debounce window resets the timer (single flush)", () => {
+    vi.useFakeTimers()
+    const setItemSpy = vi.spyOn(Storage.prototype, "setItem")
+
+    etagCache.set("flush:a", '"a"')
+    vi.advanceTimersByTime(20_000)
+    etagCache.set("flush:b", '"b"') // resets the 30s window
+    vi.advanceTimersByTime(20_000) // 40s total but only 20s since last set → no flush yet
+
+    expect(setItemSpy.mock.calls.filter(([k]) => k.startsWith("ue:etag-cache")).length).toBe(0)
+
+    vi.advanceTimersByTime(10_000) // now 30s since last set → flush fires once
+
+    const calls = setItemSpy.mock.calls.filter(([k]) => k.startsWith("ue:etag-cache"))
+    expect(calls.length).toBe(1)
+    expect(calls[0]![1]).toContain("flush:b")
+  })
+
+  it("visibilitychange to hidden flushes immediately (no timer wait)", () => {
+    const setItemSpy = vi.spyOn(Storage.prototype, "setItem")
+    etagCache.set("vis:k", '"vis-tag"')
+
+    setItemSpy.mockClear()
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => "hidden",
+    })
+    document.dispatchEvent(new Event("visibilitychange"))
+
+    const calls = setItemSpy.mock.calls.filter(([k]) => k.startsWith("ue:etag-cache"))
+    expect(calls.length).toBeGreaterThanOrEqual(1)
+    expect(calls[calls.length - 1]![1]).toContain("vis:k")
+  })
+
+  it("evicts the oldest 50% and retries once on QuotaExceededError", () => {
+    // Seed three entries with distinct lastUsed timestamps via Date.now control.
+    const nowSpy = vi.spyOn(Date, "now")
+    nowSpy.mockReturnValue(1000)
+    etagCache.set("q:oldest", '"o"')
+    nowSpy.mockReturnValue(2000)
+    etagCache.set("q:mid", '"m"')
+    nowSpy.mockReturnValue(3000)
+    etagCache.set("q:newest", '"n"')
+    nowSpy.mockReturnValue(4000)
+
+    const realSetItem = Storage.prototype.setItem
+    let throwOnce = true
+    const setItemSpy = vi.spyOn(Storage.prototype, "setItem").mockImplementation(function (
+      this: Storage,
+      key: string,
+      value: string
+    ) {
+      if (key.startsWith("ue:etag-cache") && throwOnce) {
+        throwOnce = false
+        throw new DOMException("quota", "QuotaExceededError")
+      }
+      // Delegate to the real impl for the retry write.
+      realSetItem.call(this, key, value)
+    })
+
+    // Trigger an immediate flush via visibilitychange (avoids the 30s timer).
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => "hidden",
+    })
+    document.dispatchEvent(new Event("visibilitychange"))
+
+    // Two write attempts: the failing one + the retry after eviction.
+    const cacheWrites = setItemSpy.mock.calls.filter(([k]) => k.startsWith("ue:etag-cache"))
+    expect(cacheWrites.length).toBe(2)
+
+    // ceil(3/2) = 2 oldest evicted → only the newest survives in memory.
+    nowSpy.mockReturnValue(5000)
+    expect(etagCache.get("q:oldest")).toBeUndefined()
+    expect(etagCache.get("q:mid")).toBeUndefined()
+    expect(etagCache.get("q:newest")).toBe('"n"')
+
+    nowSpy.mockRestore()
+  })
+})
+
+describe("etagCache — lazy hydration on first access (isolated module)", () => {
+  const KEY = "ue:etag-cache:v1"
+
+  beforeEach(() => {
+    vi.resetModules()
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  it("hydrates the in-memory map from localStorage on first get()", async () => {
+    const seeded: [string, { tag: string; lastUsed: number }][] = [
+      ["seeded:key", { tag: '"seeded-tag"', lastUsed: 123 }],
+    ]
+    localStorage.setItem(KEY, JSON.stringify(seeded))
+
+    const mod = await import("../etagCache")
+    // First access triggers hydration from the seeded localStorage payload.
+    expect(mod.etagCache.get("seeded:key")).toBe('"seeded-tag"')
+  })
+
+  it("starts empty and logs a warning when stored JSON is corrupt", async () => {
+    localStorage.setItem(KEY, "{not-valid-json")
+
+    const mod = await import("../etagCache")
+    // Corrupt payload → hydration fails gracefully to an empty map, no throw.
+    expect(() => mod.etagCache.get("anything")).not.toThrow()
+    expect(mod.etagCache.get("anything")).toBeUndefined()
   })
 })

--- a/frontend/src/components/__tests__/NotificationsBell.test.tsx
+++ b/frontend/src/components/__tests__/NotificationsBell.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen } from "@testing-library/react"
+import { act, fireEvent, render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import type { useNotifications } from "@/hooks/useNotifications"
 import NotificationsBell from "../feedback/NotificationsBell"
 
@@ -237,5 +237,192 @@ describe("NotificationsBell", () => {
     await user.click(openButton)
 
     expect(screen.getByText("Couldn't load more notifications")).toBeInTheDocument()
+  })
+
+  describe("dropdown positioning", () => {
+    const originalInnerWidth = window.innerWidth
+
+    const setInnerWidth = (width: number) => {
+      Object.defineProperty(window, "innerWidth", {
+        configurable: true,
+        writable: true,
+        value: width,
+      })
+    }
+
+    afterEach(() => {
+      setInnerWidth(originalInnerWidth)
+    })
+
+    it("computes desktop coordinates (right offset, no mobile width)", async () => {
+      setInnerWidth(1024)
+      const state = baseState()
+      useNotificationsMock.mockReturnValue(state)
+
+      const user = userEvent.setup()
+      render(<NotificationsBell />)
+
+      await user.click(screen.getByRole("button", { name: "Open notifications" }))
+
+      const dropdown = screen.getByRole("heading", { name: "Notifications" }).closest("div")!
+        .parentElement!.parentElement as HTMLElement
+      // jsdom getBoundingClientRect is all-zero → top = 0 + 12, right = 1024 - 0
+      expect(dropdown.style.top).toBe("12px")
+      expect(dropdown.style.right).toBe("1024px")
+      // Desktop branch leaves width unset (undefined → empty string)
+      expect(dropdown.style.width).toBe("")
+    })
+
+    it("computes mobile coordinates (no right offset, viewport-relative width)", async () => {
+      setInnerWidth(500)
+      const state = baseState()
+      useNotificationsMock.mockReturnValue(state)
+
+      const user = userEvent.setup()
+      render(<NotificationsBell />)
+
+      await user.click(screen.getByRole("button", { name: "Open notifications" }))
+
+      const dropdown = screen.getByRole("heading", { name: "Notifications" }).closest("div")!
+        .parentElement!.parentElement as HTMLElement
+      expect(dropdown.style.top).toBe("12px")
+      // Mobile branch sets right to null → undefined → empty string
+      expect(dropdown.style.right).toBe("")
+      expect(dropdown.style.width).toBe("calc(100vw - 2rem)")
+    })
+
+    it("recomputes position when the window resizes", async () => {
+      setInnerWidth(1024)
+      const state = baseState()
+      useNotificationsMock.mockReturnValue(state)
+
+      const user = userEvent.setup()
+      render(<NotificationsBell />)
+
+      await user.click(screen.getByRole("button", { name: "Open notifications" }))
+
+      const findDropdown = () =>
+        screen.getByRole("heading", { name: "Notifications" }).closest("div")!.parentElement!
+          .parentElement as HTMLElement
+
+      expect(findDropdown().style.right).toBe("1024px")
+
+      // Shrink below the mobile breakpoint and fire the resize listener
+      setInnerWidth(500)
+      act(() => {
+        window.dispatchEvent(new Event("resize"))
+      })
+
+      const dropdown = findDropdown()
+      expect(dropdown.style.right).toBe("")
+      expect(dropdown.style.width).toBe("calc(100vw - 2rem)")
+    })
+  })
+
+  describe("click-outside handling", () => {
+    it("closes the dropdown when clicking outside the button and dropdown", async () => {
+      const state = baseState()
+      useNotificationsMock.mockReturnValue(state)
+
+      const user = userEvent.setup()
+      render(<NotificationsBell />)
+
+      await user.click(screen.getByRole("button", { name: "Open notifications" }))
+      expect(screen.getByRole("heading", { name: "Notifications" })).toBeInTheDocument()
+
+      // mousedown on document.body — outside both refs → closes
+      fireEvent.mouseDown(document.body)
+
+      expect(screen.queryByRole("heading", { name: "Notifications" })).not.toBeInTheDocument()
+    })
+
+    it("keeps the dropdown open when clicking inside it", async () => {
+      const state = baseState()
+      useNotificationsMock.mockReturnValue(state)
+
+      const user = userEvent.setup()
+      render(<NotificationsBell />)
+
+      await user.click(screen.getByRole("button", { name: "Open notifications" }))
+
+      const heading = screen.getByRole("heading", { name: "Notifications" })
+      // mousedown inside the dropdown → guard short-circuits, stays open
+      fireEvent.mouseDown(heading)
+
+      expect(screen.getByRole("heading", { name: "Notifications" })).toBeInTheDocument()
+    })
+
+    it("keeps the dropdown open when clicking the trigger button itself", async () => {
+      const state = baseState()
+      useNotificationsMock.mockReturnValue(state)
+
+      const user = userEvent.setup()
+      render(<NotificationsBell />)
+
+      const openButton = screen.getByRole("button", { name: "Open notifications" })
+      await user.click(openButton)
+
+      // mousedown on the button is inside buttonRef → contains() guard keeps it open
+      fireEvent.mouseDown(openButton)
+
+      expect(screen.getByRole("heading", { name: "Notifications" })).toBeInTheDocument()
+    })
+  })
+
+  describe("bulk actions", () => {
+    it("marks all notifications as read", async () => {
+      const state = baseState()
+      state.data = [
+        {
+          id: "uuid-1",
+          title: "Welcome",
+          body: "",
+          created_at: "2024-01-01T00:00:00Z",
+          read: false,
+        },
+      ]
+      state.unreadCount = 1
+      const markAll = vi.fn()
+      state.markAll = markAll
+      useNotificationsMock.mockReturnValue(state)
+
+      const user = userEvent.setup()
+      render(<NotificationsBell />)
+
+      await user.click(screen.getByRole("button", { name: "Open notifications" }))
+      await user.click(screen.getByTitle("Mark all as read"))
+
+      expect(markAll).toHaveBeenCalledTimes(1)
+    })
+
+    it("clears all notifications and closes the dropdown on success", async () => {
+      const state = baseState()
+      state.data = [
+        {
+          id: "uuid-1",
+          title: "Welcome",
+          body: "",
+          created_at: "2024-01-01T00:00:00Z",
+          read: true,
+        },
+      ]
+      const clearAll = vi.fn((_arg?: unknown, opts?: { onSuccess?: () => void }) => {
+        opts?.onSuccess?.()
+      })
+      state.clearAll = clearAll as NotificationsState["clearAll"]
+      useNotificationsMock.mockReturnValue(state)
+
+      const user = userEvent.setup()
+      render(<NotificationsBell />)
+
+      await user.click(screen.getByRole("button", { name: "Open notifications" }))
+      expect(screen.getByRole("heading", { name: "Notifications" })).toBeInTheDocument()
+
+      await user.click(screen.getByTitle("Clear"))
+
+      expect(clearAll).toHaveBeenCalledTimes(1)
+      // onSuccess callback flips isOpen → false, unmounting the dropdown
+      expect(screen.queryByRole("heading", { name: "Notifications" })).not.toBeInTheDocument()
+    })
   })
 })

--- a/frontend/src/components/schedule/__tests__/scheduleUtils.test.ts
+++ b/frontend/src/components/schedule/__tests__/scheduleUtils.test.ts
@@ -1,0 +1,227 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  buildLessonsByDay,
+  getEndTimeStr,
+  getTimeStr,
+  groupsStorageKey,
+  type Lesson,
+  readFromStorage,
+  SCHEDULE_STORAGE_TTL_MS,
+  scheduleStorageKey,
+  STORAGE_SCHEMA_VERSION,
+  writeToStorage,
+} from "@/components/schedule/scheduleUtils"
+
+// Fixed wall-clock so TTL math is deterministic.
+const FIXED_NOW = new Date("2026-06-16T12:00:00.000Z")
+
+const makeLesson = (overrides: Partial<Lesson> = {}): Lesson => ({
+  id: "l1",
+  weekday: "Monday",
+  parity: "both",
+  start_time: "09:00",
+  end_time: "10:30",
+  ...overrides,
+})
+
+beforeEach(() => {
+  localStorage.clear()
+  vi.useFakeTimers()
+  vi.setSystemTime(FIXED_NOW)
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  localStorage.clear()
+})
+
+// ---------------------------------------------------------------------------
+// readFromStorage / writeToStorage
+// ---------------------------------------------------------------------------
+describe("readFromStorage / writeToStorage", () => {
+  it("round-trips a value written by writeToStorage", () => {
+    const key = scheduleStorageKey("g1")
+    writeToStorage(key, { a: 1, b: "two" })
+
+    const result = readFromStorage<{ a: number; b: string }>(key)
+    expect(result).toEqual({ value: { a: 1, b: "two" }, timestamp: FIXED_NOW.getTime() })
+  })
+
+  it("returns undefined when the key is absent", () => {
+    expect(readFromStorage(groupsStorageKey)).toBeUndefined()
+  })
+
+  it("returns undefined and removes entry on schema version mismatch", () => {
+    const key = scheduleStorageKey("g2")
+    localStorage.setItem(
+      key,
+      JSON.stringify({
+        version: STORAGE_SCHEMA_VERSION + 1,
+        timestamp: FIXED_NOW.getTime(),
+        data: { stale: true },
+      })
+    )
+
+    expect(readFromStorage(key)).toBeUndefined()
+    expect(localStorage.getItem(key)).toBeNull()
+  })
+
+  it("respects a custom version option (matching custom version reads back)", () => {
+    const key = scheduleStorageKey("g-custom")
+    writeToStorage(key, "payload", { version: 9 })
+
+    // Default version (1) sees a mismatch and removes it.
+    expect(readFromStorage(key)).toBeUndefined()
+
+    // Re-write and read with the matching custom version.
+    writeToStorage(key, "payload", { version: 9 })
+    expect(readFromStorage<string>(key, { version: 9 })).toEqual({
+      value: "payload",
+      timestamp: FIXED_NOW.getTime(),
+    })
+  })
+
+  it("returns undefined and removes entry once TTL has expired", () => {
+    const key = scheduleStorageKey("g3")
+    writeToStorage(key, { fresh: false })
+
+    // Advance just past the default TTL window.
+    vi.setSystemTime(new Date(FIXED_NOW.getTime() + SCHEDULE_STORAGE_TTL_MS + 1))
+
+    expect(readFromStorage(key)).toBeUndefined()
+    expect(localStorage.getItem(key)).toBeNull()
+  })
+
+  it("returns the value while still inside the TTL window", () => {
+    const key = scheduleStorageKey("g4")
+    writeToStorage(key, { fresh: true })
+
+    // Advance to exactly the TTL boundary (diff === maxAgeMs, not greater).
+    vi.setSystemTime(new Date(FIXED_NOW.getTime() + SCHEDULE_STORAGE_TTL_MS))
+
+    expect(readFromStorage<{ fresh: boolean }>(key)).toEqual({
+      value: { fresh: true },
+      timestamp: FIXED_NOW.getTime(),
+    })
+  })
+
+  it("honors a custom maxAgeMs option", () => {
+    const key = scheduleStorageKey("g5")
+    writeToStorage(key, "v")
+
+    vi.setSystemTime(new Date(FIXED_NOW.getTime() + 1000))
+    // 1000ms elapsed, maxAge 500ms → expired.
+    expect(readFromStorage<string>(key, { maxAgeMs: 500 })).toBeUndefined()
+  })
+
+  it("returns undefined and removes entry on NaN timestamp", () => {
+    const key = scheduleStorageKey("g6")
+    localStorage.setItem(
+      key,
+      JSON.stringify({
+        version: STORAGE_SCHEMA_VERSION,
+        timestamp: "not-a-number",
+        data: { x: 1 },
+      })
+    )
+
+    expect(readFromStorage(key)).toBeUndefined()
+    expect(localStorage.getItem(key)).toBeNull()
+  })
+
+  it("returns undefined and removes entry on a missing timestamp field", () => {
+    const key = scheduleStorageKey("g7")
+    localStorage.setItem(
+      key,
+      JSON.stringify({
+        version: STORAGE_SCHEMA_VERSION,
+        data: { x: 1 },
+      })
+    )
+
+    expect(readFromStorage(key)).toBeUndefined()
+    expect(localStorage.getItem(key)).toBeNull()
+  })
+
+  it("returns undefined for a non-object stored payload without removing", () => {
+    const key = scheduleStorageKey("g8")
+    localStorage.setItem(key, JSON.stringify(42))
+
+    expect(readFromStorage(key)).toBeUndefined()
+    // Non-object short-circuits before any remove() call.
+    expect(localStorage.getItem(key)).toBe("42")
+  })
+
+  it("returns undefined when version matches and ts is fresh but 'data' key is absent", () => {
+    const key = scheduleStorageKey("g9")
+    localStorage.setItem(
+      key,
+      JSON.stringify({
+        version: STORAGE_SCHEMA_VERSION,
+        timestamp: FIXED_NOW.getTime(),
+      })
+    )
+
+    // Passes version + TTL guards, then fails the `"data" in parsed` check.
+    expect(readFromStorage(key)).toBeUndefined()
+    expect(localStorage.getItem(key)).not.toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// extractHHMM via getTimeStr / getEndTimeStr
+// ---------------------------------------------------------------------------
+describe("getTimeStr / getEndTimeStr (extractHHMM regex)", () => {
+  it("returns '' for null/undefined/empty time fields", () => {
+    expect(getTimeStr(makeLesson({ start_time: null }))).toBe("")
+    expect(getTimeStr(makeLesson({ start_time: "" }))).toBe("")
+    expect(getEndTimeStr(makeLesson({ end_time: null }))).toBe("")
+  })
+
+  it("extracts HH:MM from a plain HH:MM string", () => {
+    expect(getTimeStr(makeLesson({ start_time: "09:30" }))).toBe("09:30")
+  })
+
+  it("extracts the first HH:MM match from an ISO datetime", () => {
+    expect(getTimeStr(makeLesson({ start_time: "2026-06-16T08:05:00Z" }))).toBe("08:05")
+  })
+
+  it("extracts HH:MM from an HH:MM:SS string", () => {
+    expect(getEndTimeStr(makeLesson({ end_time: "14:45:00" }))).toBe("14:45")
+  })
+
+  it("returns '' when no HH:MM pattern exists (regex no-match branch)", () => {
+    expect(getTimeStr(makeLesson({ start_time: "morning" }))).toBe("")
+    // Single-digit-hour formats lack the required two-digit pair.
+    expect(getTimeStr(makeLesson({ start_time: "9:30" }))).toBe("")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildLessonsByDay
+// ---------------------------------------------------------------------------
+describe("buildLessonsByDay", () => {
+  it("groups lessons by weekday and sorts each day by start time", () => {
+    const schedule: Lesson[] = [
+      makeLesson({ id: "m2", weekday: "Monday", start_time: "11:00" }),
+      makeLesson({ id: "m1", weekday: "Monday", start_time: "09:00" }),
+      makeLesson({ id: "t1", weekday: "Tuesday", start_time: "10:00" }),
+    ]
+    const result = buildLessonsByDay(schedule, ["Monday", "Tuesday"])
+
+    expect([...result.keys()]).toEqual(["Monday", "Tuesday"])
+    expect(result.get("Monday")?.map((l) => l.id)).toEqual(["m1", "m2"])
+    expect(result.get("Tuesday")?.map((l) => l.id)).toEqual(["t1"])
+  })
+
+  it("creates an empty array entry for a weekday with no lessons", () => {
+    const result = buildLessonsByDay([makeLesson({ weekday: "Monday" })], ["Monday", "Wednesday"])
+    expect(result.get("Wednesday")).toEqual([])
+  })
+
+  it("returns an empty map when no weekdays are supplied", () => {
+    const result = buildLessonsByDay([makeLesson()], [])
+    expect(result.size).toBe(0)
+  })
+})

--- a/frontend/src/components/schedule/dialogs/__tests__/AddLessonDialog.test.tsx
+++ b/frontend/src/components/schedule/dialogs/__tests__/AddLessonDialog.test.tsx
@@ -1,0 +1,325 @@
+import { useEffect, type ReactNode } from "react"
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+const apiMocks = vi.hoisted(() => ({
+  post: vi.fn(() => Promise.resolve({ data: {} })),
+}))
+
+vi.mock("@/api/client", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return {
+    ...actual,
+    default: { post: apiMocks.post },
+  }
+})
+vi.mock("@/app/logger", () => ({ logError: vi.fn() }))
+vi.mock("framer-motion", async () =>
+  (await import("@/tests/helpers/framerMotionMock")).framerMotionMock()
+)
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "en", changeLanguage: () => Promise.resolve() },
+  }),
+}))
+
+import { AddLessonDialog } from "@/components/schedule/dialogs/AddLessonDialog"
+import { SchedulePageProvider, useSchedulePage } from "@/contexts/SchedulePageContext"
+import type { LessonTypeConfig } from "@/components/schedule/scheduleUtils"
+import { logError } from "@/app/logger"
+
+const LESSON_TYPE_OPTIONS = [
+  { value: "lecture", label: "Лекция" },
+  { value: "practice", label: "Практика" },
+]
+
+const LESSON_TYPE_CONFIGS: LessonTypeConfig[] = [
+  { id: "lecture", backend: ["LECTURE", "lec"], label: "Лекция", color: "#111" },
+  { id: "practice", backend: ["PRACTICE"], label: "Практика", color: "#222" },
+  // Config with an empty backend array — exercises the `?? addFields.lessonType`
+  // fallback in the backend-type resolver.
+  { id: "seminar", backend: [], label: "Семинар", color: "#333" },
+]
+
+function makeBaseProps(overrides: Partial<Parameters<typeof AddLessonDialog>[0]> = {}) {
+  return {
+    selectedGroupId: "g1" as string | null,
+    defaultLessonType: "lecture",
+    lessonTypeOptions: LESSON_TYPE_OPTIONS,
+    lessonTypeConfigs: LESSON_TYPE_CONFIGS,
+    refresh: vi.fn(),
+    ...overrides,
+  }
+}
+
+/**
+ * Opens the "add" dialog and seeds `addDay` so the submit path is reachable.
+ * Pass `addDay = null` to exercise the early-return guard in `handleAddLesson`.
+ */
+function OpenAddHarness({
+  addDay = "monday",
+  children,
+}: {
+  addDay?: string | null
+  children: ReactNode
+}) {
+  const { openDialog, setAddDay } = useSchedulePage()
+  useEffect(() => {
+    openDialog("add")
+    setAddDay(addDay)
+  }, [openDialog, setAddDay, addDay])
+  return <>{children}</>
+}
+
+function renderDialog(
+  props: ReturnType<typeof makeBaseProps> = makeBaseProps(),
+  addDay: string | null = "monday"
+) {
+  return render(
+    <SchedulePageProvider>
+      <OpenAddHarness addDay={addDay}>
+        <AddLessonDialog {...props} />
+      </OpenAddHarness>
+    </SchedulePageProvider>
+  )
+}
+
+/** Fills the 3 required fields so `isFormValid` becomes true. */
+function fillRequiredFields() {
+  fireEvent.change(screen.getByLabelText("schedule:form.subject"), {
+    target: { value: "Линейная алгебра" },
+  })
+  fireEvent.change(screen.getByLabelText("schedule:form.startTime"), {
+    target: { value: "09:00" },
+  })
+  fireEvent.change(screen.getByLabelText("schedule:form.endTime"), {
+    target: { value: "10:30" },
+  })
+}
+
+describe("AddLessonDialog", () => {
+  beforeEach(() => {
+    apiMocks.post.mockClear()
+    apiMocks.post.mockResolvedValue({ data: {} })
+    vi.mocked(logError).mockClear()
+  })
+
+  it("renders the add form when the 'add' dialog is active", () => {
+    renderDialog()
+    expect(screen.getByText("schedule:dialog.addTitle")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "schedule:buttons.add" })).toBeInTheDocument()
+  })
+
+  it("disables the submit button until all required fields are filled (isFormValid)", () => {
+    renderDialog()
+    const submit = screen.getByRole("button", { name: "schedule:buttons.add" })
+    expect(submit).toBeDisabled()
+
+    fillRequiredFields()
+    expect(submit).toBeEnabled()
+  })
+
+  it("keeps submit disabled when only some required fields are filled", () => {
+    renderDialog()
+    fireEvent.change(screen.getByLabelText("schedule:form.subject"), {
+      target: { value: "X" },
+    })
+    // start/end times still empty.
+    expect(screen.getByRole("button", { name: "schedule:buttons.add" })).toBeDisabled()
+  })
+
+  it("submits successfully: posts mapped payload, success snackbar, refresh, close", async () => {
+    const user = userEvent.setup()
+    const props = makeBaseProps()
+    renderDialog(props)
+
+    fillRequiredFields()
+    await user.click(screen.getByRole("button", { name: "schedule:buttons.add" }))
+
+    await waitFor(() => expect(apiMocks.post).toHaveBeenCalledTimes(1))
+    expect(apiMocks.post).toHaveBeenCalledWith(
+      "/schedule",
+      expect.objectContaining({
+        subject: "Линейная алгебра",
+        // lecture config -> backend[0] = "LECTURE"
+        lesson_type: "LECTURE",
+        start_time: "mondayT09:00:00",
+        end_time: "mondayT10:30:00",
+        weekday: "monday",
+        parity: "both",
+        group_id: "g1",
+      })
+    )
+    await waitFor(() => expect(props.refresh).toHaveBeenCalledTimes(1))
+    // Dialog closed on success.
+    expect(screen.queryByText("schedule:dialog.addTitle")).not.toBeInTheDocument()
+    expect(logError).not.toHaveBeenCalled()
+  })
+
+  it("falls back to addFields.lessonType when the matched config has an empty backend array", async () => {
+    const user = userEvent.setup()
+    const props = makeBaseProps({
+      defaultLessonType: "seminar",
+      lessonTypeOptions: [...LESSON_TYPE_OPTIONS, { value: "seminar", label: "Семинар" }],
+    })
+    renderDialog(props)
+
+    fillRequiredFields()
+    await user.click(screen.getByRole("button", { name: "schedule:buttons.add" }))
+
+    await waitFor(() => expect(apiMocks.post).toHaveBeenCalledTimes(1))
+    // seminar config has backend: [] -> resolver falls back to the id itself.
+    expect(apiMocks.post).toHaveBeenCalledWith(
+      "/schedule",
+      expect.objectContaining({ lesson_type: "seminar" })
+    )
+  })
+
+  it("uses the raw lessonType when no config matches", async () => {
+    const user = userEvent.setup()
+    const props = makeBaseProps({
+      defaultLessonType: "unknown-type",
+      lessonTypeOptions: [...LESSON_TYPE_OPTIONS, { value: "unknown-type", label: "Unknown" }],
+    })
+    renderDialog(props)
+
+    fillRequiredFields()
+    await user.click(screen.getByRole("button", { name: "schedule:buttons.add" }))
+
+    await waitFor(() => expect(apiMocks.post).toHaveBeenCalledTimes(1))
+    expect(apiMocks.post).toHaveBeenCalledWith(
+      "/schedule",
+      expect.objectContaining({ lesson_type: "unknown-type" })
+    )
+  })
+
+  it("shows the error snackbar and logs when the POST fails", async () => {
+    const user = userEvent.setup()
+    apiMocks.post.mockRejectedValueOnce(new Error("network"))
+    const props = makeBaseProps()
+    renderDialog(props)
+
+    fillRequiredFields()
+    await user.click(screen.getByRole("button", { name: "schedule:buttons.add" }))
+
+    await waitFor(() =>
+      expect(logError).toHaveBeenCalledWith("Failed to add lesson", expect.any(Error))
+    )
+    // Refresh not fired on failure; dialog stays open.
+    expect(props.refresh).not.toHaveBeenCalled()
+    expect(screen.getByText("schedule:dialog.addTitle")).toBeInTheDocument()
+  })
+
+  it("does not submit when selectedGroupId is null (early-return guard)", async () => {
+    const user = userEvent.setup()
+    const props = makeBaseProps({ selectedGroupId: null })
+    renderDialog(props)
+
+    fillRequiredFields()
+    await user.click(screen.getByRole("button", { name: "schedule:buttons.add" }))
+
+    // handleAddLesson returns early -> no POST.
+    expect(apiMocks.post).not.toHaveBeenCalled()
+  })
+
+  it("does not submit when addDay is null (early-return guard)", async () => {
+    const user = userEvent.setup()
+    const props = makeBaseProps()
+    renderDialog(props, null)
+
+    fillRequiredFields()
+    await user.click(screen.getByRole("button", { name: "schedule:buttons.add" }))
+
+    expect(apiMocks.post).not.toHaveBeenCalled()
+  })
+
+  it("submits via form Enter and resets the text fields after success", async () => {
+    const user = userEvent.setup()
+    const props = makeBaseProps()
+    renderDialog(props)
+
+    fillRequiredFields()
+    // also fill teacher/room so the reset is observable
+    fireEvent.change(screen.getByLabelText("schedule:form.teacher"), {
+      target: { value: "Иванова Е.А." },
+    })
+    fireEvent.change(screen.getByLabelText("schedule:form.room"), {
+      target: { value: "ГУК-305" },
+    })
+
+    screen.getByLabelText("schedule:form.subject").focus()
+    await user.keyboard("{Enter}")
+
+    await waitFor(() => expect(apiMocks.post).toHaveBeenCalledTimes(1))
+    // After a successful add the dialog closes; the text fields are reset in state.
+    expect(screen.queryByText("schedule:dialog.addTitle")).not.toBeInTheDocument()
+  })
+
+  it("does not render the form when the 'add' dialog is not active", () => {
+    render(
+      <SchedulePageProvider>
+        <AddLessonDialog {...makeBaseProps()} />
+      </SchedulePageProvider>
+    )
+    expect(screen.queryByText("schedule:dialog.addTitle")).not.toBeInTheDocument()
+  })
+
+  it("resets lessonType to the new defaultLessonType when current type is no longer valid (sync effect)", () => {
+    const props = makeBaseProps()
+    const { rerender } = renderDialog(props)
+
+    // Re-render with a different defaultLessonType + an options list that no
+    // longer contains the current "lecture" value -> effect resets to default.
+    const nextProps = makeBaseProps({
+      defaultLessonType: "practice",
+      lessonTypeOptions: [{ value: "practice", label: "Практика" }],
+    })
+    rerender(
+      <SchedulePageProvider>
+        <OpenAddHarness addDay="monday">
+          <AddLessonDialog {...nextProps} />
+        </OpenAddHarness>
+      </SchedulePageProvider>
+    )
+
+    // The lesson-type select now reflects the new default's label.
+    const comboboxes = screen.getAllByRole("combobox")
+    expect(comboboxes[0]!).toHaveTextContent("Практика")
+  })
+
+  it("keeps the current lessonType when it is still valid after a prop change (sync effect no-op)", () => {
+    const props = makeBaseProps()
+    const { rerender } = renderDialog(props)
+
+    // defaultLessonType changes but "lecture" is still a valid option -> effect
+    // returns prev unchanged.
+    const nextProps = makeBaseProps({ defaultLessonType: "practice" })
+    rerender(
+      <SchedulePageProvider>
+        <OpenAddHarness addDay="monday">
+          <AddLessonDialog {...nextProps} />
+        </OpenAddHarness>
+      </SchedulePageProvider>
+    )
+
+    const comboboxes = screen.getAllByRole("combobox")
+    expect(comboboxes[0]!).toHaveTextContent("Лекция")
+  })
+
+  it("does nothing in the sync effect when defaultLessonType is empty", () => {
+    const props = makeBaseProps({ defaultLessonType: "" })
+    renderDialog(props)
+    // Empty default -> effect returns early; dialog still renders.
+    expect(screen.getByText("schedule:dialog.addTitle")).toBeInTheDocument()
+  })
+
+  it("closes the dialog via the cancel button", async () => {
+    const user = userEvent.setup()
+    renderDialog()
+    expect(screen.getByText("schedule:dialog.addTitle")).toBeInTheDocument()
+    await user.click(screen.getByRole("button", { name: "common:buttons.cancel" }))
+    expect(screen.queryByText("schedule:dialog.addTitle")).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/utils/__tests__/sanitize.fallback.test.ts
+++ b/frontend/src/utils/__tests__/sanitize.fallback.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { sanitize_rich_text, strip_html } from "wasm-sanitizer"
+import { logWarning } from "@/app/logger"
+import { sanitizeNewsHtml, sanitizeNewsText } from "../sanitize"
+
+// This file mocks the wasm-sanitizer package per-file (vi.mock is hoisted) so we
+// can drive the RZ-24-04 regex fallback + Trusted Types policy-failure branches
+// that the WASM-initialized happy path in setupTests.ts never reaches.
+vi.mock("wasm-sanitizer", () => ({
+  sanitize_rich_text: vi.fn((s: string) => s),
+  strip_html: vi.fn((s: string) => s),
+}))
+
+vi.mock("@/app/logger", () => ({
+  logWarning: vi.fn((..._args: unknown[]) => undefined),
+}))
+
+type TrustedTypesWindow = Window & {
+  trustedTypes?: unknown
+  __dompurifyNewsPolicy?: unknown
+}
+
+const win = window as unknown as TrustedTypesWindow
+const originalTrustedTypes = win.trustedTypes
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  delete win.__dompurifyNewsPolicy
+  // Default: no Trusted Types support, so sanitizeNewsHtml uses the direct
+  // sanitize_rich_text path (or its catch fallback).
+  win.trustedTypes = undefined
+})
+
+afterEach(() => {
+  win.trustedTypes = originalTrustedTypes
+  delete win.__dompurifyNewsPolicy
+})
+
+// ---------------------------------------------------------------------------
+// (a) wasm-sanitizer unavailable / throwing -> regex fallback strips tags
+// ---------------------------------------------------------------------------
+describe("sanitizeNewsHtml — regex fallback (RZ-24-04)", () => {
+  it("falls back to stripping tags when sanitize_rich_text throws", async () => {
+    vi.mocked(sanitize_rich_text).mockImplementation(() => {
+      throw new Error("wasm unavailable")
+    })
+    const result = await sanitizeNewsHtml("<script>alert(1)</script><p>hello</p>")
+    expect(result).toBe("alert(1)hello")
+  })
+
+  it("never renders nothing — preserves text content on fallback", async () => {
+    vi.mocked(sanitize_rich_text).mockImplementation(() => {
+      throw new Error("boom")
+    })
+    const result = await sanitizeNewsHtml("<b>visible text</b>")
+    expect(result).toBe("visible text")
+  })
+
+  it("uses sanitize_rich_text directly when it does not throw (no Trusted Types)", async () => {
+    vi.mocked(sanitize_rich_text).mockImplementation((s: string) => `[clean]${s}`)
+    const result = await sanitizeNewsHtml("<p>x</p>")
+    expect(result).toBe("[clean]<p>x</p>")
+    expect(sanitize_rich_text).toHaveBeenCalledWith("<p>x</p>")
+  })
+
+  it("coerces null/undefined to empty string before fallback", async () => {
+    vi.mocked(sanitize_rich_text).mockImplementation(() => {
+      throw new Error("boom")
+    })
+    expect(await sanitizeNewsHtml(null)).toBe("")
+    expect(await sanitizeNewsHtml(undefined)).toBe("")
+  })
+})
+
+describe("sanitizeNewsText — regex fallback (RZ-24-04)", () => {
+  it("falls back to stripping tags when strip_html throws", async () => {
+    vi.mocked(strip_html).mockImplementation(() => {
+      throw new Error("wasm unavailable")
+    })
+    const result = await sanitizeNewsText("<span>plain</span> <i>text</i>")
+    expect(result).toBe("plain text")
+  })
+
+  it("uses strip_html directly when it does not throw", async () => {
+    vi.mocked(strip_html).mockImplementation((s: string) => `[stripped]${s}`)
+    const result = await sanitizeNewsText("<p>y</p>")
+    expect(result).toBe("[stripped]<p>y</p>")
+    expect(strip_html).toHaveBeenCalledWith("<p>y</p>")
+  })
+
+  it("coerces null/undefined to empty string", async () => {
+    vi.mocked(strip_html).mockImplementation((s: string) => s)
+    expect(await sanitizeNewsText(null)).toBe("")
+    expect(await sanitizeNewsText(undefined)).toBe("")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// (b) Trusted Types policy creation failure -> policy = false flag path
+// ---------------------------------------------------------------------------
+describe("sanitizeNewsHtml — Trusted Types policy creation failure", () => {
+  it("sets __dompurifyNewsPolicy = false and falls back to direct sanitize when createPolicy throws", async () => {
+    const factory = {
+      createPolicy: vi.fn(() => {
+        throw new Error("CSP rejects trusted-types policy")
+      }),
+    }
+    win.trustedTypes = factory
+    vi.mocked(sanitize_rich_text).mockImplementation((s: string) => `[clean]${s}`)
+
+    const result = await sanitizeNewsHtml("<p>z</p>")
+
+    expect(factory.createPolicy).toHaveBeenCalledTimes(1)
+    expect(win.__dompurifyNewsPolicy).toBe(false)
+    expect(logWarning).toHaveBeenCalledWith(
+      "Unable to create dompurify-news trusted types policy",
+      expect.objectContaining({ error: expect.any(Error) })
+    )
+    // policy resolved to null -> direct sanitize_rich_text path used
+    expect(result).toBe("[clean]<p>z</p>")
+  })
+
+  it("does not retry createPolicy once __dompurifyNewsPolicy is already false (cached failure)", async () => {
+    const factory = {
+      createPolicy: vi.fn(() => {
+        throw new Error("CSP rejects trusted-types policy")
+      }),
+    }
+    win.trustedTypes = factory
+    win.__dompurifyNewsPolicy = false
+    vi.mocked(sanitize_rich_text).mockImplementation((s: string) => s)
+
+    await sanitizeNewsHtml("<p>a</p>")
+
+    expect(factory.createPolicy).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// (c) policy caching on the 2nd call
+// ---------------------------------------------------------------------------
+describe("sanitizeNewsHtml — Trusted Types policy caching", () => {
+  it("creates the policy once and reuses the cached instance on the 2nd call", async () => {
+    const createHTML = vi.fn((s: string) => `[tt]${s}`)
+    const policy = { createHTML }
+    const factory = {
+      createPolicy: vi.fn(() => policy),
+    }
+    win.trustedTypes = factory
+
+    const first = await sanitizeNewsHtml("<p>1</p>")
+    const second = await sanitizeNewsHtml("<p>2</p>")
+
+    expect(factory.createPolicy).toHaveBeenCalledTimes(1)
+    expect(win.__dompurifyNewsPolicy).toBe(policy)
+    expect(first).toBe("[tt]<p>1</p>")
+    expect(second).toBe("[tt]<p>2</p>")
+    expect(createHTML).toHaveBeenCalledTimes(2)
+    // WASM sanitize path never touched when a policy is in play
+    expect(sanitize_rich_text).not.toHaveBeenCalled()
+  })
+
+  it("returns null policy (no createPolicy call) when trustedTypes is absent", async () => {
+    win.trustedTypes = undefined
+    vi.mocked(sanitize_rich_text).mockImplementation((s: string) => `[direct]${s}`)
+
+    const result = await sanitizeNewsHtml("<p>q</p>")
+
+    expect(result).toBe("[direct]<p>q</p>")
+    expect(win.__dompurifyNewsPolicy).toBeUndefined()
+  })
+})

--- a/security/audit-allowlist.yaml
+++ b/security/audit-allowlist.yaml
@@ -565,6 +565,58 @@ npm:
       reason: |
         Package-name rollup — lighthouse (via @lhci/cli) is flagged via its
         transitive ws/protobufjs deps. CI performance-audit tooling, not bundled.
+    - id: "1121186"
+      package: "undici"
+      owner: frontend@university.example
+      expires: 2026-09-21
+      reason: |
+        Fresh-disclosure (2026-06) undici TLS certificate validation bypass (high).
+        Transitive only (no direct dep); the Vite browser bundle uses native fetch,
+        so undici is Node-only build/SSR tooling and not reachable by clients. The
+        SSR server only calls the trusted internal backend. fixAvailable via a
+        transitive bump — tracked for a dedicated dep-hygiene pass (testing W17).
+    - id: "1121188"
+      package: "undici"
+      owner: frontend@university.example
+      expires: 2026-09-21
+      reason: |
+        Fresh-disclosure (2026-06) undici cross-user information disclosure (moderate).
+        Transitive undici; not in the browser bundle (native fetch). See id 1121186.
+    - id: "1121190"
+      package: "undici"
+      owner: frontend@university.example
+      expires: 2026-09-21
+      reason: |
+        Fresh-disclosure (2026-06) undici WebSocket client DoS (high). Transitive
+        undici; not in the browser bundle (native fetch). See id 1121186.
+    - id: "1121240"
+      package: "undici"
+      owner: frontend@university.example
+      expires: 2026-09-21
+      reason: |
+        Fresh-disclosure (2026-06) undici HTTP header injection via Set-Cookie
+        (moderate). Transitive undici; not in the browser bundle. See id 1121186.
+    - id: "1121243"
+      package: "undici"
+      owner: frontend@university.example
+      expires: 2026-09-21
+      reason: |
+        Fresh-disclosure (2026-06) undici WebSocket client DoS (high, second source).
+        Transitive undici; not in the browser bundle. See id 1121186.
+    - id: "1121248"
+      package: "undici"
+      owner: frontend@university.example
+      expires: 2026-09-21
+      reason: |
+        Fresh-disclosure (2026-06) undici HTTP response queue poisoning (low).
+        Transitive undici; not in the browser bundle. See id 1121186.
+    - id: "1121253"
+      package: "undici"
+      owner: frontend@university.example
+      expires: 2026-09-21
+      reason: |
+        Fresh-disclosure (2026-06) undici Set-Cookie SameSite attribute downgrade
+        (low). Transitive undici; not in the browser bundle. See id 1121186.
 
 pip:
   advisories:

--- a/services/file-processor/cmd/file-processor/main_coverage_test.go
+++ b/services/file-processor/cmd/file-processor/main_coverage_test.go
@@ -29,7 +29,7 @@ func TestInitLogger_ReturnsJSONLogger(t *testing.T) {
 	logger := initLogger()
 	require.NotNil(t, logger)
 	// Smoke: a log call must not panic with the custom ReplaceAttr time handler.
-	logger.Info("init-logger-smoke", "k", "v")
+	logger.InfoContext(context.Background(), "init-logger-smoke", "k", "v")
 }
 
 func TestInitSentry_NoDSNIsNoOp(t *testing.T) {

--- a/services/file-processor/cmd/file-processor/main_coverage_test.go
+++ b/services/file-processor/cmd/file-processor/main_coverage_test.go
@@ -1,0 +1,105 @@
+package main
+
+// Coverage tests (testing session 16) for cmd bootstrap helpers that don't need
+// a live Temporal/NATS/MinIO connection: initLogger, initSentry (no-DSN + bad-DSN),
+// initTracer (production-insecure guard + dev success path), and the stream-auth
+// error path + authedServerStream.Context() wrapper. The genuinely
+// integration-shaped funcs (connectTemporal Dial loop, setupTemporalWorker /
+// startNatsSubscriber / runServers / setupGraphQLServer with os.Exit) stay
+// covered by the integration suite, not here.
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/university-ecosystem/file-processor/internal/config"
+	"google.golang.org/grpc"
+)
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func TestInitLogger_ReturnsJSONLogger(t *testing.T) {
+	logger := initLogger()
+	require.NotNil(t, logger)
+	// Smoke: a log call must not panic with the custom ReplaceAttr time handler.
+	logger.Info("init-logger-smoke", "k", "v")
+}
+
+func TestInitSentry_NoDSNIsNoOp(t *testing.T) {
+	// Empty DSN takes the early return — no global Sentry hub is mutated.
+	initSentry(context.Background(), &config.Config{SentryDSN: "", Environment: "test"}, discardLogger())
+}
+
+func TestInitSentry_MalformedDSNLogsError(t *testing.T) {
+	// A malformed DSN makes sentry.Init return an error → the error branch runs.
+	// sentry.Init parses the DSN synchronously and does no network on a bad parse.
+	initSentry(context.Background(), &config.Config{SentryDSN: "not-a-valid-dsn", Environment: "test"}, discardLogger())
+}
+
+func TestInitTracer_ProductionInsecureForbidden(t *testing.T) {
+	_, err := initTracer(context.Background(),
+		&config.Config{OTLPInsecure: true, Environment: "production"}, discardLogger())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "forbidden in production")
+}
+
+func TestInitTracer_DevInsecureSucceeds(t *testing.T) {
+	// The OTLP gRPC exporter dials lazily, so New() returns without a collector.
+	tp, err := initTracer(context.Background(),
+		&config.Config{OTLPInsecure: true, Environment: "development", OTLPEndpoint: "localhost:4317"},
+		discardLogger())
+	require.NoError(t, err)
+	require.NotNil(t, tp)
+	// Shut down to stop the batch-span-processor goroutine cleanly.
+	require.NoError(t, tp.Shutdown(context.Background()))
+}
+
+func TestSelectiveStreamAuth_AuthErrorBlocksHandler(t *testing.T) {
+	authFn := func(ctx context.Context) (context.Context, error) {
+		return nil, errors.New("invalid stream token")
+	}
+	interceptor := selectiveStreamAuth(authFn)
+
+	handlerCalled := false
+	handler := func(srv interface{}, ss grpc.ServerStream) error {
+		handlerCalled = true
+		return nil
+	}
+
+	ss := &mockServerStream{ctx: context.Background()}
+	info := &grpc.StreamServerInfo{FullMethod: "/file_processor.v1.FileProcessingService/Watch"}
+	err := interceptor(nil, ss, info, handler)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid stream token")
+	assert.False(t, handlerCalled, "handler must NOT run when stream auth fails")
+}
+
+type authCtxKey struct{}
+
+func TestSelectiveStreamAuth_WrappedStreamCarriesAuthedContext(t *testing.T) {
+	// authFn injects a value; the handler must observe it via the WRAPPED stream's
+	// Context() — exercising authedServerStream.Context().
+	authFn := func(ctx context.Context) (context.Context, error) {
+		return context.WithValue(ctx, authCtxKey{}, "sub-123"), nil
+	}
+	interceptor := selectiveStreamAuth(authFn)
+
+	var seen interface{}
+	handler := func(srv interface{}, ss grpc.ServerStream) error {
+		seen = ss.Context().Value(authCtxKey{})
+		return nil
+	}
+
+	ss := &mockServerStream{ctx: context.Background()}
+	info := &grpc.StreamServerInfo{FullMethod: "/file_processor.v1.FileProcessingService/Watch"}
+	require.NoError(t, interceptor(nil, ss, info, handler))
+	assert.Equal(t, "sub-123", seen, "wrapped stream must carry the authed context value")
+}

--- a/services/file-processor/internal/workflow/workflow_coverage_test.go
+++ b/services/file-processor/internal/workflow/workflow_coverage_test.go
@@ -77,10 +77,10 @@ func (f *fakeS3) handler() http.HandlerFunc {
 			w.Header().Set("Content-Length", strconv.Itoa(len(f.getBody)))
 			w.WriteHeader(http.StatusOK)
 			if r.Method == http.MethodGet {
-				_, _ = w.Write(f.getBody)
+				_, _ = w.Write(f.getBody) //nolint:errcheck // test server best-effort
 			}
 		case http.MethodPut:
-			b, _ := io.ReadAll(r.Body)
+			b, _ := io.ReadAll(r.Body) //nolint:errcheck // test handler best-effort
 			f.putBody = b
 			status := f.putStatus
 			if status == 0 {

--- a/services/file-processor/internal/workflow/workflow_coverage_test.go
+++ b/services/file-processor/internal/workflow/workflow_coverage_test.go
@@ -1,0 +1,242 @@
+package workflow
+
+// Default-run (no build tag) coverage tests for the MinIO-touching activity
+// paths. The existing workflow_integration_test.go covers the same happy path
+// but is gated behind `//go:build integration` (needs a real MinIO container via
+// testcontainers + Docker), so it does NOT contribute to the default `go test`
+// coverage the CI gate measures. These tests stand up a lightweight in-process
+// fake-S3 HTTP server (httptest) and point a real *minio.Client at it, exercising
+// downloadAndDecodeImage + ResizeImageActivity without Docker. (Testing session 16.)
+
+import (
+	"bytes"
+	"context"
+	"image"
+	"image/png"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// makeRGBAPNG returns the bytes of a valid w×h RGBA PNG. Mirrors the integration
+// test's makeTestPNG but lives in a non-build-tagged file so it compiles in the
+// default test run.
+func makeRGBAPNG(t *testing.T, w, h int) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	var buf bytes.Buffer
+	require.NoError(t, png.Encode(&buf, img))
+	return buf.Bytes()
+}
+
+// minioClientFor builds a path-style *minio.Client pointed at the given test
+// server URL. Region is pinned so minio-go skips the GetBucketLocation probe.
+func minioClientFor(t *testing.T, serverURL string) *minio.Client {
+	t.Helper()
+	u, err := url.Parse(serverURL)
+	require.NoError(t, err)
+	client, err := minio.New(u.Host, &minio.Options{
+		Creds:  credentials.NewStaticV4("test", "test", ""),
+		Secure: false,
+		Region: "us-east-1",
+	})
+	require.NoError(t, err)
+	return client
+}
+
+// fakeS3 serves a minimal subset of the S3 object API: GET returns getBody,
+// PUT captures the uploaded bytes into putBody and replies with the configured
+// putStatus. A nil getBody on GET yields a 404.
+type fakeS3 struct {
+	getBody   []byte
+	putStatus int
+	putBody   []byte
+}
+
+func (f *fakeS3) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet, http.MethodHead:
+			if f.getBody == nil {
+				http.Error(w, "not found", http.StatusNotFound)
+				return
+			}
+			w.Header().Set("Content-Type", "image/png")
+			w.Header().Set("ETag", `"deadbeef"`)
+			w.Header().Set("Last-Modified", time.Now().UTC().Format(http.TimeFormat))
+			w.Header().Set("Accept-Ranges", "bytes")
+			w.Header().Set("Content-Length", strconv.Itoa(len(f.getBody)))
+			w.WriteHeader(http.StatusOK)
+			if r.Method == http.MethodGet {
+				_, _ = w.Write(f.getBody)
+			}
+		case http.MethodPut:
+			b, _ := io.ReadAll(r.Body)
+			f.putBody = b
+			status := f.putStatus
+			if status == 0 {
+				status = http.StatusOK
+			}
+			w.Header().Set("ETag", `"deadbeef"`)
+			w.WriteHeader(status)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}
+}
+
+func TestDownloadAndDecodeImage_HappyPath(t *testing.T) {
+	fs := &fakeS3{getBody: makeRGBAPNG(t, 40, 30)}
+	srv := httptest.NewServer(fs.handler())
+	defer srv.Close()
+
+	a := &FileActivities{MinioClient: minioClientFor(t, srv.URL), Bucket: "bucket"}
+	// Pass a deadline so the deadliner (SetReadDeadline) branch is exercised.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	img, format, err := a.downloadAndDecodeImage(ctx, "in/img.png")
+	require.NoError(t, err)
+	require.NotNil(t, img)
+	assert.Equal(t, "png", format)
+	assert.Equal(t, 40, img.Bounds().Dx())
+	assert.Equal(t, 30, img.Bounds().Dy())
+}
+
+func TestDownloadAndDecodeImage_DecodeError(t *testing.T) {
+	fs := &fakeS3{getBody: []byte("this is not an image")}
+	srv := httptest.NewServer(fs.handler())
+	defer srv.Close()
+
+	a := &FileActivities{MinioClient: minioClientFor(t, srv.URL), Bucket: "bucket"}
+	_, _, err := a.downloadAndDecodeImage(context.Background(), "in/garbage.png")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to decode image")
+}
+
+func TestResizeImageActivity_HappyPath(t *testing.T) {
+	fs := &fakeS3{getBody: makeRGBAPNG(t, 100, 100)}
+	srv := httptest.NewServer(fs.handler())
+	defer srv.Close()
+
+	a := &FileActivities{MinioClient: minioClientFor(t, srv.URL), Bucket: "bucket"}
+	job := ProcessJob{
+		ID:        "job-ok",
+		Type:      "resize",
+		SourceKey: "in/img.png",
+		DestKey:   "out/img.png",
+		Options:   map[string]interface{}{"width": 50, "height": 50},
+	}
+	res, err := a.ResizeImageActivity(context.Background(), job)
+	require.NoError(t, err)
+	require.True(t, res.Success)
+	assert.Equal(t, "out/img.png", res.DestKey)
+	assert.Equal(t, "job-ok", res.JobID)
+
+	// minio-go uploads over plain HTTP using AWS streaming-signature chunk
+	// encoding, so the captured PUT body is the chunk-wrapped payload, not raw
+	// PNG bytes — asserting it is non-empty is the meaningful default-run check.
+	// The clean PNG round-trip is verified by workflow_integration_test.go
+	// against a real MinIO container (which de-chunks the upload).
+	require.NotEmpty(t, fs.putBody)
+}
+
+func TestResizeImageActivity_BadSourceKey(t *testing.T) {
+	// No server contact: sanitizeMinIOKey rejects before any MinIO call.
+	a := &FileActivities{MinioClient: &minio.Client{}, Bucket: "bucket"}
+	job := ProcessJob{ID: "j", SourceKey: "../../etc/passwd", DestKey: "out/x.png"}
+	_, err := a.ResizeImageActivity(context.Background(), job)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "path traversal")
+}
+
+func TestResizeImageActivity_BadDestKey(t *testing.T) {
+	a := &FileActivities{MinioClient: &minio.Client{}, Bucket: "bucket"}
+	job := ProcessJob{ID: "j", SourceKey: "in/ok.png", DestKey: "images/../../passwd"}
+	_, err := a.ResizeImageActivity(context.Background(), job)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "path traversal")
+}
+
+func TestResizeImageActivity_InvalidDimensions(t *testing.T) {
+	fs := &fakeS3{getBody: makeRGBAPNG(t, 100, 100)}
+	srv := httptest.NewServer(fs.handler())
+	defer srv.Close()
+
+	a := &FileActivities{MinioClient: minioClientFor(t, srv.URL), Bucket: "bucket"}
+	job := ProcessJob{
+		ID:        "j",
+		SourceKey: "in/img.png",
+		DestKey:   "out/img.png",
+		Options:   map[string]interface{}{"width": "not-a-number"},
+	}
+	_, err := a.ResizeImageActivity(context.Background(), job)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid dimensions")
+}
+
+func TestResizeImageActivity_TooManyPixels(t *testing.T) {
+	fs := &fakeS3{getBody: makeRGBAPNG(t, 100, 100)}
+	srv := httptest.NewServer(fs.handler())
+	defer srv.Close()
+
+	a := &FileActivities{MinioClient: minioClientFor(t, srv.URL), Bucket: "bucket"}
+	job := ProcessJob{
+		ID:        "j",
+		SourceKey: "in/img.png",
+		DestKey:   "out/img.png",
+		// Each dimension <= maxImageDimension (4096) but product > maxImagePixels (8M).
+		Options: map[string]interface{}{"width": 4000, "height": 4000},
+	}
+	_, err := a.ResizeImageActivity(context.Background(), job)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceed limit")
+}
+
+func TestResizeImageActivity_UploadError(t *testing.T) {
+	fs := &fakeS3{getBody: makeRGBAPNG(t, 100, 100), putStatus: http.StatusInternalServerError}
+	srv := httptest.NewServer(fs.handler())
+	defer srv.Close()
+
+	a := &FileActivities{MinioClient: minioClientFor(t, srv.URL), Bucket: "bucket"}
+	job := ProcessJob{
+		ID:        "j",
+		SourceKey: "in/img.png",
+		DestKey:   "out/img.png",
+		Options:   map[string]interface{}{"width": 50, "height": 50},
+	}
+	_, err := a.ResizeImageActivity(context.Background(), job)
+	require.Error(t, err)
+}
+
+func TestGetValidatedDimension_ParsesInt32AndInt64(t *testing.T) {
+	r32, err := getValidatedDimension(map[string]interface{}{"width": int32(640)}, "width", 800)
+	require.NoError(t, err)
+	assert.Equal(t, 640, r32)
+
+	r64, err := getValidatedDimension(map[string]interface{}{"height": int64(480)}, "height", 600)
+	require.NoError(t, err)
+	assert.Equal(t, 480, r64)
+}
+
+func TestGetValidatedDimension_ParsesValidNumericString(t *testing.T) {
+	res, err := getValidatedDimension(map[string]interface{}{"width": "1280"}, "width", 800)
+	require.NoError(t, err)
+	assert.Equal(t, 1280, res)
+}
+
+func TestGetValidatedDimension_ErrorsOnUnsupportedType(t *testing.T) {
+	// A bool value hits the switch default arm ("invalid type for ...").
+	_, err := getValidatedDimension(map[string]interface{}{"width": true}, "width", 800)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid type")
+}

--- a/services/gateway/go.mod
+++ b/services/gateway/go.mod
@@ -3,6 +3,7 @@ module github.com/university-ecosystem/gateway
 go 1.26.4
 
 require (
+	github.com/alicebob/miniredis/v2 v2.38.0
 	github.com/getsentry/sentry-go v0.46.2
 	github.com/getsentry/sentry-go/gin v0.46.2
 	github.com/gin-contrib/cors v1.7.7
@@ -78,6 +79,7 @@ require (
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/tklauser/go-sysconf v0.3.16 // indirect
 	github.com/tklauser/numcpus v0.11.0 // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.mongodb.org/mongo-driver/v2 v2.6.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect

--- a/services/gateway/go.sum
+++ b/services/gateway/go.sum
@@ -6,6 +6,8 @@ github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEK
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
+github.com/alicebob/miniredis/v2 v2.38.0 h1:nZAzCR+Lj+Vxk4ZXzm2NuKq2O33RXj1XxJ2e2uP9jiw=
+github.com/alicebob/miniredis/v2 v2.38.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
@@ -210,6 +212,8 @@ github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/ugorji/go/codec v1.3.1 h1:waO7eEiFDwidsBN6agj1vJQ4AG7lh2yqXyOXqhgQuyY=
 github.com/ugorji/go/codec v1.3.1/go.mod h1:pRBVtBSKl77K30Bv8R2P+cLSGaTtex6fsA2Wjqmfxj4=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 github.com/zeebo/xxh3 v1.1.0 h1:s7DLGDK45Dyfg7++yxI0khrfwq9661w9EN78eP/UZVs=

--- a/services/gateway/middleware/auth_pubsub_test.go
+++ b/services/gateway/middleware/auth_pubsub_test.go
@@ -1,0 +1,87 @@
+package middleware
+
+// Coverage tests (testing session 16) for the Redis pub/sub session-revocation
+// listener (ListenForRevocations + listenOnce). The existing auth_redis_test.go
+// uses a hand-rolled RESP mock that cannot speak pub/sub, so these paths scored
+// ~0% in the default run (the live path was only covered by the //go:build
+// integration testcontainers tier). miniredis implements SUBSCRIBE/PUBLISH, so we
+// can exercise the listener end-to-end without Docker.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListenOnce_RemovesL1KeyOnRevocationMessage(t *testing.T) {
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+
+	m := NewJWTMiddleware(testSecret, client)
+	m.l1cache.Add("revoked:jti:abc", cacheEntry{exists: true, storedAt: time.Now()})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() { m.listenOnce(ctx); close(done) }()
+
+	// Republish on each tick to dodge the subscribe/publish race: if the message
+	// is published before SUBSCRIBE registers, it's lost — retrying guarantees
+	// at least one lands after the listener is live.
+	require.Eventually(t, func() bool {
+		_ = client.Publish(context.Background(), "session:revocations", "abc").Err()
+		_, ok := m.l1cache.Get("revoked:jti:abc")
+		return !ok
+	}, 3*time.Second, 50*time.Millisecond)
+
+	// go-redis v9's Channel() auto-reconnects rather than closing the Go channel
+	// on disconnect, so mr.Close() is not a reliable exit. Instead cancel the ctx
+	// and publish more messages: listenOnce checks ctx.Done() as it processes each
+	// received message, so the next delivery makes it return.
+	cancel()
+	require.Eventually(t, func() bool {
+		_ = client.Publish(context.Background(), "session:revocations", "drain").Err()
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	}, 3*time.Second, 50*time.Millisecond)
+}
+
+func TestListenForRevocations_NilRedisIsNoOp(t *testing.T) {
+	m := NewJWTMiddleware(testSecret, nil)
+	// m.redis == nil guard returns immediately and spawns no goroutine.
+	m.ListenForRevocations(context.Background())
+}
+
+func TestListenForRevocations_ProcessesThenReconnectsOnDisconnect(t *testing.T) {
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+
+	m := NewJWTMiddleware(testSecret, client)
+	m.l1cache.Add("revoked:jti:xyz", cacheEntry{exists: true, storedAt: time.Now()})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	m.ListenForRevocations(ctx) // spawns the listener goroutine
+
+	require.Eventually(t, func() bool {
+		_ = client.Publish(context.Background(), "session:revocations", "xyz").Err()
+		_, ok := m.l1cache.Get("revoked:jti:xyz")
+		return !ok
+	}, 3*time.Second, 50*time.Millisecond)
+
+	// Disconnect → the listener observes the closed channel, increments the
+	// disconnect metric, purges L1, computes backoff, then exits on ctx cancel.
+	mr.Close()
+	cancel()
+	time.Sleep(150 * time.Millisecond) // allow the goroutine to observe cancel + return
+}

--- a/services/gateway/middleware/auth_pubsub_test.go
+++ b/services/gateway/middleware/auth_pubsub_test.go
@@ -20,7 +20,7 @@ import (
 func TestListenOnce_RemovesL1KeyOnRevocationMessage(t *testing.T) {
 	mr := miniredis.RunT(t)
 	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
-	t.Cleanup(func() { _ = client.Close() })
+	t.Cleanup(func() { _ = client.Close() }) //nolint:errcheck // best-effort cleanup
 
 	m := NewJWTMiddleware(testSecret, client)
 	m.l1cache.Add("revoked:jti:abc", cacheEntry{exists: true, storedAt: time.Now()})
@@ -34,7 +34,7 @@ func TestListenOnce_RemovesL1KeyOnRevocationMessage(t *testing.T) {
 	// is published before SUBSCRIBE registers, it's lost — retrying guarantees
 	// at least one lands after the listener is live.
 	require.Eventually(t, func() bool {
-		_ = client.Publish(context.Background(), "session:revocations", "abc").Err()
+		_ = client.Publish(context.Background(), "session:revocations", "abc").Err() //nolint:errcheck // fire-and-forget; Eventually retries
 		_, ok := m.l1cache.Get("revoked:jti:abc")
 		return !ok
 	}, 3*time.Second, 50*time.Millisecond)
@@ -45,7 +45,7 @@ func TestListenOnce_RemovesL1KeyOnRevocationMessage(t *testing.T) {
 	// received message, so the next delivery makes it return.
 	cancel()
 	require.Eventually(t, func() bool {
-		_ = client.Publish(context.Background(), "session:revocations", "drain").Err()
+		_ = client.Publish(context.Background(), "session:revocations", "drain").Err() //nolint:errcheck // fire-and-forget; Eventually retries
 		select {
 		case <-done:
 			return true
@@ -64,7 +64,7 @@ func TestListenForRevocations_NilRedisIsNoOp(t *testing.T) {
 func TestListenForRevocations_ProcessesThenReconnectsOnDisconnect(t *testing.T) {
 	mr := miniredis.RunT(t)
 	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
-	t.Cleanup(func() { _ = client.Close() })
+	t.Cleanup(func() { _ = client.Close() }) //nolint:errcheck // best-effort cleanup
 
 	m := NewJWTMiddleware(testSecret, client)
 	m.l1cache.Add("revoked:jti:xyz", cacheEntry{exists: true, storedAt: time.Now()})
@@ -74,7 +74,7 @@ func TestListenForRevocations_ProcessesThenReconnectsOnDisconnect(t *testing.T) 
 	m.ListenForRevocations(ctx) // spawns the listener goroutine
 
 	require.Eventually(t, func() bool {
-		_ = client.Publish(context.Background(), "session:revocations", "xyz").Err()
+		_ = client.Publish(context.Background(), "session:revocations", "xyz").Err() //nolint:errcheck // fire-and-forget; Eventually retries
 		_, ok := m.l1cache.Get("revoked:jti:xyz")
 		return !ok
 	}, 3*time.Second, 50*time.Millisecond)

--- a/services/gateway/middleware/ratelimit_miniredis_test.go
+++ b/services/gateway/middleware/ratelimit_miniredis_test.go
@@ -1,0 +1,67 @@
+package middleware
+
+// Coverage tests (testing session 16) for the Redis-backed rate-limiter SUCCESS
+// paths. The existing ratelimit_test.go covers getClientKey / inMemoryAllow /
+// isHealthPath / the Redis-error fallback / the bad-URL error, but NewRateLimiter's
+// Ping-OK path and Middleware's redis_rate.Allow success+headers+429 branches
+// need a live Redis. miniredis runs the redis_rate GCRA Lua script (gopher-lua),
+// so these execute without Docker.
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRateLimiter_SuccessWithMiniredis(t *testing.T) {
+	mr := miniredis.RunT(t)
+	rl, err := NewRateLimiter(context.Background(), "redis://"+mr.Addr(), 10, 10)
+	require.NoError(t, err)
+	require.NotNil(t, rl)
+	assert.NotNil(t, rl.GetClient())
+}
+
+func TestRateLimiter_Middleware_HealthExemptAndLimitEnforced(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	mr := miniredis.RunT(t)
+	rl, err := NewRateLimiter(context.Background(), "redis://"+mr.Addr(), 1, 1)
+	require.NoError(t, err)
+
+	r := gin.New()
+	r.Use(rl.Middleware(context.Background()))
+	r.GET("/health", func(c *gin.Context) { c.Status(http.StatusOK) })
+	r.GET("/api/thing", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	// Health path bypasses the limiter entirely — always 200.
+	for i := 0; i < 5; i++ {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/health", nil)
+		r.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code)
+	}
+
+	// Non-exempt path at rps=1: at least one request passes and the limiter
+	// eventually returns 429 (true whether redis_rate or the in-memory fallback
+	// does the limiting).
+	var got200, got429 bool
+	for i := 0; i < 12; i++ {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/api/thing", nil)
+		req.RemoteAddr = "203.0.113.7:1234"
+		r.ServeHTTP(w, req)
+		switch w.Code {
+		case http.StatusOK:
+			got200 = true
+		case http.StatusTooManyRequests:
+			got429 = true
+		}
+	}
+	assert.True(t, got200, "at least one request must be allowed")
+	assert.True(t, got429, "rate limiter must eventually return 429")
+}

--- a/services/ws-hub/go.mod
+++ b/services/ws-hub/go.mod
@@ -29,6 +29,7 @@ require (
 require go.yaml.in/yaml/v2 v2.4.3 // indirect
 
 require (
+	github.com/alicebob/miniredis/v2 v2.38.0
 	github.com/testcontainers/testcontainers-go v0.42.0
 	github.com/testcontainers/testcontainers-go/modules/nats v0.42.0
 	github.com/testcontainers/testcontainers-go/modules/redis v0.42.0
@@ -90,6 +91,7 @@ require (
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/tklauser/go-sysconf v0.3.16 // indirect
 	github.com/tklauser/numcpus v0.11.0 // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.44.0 // indirect

--- a/services/ws-hub/go.sum
+++ b/services/ws-hub/go.sum
@@ -6,6 +6,8 @@ github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEK
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
+github.com/alicebob/miniredis/v2 v2.38.0 h1:nZAzCR+Lj+Vxk4ZXzm2NuKq2O33RXj1XxJ2e2uP9jiw=
+github.com/alicebob/miniredis/v2 v2.38.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
@@ -195,6 +197,8 @@ github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYI
 github.com/tklauser/go-sysconf v0.3.16/go.mod h1:/qNL9xxDhc7tx3HSRsLWNnuzbVfh3e7gh/BmM179nYI=
 github.com/tklauser/numcpus v0.11.0 h1:nSTwhKH5e1dMNsCdVBukSZrURJRoHbSEQjdEbY+9RXw=
 github.com/tklauser/numcpus v0.11.0/go.mod h1:z+LwcLq54uWZTX0u/bGobaV34u6V7KNlTZejzM6/3MQ=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 github.com/zeebo/xxh3 v1.1.0 h1:s7DLGDK45Dyfg7++yxI0khrfwq9661w9EN78eP/UZVs=

--- a/services/ws-hub/main_coverage_test.go
+++ b/services/ws-hub/main_coverage_test.go
@@ -24,7 +24,7 @@ func discardLogger() *slog.Logger {
 func TestInitLogger_ReturnsLogger(t *testing.T) {
 	logger := initLogger()
 	require.NotNil(t, logger)
-	logger.Info("init-logger-smoke")
+	logger.InfoContext(context.Background(), "init-logger-smoke")
 }
 
 func TestInitRedis_SuccessWithMiniredis(t *testing.T) {
@@ -32,7 +32,7 @@ func TestInitRedis_SuccessWithMiniredis(t *testing.T) {
 	cfg := &config.Config{RedisURL: mr.Addr()}
 	rdb := initRedis(context.Background(), cfg, discardLogger())
 	require.NotNil(t, rdb, "Ping must succeed against miniredis → L2 enabled")
-	t.Cleanup(func() { _ = rdb.Close() })
+	t.Cleanup(func() { _ = rdb.Close() }) //nolint:errcheck // best-effort cleanup
 	require.NoError(t, rdb.Ping(context.Background()).Err())
 }
 

--- a/services/ws-hub/main_coverage_test.go
+++ b/services/ws-hub/main_coverage_test.go
@@ -1,0 +1,44 @@
+package main
+
+// Coverage tests (testing session 16) for the no-network bootstrap helpers in
+// main.go (initLogger + initRedis). The integration-shaped helpers (initNats /
+// setupHub / setupHandlers / runServer — live NATS, os.Exit, global ServeMux)
+// stay out of the default run.
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/university-ecosystem/ws-hub/pkg/config"
+)
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func TestInitLogger_ReturnsLogger(t *testing.T) {
+	logger := initLogger()
+	require.NotNil(t, logger)
+	logger.Info("init-logger-smoke")
+}
+
+func TestInitRedis_SuccessWithMiniredis(t *testing.T) {
+	mr := miniredis.RunT(t)
+	cfg := &config.Config{RedisURL: mr.Addr()}
+	rdb := initRedis(context.Background(), cfg, discardLogger())
+	require.NotNil(t, rdb, "Ping must succeed against miniredis → L2 enabled")
+	t.Cleanup(func() { _ = rdb.Close() })
+	require.NoError(t, rdb.Ping(context.Background()).Err())
+}
+
+func TestInitRedis_PingFailureReturnsNil(t *testing.T) {
+	// Nothing listening on :1 → Ping fails → initRedis degrades to nil (no L2).
+	cfg := &config.Config{RedisURL: "127.0.0.1:1"}
+	rdb := initRedis(context.Background(), cfg, discardLogger())
+	assert.Nil(t, rdb)
+}

--- a/services/ws-hub/pkg/hub/auth_client_redis_test.go
+++ b/services/ws-hub/pkg/hub/auth_client_redis_test.go
@@ -28,7 +28,7 @@ func newMiniredisClient(t *testing.T) (*miniredis.Miniredis, *redis.Client) {
 	t.Helper()
 	mr := miniredis.RunT(t)
 	rc := redis.NewClient(&redis.Options{Addr: mr.Addr()})
-	t.Cleanup(func() { _ = rc.Close() })
+	t.Cleanup(func() { _ = rc.Close() }) //nolint:errcheck // best-effort cleanup
 	return mr, rc
 }
 

--- a/services/ws-hub/pkg/hub/auth_client_redis_test.go
+++ b/services/ws-hub/pkg/hub/auth_client_redis_test.go
@@ -1,0 +1,92 @@
+package hub
+
+// Coverage tests (testing session 16) for the Redis L2 paths in the internal-API
+// auth client. The existing auth_client_test.go builds every client with a nil
+// *redis.Client, so the L2 read-hit / write-back / Invalidate-delete branches in
+// CanJoinRoom + Invalidate never executed. miniredis gives a real go-redis L2
+// without Docker. Also covers StartEviction (a documented no-op since Wave 7).
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	rdUser  = "11111111-1111-1111-1111-111111111111"
+	rdRoom  = "22222222-2222-2222-2222-222222222222"
+	rdRoom2 = "33333333-3333-3333-3333-333333333333"
+)
+
+func newMiniredisClient(t *testing.T) (*miniredis.Miniredis, *redis.Client) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	rc := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rc.Close() })
+	return mr, rc
+}
+
+func TestStartEviction_NoOpIsSafe(t *testing.T) {
+	c := NewInternalAPIAuthClient("http://localhost", nil)
+	c.StartEviction(context.Background()) // no-op since Wave 7; just exercises it
+}
+
+func TestCanJoinRoom_RedisL2Hit(t *testing.T) {
+	mr, rc := newMiniredisClient(t)
+	require.NoError(t, mr.Set("auth:perms:"+rdUser+":"+rdRoom, "1"))
+
+	c := NewInternalAPIAuthClient("http://unused.invalid", rc)
+	assert.True(t, c.CanJoinRoom(context.Background(), rdUser, rdRoom),
+		"L2 hit of \"1\" must allow without an HTTP call")
+
+	// L1 must be populated from L2.
+	entry, ok := c.cache.Get(rdUser + ":" + rdRoom)
+	require.True(t, ok)
+	assert.True(t, entry.allowed)
+}
+
+func TestCanJoinRoom_SlowPathWritesRedisL2(t *testing.T) {
+	mr, rc := newMiniredisClient(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK) // backend says allowed
+	}))
+	defer server.Close()
+
+	c := NewInternalAPIAuthClient(server.URL, rc)
+	assert.True(t, c.CanJoinRoom(context.Background(), rdUser, rdRoom))
+
+	// The slow path must write the decision back to L2.
+	val, err := mr.Get("auth:perms:" + rdUser + ":" + rdRoom)
+	require.NoError(t, err)
+	assert.Equal(t, "1", val)
+}
+
+func TestInvalidate_SingleRoomDeletesRedisL2(t *testing.T) {
+	mr, rc := newMiniredisClient(t)
+	key := "auth:perms:" + rdUser + ":" + rdRoom
+	require.NoError(t, mr.Set(key, "1"))
+
+	c := NewInternalAPIAuthClient("http://localhost", rc)
+	c.Invalidate(rdUser, rdRoom)
+	assert.False(t, mr.Exists(key), "single-room invalidation must delete the L2 key")
+}
+
+func TestInvalidate_WildcardDeletesAllUserRedisL2(t *testing.T) {
+	mr, rc := newMiniredisClient(t)
+	k1 := "auth:perms:" + rdUser + ":" + rdRoom
+	k2 := "auth:perms:" + rdUser + ":" + rdRoom2
+	require.NoError(t, mr.Set(k1, "1"))
+	require.NoError(t, mr.Set(k2, "0"))
+
+	c := NewInternalAPIAuthClient("http://localhost", rc)
+	c.Invalidate(rdUser, "") // wildcard: SCAN + DEL every auth:perms:<user>:* key
+
+	assert.False(t, mr.Exists(k1))
+	assert.False(t, mr.Exists(k2))
+}

--- a/services/ws-hub/pkg/hub/hub_nats_branches_test.go
+++ b/services/ws-hub/pkg/hub/hub_nats_branches_test.go
@@ -1,0 +1,61 @@
+package hub
+
+// Coverage tests (testing session 16) for the NATS-handler branches the existing
+// hub_nats_test.go leaves out: the appCtx.Done() early-return in
+// handleNotifications + handleCacheInvalidation, and the broadcast-full drop in
+// handleNotifications. Mirrors the handleChat cancelled/full tests.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHandleNotifications_CancelledContextReturnsEarly(t *testing.T) {
+	h := newNatsTestHub(&mockAuthClient{allowed: true}, "", 10)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	handler := h.handleNotifications(ctx)
+
+	handler(&nats.Msg{Subject: "notifications.user-1", Data: []byte(`{"to":"user-1"}`)})
+
+	select {
+	case msg := <-h.Broadcast:
+		t.Fatalf("expected no broadcast after context cancel, got %+v", msg)
+	default:
+	}
+}
+
+func TestHandleNotifications_FullChannelDrops(t *testing.T) {
+	h := newNatsTestHub(&mockAuthClient{allowed: true}, "", 1)
+	handler := h.handleNotifications(context.Background())
+
+	handler(&nats.Msg{Subject: "notifications.u", Data: []byte(`{"to":"u","payload":{"n":1}}`)})
+	handler(&nats.Msg{Subject: "notifications.u", Data: []byte(`{"to":"u","payload":{"n":2}}`)})
+
+	first := recvBroadcast(t, h)
+	assert.Equal(t, "notification", first.Type)
+	select {
+	case msg := <-h.Broadcast:
+		t.Fatalf("second notification should have been dropped, got %+v", msg)
+	default:
+	}
+}
+
+func TestHandleCacheInvalidation_CancelledContextReturnsEarly(t *testing.T) {
+	auth := &recordingAuthClient{}
+	h := newNatsTestHub(auth, "secret", 10)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	handler := h.handleCacheInvalidation(ctx)
+
+	payload := signedInvalidationPayload(t, "secret", invalidationData{
+		RoomID: "11111111-1111-1111-1111-111111111111",
+		UserID: "22222222-2222-2222-2222-222222222222",
+	})
+	handler(&nats.Msg{Subject: "cache.invalidate", Data: payload})
+
+	assert.Empty(t, auth.calls(), "cancelled context must short-circuit before any Invalidate")
+}


### PR DESCRIPTION
## Summary

Testing **Session 16** — a multi-front coverage push. With the frontend already near-ceiling (91.35%), the headroom this session was on the **Go services**, plus a clean frontend long-tail sweep. All work is **tests-only** (no production behavior changes).

| Front | Before | After | Floor (gate) |
|---|---|---|---|
| Go **file-processor** | 52.3% | **67.4%** (+15.1) | 50 → **65** |
| Go **gateway** | 68.9% | **75.8%** (+6.9) | 66 → **73** |
| Go **ws-hub** | 68.8% | **72.7%** (+3.9) | 66 → **70** |
| **Frontend** | 91.35% | +54 it() (long-tail) | 90/80/81/90 (held) |

## What changed

### Go file-processor (`36203b1d`)
- `workflow.go` 41.4 → 84.7%: `ResizeImageActivity` + `downloadAndDecodeImage` were covered only by the `//go:build integration` testcontainers suite (needs Docker), so they scored 0% in the default `go test` the CI gate measures. New `workflow_coverage_test.go` stands up an in-process **httptest fake-S3** server and points a real `*minio.Client` at it — exercising download/decode/resize/encode/upload without Docker. Plus the missing `getValidatedDimension` branches + `ResizeImageActivity` early-error arms.
- `cmd/main.go` 33 → 44.4%: no-network bootstrap helpers (`initLogger`, `initSentry`, `initTracer` prod-insecure guard + dev lazy-dial, stream-auth error path, `authedServerStream.Context()`).

### Go gateway (`6e70bc99`) — adds `miniredis` (test-only)
- Pub/sub revocation listener `listenOnce` 0 → 80% + `ListenForRevocations` 9.5 → 90.5% (miniredis SUBSCRIBE/PUBLISH; teardown via the per-message `ctx.Done()` check since go-redis v9 `Channel()` auto-reconnects rather than closing on disconnect).
- Rate limiter `NewRateLimiter` 30 → 90% + `Middleware` 53.8 → 100% (redis_rate GCRA Lua runs on miniredis/gopher-lua).

### Go ws-hub (`fbcb00ee`) — adds `miniredis` (test-only)
- `CanJoinRoom` 59.5 → 89.2% + `Invalidate` 73.7 → 100% (Redis L2 read-hit / write-back / SCAN-DEL — existing tests passed a nil redis client).
- NATS handler ctx-done + notification full-channel branches; root `main.go` `initLogger`/`initRedis` 0 → 100%.

### Frontend long-tail (`237a77f6`) — +54 it() across 6 files, tests only
`sanitize` WASM/Trusted-Types fallbacks · `scheduleUtils` storage/TTL/grouping · `api/client` 429-retry + trace-context · `etagCache` epoch/HMAC/quota/flush · `NotificationsBell` coords/resize/pagination · `AddLessonDialog` (new).

## Reviewer notes

- **`readCachedEnvelope` source bug — intentionally NOT fixed here.** `useProfileSync.ts`'s `readCachedEnvelope()` never returns the parsed value (always `undefined`), leaving the whole cache-restore subsystem dead. Fixing the one-liner un-deadens it, but for v4-encrypted caches the sync bootstrap returns an `id:"-1"` placeholder that is only replaced if the async decrypt succeeds — on any decrypt/cache-corruption failure the user is left as a fake `-1` user with no auto-fetch recovery. That's auth-security-adjacent and needs browser-level QA, so it's **deferred to a dedicated fix-with-QA wave** rather than shipped unverified in a coverage PR.
- Go: `gofmt -l` + `go vet ./...` clean; `go.mod` diffs are additive (`miniredis` + `gopher-lua` indirect, both test-only).
- Frontend: project-wide `tsc --noEmit` = 0 errors; the 6 new/modified test files pass collectively (93 tests); no production source touched.
- Frontend gate not ratcheted (already near-ceiling; the known full-suite-parallel MSW flakes block a clean local coverage snapshot — the added tests still raise coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)