### PR TITLE
fix(scorecard): raise Pinned-Dependencies to 10/10 and harden .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,12 +28,20 @@ smoke_*_logs.txt
 # Go coverage output
 cover.out
 coverage.out
+coverage.json
+coverage
 
 # Test databases
 test.db
 test-migration.db
 test_gw*.db
+test_sch.db
+university.db
 cache/images/cache.db
+
+# Compiled binaries (Go, Rust, Windows)
+*.exe
+*.out
 
 pids
 *.pid

--- a/Dockerfile.protogen
+++ b/Dockerfile.protogen
@@ -10,8 +10,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Buf Binary
-RUN curl -L -o /usr/local/bin/buf "https://github.com/bufbuild/buf/releases/download/v1.50.0/buf-$(uname -s)-$(uname -m)" && \
+# Install Buf Binary — pinned to v1.50.0 with verified SHA256 integrity check.
+# Digest sourced from: https://github.com/bufbuild/buf/releases/download/v1.50.0/sha256.txt
+# Architecture: Linux-x86_64 (CI runners are amd64). Update both when upgrading buf.
+RUN set -eux; \
+    BUF_VERSION="v1.50.0"; \
+    BUF_SHA256="154ea883ce098eac4fa106ff9ee4e4964bb97f809dd8ec9c34a432b466ce1494"; \  # pragma: allowlist secret
+    curl -fsSL -o /usr/local/bin/buf \
+        "https://github.com/bufbuild/buf/releases/download/${BUF_VERSION}/buf-Linux-x86_64"; \
+    echo "${BUF_SHA256}  /usr/local/bin/buf" | sha256sum -c -; \
     chmod +x /usr/local/bin/buf
 
 # Install Go Plugins with pinned versions

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -15,8 +15,6 @@ RUN --mount=type=cache,id=apt-lists-test,target=/var/lib/apt/lists \
     && rm -rf /var/lib/apt/lists/* \
     && groupadd --system --gid 10001 app \
     && useradd --system --uid 10001 --gid app --home-dir /home/app --shell /bin/bash app
-RUN python -m pip install --no-cache-dir --upgrade pip==26.1
-
 # MOD-30-05: Install Rust toolchain from official Docker image instead of
 # curl|sh (supply chain risk — executing unversioned script from internet).
 # Pin to a specific Rust version for reproducible builds.

--- a/backend.Dockerfile
+++ b/backend.Dockerfile
@@ -31,7 +31,6 @@ RUN --mount=type=cache,id=apt-lists-builder,target=/var/lib/apt/lists \
     build-essential \
     curl \
     && rm -rf /var/lib/apt/lists/*
-RUN python -m pip install --no-cache-dir --upgrade pip==26.1
 
 # Copy Rust toolchain from the dedicated stage.
 COPY --from=rust-toolchain /usr/local/cargo /usr/local/cargo
@@ -78,7 +77,6 @@ RUN --mount=type=cache,id=apt-lists-runtime,target=/var/lib/apt/lists \
     && rm -rf /var/lib/apt/lists/* \
     && groupadd --system --gid 10001 app \
     && useradd --system --uid 10001 --gid app --home-dir /home/app --shell /usr/sbin/nologin --no-create-home app
-RUN python -m pip install --no-cache-dir --upgrade pip==26.1
 
 # Copy virtual environment from builder
 COPY --from=builder --chown=app:app /opt/venv /opt/venv


### PR DESCRIPTION
## Summary

Remediates all actionable findings from the OSSF Scorecard v2.4.3 run.

## Changes

### Pinned-Dependencies: 9/10 → 10/10

**Remove redundant pip upgrade** from 3 Dockerfile stages:
- `Dockerfile.test` (builder stage)
- `backend.Dockerfile` (builder stage + runtime stage)

All package management uses `uv sync --frozen`; pip is never invoked directly,
so upgrading it was dead code that Scorecard flagged as "pipCommand not pinned by hash".

**Pin buf binary in `Dockerfile.protogen`** with verified SHA256:
- Was: bare curl install without integrity check ("curlCommand not pinned by hash")
- Now: download verified against official sha256.txt digest 154ea883... (buf v1.50.0 Linux-x86_64)

### .gitignore hardening

Add missing patterns to prevent future accidental commits of local build artifacts:
- `*.exe`, `*.out` -- Go/Rust compiled binaries
- `coverage.json`, `coverage` -- raw coverage artifacts
- `test_sch.db`, `university.db` -- named SQLite test databases

All listed files confirmed not tracked in the git index (local-only); additions are a forward-looking guard.

## Scorecard impact

| Check | Before | After |
|---|---|---|
| Pinned-Dependencies | 9/10 | **10/10** |
| Binary-Artifacts | 10/10 | 10/10 (unchanged) |
| Branch-Protection | 5/10 | 5/10 (requires GitHub UI settings) |

Branch-Protection improvements require GitHub repository ruleset changes and are tracked separately.
