### PR TITLE
fix(scorecard): disable webapp publish for filtered SARIF

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -36,8 +36,11 @@ jobs:
         with:
           results_file: scorecard-results.sarif
           results_format: sarif
-          # Publish to public Scorecard API (shows badge on README, requires public repo)
-          publish_results: true
+          # Disabled because this job post-processes SARIF with a `run:` step.
+          # The public Scorecard API only accepts workflows whose Scorecard job
+          # contains `uses:` steps exclusively; Code Scanning still receives the
+          # filtered SARIF via github/codeql-action/upload-sarif below.
+          publish_results: false
 
       - name: Filter policy-only Scorecard SARIF findings
         shell: python


### PR DESCRIPTION
Summary:
- set Scorecard publish_results to false because the job post-processes SARIF with a run step
- keep GitHub Code Scanning upload intact via upload-sarif after filtering policy-only findings

Why:
- ossf/scorecard-action rejects public webapp publication when the Scorecard job contains run steps: workflow verification failed: scorecard job must only have steps with uses

Verification:
- scorecard.yml parses as YAML
- ruff security lint passes
- git diff vs origin/main contains only .github/workflows/scorecard.yml