### PR TITLE
fix(scorecard): restore SARIF ownership before filtering

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -42,6 +42,9 @@ jobs:
           # filtered SARIF via github/codeql-action/upload-sarif below.
           publish_results: false
 
+      - name: Normalize Scorecard SARIF ownership
+        run: sudo chown "$USER:$USER" scorecard-results.sarif
+
       - name: Filter policy-only Scorecard SARIF findings
         shell: python
         run: |


### PR DESCRIPTION
Summary:
- chown scorecard-results.sarif back to the runner user after the Docker-based Scorecard action
- allow the following Python filter step to rewrite the SARIF file before upload-sarif

Why:
- Scorecard writes scorecard-results.sarif from a Docker container, so the runner hit PermissionError: [Errno 13] Permission denied when Path.write_text tried to rewrite it.

Verification:
- scorecard.yml parses as YAML
- git diff --check passed
- remote push typecheck hook passed
- diff vs origin/main is only .github/workflows/scorecard.yml (+3 lines)