### PR TITLE
fix: reduce code scanning false positives

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,5 +1,9 @@
 name: "Custom CodeQL config"
 
+paths-ignore:
+  - tests/**
+  - frontend/rust-crypto/tests/**
+
 # RZ-W17-04/05 (Wave 17): Scoped exclusions to specific reviewed files only.
 # Previously, py/path-injection was blanket-excluded via tag filter (disabled
 # ALL path injection detection project-wide), and py/weak-cryptographic-algorithm

--- a/app/services/storage.py
+++ b/app/services/storage.py
@@ -58,8 +58,13 @@ class StaticFSStorage(StorageBackend):
         cleaned = relative_path.strip().strip("/")
         if not cleaned:
             raise ValueError("Relative path must not be empty")
+        if "\x00" in cleaned or "\\" in cleaned:
+            raise ValueError("Relative path contains invalid characters")
         candidate = Path(cleaned)
-        if candidate.is_absolute() or any(part == ".." for part in candidate.parts):
+        if candidate.is_absolute():
+            raise ValueError("Relative path must not be absolute")
+        parts = candidate.parts
+        if not parts or any(part in {"", ".", ".."} for part in parts):
             raise ValueError("Relative path must not escape base directory")
         return candidate
 

--- a/app/services/storage.py
+++ b/app/services/storage.py
@@ -73,7 +73,7 @@ class StaticFSStorage(StorageBackend):
         """
         target = self.base_dir / relative_path
         try:
-            resolved = target.resolve(strict=False)
+            resolved = target.resolve(strict=False)  # codeql[py/path-injection]
         except OSError as exc:
             raise ValueError(f"Cannot resolve path: {exc}") from exc
         base_resolved = self.base_dir.resolve()

--- a/frontend/scripts/server-prod.mjs
+++ b/frontend/scripts/server-prod.mjs
@@ -129,7 +129,7 @@ function serveStatic(req, res, urlPath) {
   }
   const stream = createReadStream(filePath)
   stream.on("error", (err) => {
-    console.error(`server-prod: read error for ${filePath}:`, err)
+    console.error("server-prod: read error for static file", filePath, err)
     if (!res.writableEnded) res.end()
   })
   stream.pipe(res)

--- a/frontend/src/utils/htmlText.ts
+++ b/frontend/src/utils/htmlText.ts
@@ -21,10 +21,8 @@ export const htmlToPlainText = (html: string | null | undefined): string => {
   const source = html ?? ""
   if (!source) return ""
 
-  if (typeof document !== "undefined") {
-    const template = document.createElement("template")
-    template.innerHTML = source
-    return template.content.textContent ?? ""
+  if (typeof DOMParser !== "undefined") {
+    return new DOMParser().parseFromString(source, "text/html").body.textContent ?? ""
   }
 
   return stripTagsByState(source)

--- a/frontend/src/utils/sanitizeArticleHtml.ts
+++ b/frontend/src/utils/sanitizeArticleHtml.ts
@@ -22,12 +22,33 @@ const DANGEROUS_TAGS = new Set([
 ])
 
 const URL_ATTRIBUTES = new Set(["href", "src", "action"])
+const SAFE_DATA_IMAGE_URL_PATTERN =
+  /^data:image\/(?:avif|gif|jpeg|jpg|png|webp);base64,[a-z0-9+/=\s]+$/i
+
+const getUrlProtocol = (value: string): string | null => {
+  const compact = [...value.trim()]
+    .filter((char) => {
+      const code = char.charCodeAt(0)
+      return code > 0x1f && code !== 0x7f && !/\s/.test(char)
+    })
+    .join("")
+  if (!compact) return null
+
+  try {
+    return new URL(compact, "https://ue.local").protocol.toLowerCase()
+  } catch {
+    return null
+  }
+}
 
 const isUnsafeUrlAttribute = (name: string, value: string): boolean => {
-  const normalized = value.trim().toLowerCase()
-  if (normalized.startsWith("javascript:")) return true
-  if (name === "src" && normalized.startsWith("data:")) {
-    return !normalized.startsWith("data:image/")
+  const protocol = getUrlProtocol(value)
+  if (!protocol) return true
+  if (protocol === "javascript:" || protocol === "vbscript:" || protocol === "file:") {
+    return true
+  }
+  if (protocol === "data:") {
+    return name !== "src" || !SAFE_DATA_IMAGE_URL_PATTERN.test(value.trim())
   }
   return false
 }


### PR DESCRIPTION
## Summary
- harden article URL sanitization and plain-text HTML extraction
- add CodeQL path ignores for test-only fixtures and KAT vectors
- suppress validated storage path resolve finding and remove tainted static-file log template

## Verification
- npx prettier --write src/utils/sanitizeArticleHtml.ts src/utils/htmlText.ts scripts/server-prod.mjs
- npx eslint --fix --no-warn-ignored src/utils/sanitizeArticleHtml.ts
- npx vitest run src/utils/__tests__/sanitizeArticleHtml.test.ts
- npx vitest run src/utils/__tests__/sanitizeArticleHtml.test.ts src/utils/__tests__/sanitize.test.ts
- uv run pytest tests/test_storage.py tests/test_storage_coverage.py -q -W ignore::DeprecationWarning
- pre-commit hooks during commit/amend passed
- pre-push frontend typecheck passed