### PR TITLE
chore: fix TruffleHog BASE and HEAD same commit push error

### DIFF
--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -24,6 +24,5 @@ jobs:
         uses: trufflesecurity/trufflehog@0f58ae7c5036094a1e3e750d18772af92821b503 # v3.90.5
         with:
           path: ./
-          base: ${{ github.event.repository.default_branch }}
-          head: HEAD
           extra_args: --debug --only-verified
+


### PR DESCRIPTION
Fixes TruffleHog crash when base and head commits are identical on push event by omitting them to fall back to filesystem scan.