### PR TITLE
fix: strip_html idempotency + flaky sw.test.ts (audit findings)

### DIFF
--- a/crates/pyo3-sanitizer/src/lib.rs
+++ b/crates/pyo3-sanitizer/src/lib.rs
@@ -68,6 +68,11 @@ pub fn sanitize_rich_text(html: &str) -> String {
 
     let url_schemes: HashSet<&str> = ["http", "https"].iter().copied().collect();
 
+    // WHY: html5ever (used internally by ammonia) processes null bytes (\0)
+    // as part of text nodes rather than removing them outright.  When \0
+    // precedes U+FEFF, the tokeniser leaves FEFF in the first-pass output but
+    // removes it on the second pass — breaking idempotency.  Stripping both
+    // characters post-ammonia is the minimal correct fix.
     Builder::new()
         .tags(allowed_tags)
         .tag_attributes(attributes)
@@ -75,6 +80,8 @@ pub fn sanitize_rich_text(html: &str) -> String {
         .link_rel(Some("noopener noreferrer"))
         .clean(html)
         .to_string()
+        .replace('\0', "")
+        .replace('\u{feff}', "")
 }
 
 #[pyfunction]
@@ -91,7 +98,13 @@ pub fn py_sanitize_rich_text(html: &str) -> PyResult<String> {
 /// where rich formatting is unwanted.
 pub fn sanitize_html_basic(html: &str) -> String {
     let allowed_tags: HashSet<&str> = ["b", "i", "em", "strong"].iter().copied().collect();
-    Builder::new().tags(allowed_tags).clean(html).to_string()
+    // WHY: same html5ever null-byte + BOM idempotency issue as strip_html.
+    Builder::new()
+        .tags(allowed_tags)
+        .clean(html)
+        .to_string()
+        .replace('\0', "")
+        .replace('\u{feff}', "")
 }
 
 #[pyfunction]
@@ -106,7 +119,18 @@ pub fn py_sanitize_html_basic(html: &str) -> PyResult<String> {
 ///
 /// Use this when storing or indexing content where markup must be absent.
 pub fn strip_html(html: &str) -> String {
-    Builder::new().tags(HashSet::new()).clean(html).to_string()
+    // Run ammonia's tag-stripping pass first.
+    let cleaned = Builder::new().tags(HashSet::new()).clean(html).to_string();
+
+    // WHY: html5ever (used internally by ammonia) processes null bytes (\0)
+    // as part of text nodes rather than removing them outright.  When \0
+    // precedes a BOM/ZWNBSP (U+FEFF), the presence of \0 changes how the
+    // HTML5 tokeniser handles U+FEFF on the *first* call (leaving it in the
+    // output) while the *second* call (now without \0) removes it — breaking
+    // idempotency.  Stripping both characters after ammonia runs is the
+    // minimal, correct fix that restores the invariant:
+    //   strip_html(strip_html(x)) == strip_html(x)  for all x.
+    cleaned.replace('\0', "").replace('\u{feff}', "")
 }
 
 #[pyfunction]
@@ -325,6 +349,18 @@ mod tests {
         assert!(!out.contains('<'), "no tags must remain");
         assert!(out.contains("outer"), "outer text must survive");
         assert!(out.contains("inner"), "inner text must survive");
+    }
+
+    #[test]
+    fn test_strip_html_null_byte_and_bom_idempotent() {
+        // Regression: proptest found strip_html was not idempotent on null + BOM
+        let input = "\0\u{feff}";
+        let first = strip_html(input);
+        let second = strip_html(&first);
+        assert_eq!(first, second, "strip_html must be idempotent");
+        // Also verify the output contains no null bytes or BOM
+        assert!(!first.contains('\0'), "strip_html must remove null bytes");
+        assert!(!first.contains('\u{feff}'), "strip_html must remove BOM characters");
     }
 
     #[test]

--- a/frontend/src/tests/sw.test.ts
+++ b/frontend/src/tests/sw.test.ts
@@ -235,7 +235,6 @@ const loadServiceWorker = async () => {
 
 let originalSelf: typeof globalThis
 let listeners: Map<string, ((event: Event) => void)[]>
-let originalCaches: CacheStorage | undefined
 let swModule: SwModule | undefined
 
 beforeEach(async () => {
@@ -243,12 +242,13 @@ beforeEach(async () => {
   const created = createServiceWorkerScope()
   listeners = created.listeners
   originalSelf = self
-  const globalWithCaches = globalThis as typeof globalThis & { caches?: CacheStorage }
-  originalCaches = globalWithCaches.caches
   Object.assign(globalThis as typeof globalThis & { self: TestServiceWorkerScope }, {
     self: created.scope,
   })
-  globalWithCaches.caches = created.scope.caches
+  // Use vi.stubGlobal so Vitest tracks the stub and vi.unstubAllGlobals() in
+  // afterEach restores the original value — prevents leaks into sibling workers
+  // that share the same process (fixes flaky api.test.ts clearSessionCaches).
+  vi.stubGlobal("caches", created.scope.caches)
   swModule = await import("@/sw")
   // Explicitly initialize offline queue to ensure IndexedDB stores exist
   // even if bootstrap fails due to mock issues
@@ -260,12 +260,8 @@ afterEach(async () => {
   // Note: deleteDatabase() removed to prevent hook timeouts with fake-indexeddb
   vi.restoreAllMocks()
   vi.clearAllMocks()
-  const globalWithCaches = globalThis as typeof globalThis & { caches?: CacheStorage }
-  if (originalCaches) {
-    globalWithCaches.caches = originalCaches
-  } else {
-    Reflect.deleteProperty(globalWithCaches, "caches")
-  }
+  // vi.stubGlobal("caches") in beforeEach is reverted here automatically.
+  vi.unstubAllGlobals()
   Object.assign(globalThis as typeof globalThis & { self: typeof originalSelf }, {
     self: originalSelf,
   })


### PR DESCRIPTION
## Исправления по результатам финального аудита

### Bug 1 — Rust: strip_html не идемпотентна (production bug)
- **Файл:** crates/pyo3-sanitizer/src/lib.rs
- **Причина:** html5ever tokeniser обрабатывал null-byte + BOM по-разному при первом и втором вызове
- **Fix:** явная постобработка .replace('\0', '').replace('\u{feff}', '') во всех 3 функциях
- **Обнаружено:** proptest minimal input = null-byte + BOM
- **Коммит:** cfe6f8f90

### Bug 2 — Frontend: flaky test (global state leak)
- **Файл:** frontend/src/tests/sw.test.ts
- **Причина:** прямое присваивание globalThis.caches вместо vi.stubGlobal()
- **Fix:** vi.stubGlobal() + vi.unstubAllGlobals() в afterEach
- **Коммит:** 46c3f518e