### PR TITLE
feat(quality): bootstrap trusted performance assets

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,6 +11,12 @@
 # CI/CD workflow changes affect the entire security posture of the project.
 .github/workflows/ @egorribun
 
+# The paired performance tools decide required merge contexts; changes need the
+# same owner review as the workflows that invoke them.
+scripts/quality/compare_paired_benchmarks.py @egorribun
+scripts/quality/capture_isolated_benchmarks.py @egorribun
+containers/quality/Dockerfile.performance-rust @egorribun
+
 # Infrastructure secrets and compose files contain credentials and network config.
 docker-compose*.yml @egorribun
 .env.docker.example @egorribun

--- a/containers/quality/Dockerfile.performance-rust
+++ b/containers/quality/Dockerfile.performance-rust
@@ -1,0 +1,26 @@
+# syntax=docker/dockerfile:1.12
+#checkov:skip=CKV_DOCKER_2:This disposable, non-networked benchmark image runs only inside GitHub-hosted CI and is never deployed as a service.
+# This image is built only from the protected base worktree with an empty build
+# context. Do not add COPY instructions that read candidate source files.
+FROM python:3.14-slim-bookworm@sha256:23c59390fc717bf09f9336908199a0ae75d9c4264bf296123f94ad772fea3b52
+
+# Reuse the pinned Rust toolchain already used by the repository's test image.
+COPY --from=rust:1.94.1-slim-bookworm@sha256:cf9dd0ec73e75f827fe59123fff9dc65af1a1c8363c3c31ee8d7f8ad0b6a5fb2 /usr/local/rustup /usr/local/rustup
+COPY --from=rust:1.94.1-slim-bookworm@sha256:cf9dd0ec73e75f827fe59123fff9dc65af1a1c8363c3c31ee8d7f8ad0b6a5fb2 /usr/local/cargo /usr/local/cargo
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        git \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd --system --gid 10001 benchmark \
+    && useradd --system --uid 10001 --gid benchmark --home-dir /tmp/home --shell /usr/sbin/nologin --no-create-home benchmark
+
+ENV RUSTUP_HOME="/usr/local/rustup" \
+    CARGO_HOME="/usr/local/cargo" \
+    LD_LIBRARY_PATH="/usr/local/lib" \
+    PATH="/usr/local/cargo/bin:${PATH}"
+
+WORKDIR /src
+USER benchmark

--- a/docs/superpowers/plans/2026-08-11-same-run-performance-gates.md
+++ b/docs/superpowers/plans/2026-08-11-same-run-performance-gates.md
@@ -1,0 +1,391 @@
+# Same-run Performance Gates Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace invalid cross-run historical blocking comparisons with a statistically sound, fail-closed same-run base/head performance gate, while preserving the existing required contexts and a strict greater-than-10-percent regression policy.
+
+**Architecture:** The two required regression jobs resolve immutable base and candidate SHAs, execute both revisions in an isolated GitHub-hosted runner, alternate twelve base/head pairs, and retain every raw output. A new standard-library Python comparator validates the evidence, evaluates paired lower-is-better ratios, and emits a deterministic machine-readable decision. Historical `benchmark-action` chart publication becomes an isolated main-only publisher; it cannot decide pull-request acceptance.
+
+**Tech Stack:** Python 3.14 standard library and pytest, GitHub Actions, Go 1.26 benchmark output, Rust Criterion bencher output, YAML/actionlint, Git worktrees, GitHub artifacts.
+
+## Global Constraints
+
+- Preserve the exact required context names `WS-Hub Go Benchmark Regression Gate` and `Rust Native Optimizer Regression Gate`; preserve the currently required advisory context names `Run Go Benchmarks` and `Rust Criterion Benchmarks (pyo3-sanitizer)` as read-only evidence jobs.
+- Retain the policy threshold exactly: a confirmed regression is a metric whose paired median ratio is **strictly greater than `1.10`** and whose deterministic one-sided 95% bootstrap lower bound is also **strictly greater than `1.10`**. Do not lower the threshold, sample count, workload, or test scope to make a run pass.
+- Require exactly twelve complete paired samples for each benchmark/metric. Missing, malformed, non-finite, duplicate, mismatched, or incomplete evidence is an integrity failure, never a pass or a fallback to `gh-pages` history.
+- Use only GitHub-hosted runners for public pull-request execution. Do not introduce `self-hosted`, a configurable runner label, `pull_request_target`, mutable branch-name comparison inputs, or a persistent runner requirement.
+- Use immutable SHA inputs: PR base and GitHub's synthetic merge `github.sha`, `github.event.before` and `github.sha` for a main push, and a required `base_sha` plus the dispatch ref SHA for manual evidence. Reject all-zero, identical, and non-ancestor base/candidate pairs.
+- Run the decision comparator only from the detached immutable base worktree. If that base lacks the tool during first rollout, fail closed rather than falling back to candidate/PR source; document the deliberate bootstrap sequence.
+- Keep broad historical charts advisory (`fail-on-alert: false`) and give write capability only to an explicit main-only history-publisher job. PR and manual jobs must be `contents: read`, must not comment, and must not publish history.
+- Use `apply_patch` for repository edits, preserve unrelated worktree changes, do not include a `Co-Authored-By` trailer, and do not associate testing/quality work with waves.
+- Do not update the live roadmap as closed until a fresh hosted run on the new implementation has completed and its raw artifacts/comparison output are inspected.
+
+## Required two-phase bootstrap
+
+The comparator, capture helper, and Rust image must be read from the immutable
+base worktree. They therefore cannot safely be introduced and enforced by the
+same pull request: its base commit has no trusted copy of those assets.
+
+1. **Phase 1 — asset bootstrap.** Publish only the protected comparator,
+   capture helper, Rust Dockerfile, ownership/config prerequisites, unit tests,
+   and this runbook. Its staged diff must contain **zero**
+   `.github/workflows/**` changes. The current base workflow's path filter will
+   intentionally leave required benchmark contexts absent for this asset-only
+   PR; widening that legacy workflow would execute its write-capable jobs for
+   every PR, so it is not an acceptable workaround. Because GitHub evaluates
+   CODEOWNERS from the PR base and `main` does not yet contain these new rules,
+   Phase 1 requires a documented explicit owner/manual review of the complete
+   staged diff before the repository's one-time `RepositoryRole` admin bypass.
+   Record this exact bootstrap reason in the PR description or merge commit,
+   as required by `AGENTS.md`: `asset bootstrap / no safe preexisting required
+   context; base is missing base-trusted performance tooling; retaining path
+   filter avoids widening legacy writable PR workflow`. This exception never
+   counts as hosted performance proof; CODEOWNERS enforcement begins in Phase
+   2 once the Phase-1 SHA is on `main`.
+2. **Phase 2 — enforcement.** Only after the Phase-1 SHA is in `main`, rebase
+   or create the activation PR so its base worktree contains all trusted assets.
+   It enables the read-only isolated workflows, removes the PR path filter only
+   as part of the accompanying permission refactor, and must pass ordinary
+   required contexts with no bypass. A change to the helper or Dockerfile takes
+   effect in the next base revision; if a trusted asset itself needs an
+   emergency repair, use the same reviewed two-step release procedure and the
+   documented emergency bypass rather than falling back to candidate code.
+
+## Comparator Contract
+
+The new `scripts/quality/compare_paired_benchmarks.py` command will expose this stable CLI:
+
+```powershell
+uv run python scripts/quality/compare_paired_benchmarks.py `
+  --format go `
+  --base-dir artifacts/ws-hub/base `
+  --candidate-dir artifacts/ws-hub/candidate `
+  --expected-pairs 12 `
+  --base-revision <40-hex-base-sha> `
+  --candidate-revision <40-hex-head-sha> `
+  --toolchain-json artifacts/ws-hub/toolchain.json `
+  --output artifacts/ws-hub/comparison.json
+```
+
+Each directory contains exactly `pair-01.txt` through `pair-12.txt`. The command pairs files by that canonical filename, rather than by filesystem ordering. It writes JSON even for an integrity failure when enough metadata is available, and exits `0` for a validated pass, `1` for a statistically confirmed regression, and `2` for invalid evidence or command usage.
+
+The result has this shape (additional diagnostic fields are allowed, but these keys are mandatory):
+
+```json
+{
+  "schema_version": 1,
+  "format": "go",
+  "base_revision": "<sha>",
+  "candidate_revision": "<sha>",
+  "expected_pairs": 12,
+  "threshold_ratio": 1.1,
+  "toolchain": {"go": "go version ..."},
+  "decision": "pass",
+  "metrics": [
+    {
+      "benchmark": "BenchmarkClientLookup",
+      "metric": "ns/op",
+      "base_values": [1.0],
+      "candidate_values": [1.01],
+      "ratios": [1.01],
+      "median_ratio": 1.01,
+      "one_sided_95_lower_bound": 0.99,
+      "decision": "pass"
+    }
+  ]
+}
+```
+
+For Go, accept canonical `go test -benchmem` records such as `BenchmarkClientLookup-8 100 12.5 ns/op 4 B/op 1 allocs/op`; normalize the terminal processor suffix consistently and require all three lower-is-better units. The required WS-Hub command includes `-benchmem`, so a missing Go allocation metric is invalid evidence, not a reduced latency-only gate. For Criterion bencher output, accept canonical `test <name> ... bench: <number> ns/iter ...` records and normalize `ns/iter` to the `ns/op` metric. Reject unsupported or repeated records instead of guessing.
+
+For `ns/op` and any positive-valued allocation metric, compute `candidate_value / base_value` for every pair. Seed `random.Random` from the SHA-256 digest of the canonical serialized metric identity and ratios, resample the twelve paired ratios 10,000 times, calculate a median per resample, and take the deterministic fifth percentile as the one-sided 95% lower bound. A non-finite or negative value, zero `ns/op` base, empty bootstrap distribution, or absent metric on either side is invalid evidence.
+
+`B/op` and `allocs/op` legitimately use zero. When all twelve base and candidate values are zero, report an explicit `zero_stable` pass without fabricating a ratio. When all base values are zero and any candidate value is positive, report a confirmed allocation regression (an infinite relative increase). A mixture of zero and nonzero base allocation values is an integrity failure, because no single finite ratio distribution can represent it. This preserves strict allocation regression detection without making allocation-free benchmarks permanently red.
+
+---
+
+### Task 1: Specify the comparator with failing tests first
+
+**Files:**
+- Create: `tests/test_compare_paired_benchmarks.py`
+- Create: `scripts/quality/compare_paired_benchmarks.py`
+- Read: `scripts/quality/aggregate_go_benchmarks.py`
+- Read: `tests/test_aggregate_go_benchmarks.py`
+
+**Interfaces:**
+- Input: twelve named raw base files and twelve named raw candidate files in Go or Criterion bencher format, SHA metadata, and a toolchain JSON file.
+- Output: a versioned comparison JSON document and exit status `0`, `1`, or `2` as defined above.
+
+- [ ] **Step 1: Write RED parser/validation tests for one valid Go pair and one valid Criterion pair.**
+
+  Create fixtures through `tmp_path` that write `pair-01.txt` through `pair-12.txt`, with a stable `BenchmarkLookup-8 ... ns/op B/op allocs/op` Go record and a stable `test native_conflicts/100 ... bench: 120 ns/iter (+/- 4)` Criterion record. Assert that parsing preserves the benchmark identity, normalizes Criterion to `ns/op`, and returns exactly twelve ordered values for each present metric.
+
+  Also add parameterized RED tests that expect `EvidenceIntegrityError` for: a missing `pair-12.txt`, a duplicate benchmark record in one raw file, a malformed numeric token, `nan`/`inf`, zero `ns/op` base, a mixed zero/nonzero allocation baseline, a metric present on only one side, and a base/candidate benchmark-name mismatch. Add explicit tests that twelve `0 B/op`/`0 allocs/op` values are a `zero_stable` pass, while any positive candidate allocation against an all-zero base is a regression.
+
+  Run:
+
+  ```powershell
+  uv run pytest -q tests/test_compare_paired_benchmarks.py
+  ```
+
+  Expected before implementation: collection fails because the comparator module does not yet exist.
+
+- [ ] **Step 2: Implement typed, fail-closed parsers and pair loading.**
+
+  Add frozen dataclasses `BenchmarkSample`, `MetricComparison`, and `ComparisonResult`, plus `EvidenceIntegrityError`. Implement `parse_go_benchmark_output(text: str) -> dict[str, dict[str, float]]` and `parse_bencher_output(text: str) -> dict[str, dict[str, float]]`; validate each numeric token with `math.isfinite`, reject duplicate `(benchmark, metric)` records in a single file, and use a deliberate regex for each supported format.
+
+  Implement `load_paired_samples(base_dir, candidate_dir, expected_pairs, parser)` so it requires precisely `pair-{index:02d}.txt` on both sides, rejects unexpected pair files, checks the complete benchmark/metric key set on every pair, and produces ordered base/candidate value arrays. Do not read files through a glob whose order can vary.
+
+- [ ] **Step 3: Make the parser suite GREEN and run adjacent quality tests.**
+
+  Run:
+
+  ```powershell
+  uv run pytest -q tests/test_compare_paired_benchmarks.py tests/test_aggregate_go_benchmarks.py
+  uv run ruff check scripts/quality/compare_paired_benchmarks.py tests/test_compare_paired_benchmarks.py
+  uv run ruff format --check scripts/quality/compare_paired_benchmarks.py tests/test_compare_paired_benchmarks.py
+  ```
+
+  Expected: all tests pass; no parser accepts an ambiguous record.
+
+### Task 2: Implement deterministic statistics, report generation, and CLI behavior
+
+**Files:**
+- Modify: `scripts/quality/compare_paired_benchmarks.py`
+- Modify: `tests/test_compare_paired_benchmarks.py`
+
+**Interfaces:**
+- Input: validated ordered paired values from Task 1.
+- Output: per-metric ratios, median, deterministic one-sided lower bound, decision, and report file.
+
+- [ ] **Step 1: Add RED decision-boundary and deterministic-output tests.**
+
+  Cover all three policy edges with synthetic twelve-pair fixtures:
+
+  ```python
+  # Always 1.10: not a failure because the policy is strictly greater.
+  ratios_at_threshold = [1.10] * 12
+  # Median > 1.10 but lower confidence bound <= 1.10: not proven; pass.
+  noisy_ratios = [1.00] * 5 + [1.11] * 7
+  # Every pair > 1.10: confirmed regression.
+  proven_ratios = [1.12] * 12
+  ```
+
+  Assert that a repeated call produces byte-identical JSON, reports raw values and revisions/toolchain, returns `0` for the first two cases, returns `1` for the third, and reports `2` for an integrity failure. Include a test that one failed metric makes the aggregate decision `regression` even when all other metrics pass.
+
+- [ ] **Step 2: Implement deterministic one-sided bootstrap and report assembly.**
+
+  Implement `paired_median_ratio(base_values, candidate_values)`, `bootstrap_lower_bound(ratios, confidence=0.95, iterations=10_000)`, and `compare_paired_samples(...)`. Implement the explicit zero-allocation branch from the contract before division. Build the bootstrap seed from `hashlib.sha256(json.dumps({"benchmark": name, "metric": unit, "ratios": ratios}, sort_keys=True, separators=(",", ":")).encode()).digest()` and use `random.Random(seed_int)`. Sort bootstrap medians and select index `floor((1 - confidence) * iterations)`.
+
+  Set a metric decision to `regression` only if both its median and bound are `> 1.10`; set aggregate decision to `pass` only when every metric passes. Serialize with sorted keys, compact stable separators, and a final newline so repeated execution is byte-for-byte reproducible.
+
+- [ ] **Step 3: Implement the command-line boundary and make the statistics suite GREEN.**
+
+  Use `argparse` with required `--format`, `--base-dir`, `--candidate-dir`, `--base-revision`, `--candidate-revision`, `--toolchain-json`, and `--output`; default `--expected-pairs` to `12` but reject any value other than `12`. Validate full 40-hex commit SHAs, load a JSON object toolchain, write the result atomically through a sibling temporary file plus `Path.replace`, and map exceptions to exit `2` without a traceback unless `--verbose` is explicitly supplied.
+
+  Run:
+
+  ```powershell
+  uv run pytest -q tests/test_compare_paired_benchmarks.py
+  uv run python scripts/quality/compare_paired_benchmarks.py --help
+  uv run ruff check scripts/quality/compare_paired_benchmarks.py tests/test_compare_paired_benchmarks.py
+  uv run ruff format --check scripts/quality/compare_paired_benchmarks.py tests/test_compare_paired_benchmarks.py
+  ```
+
+  Expected: all policy boundaries and deterministic report checks pass.
+
+### Task 3: Convert the required WS-Hub gate to same-run paired evidence
+
+**Files:**
+- Modify: `.github/workflows/benchmark.yml`
+- Modify: `tests/test_quality_workflow_contract.py`
+
+**Interfaces:**
+- Input: an immutable base SHA and candidate SHA, plus the exact WS-Hub source at both revisions.
+- Output: `artifacts/performance/ws-hub/base/pair-01.txt` through `pair-12.txt`, corresponding candidate files, `toolchain.json`, `comparison.json`, and the unchanged required context.
+
+- [ ] **Step 1: Write RED workflow-contract tests before changing YAML.**
+
+  Replace the historical-action assertions for `ws-hub-regression` with assertions that it has the unchanged name, `runs-on: ubuntu-latest`, `permissions: {contents: read}`, an explicit immutable base resolver, and no `benchmark-action/github-action-benchmark` step. Require the resolver text to contain all PR/push SHA sources, the all-zero guard, `git fetch`, `git cat-file -e`, and `git worktree add --detach`.
+
+  Require the capture text to invoke only the base-worktree helper through an
+  absolute trusted Python executable with `-I`; pass a fresh
+  `${RUNNER_TEMP}` artifact root, the immutable revisions, and `--format go`.
+  Require the helper rather than YAML to own the exact twelve-pair alternation,
+  warm-up, `go mod download && go mod verify` prefetch, and offline
+  `go test -mod=readonly -buildvcs=false -bench=. -run=^$ -benchmem -count=1
+  -benchtime=1s ./...` measurement. Reject a capture-step `EXIT` trap, host
+  `actions/cache`, bare `python`, candidate helper paths, and host-side raw
+  benchmark commands. Require comparator invocation with `--format go`,
+  `--expected-pairs 12`, both revisions, and host-only raw/JSON artifact upload.
+
+- [ ] **Step 2: Implement immutable setup and alternating WS-Hub capture.**
+
+  Check out `github.sha` with `fetch-depth: 0` and `persist-credentials: false`;
+  resolve/fetch/validate immutable SHA pairs; reject equal/non-ancestor pairs;
+  and create a detached base worktree under `${RUNNER_TEMP}`. Hash and retain
+  the base comparator before the helper runs. Invoke the base-only helper with
+  distinct base/candidate source mounts and a new host-only evidence root below
+  `${RUNNER_TEMP}`; it creates private per-side caches, prefetches over the
+  network, and makes every recorded measurement offline in a non-root,
+  read-only, capability-dropped Docker container with CPU/memory/PID/output
+  bounds. It records the container tool version, image reference/content ID,
+  Docker version, and trusted Rust-Dockerfile hash.
+
+  Recheck the comparator hash, invoke it with the trusted absolute Python
+  executable and `-I`, then upload the complete evidence root with `if:
+  always()`. Add a separate `Cleanup detached base worktree` step after
+  comparison and upload, also `if: always()`; never use a capture-step `EXIT`
+  trap. Do not aggregate repeated samples or mutate a checkout.
+
+- [ ] **Step 3: Make the WS-Hub contract suite GREEN.**
+
+  Run:
+
+  ```powershell
+  uv run pytest -q tests/test_quality_workflow_contract.py -k "performance or manual_performance"
+  actionlint .github/workflows/benchmark.yml
+  ```
+
+  Expected: the required WS-Hub context remains present, but no historical cross-run result can choose its pass/fail decision.
+
+### Task 4: Convert the required Rust-native and manual gates, then isolate historical publication
+
+**Files:**
+- Modify: `.github/workflows/benchmark.yml`
+- Modify: `.github/workflows/manual-performance-evidence.yml`
+- Modify: `tests/test_quality_workflow_contract.py`
+
+**Interfaces:**
+- Input: the same immutable revisions and Native Rust Criterion bencher command at both revisions.
+- Output: a separate native raw-evidence artifact and the same comparator decision; manual runs are distinct/read-only; charts publish only from `main`.
+
+- [ ] **Step 1: Add RED contract tests for native/manual/security invariants.**
+
+  Require the unchanged required Rust-native context to use the same
+  resolver/base-helper/comparator structure with `--format rust`, the trusted
+  base Dockerfile path, twelve alternating pairs, a trusted base-worktree
+  comparator, and a raw artifact. Require that
+  `manual-performance-evidence.yml` has a required string
+  `workflow_dispatch.inputs.base_sha`, `permissions: {contents: read}`, all
+  jobs explicitly read-only, distinct manual job names, strict ancestor
+  validation, and the same helper boundary.
+
+  Require no workflow text contains `pull_request_target`, `self-hosted`, `PERFORMANCE_BENCHMARK_RUNNER`, or a `runs-on` expression/variable. Require all PR-facing jobs use `persist-credentials: false`; require `comment-on-alert: false` wherever historical `benchmark-action` remains. Require any `contents: write` permission to exist only on a job whose `if` restricts it to `push` on `refs/heads/main`.
+
+- [ ] **Step 2: Implement Rust-native same-run capture and manual evidence.**
+
+  Do not install or run a host Rust toolchain in the required native jobs. Build
+  the digest-pinned Rust/Python image from only the base-worktree Dockerfile and
+  an empty build context. The helper performs `cargo fetch --locked
+  --manifest-path native/rust_ext/Cargo.toml` before the offline warm-up and
+  twelve alternating `cargo bench --locked --offline --manifest-path
+  native/rust_ext/Cargo.toml --bench conflict_bench --no-default-features --
+  --output-format bencher` measurements. Store base/candidate `pair-01.txt`
+  through `pair-12.txt` under a native-specific host-only artifact root and
+  call the comparator with `--format bencher`. Set the manual dispatch input to
+  required, validate/fetch it with the same base resolver, and keep all its
+  jobs read-only and uniquely named.
+
+- [ ] **Step 3: Move historical charts into a main-only publisher.**
+
+  Keep `benchmark` and `rust-criterion` as read-only, advisory evidence jobs so their existing required context names still exist on PRs. Remove their `benchmark-action` calls and upload their raw outputs as artifacts. Add a separate `publish-performance-history` job that:
+
+  - has `needs` on the four evidence/regression jobs;
+  - has `if: github.event_name == 'push' && github.ref == 'refs/heads/main'`;
+  - alone declares `permissions: {contents: write}`;
+  - downloads the raw advisory artifacts and invokes `benchmark-action/github-action-benchmark` with `auto-push: true`, `comment-on-alert: false`, and `fail-on-alert: false` for the Go and Criterion histories.
+
+  The publisher must not run on PR or manual evidence paths. The two comparator jobs, not the publisher, own all outcomes for the required 110% contexts.
+
+- [ ] **Step 4: Make native/manual/publisher contracts GREEN.**
+
+  Run:
+
+  ```powershell
+  uv run pytest -q tests/test_quality_workflow_contract.py -k "performance or manual_performance"
+  actionlint .github/workflows/benchmark.yml .github/workflows/manual-performance-evidence.yml
+  ```
+
+  Expected: no public PR code receives write credentials or a self-hosted execution route, and manual evidence cannot satisfy a required pull-request check.
+
+### Task 5: Integrate, review, publish, and verify fresh remote evidence
+
+**Files:**
+- Modify: `docs/testing/roadmap-100-percent-quality-closure-plan.md` only after a fresh successful hosted run
+- Read: all files changed by Tasks 1–4, `.github/actionlint.yaml`, current GitHub ruleset/run artifacts
+
+**Interfaces:**
+- Input: completed implementation and fresh workflow runs at the pushed commit.
+- Output: published code, artifact-backed result, accurate roadmap evidence, or a narrow external blocker record.
+
+- [ ] **Step 1: Run focused and cross-file local verification.**
+
+  Run:
+
+  ```powershell
+  uv run pytest -q tests/test_compare_paired_benchmarks.py tests/test_capture_isolated_benchmarks.py tests/test_aggregate_go_benchmarks.py tests/test_quality_workflow_contract.py
+  uv run ruff check scripts/quality/compare_paired_benchmarks.py scripts/quality/capture_isolated_benchmarks.py tests/test_compare_paired_benchmarks.py tests/test_capture_isolated_benchmarks.py tests/test_quality_workflow_contract.py
+  uv run ruff format --check scripts/quality/compare_paired_benchmarks.py scripts/quality/capture_isolated_benchmarks.py tests/test_compare_paired_benchmarks.py tests/test_capture_isolated_benchmarks.py tests/test_quality_workflow_contract.py
+  actionlint .github/workflows/benchmark.yml .github/workflows/manual-performance-evidence.yml
+  git diff --check
+  ```
+
+  Expected: zero failures. If a command fails, use `superpowers:systematic-debugging` before modifying the implementation; do not paper over the failure with `continue-on-error` or reduced assertions.
+
+- [ ] **Step 2: Conduct an independent focused code review before publication.**
+
+  Review parser ambiguity, SHA validation/ancestry, trusted helper/comparator
+  bootstrap behavior, container mounts/network/permissions/resource bounds,
+  streaming output cap, image provenance, temporary-worktree cleanup, shell
+  quoting, pair ordering, job permissions, branch/event guards, manual context
+  disjointness, artifact coverage, and preservation of all required job names.
+  Resolve every P1/P2 finding with a regression test and rerun Step 1. Ensure
+  `.github/CODEOWNERS` owns the comparator, helper, and Dockerfile and the
+  active ruleset requires code-owner review before merge.
+
+- [ ] **Step 3: Commit and push the implementation.**
+
+  Stage only approved changed paths, check the staged diff, and publish:
+
+  ```powershell
+  git diff --cached --check
+  git commit -m "fix(quality): compare performance within one runner"
+  git push origin egorribun
+  git ls-remote --heads origin egorribun
+  ```
+
+  Expected: the remote branch SHA equals the local committed SHA and the pre-push checks pass.
+
+- [ ] **Step 4: Obtain fresh hosted proof and inspect it.**
+
+  Wait for the PR workflow at the new SHA; if the benchmark path is not triggered by the changed paths, dispatch a workflow that includes the same code/commit and required base SHA without changing source scope. Inspect both required jobs, download or view the artifacts, and verify `comparison.json` records twelve base/candidate values per metric, exact revisions, a GitHub-hosted run, the `1.1` threshold, and a comparator-owned decision.
+
+  Run:
+
+  ```powershell
+  gh run list --commit <new-sha> --workflow benchmark.yml --json databaseId,status,conclusion,url
+  gh run view <run-id> --log-failed
+  ```
+
+  Expected: both preserved required contexts are green due valid same-run evidence, not due `gh-pages` comparison.
+
+- [ ] **Step 5: Update the roadmap only with live evidence, then publish that documentation separately.**
+
+  Add the run ID, commit SHA, artifact/comparison fact, and remaining external certification blockers (Codecov authorization, absent DAST target, certification key, and genuine 30-day window) to the roadmap. Do not claim full closure until all external gates are genuinely satisfied. Re-run relevant roadmap/contract checks, commit as `docs(quality): record same-run performance evidence`, push, and verify the remote SHA.
+
+## Plan self-review
+
+- [ ] Confirm every approved-spec invariant maps to at least one test and implementation step: immutable revisions, GitHub-hosted-only execution, twelve alternating pairs, strict 1.10 threshold, deterministic one-sided bound, fail-closed parser, artifact retention, no PR write token, main-only advisory publisher, and manual-context isolation.
+- [ ] Search this plan for unfinished planning markers before execution:
+
+  ```powershell
+  $forbidden = ('TO' + 'DO') + '|' + ('TB' + 'D') + '|' + ('place' + 'holder') + '|' + ('implement' + ' later') + '|' + ('fill' + ' in')
+  rg -n -- $forbidden docs/superpowers/plans/2026-08-11-same-run-performance-gates.md
+  ```
+
+- [ ] Verify Markdown and repository diff integrity:
+
+  ```powershell
+  git diff --check -- docs/superpowers/plans/2026-08-11-same-run-performance-gates.md
+  ```

--- a/docs/superpowers/specs/2026-08-11-same-run-performance-gate-design.md
+++ b/docs/superpowers/specs/2026-08-11-same-run-performance-gate-design.md
@@ -1,0 +1,199 @@
+# Same-run performance regression gates
+
+**Status:** approved by the repository owner on 2026-08-11. Phase 1 supplies
+the protected comparator, container-capture helper, image definition, and
+tests; Phase 2 may activate the required workflows only after Phase 1 is in
+`main`, so the detached base worktree can supply every trusted tool.
+
+## Problem and decision
+
+The two blocking raw benchmark jobs (`WS-Hub Go Benchmark Regression Gate` and
+`Rust Native Optimizer Regression Gate`) currently compare a PR result with a
+historical result stored on `gh-pages`. That comparison is not a valid source
+regression signal on generic GitHub-hosted hardware: the failed WS-Hub run at
+`232e243c6` compared an AMD EPYC 7763 baseline with an Intel Xeon 8370C run,
+although the WS-Hub source, Go module inputs, and aggregation script were
+identical. Local repeated measurements of identical source also crossed ten
+percent on noisy samples.
+
+The repository is public and personal. It has no configured self-hosted runner
+or GitHub-hosted larger runner, so requiring a custom runner would permanently
+break the existing required contexts. Public PR code must not be routed to a
+self-hosted runner.
+
+**Decision:** replace historical cross-run blocking comparisons with a paired,
+same-run base-SHA versus head-SHA source regression gate. Keep the existing
+`110%` threshold and fail-closed behavior; make historical dashboards
+non-blocking evidence only.
+
+## Alternatives considered
+
+1. **Same-run paired comparison (selected).** Both revisions execute in the
+   same GitHub-hosted VM with an identical toolchain and an alternating run
+   order. This removes the CPU-class change that caused the false positive and
+   adds a statistical confidence requirement for noisy samples.
+2. **Dedicated GitHub-hosted larger runner.** This would retain a historical
+   baseline model, but cannot be configured on this personal repository without
+   an organization/plan migration and external provisioning.
+3. **Self-hosted runner.** Rejected for this public PR surface: an untrusted
+   fork can execute workflow code, making a self-hosted runner unsafe without
+   independent isolation and approval controls.
+
+## Architecture
+
+### Revision selection and isolation
+
+Each blocking job remains GitHub-hosted Linux and resolves an immutable base
+revision before any benchmark command:
+
+- pull request: `github.event.pull_request.base.sha`;
+- push to `main`: `github.event.before`, rejecting the all-zero initial-push
+  SHA; and
+- manual evidence: a required `base_sha` workflow-dispatch input.
+
+For a pull request, the candidate is `github.sha`, GitHub's immutable synthetic
+merge commit, rather than a potentially stale raw head SHA. The workflow
+requires the base to be a strict ancestor of the candidate in every mode; this
+prevents comparing an unrelated or behind branch with the current base.
+
+The workflow fetches each exact object and creates a detached temporary Git
+worktree for the base revision. The normal checkout is the candidate merge/head
+revision.
+Neither workflow uses `pull_request_target`, a self-hosted label, a repository
+variable that selects a runner, nor mutable branch names as the comparison
+input.
+
+The comparison decision runs the comparator from the immutable base worktree,
+not from candidate/PR source. If that trusted base revision does not yet contain
+the comparator, the job fails closed with no candidate fallback. The initial
+rollout consequently needs an intentional bootstrap merge before a later
+evidence PR can be green under the new trusted-comparator policy.
+
+### Container execution boundary
+
+The Phase-2 workflow delegates capture to the base-worktree helper
+`scripts/quality/capture_isolated_benchmarks.py`. Base and candidate benchmark
+commands run in separate disposable Docker containers. Each container receives
+only its own source worktree mounted read-only at `/src` and a private
+per-side cache volume at `/cache`; it receives neither the artifact directory,
+the comparator, a Docker socket, nor `GITHUB_*`, `RUNNER_*`, or token
+environment variables.
+
+Measurements run with no network, a read-only root filesystem, Docker's
+default seccomp profile (never `seccomp=unconfined`), dropped Linux
+capabilities, no-new-privileges, a non-root uid, PID/CPU/memory/swap limits,
+and bounded tmpfs mounts. A short networked dependency-prefetch run is allowed
+only before measurement, with the same source and resource boundary. Raw
+stdout is captured by the trusted host helper into a fresh directory beneath
+`RUNNER_TEMP`; the helper disables GitHub workflow-command parsing while it
+captures output, enforces a streaming size limit, and kills an overflowing
+capture.
+
+The Go image is digest-pinned. The Rust image is built from a Dockerfile copied
+only from the protected base worktree using an empty build context; it never
+copies candidate files. This prevents a pull-request checkout from replacing
+the measurement harness or host evidence. It is not a cryptographic attestation
+of benchmark semantics: a reviewed source change can still emit syntactically
+valid but misleading benchmark output. CODEOWNERS, branch protection, and
+review remain the control for that residual source-level risk.
+
+### Paired sampling
+
+The workflows collect **twelve pairs** of measurements for each benchmark
+suite. Odd-numbered pairs run base then head; even-numbered pairs run head then
+base. Each command uses a fixed toolchain, disables test-result caching, warms
+the build before recording samples, and writes one raw output file per
+revision/pair. This alternation reduces thermal and temporary-host-load drift.
+
+- WS-Hub uses `go test -bench=. -run=^$ -benchmem -count=1 -benchtime=1s ./...`.
+- Native Rust uses the existing `conflict_bench` Criterion/bencher command with
+  one recorded invocation per side/pair and the same feature flags as today.
+
+Any setup failure, invalid base SHA, command failure, missing output, or an
+incomplete pair fails the required job. There is no silent fallback to a
+historical `gh-pages` result.
+
+### Comparator
+
+A new pure-Python quality utility parses the existing Go and bencher output
+formats into per-benchmark paired samples. It compares lower-is-better metrics:
+`ns/op`, `B/op`, and `allocs/op` where present.
+
+The required WS-Hub command always uses `-benchmem`; therefore every accepted
+Go record must contain all three of those metrics. Criterion bencher output has
+only `ns/iter` (normalized to `ns/op`). Missing expected Go allocation metrics
+are invalid evidence rather than a silent latency-only comparison.
+
+For every metric, it requires twelve complete finite pairs and computes the
+candidate/base ratio for each pair. It fails only when both conditions hold:
+
+1. the paired median ratio is strictly greater than `1.10`; and
+2. a deterministic, one-sided 95% bootstrap lower confidence bound for that
+   paired median is strictly greater than `1.10`.
+
+Malformed values, benchmark-name mismatches, duplicates within one sample,
+insufficient samples, or an inability to calculate a confidence bound are
+integrity failures rather than passes. The JSON result records raw values,
+ratios, median, lower bound, threshold, decision, revisions, and toolchain.
+
+`B/op` and `allocs/op` may legitimately be zero. An all-zero base/candidate
+allocation metric is recorded as an explicit stable pass; a positive candidate
+allocation against an all-zero base is a regression, and mixed zero/nonzero
+allocation baselines fail integrity because they have no single finite ratio
+distribution. Zero is never accepted for a `ns/op` base measurement.
+
+This retains a real ten-percent blocking threshold while avoiding a claim of
+regression from a single noisy or hardware-incomparable sample.
+
+### Evidence, history, and permissions
+
+The required PR jobs publish raw base/head files and the comparison JSON as
+artifacts. Historical `benchmark-action` charts may remain useful, but their
+alerts cannot decide PR acceptance: their `fail-on-alert` setting is advisory.
+Only the paired comparator controls the existing required context names.
+
+History publication is isolated to a main-only publisher job with
+`contents: write`. PR and manual-evidence jobs receive `contents: read` and do
+not publish or comment. Manual evidence uses distinct job names, takes a
+required base SHA, and is never eligible to satisfy a PR ruleset context.
+
+## Files and responsibilities
+
+| File | Change |
+| --- | --- |
+| `scripts/quality/compare_paired_benchmarks.py` | Pure parser, pairing, deterministic bootstrap, JSON report, and fail-closed CLI. |
+| `tests/test_compare_paired_benchmarks.py` | Parser, valid pass/fail, confidence boundary, malformed/missing/mismatched evidence, and deterministic-output tests. |
+| `scripts/quality/capture_isolated_benchmarks.py` | Base-trusted isolated Docker capture, bounded host-only raw evidence, and toolchain provenance. |
+| `containers/quality/Dockerfile.performance-rust` | Digest-pinned non-root Rust/Python benchmark image built from the base worktree only. |
+| `tests/test_capture_isolated_benchmarks.py` | Container boundary, output-cap, manifest-selection, and Dockerfile provenance tests. |
+| `.github/workflows/benchmark.yml` | Immutable base retrieval, alternating pair capture, required comparator step, artifact upload, and main-only advisory history publisher. |
+| `.github/workflows/manual-performance-evidence.yml` | Required `base_sha`, the same read-only paired evidence path, and distinct manual contexts. |
+| `tests/test_quality_workflow_contract.py` | Enforce source-only base/head selection, twelve pairs, alternation, 110% threshold, fail-closed evidence, artifact retention, job permissions, and absence of self-hosted/`pull_request_target` execution. |
+| `docs/testing/roadmap-100-percent-quality-closure-plan.md` | Replace the obsolete historical-baseline claim with the current paired-gate policy and live evidence after remote validation. |
+
+## Acceptance criteria
+
+1. Both required context names remain unchanged and block on a statistically
+   proven ratio greater than 110%.
+2. A workflow-only PR compares identical source revisions in one hosted VM and
+   cannot fail solely because a previous run used different hardware.
+3. Invalid, missing, or incomplete evidence fails closed.
+4. Public PR jobs run only on GitHub-hosted runners with read-only content
+   permissions; only a main-only history publisher can write.
+5. Unit and workflow-contract tests cover every invariant, and actionlint plus
+   YAML parsing pass.
+6. Once Phase 1 is on `main`, comparator/workflow changes are code-owned and
+   the active ruleset requires code-owner review. Because Phase 1's base lacks
+   those new ownership rules, its exceptional bootstrap requires documented
+   explicit owner/manual review plus the recorded one-time bypass reason; it
+   cannot be presented as enforced CODEOWNERS approval.
+7. Phase 1 lands in `main` before the Phase-2 workflow activation; a fresh
+   hosted PR run then validates the new gate before roadmap evidence is
+   updated; historical dashboard data is not presented as certification.
+
+## Non-goals
+
+This design does not claim that a generic VM can provide a universal absolute
+performance baseline or cryptographically attest benchmark semantics, does not
+lower the ten-percent threshold, does not hide historical charts, and does not
+provision infrastructure or expose a self-hosted runner to public PRs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -540,7 +540,8 @@ pytest_add_cli_args_test_selection = [
 # Copy the repository-contract paths into the isolated tree so the full nightly
 # run can measure them without a false collection failure. The mutation-score
 # parser contract imports `scripts/check_mutation_score.py`; copying its parent
-# directory prevents that test from breaking mutmut's clean-test baseline.
+# directory prevents that test from breaking mutmut's clean-test baseline. The
+# isolated-performance tool test also reads its trusted Rust Dockerfile.
 also_copy = [
     ".github",
     ".lighthouserc.js",
@@ -560,6 +561,7 @@ also_copy = [
     ".pre-commit-config.yaml",
     "Makefile",
     "docs",
+    "containers/quality",
     "k8s/kyverno",
     "k8s/backend",
     "k8s/frontend",

--- a/scripts/quality/capture_isolated_benchmarks.py
+++ b/scripts/quality/capture_isolated_benchmarks.py
@@ -1,0 +1,1046 @@
+"""Capture paired benchmarks in disposable, unprivileged Docker containers."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+import uuid
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import BinaryIO
+
+GO_IMAGE = (
+    "docker.io/library/golang:1.26.5-bookworm@"
+    "sha256:53eeac89074db483fdf0ab3be1df32bf6e47562263d2d0d6baa7f26acb4957dd"
+)
+DOCKER_BINARY = Path("/usr/bin/docker")
+TIMEOUT_BINARY = Path("/usr/bin/timeout")
+CONTAINER_USER = "10001:10001"
+PAIR_COUNT = 12
+MAX_OUTPUT_BYTES = 16 * 1024 * 1024
+CONTAINER_MEMORY = "6g"
+CONTAINER_CPUS = "2.0"
+CONTAINER_PIDS_LIMIT = "512"
+CACHE_VOLUME_SIZE = "2g"
+RUST_TOOLCHAIN = "1.94.1"
+CONTAINER_LOG_ARGUMENTS = (
+    "--log-driver",
+    "local",
+    "--log-opt",
+    "max-size=16m",
+    "--log-opt",
+    "max-file=1",
+    "--log-opt",
+    "compress=false",
+)
+# These paths exist only inside an isolated container's private tmpfs mounts.
+CONTAINER_HOME = "/tmp/home"  # noqa: S108
+CONTAINER_TMPFS = "/tmp:rw,exec,nosuid,nodev,size=4g,mode=1777"  # noqa: S108
+CONTAINER_SMALL_TMPFS = "/tmp:rw,exec,nosuid,nodev,size=64m,mode=1777"  # noqa: S108
+CONTAINER_RUN_TMPFS = "/run:rw,nosuid,nodev,size=64m,mode=1777"
+_CAPTURE_READ_BYTES = 64 * 1024
+_TERMINATE_WAIT_SECONDS = 30
+CONTROL_PLANE_TIMEOUT_SECONDS = 30
+_SHA_RE = re.compile(r"^[0-9a-fA-F]{40}$")
+_IMAGE_ID_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+_CONTAINER_NAME_RE = re.compile(r"^quality-benchmark-[0-9a-f]{32}$")
+_VOLUME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
+_FORBIDDEN_ENV_PREFIXES = ("GITHUB_", "RUNNER_", "DOCKER_")
+
+
+class CaptureError(RuntimeError):
+    """Raised when isolated benchmark evidence cannot be safely collected."""
+
+
+@dataclass(frozen=True)
+class CaptureArguments:
+    """Validated immutable inputs for one complete paired benchmark suite."""
+
+    format_name: str
+    base_worktree: Path
+    candidate_worktree: Path
+    artifact_root: Path
+    runner_temp: Path
+    base_revision: str
+    candidate_revision: str
+    rust_dockerfile: Path | None
+
+
+def _validate_sha(value: str, label: str) -> str:
+    if _SHA_RE.fullmatch(value) is None or value == "0" * 40:
+        raise CaptureError(f"{label} must be a non-zero 40-hex commit SHA")
+    return value
+
+
+def _resolve_existing_directory(path: Path, label: str) -> Path:
+    try:
+        resolved = path.resolve(strict=True)
+    except OSError as exc:
+        raise CaptureError(f"Unable to resolve {label}: {exc}") from exc
+    if not resolved.is_dir():
+        raise CaptureError(f"{label} must be a directory: {resolved}")
+    return resolved
+
+
+def _validate_distinct_worktrees(base_worktree: Path, candidate_worktree: Path) -> None:
+    """Reject accidental same-tree comparisons before a container is started."""
+
+    if base_worktree == candidate_worktree:
+        raise CaptureError("Base and candidate worktrees must be different directories")
+
+
+def _resolve_worktree_head(worktree: Path, label: str) -> str:
+    """Resolve one supplied worktree to the immutable commit Git will mount."""
+
+    resolved_head = _run_checked(
+        ("git", "-C", str(worktree), "rev-parse", "--verify", "HEAD^{commit}"),
+        f"resolve {label} Git HEAD",
+    ).stdout.strip()
+    if _SHA_RE.fullmatch(resolved_head) is None or resolved_head == "0" * 40:
+        raise CaptureError(f"Git returned an invalid {label} HEAD commit")
+    return resolved_head.lower()
+
+
+def _validate_worktree_revisions(
+    *,
+    base_worktree: Path,
+    candidate_worktree: Path,
+    base_revision: str,
+    candidate_revision: str,
+) -> None:
+    """Bind declared provenance to both worktrees before capture can begin."""
+
+    actual_base_revision = _resolve_worktree_head(base_worktree, "base worktree")
+    actual_candidate_revision = _resolve_worktree_head(
+        candidate_worktree, "candidate worktree"
+    )
+    if actual_base_revision != base_revision.lower():
+        raise CaptureError("Git HEAD does not match declared base revision")
+    if actual_candidate_revision != candidate_revision.lower():
+        raise CaptureError("Git HEAD does not match declared candidate revision")
+
+
+def _validate_image_content_id(value: str) -> str:
+    """Accept only Docker's immutable content-addressed image identifier."""
+
+    normalized = value.strip()
+    if _IMAGE_ID_RE.fullmatch(normalized) is None:
+        raise CaptureError(f"Docker returned an invalid image content ID: {value!r}")
+    return normalized
+
+
+def _new_container_name() -> str:
+    """Return an unguessable host-generated Docker name for forced cleanup."""
+
+    return f"quality-benchmark-{uuid.uuid4().hex}"
+
+
+def _new_volume_name() -> str:
+    """Return an unguessable host-generated name for one bounded cache volume."""
+
+    return f"quality-benchmark-cache-{uuid.uuid4().hex}"
+
+
+def _validate_container_name(value: str) -> str:
+    if _CONTAINER_NAME_RE.fullmatch(value) is None:
+        raise CaptureError(f"Container name is invalid: {value!r}")
+    return value
+
+
+def _is_within(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+def prepare_artifact_root(artifact_root: Path, runner_temp: Path) -> Path:
+    """Create a fresh output root below trusted runner temp, never a checkout."""
+
+    trusted_temp = _resolve_existing_directory(runner_temp, "runner temp")
+    resolved_root = artifact_root.resolve(strict=False)
+    if not _is_within(resolved_root, trusted_temp) or resolved_root == trusted_temp:
+        raise CaptureError(
+            "Artifact root must be a fresh directory under the trusted runner temp"
+        )
+    if resolved_root.exists():
+        raise CaptureError(f"Artifact root must not already exist: {resolved_root}")
+    try:
+        resolved_root.mkdir(mode=0o700, parents=False)
+        resolved_root.chmod(0o700)
+    except OSError as exc:
+        raise CaptureError(f"Unable to create artifact root: {exc}") from exc
+    return resolved_root
+
+
+def _validate_environment(environment: Mapping[str, str]) -> None:
+    for key, value in environment.items():
+        if not key or "=" in key or "\x00" in key or "\x00" in value:
+            raise CaptureError(f"Invalid container environment variable: {key!r}")
+        if key.startswith(_FORBIDDEN_ENV_PREFIXES):
+            raise CaptureError(
+                f"Host-controlled environment cannot enter container: {key}"
+            )
+
+
+def _bounded_docker_run_options(
+    *,
+    container_name: str,
+    network: str,
+    tmpfs_mounts: Sequence[str],
+    remove: bool = False,
+    cache_initialization: bool = False,
+) -> list[str]:
+    """Return the mandatory isolation/resource options for every Docker run.
+
+    Cache initialization is the only root exception: it creates the private
+    volume directory with the unprivileged benchmark UID/GID before any source
+    code is mounted or executed. Every other run uses ``CONTAINER_USER``.
+    """
+
+    if network not in {"bridge", "none"}:
+        raise CaptureError(f"Unsupported container network mode: {network}")
+    _validate_container_name(container_name)
+    command = [
+        str(DOCKER_BINARY),
+        "run",
+        "--name",
+        container_name,
+    ]
+    if remove:
+        command.append("--rm")
+    command.extend(
+        (
+            "--init",
+            "--platform",
+            "linux/amd64",
+            "--network",
+            network,
+            "--read-only",
+            *CONTAINER_LOG_ARGUMENTS,
+            "--cap-drop",
+            "ALL",
+            "--security-opt",
+            "no-new-privileges=true",
+            "--memory",
+            CONTAINER_MEMORY,
+            "--memory-swap",
+            CONTAINER_MEMORY,
+            "--cpus",
+            CONTAINER_CPUS,
+            "--pids-limit",
+            CONTAINER_PIDS_LIMIT,
+            "--user",
+            "0:0" if cache_initialization else CONTAINER_USER,
+        )
+    )
+    for tmpfs_mount in tmpfs_mounts:
+        command.extend(("--tmpfs", tmpfs_mount))
+    return command
+
+
+def build_container_command(
+    *,
+    image: str,
+    source_worktree: Path,
+    cache_volume: str,
+    container_name: str,
+    workdir: str,
+    network: str,
+    environment: Mapping[str, str],
+    program: Sequence[str],
+) -> list[str]:
+    """Build one explicit Docker invocation without host environment inheritance."""
+
+    source = _resolve_existing_directory(source_worktree, "source worktree")
+    if not image or any(character.isspace() for character in image):
+        raise CaptureError("Container image reference is invalid")
+    if _VOLUME_RE.fullmatch(cache_volume) is None:
+        raise CaptureError(f"Container cache volume is invalid: {cache_volume!r}")
+    if not workdir.startswith("/src/"):
+        raise CaptureError("Container workdir must stay below the read-only /src mount")
+    if not program or any(not token or "\x00" in token for token in program):
+        raise CaptureError("Container program is invalid")
+    _validate_environment(environment)
+
+    command = _bounded_docker_run_options(
+        container_name=container_name,
+        network=network,
+        tmpfs_mounts=(CONTAINER_TMPFS, CONTAINER_RUN_TMPFS),
+    )
+    command.extend(
+        (
+            "--mount",
+            f"type=bind,src={source},dst=/src,readonly",
+            "--mount",
+            f"type=volume,src={cache_volume},dst=/cache",
+            "--workdir",
+            workdir,
+        )
+    )
+    for key in sorted(environment):
+        command.extend(("--env", f"{key}={environment[key]}"))
+    return [*command, image, *program]
+
+
+def _run_checked(
+    command: Sequence[str], description: str
+) -> subprocess.CompletedProcess[str]:
+    try:
+        completed = subprocess.run(  # noqa: S603 - all command tokens are constructed locally.
+            list(command),
+            check=False,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=CONTROL_PLANE_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise CaptureError(
+            f"{description} did not complete within {CONTROL_PLANE_TIMEOUT_SECONDS} seconds"
+        ) from exc
+    except OSError as exc:
+        raise CaptureError(f"Unable to {description}: {exc}") from exc
+    if completed.returncode != 0:
+        raise CaptureError(
+            f"{description} failed with exit status {completed.returncode}"
+        )
+    return completed
+
+
+def _copy_limited_stream(source: BinaryIO, destination: BinaryIO) -> bool:
+    """Copy output until its byte cap; return whether the cap was exceeded."""
+
+    written = 0
+    while block := source.read(_CAPTURE_READ_BYTES):
+        remaining = MAX_OUTPUT_BYTES - written
+        if remaining <= 0:
+            return True
+        destination.write(block[:remaining])
+        written += min(len(block), remaining)
+        if len(block) > remaining:
+            return True
+    return False
+
+
+def _terminate_capture_process(process: subprocess.Popen[bytes]) -> None:
+    """Terminate the timeout wrapper and its Docker child after unsafe output."""
+
+    if process.poll() is not None:
+        return
+    try:
+        if os.name == "posix":
+            try:
+                os.killpg(process.pid, signal.SIGTERM)
+            except ProcessLookupError:
+                return
+        else:  # pragma: no cover - isolated capture runs only on Linux CI.
+            process.terminate()
+        process.wait(timeout=_TERMINATE_WAIT_SECONDS)
+    except subprocess.TimeoutExpired:
+        if os.name == "posix":
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                return
+        else:  # pragma: no cover - isolated capture runs only on Linux CI.
+            process.kill()
+        process.wait()
+
+
+def _timeout_command(command: Sequence[str], *, timeout_seconds: int) -> list[str]:
+    """Wrap a capture with TERM and a mandatory subsequent KILL deadline."""
+
+    if timeout_seconds <= 0:
+        raise CaptureError("Capture timeout must be positive")
+    return [
+        str(TIMEOUT_BINARY),
+        "--foreground",
+        "--kill-after=30s",
+        f"{timeout_seconds}s",
+        *command,
+    ]
+
+
+def _force_remove_container(container_name: str) -> None:
+    """Remove a daemon-owned container even if its Docker client was killed."""
+
+    name = _validate_container_name(container_name)
+    removed = _run_container_cleanup_command(
+        [str(DOCKER_BINARY), "container", "rm", "--force", name],
+        action="force-removing",
+        container_name=name,
+    )
+    if removed.returncode == 0:
+        return
+    exists = _run_container_cleanup_command(
+        [str(DOCKER_BINARY), "container", "inspect", name],
+        action="verifying cleanup of",
+        container_name=name,
+    )
+    if exists.returncode == 0:
+        raise CaptureError(f"Unable to force-remove isolated container {name}")
+    no_such_container = "No such" in (removed.stderr + exists.stderr)
+    if not no_such_container:
+        raise CaptureError(f"Unable to verify cleanup of isolated container {name}")
+
+
+def _run_container_cleanup_command(
+    command: Sequence[str], *, action: str, container_name: str
+) -> subprocess.CompletedProcess[str]:
+    """Run bounded daemon cleanup without allowing raw client failures to escape."""
+
+    try:
+        return subprocess.run(  # noqa: S603 - command tokens are locally constructed.
+            list(command),
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=_TERMINATE_WAIT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise CaptureError(
+            "Docker container cleanup timed out while "
+            f"{action} isolated container {container_name}"
+        ) from exc
+    except OSError as exc:
+        raise CaptureError(
+            "Docker container cleanup could not start while "
+            f"{action} isolated container {container_name}: {exc}"
+        ) from exc
+
+
+def _safe_capture(
+    command: Sequence[str],
+    output_path: Path,
+    *,
+    description: str,
+    timeout_seconds: int,
+    container_name: str | None = None,
+) -> None:
+    """Capture untrusted container output without exposing GitHub command syntax."""
+
+    marker = uuid.uuid4().hex
+    print(f"::stop-commands::{marker}", flush=True)
+    return_code: int | None = None
+    output_exceeded = False
+    process: subprocess.Popen[bytes] | None = None
+    if container_name is not None:
+        _validate_container_name(container_name)
+    try:
+        with output_path.open("xb") as output:
+            process = subprocess.Popen(  # noqa: S603 - command is a fixed Docker argv list.
+                _timeout_command(command, timeout_seconds=timeout_seconds),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                start_new_session=True,
+            )
+            stream = process.stdout
+            if stream is None:
+                _terminate_capture_process(process)
+                raise CaptureError(f"Unable to capture {description} output stream")
+            try:
+                output_exceeded = _copy_limited_stream(stream, output)
+            except (
+                BaseException
+            ):  # RZ-22-01-JUSTIFIED: terminate untrusted capture before re-raise.
+                _terminate_capture_process(process)
+                raise
+            finally:
+                stream.close()
+            if output_exceeded:
+                _terminate_capture_process(process)
+            else:
+                return_code = process.wait()
+    finally:
+        try:
+            if process is not None and process.poll() is None:
+                _terminate_capture_process(process)
+            if container_name is not None:
+                _force_remove_container(container_name)
+        finally:
+            print(f"::{marker}::", flush=True)
+
+    if output_exceeded:
+        raise CaptureError(
+            f"{description} output exceeds the {MAX_OUTPUT_BYTES}-byte safety limit"
+        )
+    if return_code != 0:
+        raise CaptureError(f"{description} failed with exit status {return_code}")
+
+
+def _create_private_volume(image: str, artifact_root: Path, side: str) -> str:
+    volume = _new_volume_name()
+    completed = _run_checked(
+        (
+            str(DOCKER_BINARY),
+            "volume",
+            "create",
+            "--driver",
+            "local",
+            "--opt",
+            "type=tmpfs",
+            "--opt",
+            "device=tmpfs",
+            "--opt",
+            f"o=size={CACHE_VOLUME_SIZE},uid=10001,gid=10001,mode=0700",
+            volume,
+        ),
+        f"create {side} cache volume",
+    )
+    created_volume = completed.stdout.strip()
+    if created_volume != volume or _VOLUME_RE.fullmatch(created_volume) is None:
+        raise CaptureError(
+            f"Docker returned an unsafe cache volume name: {created_volume!r}"
+        )
+
+    container_name = _new_container_name()
+    initialize = _bounded_docker_run_options(
+        container_name=container_name,
+        network="none",
+        tmpfs_mounts=(CONTAINER_SMALL_TMPFS,),
+        cache_initialization=True,
+    )
+    initialize.extend(
+        (
+            "--mount",
+            f"type=volume,src={volume},dst=/cache",
+            image,
+            "sh",
+            "-ec",
+            "install -d -m 0700 -o 10001 -g 10001 /cache",
+        )
+    )
+    try:
+        _safe_capture(
+            initialize,
+            artifact_root / f"initialize-{side}-cache.log",
+            description=f"initialize {side} cache volume",
+            timeout_seconds=60,
+            container_name=container_name,
+        )
+    except (
+        BaseException
+    ):  # RZ-22-01-JUSTIFIED: remove the private cache volume before re-raise.
+        _remove_volume(volume)
+        raise
+    return volume
+
+
+def _remove_volume(volume: str) -> None:
+    _best_effort_docker_cleanup([str(DOCKER_BINARY), "volume", "rm", "--force", volume])
+
+
+def _best_effort_docker_cleanup(command: Sequence[str]) -> None:
+    """Bound disposable-object cleanup without obscuring the primary outcome."""
+
+    try:
+        subprocess.run(  # noqa: S603 - cleanup tokens are locally constructed.
+            list(command),
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=CONTROL_PLANE_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return
+
+
+def _container_tool_output(
+    image: str,
+    program: Sequence[str],
+    *,
+    environment: Mapping[str, str],
+) -> str:
+    _validate_environment(environment)
+    container_name = _new_container_name()
+    command = _bounded_docker_run_options(
+        container_name=container_name,
+        network="none",
+        tmpfs_mounts=(CONTAINER_SMALL_TMPFS,),
+        remove=True,
+    )
+    for key in sorted(environment):
+        command.extend(("--env", f"{key}={environment[key]}"))
+    command.extend((image, *program))
+    with tempfile.TemporaryDirectory(prefix="quality-toolchain-") as temporary_dir:
+        output_path = Path(temporary_dir) / "toolchain-output.txt"
+        _safe_capture(
+            command,
+            output_path,
+            description="query isolated toolchain",
+            timeout_seconds=CONTROL_PLANE_TIMEOUT_SECONDS,
+            container_name=container_name,
+        )
+        try:
+            return output_path.read_text(encoding="utf-8", errors="replace").strip()
+        except OSError as exc:
+            raise CaptureError(
+                f"Unable to read isolated toolchain output: {exc}"
+            ) from exc
+
+
+def _image_content_id(image: str) -> str:
+    """Resolve the immutable local image identifier after trusted setup."""
+
+    output = _run_checked(
+        (str(DOCKER_BINARY), "image", "inspect", "--format", "{{.Id}}", image),
+        "inspect isolated benchmark image",
+    ).stdout
+    return _validate_image_content_id(output)
+
+
+def _docker_server_version() -> str:
+    """Record the daemon version that enforced the capture boundary."""
+
+    version = _run_checked(
+        (str(DOCKER_BINARY), "version", "--format", "{{.Server.Version}}"),
+        "query Docker server version",
+    ).stdout.strip()
+    if not version:
+        raise CaptureError("Docker returned an empty server version")
+    return version
+
+
+def _file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as source:
+            for block in iter(lambda: source.read(1024 * 1024), b""):
+                digest.update(block)
+    except OSError as exc:
+        raise CaptureError(f"Unable to hash trusted file {path}: {exc}") from exc
+    return digest.hexdigest()
+
+
+def _build_rust_image(
+    *,
+    dockerfile: Path,
+    base_worktree: Path,
+    runner_temp: Path,
+    artifact_root: Path,
+    base_revision: str,
+) -> str:
+    try:
+        resolved_dockerfile = dockerfile.resolve(strict=True)
+    except OSError as exc:
+        raise CaptureError(f"Unable to resolve trusted Rust Dockerfile: {exc}") from exc
+    if not resolved_dockerfile.is_file() or not _is_within(
+        resolved_dockerfile, base_worktree
+    ):
+        raise CaptureError("Rust Dockerfile must be a file inside the base worktree")
+
+    image = f"quality-performance-rust:{base_revision[:12].lower()}"
+    with tempfile.TemporaryDirectory(
+        dir=runner_temp, prefix="quality-performance-rust-"
+    ) as context_directory:
+        context = Path(context_directory)
+        copied_dockerfile = context / "Dockerfile"
+        try:
+            shutil.copyfile(resolved_dockerfile, copied_dockerfile)
+        except OSError as exc:
+            raise CaptureError(
+                f"Unable to copy trusted Rust Dockerfile: {exc}"
+            ) from exc
+        try:
+            _safe_capture(
+                (
+                    str(DOCKER_BINARY),
+                    "build",
+                    "--pull",
+                    "--file",
+                    str(copied_dockerfile),
+                    "--tag",
+                    image,
+                    str(context),
+                ),
+                artifact_root / "build-rust-image.log",
+                description="build trusted Rust benchmark image",
+                timeout_seconds=900,
+            )
+        except CaptureError:
+            _remove_image(image)
+            raise
+    return image
+
+
+def _remove_image(image: str) -> None:
+    _best_effort_docker_cleanup([str(DOCKER_BINARY), "image", "rm", "--force", image])
+
+
+def _go_environment(*, offline: bool) -> dict[str, str]:
+    environment = {
+        "GOCACHE": "/cache/go-build",
+        "GOMODCACHE": "/cache/go-mod",
+        "GOPATH": "/cache/go-path",
+        "GOTOOLCHAIN": "local",
+        "HOME": CONTAINER_HOME,
+    }
+    if offline:
+        environment.update(
+            {
+                "GOFLAGS": "-mod=readonly -buildvcs=false",
+                "GOPROXY": "off",
+                "GOSUMDB": "off",
+            }
+        )
+    return environment
+
+
+def _rust_environment(*, offline: bool) -> dict[str, str]:
+    environment = {
+        "CARGO_HOME": "/cache/cargo",
+        "CARGO_TARGET_DIR": "/cache/cargo-target",
+        "HOME": CONTAINER_HOME,
+        "LD_LIBRARY_PATH": "/usr/local/lib",
+        "RUSTUP_TOOLCHAIN": RUST_TOOLCHAIN,
+    }
+    if offline:
+        environment["CARGO_NET_OFFLINE"] = "true"
+    return environment
+
+
+def _go_program() -> tuple[str, ...]:
+    return (
+        "go",
+        "test",
+        "-mod=readonly",
+        "-buildvcs=false",
+        "-bench=.",
+        "-run=^$",
+        "-benchmem",
+        "-count=1",
+        "-benchtime=1s",
+        "./...",
+    )
+
+
+def _rust_prefetch_program() -> tuple[str, ...]:
+    """Fetch dependencies for the nested extension manifest from /src."""
+
+    return (
+        "cargo",
+        "fetch",
+        "--locked",
+        "--manifest-path",
+        "native/rust_ext/Cargo.toml",
+    )
+
+
+def _rust_program(*, warm: bool) -> tuple[str, ...]:
+    program = (
+        "cargo",
+        "bench",
+        "--locked",
+        "--offline",
+        "--manifest-path",
+        "native/rust_ext/Cargo.toml",
+        "--bench",
+        "conflict_bench",
+        "--no-default-features",
+    )
+    if warm:
+        return (*program, "--no-run")
+    return (*program, "--", "--output-format", "bencher")
+
+
+def _capture_pair(
+    *,
+    image: str,
+    source_worktree: Path,
+    cache_volume: str,
+    workdir: str,
+    environment: Mapping[str, str],
+    program: Sequence[str],
+    output_path: Path,
+    description: str,
+) -> None:
+    container_name = _new_container_name()
+    _safe_capture(
+        build_container_command(
+            image=image,
+            source_worktree=source_worktree,
+            cache_volume=cache_volume,
+            container_name=container_name,
+            workdir=workdir,
+            network="none",
+            environment=environment,
+            program=program,
+        ),
+        output_path,
+        description=description,
+        timeout_seconds=300,
+        container_name=container_name,
+    )
+
+
+def _prefetch(
+    *,
+    image: str,
+    source_worktree: Path,
+    cache_volume: str,
+    workdir: str,
+    environment: Mapping[str, str],
+    program: Sequence[str],
+    output_path: Path,
+    description: str,
+) -> None:
+    container_name = _new_container_name()
+    _safe_capture(
+        build_container_command(
+            image=image,
+            source_worktree=source_worktree,
+            cache_volume=cache_volume,
+            container_name=container_name,
+            workdir=workdir,
+            network="bridge",
+            environment=environment,
+            program=program,
+        ),
+        output_path,
+        description=description,
+        timeout_seconds=600,
+        container_name=container_name,
+    )
+
+
+def _write_toolchain(
+    *,
+    artifact_root: Path,
+    format_name: str,
+    image: str,
+    base_revision: str,
+    rust_dockerfile: Path | None,
+) -> None:
+    tool_name = "go" if format_name == "go" else "rustc"
+    version_program = (
+        ("go", "version")
+        if format_name == "go"
+        else ("rustc", "--version", "--verbose")
+    )
+    version_environment = {
+        "HOME": CONTAINER_HOME,
+        "GOTOOLCHAIN": "local",
+    }
+    if format_name == "rust":
+        version_environment = {
+            "HOME": CONTAINER_HOME,
+            "RUSTUP_TOOLCHAIN": RUST_TOOLCHAIN,
+        }
+    payload: dict[str, object] = {
+        tool_name: _container_tool_output(
+            image, version_program, environment=version_environment
+        ),
+        "docker_server_version": _docker_server_version(),
+        "uname": os.uname().sysname
+        + " "
+        + os.uname().release
+        + " "
+        + os.uname().machine,
+        "image": {
+            "content_id": _image_content_id(image),
+            "reference": image,
+        },
+        "isolation": {
+            "cache": "per-side-private-docker-volume",
+            "network_during_measurement": "none",
+            "runtime": "docker",
+            "source_mount": "read-only",
+            "user": CONTAINER_USER,
+        },
+    }
+    if rust_dockerfile is not None:
+        payload["trusted_dockerfile_sha256"] = _file_sha256(rust_dockerfile)
+        payload["trusted_dockerfile_base_revision"] = base_revision
+    (artifact_root / "toolchain.json").write_text(
+        json.dumps(payload, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+
+def capture(arguments: CaptureArguments) -> None:
+    """Collect one full twelve-pair suite without mounting host evidence to code."""
+
+    if not DOCKER_BINARY.is_file() or not TIMEOUT_BINARY.is_file():
+        raise CaptureError(
+            "Required Docker isolation tools are unavailable on this runner"
+        )
+    base_revision = _validate_sha(arguments.base_revision, "base revision")
+    candidate_revision = _validate_sha(
+        arguments.candidate_revision, "candidate revision"
+    )
+    if base_revision.lower() == candidate_revision.lower():
+        raise CaptureError("Base and candidate revisions must differ")
+
+    base_worktree = _resolve_existing_directory(
+        arguments.base_worktree, "base worktree"
+    )
+    candidate_worktree = _resolve_existing_directory(
+        arguments.candidate_worktree, "candidate worktree"
+    )
+    _validate_distinct_worktrees(base_worktree, candidate_worktree)
+    _validate_worktree_revisions(
+        base_worktree=base_worktree,
+        candidate_worktree=candidate_worktree,
+        base_revision=base_revision,
+        candidate_revision=candidate_revision,
+    )
+    runner_temp = _resolve_existing_directory(arguments.runner_temp, "runner temp")
+    artifact_root = prepare_artifact_root(arguments.artifact_root, runner_temp)
+    (artifact_root / "base").mkdir()
+    (artifact_root / "candidate").mkdir()
+
+    image: str | None = None
+    base_volume: str | None = None
+    candidate_volume: str | None = None
+    try:
+        if arguments.format_name == "go":
+            image = GO_IMAGE
+            workdir = "/src/services/ws-hub"
+            prefetch_program = ("sh", "-ec", "go mod download && go mod verify")
+            prefetch_environment = _go_environment(offline=False)
+            measurement_environment = _go_environment(offline=True)
+            warm_program = _go_program()
+            measurement_program = _go_program()
+        else:
+            if arguments.rust_dockerfile is None:
+                raise CaptureError("Rust capture requires a trusted Rust Dockerfile")
+            image = _build_rust_image(
+                dockerfile=arguments.rust_dockerfile,
+                base_worktree=base_worktree,
+                runner_temp=runner_temp,
+                artifact_root=artifact_root,
+                base_revision=base_revision,
+            )
+            workdir = "/src"
+            prefetch_program = _rust_prefetch_program()
+            prefetch_environment = _rust_environment(offline=False)
+            measurement_environment = _rust_environment(offline=True)
+            warm_program = _rust_program(warm=True)
+            measurement_program = _rust_program(warm=False)
+
+        base_volume = _create_private_volume(image, artifact_root, "base")
+        candidate_volume = _create_private_volume(image, artifact_root, "candidate")
+        for side, worktree, volume in (
+            ("base", base_worktree, base_volume),
+            ("candidate", candidate_worktree, candidate_volume),
+        ):
+            _prefetch(
+                image=image,
+                source_worktree=worktree,
+                cache_volume=volume,
+                workdir=workdir,
+                environment=prefetch_environment,
+                program=prefetch_program,
+                output_path=artifact_root / f"prefetch-{side}.log",
+                description=f"prefetch {side} benchmark dependencies",
+            )
+            _capture_pair(
+                image=image,
+                source_worktree=worktree,
+                cache_volume=volume,
+                workdir=workdir,
+                environment=measurement_environment,
+                program=warm_program,
+                output_path=artifact_root / f"warm-{side}.log",
+                description=f"warm {side} benchmark build",
+            )
+
+        _write_toolchain(
+            artifact_root=artifact_root,
+            format_name=arguments.format_name,
+            image=image,
+            base_revision=base_revision,
+            rust_dockerfile=arguments.rust_dockerfile,
+        )
+        for pair in range(1, PAIR_COUNT + 1):
+            ordered_sides = (
+                (
+                    ("base", base_worktree, base_volume),
+                    ("candidate", candidate_worktree, candidate_volume),
+                )
+                if pair % 2
+                else (
+                    ("candidate", candidate_worktree, candidate_volume),
+                    ("base", base_worktree, base_volume),
+                )
+            )
+            for side, worktree, volume in ordered_sides:
+                _capture_pair(
+                    image=image,
+                    source_worktree=worktree,
+                    cache_volume=volume,
+                    workdir=workdir,
+                    environment=measurement_environment,
+                    program=measurement_program,
+                    output_path=artifact_root / side / f"pair-{pair:02d}.txt",
+                    description=f"capture {side} benchmark pair {pair:02d}",
+                )
+    finally:
+        if base_volume is not None:
+            _remove_volume(base_volume)
+        if candidate_volume is not None:
+            _remove_volume(candidate_volume)
+        if arguments.format_name == "rust" and image is not None:
+            _remove_image(image)
+
+
+def _parse_arguments(argv: Sequence[str] | None = None) -> CaptureArguments:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--format", choices=("go", "rust"), required=True)
+    parser.add_argument("--base-worktree", type=Path, required=True)
+    parser.add_argument("--candidate-worktree", type=Path, required=True)
+    parser.add_argument("--artifact-root", type=Path, required=True)
+    parser.add_argument("--runner-temp", type=Path, required=True)
+    parser.add_argument("--base-revision", required=True)
+    parser.add_argument("--candidate-revision", required=True)
+    parser.add_argument("--rust-dockerfile", type=Path)
+    parsed = parser.parse_args(argv)
+    if parsed.format == "rust" and parsed.rust_dockerfile is None:
+        parser.error("--rust-dockerfile is required for --format rust")
+    if parsed.format == "go" and parsed.rust_dockerfile is not None:
+        parser.error("--rust-dockerfile is only valid for --format rust")
+    return CaptureArguments(
+        format_name=parsed.format,
+        base_worktree=parsed.base_worktree,
+        candidate_worktree=parsed.candidate_worktree,
+        artifact_root=parsed.artifact_root,
+        runner_temp=parsed.runner_temp,
+        base_revision=parsed.base_revision,
+        candidate_revision=parsed.candidate_revision,
+        rust_dockerfile=parsed.rust_dockerfile,
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Capture evidence and return a fail-closed CI status."""
+
+    try:
+        arguments = _parse_arguments(argv)
+        capture(arguments)
+    except SystemExit as exc:
+        return exc.code if isinstance(exc.code, int) else 2
+    except CaptureError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    except (OSError, subprocess.SubprocessError) as exc:
+        print(
+            f"error: unable to capture isolated benchmark evidence: {exc}",
+            file=sys.stderr,
+        )
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/quality/compare_paired_benchmarks.py
+++ b/scripts/quality/compare_paired_benchmarks.py
@@ -1,0 +1,697 @@
+"""Compare complete same-run benchmark pairs with a deterministic confidence gate."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import random
+import re
+import sys
+import tempfile
+import traceback
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from statistics import median
+
+EXPECTED_PAIRS = 12
+THRESHOLD_RATIO = 1.10
+BOOTSTRAP_ITERATIONS = 10_000
+CONFIDENCE = 0.95
+
+_ALLOCATION_METRICS = frozenset({"B/op", "allocs/op"})
+_GO_METRICS = frozenset({"ns/op", *_ALLOCATION_METRICS})
+_SHA_RE = re.compile(r"^[0-9a-fA-F]{40}$")
+_GO_BENCHMARK_RE = re.compile(r"^Benchmark\S+$")
+_GO_PACKAGE_RE = re.compile(r"^pkg:\s+(?P<package>\S+)$")
+_PROCESS_SUFFIX_RE = re.compile(r"-\d+$")
+_INTEGER_RE = re.compile(r"^\d+$")
+_GO_NUMBER_RE = re.compile(r"^(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$")
+_BENCHER_NUMBER_RE = re.compile(
+    r"^(?:(?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$"
+)
+_BENCHER_RECORD_RE = re.compile(
+    r"^\s*test\s+(?P<benchmark>\S+)\s+\.\.\.\s+bench:\s+"
+    r"(?P<value>(?:(?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?)"
+    r"\s+ns/iter(?:\s+.*)?$"
+)
+
+MetricKey = tuple[str, str]
+PairedValues = tuple[tuple[float, ...], tuple[float, ...]]
+BenchmarkParser = Callable[[str], dict[str, dict[str, float]]]
+
+
+class EvidenceIntegrityError(ValueError):
+    """Raised when raw benchmark evidence cannot support a safe decision."""
+
+
+@dataclass(frozen=True)
+class BenchmarkSample:
+    """One finite lower-is-better measurement from a raw benchmark file."""
+
+    benchmark: str
+    metric: str
+    value: float
+
+
+@dataclass(frozen=True)
+class MetricComparison:
+    """The complete, auditable decision for one benchmark metric."""
+
+    benchmark: str
+    metric: str
+    base_values: tuple[float, ...]
+    candidate_values: tuple[float, ...]
+    ratios: tuple[float | None, ...]
+    median_ratio: float | None
+    one_sided_95_lower_bound: float | None
+    comparison_mode: str
+    decision: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "benchmark": self.benchmark,
+            "metric": self.metric,
+            "base_values": list(self.base_values),
+            "candidate_values": list(self.candidate_values),
+            "ratios": list(self.ratios),
+            "median_ratio": self.median_ratio,
+            "one_sided_95_lower_bound": self.one_sided_95_lower_bound,
+            "comparison_mode": self.comparison_mode,
+            "decision": self.decision,
+        }
+
+
+@dataclass(frozen=True)
+class ComparisonResult:
+    """A versioned report suitable for an immutable CI artifact."""
+
+    format_name: str
+    base_revision: str
+    candidate_revision: str
+    expected_pairs: int
+    toolchain: Mapping[str, object]
+    decision: str
+    metrics: tuple[MetricComparison, ...]
+    error: str | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        result: dict[str, object] = {
+            "schema_version": 1,
+            "format": self.format_name,
+            "base_revision": self.base_revision,
+            "candidate_revision": self.candidate_revision,
+            "expected_pairs": self.expected_pairs,
+            "threshold_ratio": THRESHOLD_RATIO,
+            "toolchain": dict(self.toolchain),
+            "decision": self.decision,
+            "metrics": [metric.to_dict() for metric in self.metrics],
+        }
+        if self.error is not None:
+            result["error"] = self.error
+        return result
+
+
+def _parse_measurement(
+    token: str,
+    *,
+    line: str,
+    number_pattern: re.Pattern[str],
+    allow_commas: bool = False,
+) -> float:
+    if number_pattern.fullmatch(token) is None:
+        raise EvidenceIntegrityError(f"Malformed benchmark measurement in {line!r}")
+
+    value = float(token.replace(",", "") if allow_commas else token)
+    if not math.isfinite(value) or value < 0:
+        raise EvidenceIntegrityError(f"Non-finite or negative measurement in {line!r}")
+    return value
+
+
+def parse_go_benchmark_output(text: str) -> dict[str, dict[str, float]]:
+    """Parse canonical ``go test -bench -benchmem`` output without guessing."""
+
+    records: dict[str, dict[str, float]] = {}
+    current_package: str | None = None
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if line.startswith("pkg:"):
+            package_match = _GO_PACKAGE_RE.fullmatch(line)
+            if package_match is None:
+                raise EvidenceIntegrityError(f"Malformed Go package identity: {line!r}")
+            current_package = package_match.group("package")
+            continue
+        if not line.startswith("Benchmark"):
+            continue
+        if current_package is None:
+            raise EvidenceIntegrityError(
+                f"Go benchmark record has no package identity: {line!r}"
+            )
+
+        fields = line.split()
+        if len(fields) < 4 or (len(fields) - 2) % 2:
+            raise EvidenceIntegrityError(f"Malformed Go benchmark record: {line!r}")
+
+        benchmark_token = fields[0]
+        if _GO_BENCHMARK_RE.fullmatch(benchmark_token) is None:
+            raise EvidenceIntegrityError(f"Malformed Go benchmark name: {line!r}")
+        benchmark = f"{current_package}::{_PROCESS_SUFFIX_RE.sub('', benchmark_token)}"
+        if benchmark in records:
+            raise EvidenceIntegrityError(
+                f"Duplicate Go benchmark record for {benchmark!r} in one file"
+            )
+
+        if _INTEGER_RE.fullmatch(fields[1]) is None or int(fields[1]) <= 0:
+            raise EvidenceIntegrityError(f"Malformed Go benchmark iterations: {line!r}")
+
+        metrics: dict[str, float] = {}
+        for index in range(2, len(fields), 2):
+            value = _parse_measurement(
+                fields[index], line=line, number_pattern=_GO_NUMBER_RE
+            )
+            metric = fields[index + 1]
+            if metric not in _GO_METRICS:
+                raise EvidenceIntegrityError(
+                    f"Unsupported Go benchmark metric {metric!r} in {line!r}"
+                )
+            if metric in metrics:
+                raise EvidenceIntegrityError(
+                    f"Duplicate Go benchmark metric {metric!r} in {line!r}"
+                )
+            metrics[metric] = value
+
+        if set(metrics) != _GO_METRICS:
+            raise EvidenceIntegrityError(
+                f"Incomplete Go benchmark metric set in {line!r}; expected "
+                "ns/op, B/op, and allocs/op"
+            )
+        records[benchmark] = metrics
+    return records
+
+
+def parse_bencher_output(text: str) -> dict[str, dict[str, float]]:
+    """Parse Criterion's canonical bencher output as the common ``ns/op`` unit."""
+
+    records: dict[str, dict[str, float]] = {}
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        match = _BENCHER_RECORD_RE.fullmatch(line)
+        if match is None:
+            if line.startswith("test ") and "bench:" in line:
+                raise EvidenceIntegrityError(
+                    f"Malformed bencher benchmark record: {line!r}"
+                )
+            continue
+
+        benchmark = match.group("benchmark")
+        if benchmark in records:
+            raise EvidenceIntegrityError(
+                f"Duplicate bencher benchmark record for {benchmark!r} in one file"
+            )
+        records[benchmark] = {
+            "ns/op": _parse_measurement(
+                match.group("value"),
+                line=line,
+                number_pattern=_BENCHER_NUMBER_RE,
+                allow_commas=True,
+            )
+        }
+    return records
+
+
+def _pair_paths(directory: Path, expected_pairs: int) -> tuple[Path, ...]:
+    if expected_pairs != EXPECTED_PAIRS:
+        raise EvidenceIntegrityError(
+            f"Expected pair count must be exactly {EXPECTED_PAIRS}, got {expected_pairs}"
+        )
+    if not directory.is_dir():
+        raise EvidenceIntegrityError(f"Evidence directory does not exist: {directory}")
+
+    expected_names = {f"pair-{index:02d}.txt" for index in range(1, expected_pairs + 1)}
+    unexpected = sorted(
+        entry.name for entry in directory.iterdir() if entry.name not in expected_names
+    )
+    if unexpected:
+        raise EvidenceIntegrityError(
+            f"Unexpected pair evidence entry(s) in {directory}: {', '.join(unexpected)}"
+        )
+
+    paths = tuple(
+        directory / f"pair-{index:02d}.txt" for index in range(1, expected_pairs + 1)
+    )
+    missing = [path.name for path in paths if not path.is_file()]
+    if missing:
+        raise EvidenceIntegrityError(
+            f"Missing pair evidence file(s) in {directory}: {', '.join(missing)}"
+        )
+    return paths
+
+
+def _as_samples(
+    records: dict[str, dict[str, float]],
+) -> dict[MetricKey, BenchmarkSample]:
+    if not records:
+        raise EvidenceIntegrityError(
+            "Benchmark evidence file contains no supported records"
+        )
+
+    samples: dict[MetricKey, BenchmarkSample] = {}
+    for benchmark, metrics in records.items():
+        if not benchmark or not metrics:
+            raise EvidenceIntegrityError(
+                "Benchmark evidence contains an empty identity or metric set"
+            )
+        for metric, value in metrics.items():
+            if not math.isfinite(value) or value < 0:
+                raise EvidenceIntegrityError(
+                    f"Non-finite or negative value for {benchmark!r} / {metric!r}"
+                )
+            key = (benchmark, metric)
+            if key in samples:
+                raise EvidenceIntegrityError(
+                    f"Duplicate benchmark metric {benchmark!r} / {metric!r}"
+                )
+            samples[key] = BenchmarkSample(benchmark, metric, value)
+    return samples
+
+
+def load_paired_samples(
+    base_dir: Path,
+    candidate_dir: Path,
+    expected_pairs: int,
+    parser: BenchmarkParser,
+) -> dict[MetricKey, PairedValues]:
+    """Load exactly twelve canonical pairs and require one stable metric universe."""
+
+    base_paths = _pair_paths(base_dir, expected_pairs)
+    candidate_paths = _pair_paths(candidate_dir, expected_pairs)
+    collected: dict[MetricKey, tuple[list[float], list[float]]] = {}
+    expected_keys: set[MetricKey] | None = None
+
+    for index, (base_path, candidate_path) in enumerate(
+        zip(base_paths, candidate_paths, strict=True), start=1
+    ):
+        try:
+            base_records = parser(base_path.read_text(encoding="utf-8"))
+            candidate_records = parser(candidate_path.read_text(encoding="utf-8"))
+        except OSError as exc:
+            raise EvidenceIntegrityError(
+                f"Unable to read pair {index:02d} evidence: {exc}"
+            ) from exc
+
+        base_samples = _as_samples(base_records)
+        candidate_samples = _as_samples(candidate_records)
+        base_keys = set(base_samples)
+        candidate_keys = set(candidate_samples)
+        if base_keys != candidate_keys:
+            raise EvidenceIntegrityError(
+                f"Base/candidate benchmark metrics differ in pair {index:02d}"
+            )
+        if expected_keys is None:
+            expected_keys = base_keys
+            for key in sorted(expected_keys):
+                collected[key] = ([], [])
+        elif base_keys != expected_keys:
+            raise EvidenceIntegrityError(
+                f"Benchmark metric set differs from pair 01 in pair {index:02d}"
+            )
+
+        for key in sorted(base_keys):
+            base_values, candidate_values = collected[key]
+            base_values.append(base_samples[key].value)
+            candidate_values.append(candidate_samples[key].value)
+
+    if expected_keys is None:
+        raise EvidenceIntegrityError("No paired benchmark evidence was loaded")
+    return {
+        key: (tuple(base_values), tuple(candidate_values))
+        for key, (base_values, candidate_values) in sorted(collected.items())
+    }
+
+
+def _validate_pair_values(
+    base_values: Sequence[float], candidate_values: Sequence[float]
+) -> None:
+    if not base_values or len(base_values) != len(candidate_values):
+        raise EvidenceIntegrityError(
+            "Base and candidate measurements must be non-empty pairs"
+        )
+    for value in (*base_values, *candidate_values):
+        if not math.isfinite(value) or value < 0:
+            raise EvidenceIntegrityError(
+                "Benchmark measurements must be finite and non-negative"
+            )
+
+
+def _ratios(
+    base_values: Sequence[float], candidate_values: Sequence[float]
+) -> tuple[float, ...]:
+    _validate_pair_values(base_values, candidate_values)
+    if any(value <= 0 for value in base_values):
+        raise EvidenceIntegrityError(
+            "Relative benchmark comparisons require positive base values"
+        )
+    ratios = tuple(
+        candidate / base
+        for base, candidate in zip(base_values, candidate_values, strict=True)
+    )
+    if any(not math.isfinite(value) for value in ratios):
+        raise EvidenceIntegrityError("Benchmark ratios must be finite")
+    return ratios
+
+
+def paired_median_ratio(
+    base_values: Sequence[float], candidate_values: Sequence[float]
+) -> float:
+    """Return the paired median candidate/base ratio for finite positive bases."""
+
+    return float(median(_ratios(base_values, candidate_values)))
+
+
+def bootstrap_lower_bound(
+    ratios: Sequence[float],
+    confidence: float = CONFIDENCE,
+    iterations: int = BOOTSTRAP_ITERATIONS,
+    *,
+    benchmark: str = "",
+    metric: str = "",
+) -> float:
+    """Return a deterministic one-sided bootstrap lower bound for paired ratios."""
+
+    if not ratios:
+        raise EvidenceIntegrityError("Cannot bootstrap an empty ratio distribution")
+    if not 0 < confidence < 1 or iterations <= 0:
+        raise EvidenceIntegrityError(
+            "Bootstrap confidence and iteration count are invalid"
+        )
+    if any(not math.isfinite(value) or value < 0 for value in ratios):
+        raise EvidenceIntegrityError("Bootstrap ratios must be finite and non-negative")
+
+    identity = json.dumps(
+        {"benchmark": benchmark, "metric": metric, "ratios": list(ratios)},
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    seed = int.from_bytes(hashlib.sha256(identity.encode("utf-8")).digest())
+    generator = random.Random(seed)  # noqa: S311 - deterministic statistical bootstrap.
+    sample_size = len(ratios)
+    bootstrap_medians = [
+        float(
+            median(
+                tuple(
+                    ratios[generator.randrange(sample_size)] for _ in range(sample_size)
+                )
+            )
+        )
+        for _ in range(iterations)
+    ]
+    bootstrap_medians.sort()
+    index = math.floor((1 - confidence) * iterations)
+    return bootstrap_medians[index]
+
+
+def _comparison_for_metric(
+    benchmark: str,
+    metric: str,
+    base_values: tuple[float, ...],
+    candidate_values: tuple[float, ...],
+) -> MetricComparison:
+    _validate_pair_values(base_values, candidate_values)
+
+    if metric in _ALLOCATION_METRICS and any(value == 0 for value in base_values):
+        if not all(value == 0 for value in base_values):
+            raise EvidenceIntegrityError(
+                f"Allocation baseline for {benchmark!r} / {metric!r} mixes zero and non-zero values"
+            )
+        if all(value == 0 for value in candidate_values):
+            return MetricComparison(
+                benchmark=benchmark,
+                metric=metric,
+                base_values=base_values,
+                candidate_values=candidate_values,
+                ratios=(None,) * len(base_values),
+                median_ratio=None,
+                one_sided_95_lower_bound=None,
+                comparison_mode="zero_stable",
+                decision="pass",
+            )
+        return MetricComparison(
+            benchmark=benchmark,
+            metric=metric,
+            base_values=base_values,
+            candidate_values=candidate_values,
+            ratios=(None,) * len(base_values),
+            median_ratio=None,
+            one_sided_95_lower_bound=None,
+            comparison_mode="zero_baseline_regression",
+            decision="regression",
+        )
+
+    ratios = _ratios(base_values, candidate_values)
+    median_ratio = paired_median_ratio(base_values, candidate_values)
+    lower_bound = bootstrap_lower_bound(
+        ratios,
+        benchmark=benchmark,
+        metric=metric,
+    )
+    decision = (
+        "regression"
+        if median_ratio > THRESHOLD_RATIO and lower_bound > THRESHOLD_RATIO
+        else "pass"
+    )
+    return MetricComparison(
+        benchmark=benchmark,
+        metric=metric,
+        base_values=base_values,
+        candidate_values=candidate_values,
+        ratios=ratios,
+        median_ratio=median_ratio,
+        one_sided_95_lower_bound=lower_bound,
+        comparison_mode="paired_ratio",
+        decision=decision,
+    )
+
+
+def compare_paired_samples(
+    samples: Mapping[MetricKey, PairedValues],
+    *,
+    format_name: str,
+    base_revision: str,
+    candidate_revision: str,
+    toolchain: Mapping[str, object],
+    expected_pairs: int = EXPECTED_PAIRS,
+) -> ComparisonResult:
+    """Compare all validated metrics and fail the aggregate on any regression."""
+
+    if expected_pairs != EXPECTED_PAIRS:
+        raise EvidenceIntegrityError(
+            f"Expected pair count must be exactly {EXPECTED_PAIRS}, got {expected_pairs}"
+        )
+    if not samples:
+        raise EvidenceIntegrityError(
+            "No benchmark metrics are available for comparison"
+        )
+
+    metrics: list[MetricComparison] = []
+    for (benchmark, metric), (base_values, candidate_values) in sorted(samples.items()):
+        if (
+            len(base_values) != expected_pairs
+            or len(candidate_values) != expected_pairs
+        ):
+            raise EvidenceIntegrityError(
+                f"Benchmark {benchmark!r} / {metric!r} does not contain {expected_pairs} pairs"
+            )
+        metrics.append(
+            _comparison_for_metric(benchmark, metric, base_values, candidate_values)
+        )
+
+    decision = (
+        "regression"
+        if any(metric.decision == "regression" for metric in metrics)
+        else "pass"
+    )
+    return ComparisonResult(
+        format_name=format_name,
+        base_revision=base_revision,
+        candidate_revision=candidate_revision,
+        expected_pairs=expected_pairs,
+        toolchain=toolchain,
+        decision=decision,
+        metrics=tuple(metrics),
+    )
+
+
+def _validate_revision(value: str, flag_name: str) -> str:
+    if _SHA_RE.fullmatch(value) is None or value == "0" * 40:
+        raise EvidenceIntegrityError(
+            f"{flag_name} must be a non-zero 40-hex commit SHA"
+        )
+    return value
+
+
+def _load_toolchain(path: Path) -> dict[str, object]:
+    def reject_nonstandard_constant(value: str) -> None:
+        raise EvidenceIntegrityError(
+            f"Toolchain JSON contains non-finite value {value!r}"
+        )
+
+    try:
+        parsed = json.loads(
+            path.read_text(encoding="utf-8"), parse_constant=reject_nonstandard_constant
+        )
+    except OSError as exc:
+        raise EvidenceIntegrityError(f"Unable to read toolchain JSON: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise EvidenceIntegrityError(f"Malformed toolchain JSON: {exc}") from exc
+    if not isinstance(parsed, dict):
+        raise EvidenceIntegrityError("Toolchain JSON must be an object")
+    return parsed
+
+
+def _write_result(path: Path, result: ComparisonResult) -> None:
+    payload = (
+        json.dumps(
+            result.to_dict(),
+            allow_nan=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        + "\n"
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as temporary_file:
+            temporary_file.write(payload)
+            temporary_path = Path(temporary_file.name)
+        temporary_path.replace(path)
+    finally:
+        if temporary_path is not None and temporary_path.exists():
+            temporary_path.unlink()
+
+
+def _invalid_result(
+    *,
+    format_name: str,
+    base_revision: str,
+    candidate_revision: str,
+    expected_pairs: int,
+    toolchain: Mapping[str, object],
+    error: str,
+) -> ComparisonResult:
+    return ComparisonResult(
+        format_name=format_name,
+        base_revision=base_revision,
+        candidate_revision=candidate_revision,
+        expected_pairs=expected_pairs,
+        toolchain=toolchain,
+        decision="invalid_evidence",
+        metrics=(),
+        error=error,
+    )
+
+
+def _write_invalid_result(
+    arguments: argparse.Namespace,
+    toolchain: Mapping[str, object],
+    error: str,
+) -> None:
+    try:
+        _write_result(
+            arguments.output,
+            _invalid_result(
+                format_name=arguments.format,
+                base_revision=arguments.base_revision,
+                candidate_revision=arguments.candidate_revision,
+                expected_pairs=arguments.expected_pairs,
+                toolchain=toolchain,
+                error=error,
+            ),
+        )
+    except OSError as write_error:
+        print(
+            f"error: unable to write invalid-evidence report: {write_error}",
+            file=sys.stderr,
+        )
+
+
+def _parse_arguments(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--format", choices=("go", "bencher"), required=True)
+    parser.add_argument("--base-dir", type=Path, required=True)
+    parser.add_argument("--candidate-dir", type=Path, required=True)
+    parser.add_argument("--expected-pairs", type=int, default=EXPECTED_PAIRS)
+    parser.add_argument("--base-revision", required=True)
+    parser.add_argument("--candidate-revision", required=True)
+    parser.add_argument("--toolchain-json", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--verbose", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the fail-closed comparison and map its decision to CI exit codes."""
+
+    try:
+        arguments = _parse_arguments(argv)
+    except SystemExit as exc:
+        return exc.code if isinstance(exc.code, int) else 2
+
+    toolchain: Mapping[str, object] = {}
+    try:
+        base_revision = _validate_revision(arguments.base_revision, "--base-revision")
+        candidate_revision = _validate_revision(
+            arguments.candidate_revision, "--candidate-revision"
+        )
+        if base_revision.lower() == candidate_revision.lower():
+            raise EvidenceIntegrityError(
+                "--base-revision and --candidate-revision must differ"
+            )
+        toolchain = _load_toolchain(arguments.toolchain_json)
+        parser = (
+            parse_go_benchmark_output
+            if arguments.format == "go"
+            else parse_bencher_output
+        )
+        samples = load_paired_samples(
+            arguments.base_dir,
+            arguments.candidate_dir,
+            arguments.expected_pairs,
+            parser,
+        )
+        result = compare_paired_samples(
+            samples,
+            format_name=arguments.format,
+            base_revision=base_revision,
+            candidate_revision=candidate_revision,
+            toolchain=toolchain,
+            expected_pairs=arguments.expected_pairs,
+        )
+        _write_result(arguments.output, result)
+        return 1 if result.decision == "regression" else 0
+    except EvidenceIntegrityError as exc:
+        _write_invalid_result(arguments, toolchain, str(exc))
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    except (
+        Exception
+    ) as exc:  # RZ-22-01-JUSTIFIED: fail closed on unexpected CLI failures.
+        _write_invalid_result(arguments, toolchain, str(exc))
+        if arguments.verbose:
+            traceback.print_exc()
+        else:
+            print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_capture_isolated_benchmarks.py
+++ b/tests/test_capture_isolated_benchmarks.py
@@ -1,0 +1,1107 @@
+import json
+import subprocess
+from io import BytesIO
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from scripts.quality.capture_isolated_benchmarks import (
+    CONTAINER_HOME,
+    DOCKER_BINARY,
+    TIMEOUT_BINARY,
+    CaptureArguments,
+    CaptureError,
+    _build_rust_image,
+    _container_tool_output,
+    _copy_limited_stream,
+    _create_private_volume,
+    _docker_server_version,
+    _force_remove_container,
+    _go_environment,
+    _remove_image,
+    _remove_volume,
+    _rust_environment,
+    _rust_prefetch_program,
+    _safe_capture,
+    _timeout_command,
+    _validate_distinct_worktrees,
+    _validate_image_content_id,
+    _write_toolchain,
+    build_container_command,
+    capture,
+    prepare_artifact_root,
+)
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_container_command_has_an_explicit_non_privileged_boundary(
+    tmp_path: Path,
+) -> None:
+    """Candidate code must not receive host evidence, tokens, or a writable source."""
+
+    source = tmp_path / "candidate-source"
+    source.mkdir()
+    command = build_container_command(
+        image="example.invalid/performance@sha256:" + "a" * 64,
+        source_worktree=source,
+        cache_volume="private-candidate-cache",
+        container_name="quality-benchmark-" + "a" * 32,
+        workdir="/src/services/ws-hub",
+        network="none",
+        environment={
+            "GOCACHE": "/cache/go-build",
+            "GOMODCACHE": "/cache/go-mod",
+            "GOPATH": "/cache/go-path",
+            "HOME": CONTAINER_HOME,
+        },
+        program=("go", "test", "-mod=readonly", "-bench=.", "./..."),
+    )
+    command_text = "\n".join(command)
+
+    for required_fragment in (
+        "--name",
+        "quality-benchmark-" + "a" * 32,
+        "--init",
+        "--platform",
+        "linux/amd64",
+        "--network",
+        "none",
+        "--read-only",
+        "--log-driver",
+        "local",
+        "--log-opt",
+        "max-size=16m",
+        "max-file=1",
+        "compress=false",
+        "--cap-drop",
+        "ALL",
+        "--security-opt",
+        "no-new-privileges=true",
+        "--memory",
+        "6g",
+        "--memory-swap",
+        "6g",
+        "--cpus",
+        "2.0",
+        "--pids-limit",
+        "512",
+        "--user",
+        "10001:10001",
+        "type=bind,src=" + str(source.resolve()) + ",dst=/src,readonly",
+        "type=volume,src=private-candidate-cache,dst=/cache",
+    ):
+        assert required_fragment in command_text
+
+    assert "docker.sock" not in command_text
+    assert "GITHUB_" not in command_text
+    assert "RUNNER_" not in command_text
+    assert "/artifacts" not in command_text
+    assert command.count("--mount") == 2
+    assert command.count("--log-opt") == 3
+
+    def has_docker_option(option: str) -> bool:
+        return any(
+            token == option or token.startswith(option + "=") for token in command
+        )
+
+    for forbidden_option in (
+        "--privileged",
+        "--pid",
+        "--ipc",
+        "--uts",
+        "--userns",
+        "--device",
+    ):
+        assert not has_docker_option(forbidden_option)
+    assert "seccomp=unconfined" not in command_text
+    assert "--rm" not in command
+    assert command[-5:] == [
+        "go",
+        "test",
+        "-mod=readonly",
+        "-bench=.",
+        "./...",
+    ]
+
+
+def test_limited_capture_stops_writing_before_an_untrusted_stream_can_fill_disk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The stream limit is enforced during, not after, output capture."""
+
+    monkeypatch.setattr(
+        "scripts.quality.capture_isolated_benchmarks.MAX_OUTPUT_BYTES", 8
+    )
+    destination = BytesIO()
+
+    assert _copy_limited_stream(BytesIO(b"12345678"), destination) is False
+    assert destination.getvalue() == b"12345678"
+
+    destination = BytesIO()
+    assert _copy_limited_stream(BytesIO(b"123456789"), destination) is True
+    assert destination.getvalue() == b"12345678"
+
+
+def test_rust_prefetch_selects_the_workspace_manifest() -> None:
+    """`cargo fetch` runs from /src, so it must target the nested Rust manifest."""
+
+    assert _rust_prefetch_program() == (
+        "cargo",
+        "fetch",
+        "--locked",
+        "--manifest-path",
+        "native/rust_ext/Cargo.toml",
+    )
+
+
+def test_isolated_capture_rejects_a_single_checkout_for_both_sides(
+    tmp_path: Path,
+) -> None:
+    """A wiring error must not compare a worktree with itself."""
+
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+
+    with pytest.raises(CaptureError, match="different directories"):
+        _validate_distinct_worktrees(worktree, worktree)
+
+
+def test_capture_rejects_a_mismatched_worktree_head_before_benchmark_setup(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Declared evidence revisions must match the commits actually mounted."""
+
+    base_worktree = tmp_path / "base"
+    candidate_worktree = tmp_path / "candidate"
+    runner_temp = tmp_path / "runner-temp"
+    for directory in (base_worktree, candidate_worktree, runner_temp):
+        directory.mkdir()
+    docker_binary = tmp_path / "docker"
+    timeout_binary = tmp_path / "timeout"
+    docker_binary.touch()
+    timeout_binary.touch()
+    arguments = CaptureArguments(
+        format_name="go",
+        base_worktree=base_worktree,
+        candidate_worktree=candidate_worktree,
+        artifact_root=runner_temp / "artifacts",
+        runner_temp=runner_temp,
+        base_revision="a" * 40,
+        candidate_revision="b" * 40,
+        rust_dockerfile=None,
+    )
+    observed_commands: list[list[str]] = []
+    benchmark_setup: list[str] = []
+
+    def fake_run(command: list[str], **_: object) -> SimpleNamespace:
+        observed_commands.append(command)
+        worktree = Path(command[command.index("-C") + 1])
+        revision = "c" * 40 if worktree == base_worktree else "b" * 40
+        return SimpleNamespace(returncode=0, stdout=f"{revision}\n", stderr="")
+
+    monkeypatch.setattr(
+        "scripts.quality.capture_isolated_benchmarks.DOCKER_BINARY", docker_binary
+    )
+    monkeypatch.setattr(
+        "scripts.quality.capture_isolated_benchmarks.TIMEOUT_BINARY", timeout_binary
+    )
+    monkeypatch.setattr(
+        "scripts.quality.capture_isolated_benchmarks.subprocess.run", fake_run
+    )
+    monkeypatch.setattr(
+        "scripts.quality.capture_isolated_benchmarks._create_private_volume",
+        lambda *_args: benchmark_setup.append("volume"),
+    )
+    monkeypatch.setattr(
+        "scripts.quality.capture_isolated_benchmarks._prefetch",
+        lambda **_kwargs: benchmark_setup.append("prefetch"),
+    )
+    monkeypatch.setattr(
+        "scripts.quality.capture_isolated_benchmarks._capture_pair",
+        lambda **_kwargs: benchmark_setup.append("capture"),
+    )
+    monkeypatch.setattr(
+        "scripts.quality.capture_isolated_benchmarks._write_toolchain",
+        lambda **_kwargs: benchmark_setup.append("toolchain"),
+    )
+
+    with pytest.raises(CaptureError, match="does not match declared base revision"):
+        capture(arguments)
+
+    assert observed_commands == [
+        [
+            "git",
+            "-C",
+            str(base_worktree),
+            "rev-parse",
+            "--verify",
+            "HEAD^{commit}",
+        ],
+        [
+            "git",
+            "-C",
+            str(candidate_worktree),
+            "rev-parse",
+            "--verify",
+            "HEAD^{commit}",
+        ],
+    ]
+    assert benchmark_setup == []
+
+
+def test_capture_accepts_worktrees_with_matching_declared_heads(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Matching Git commits proceed into the bounded paired capture sequence."""
+
+    base_worktree = tmp_path / "base"
+    candidate_worktree = tmp_path / "candidate"
+    runner_temp = tmp_path / "runner-temp"
+    for directory in (base_worktree, candidate_worktree, runner_temp):
+        directory.mkdir()
+    docker_binary = tmp_path / "docker"
+    timeout_binary = tmp_path / "timeout"
+    docker_binary.touch()
+    timeout_binary.touch()
+    arguments = CaptureArguments(
+        format_name="go",
+        base_worktree=base_worktree,
+        candidate_worktree=candidate_worktree,
+        artifact_root=runner_temp / "artifacts",
+        runner_temp=runner_temp,
+        base_revision="a" * 40,
+        candidate_revision="b" * 40,
+        rust_dockerfile=None,
+    )
+    observed_commands: list[list[str]] = []
+    captured_descriptions: list[str] = []
+
+    def fake_run(command: list[str], **_: object) -> SimpleNamespace:
+        observed_commands.append(command)
+        worktree = Path(command[command.index("-C") + 1])
+        revision = "a" * 40 if worktree == base_worktree else "b" * 40
+        return SimpleNamespace(returncode=0, stdout=f"{revision}\n", stderr="")
+
+    monkeypatch.setattr(
+        "scripts.quality.capture_isolated_benchmarks.DOCKER_BINARY", docker_binary
+    )
+    monkeypatch.setattr(
+        "scripts.quality.capture_isolated_benchmarks.TIMEOUT_BINARY", timeout_binary
+    )
+    monkeypatch.setattr(
+        "scripts.quality.capture_isolated_benchmarks.subprocess.run", fake_run
+    )
+    monkeypatch.setattr(
+        "scripts.quality.capture_isolated_benchmarks._create_private_volume",
+        lambda _image, _artifact_root, side: f"{side}-volume",
+    )
+    monkeypatch.setattr(
+        "scripts.quality.capture_isolated_benchmarks._prefetch", lambda **_kwargs: None
+    )
+    monkeypatch.setattr(
+        "scripts.quality.capture_isolated_benchmarks._capture_pair",
+        lambda **kwargs: captured_descriptions.append(kwargs["description"]),
+    )
+    monkeypatch.setattr(
+        "scripts.quality.capture_isolated_benchmarks._write_toolchain",
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "scripts.quality.capture_isolated_benchmarks._remove_volume",
+        lambda _volume: None,
+    )
+
+    capture(arguments)
+
+    assert observed_commands == [
+        [
+            "git",
+            "-C",
+            str(base_worktree),
+            "rev-parse",
+            "--verify",
+            "HEAD^{commit}",
+        ],
+        [
+            "git",
+            "-C",
+            str(candidate_worktree),
+            "rev-parse",
+            "--verify",
+            "HEAD^{commit}",
+        ],
+    ]
+    assert captured_descriptions == [
+        "warm base benchmark build",
+        "warm candidate benchmark build",
+        *[
+            f"capture {side} benchmark pair {pair:02d}"
+            for pair in range(1, 13)
+            for side in (("base", "candidate") if pair % 2 else ("candidate", "base"))
+        ],
+    ]
+
+
+def test_image_content_id_must_be_an_immutable_sha256_identifier() -> None:
+    """A mutable local tag alone is insufficient provenance for raw evidence."""
+
+    assert _validate_image_content_id("sha256:" + "a" * 64) == "sha256:" + "a" * 64
+    with pytest.raises(CaptureError, match="content ID"):
+        _validate_image_content_id("quality-performance-rust:mutable")
+
+
+def test_timeout_uses_a_hard_kill_deadline_and_cleanup_removes_named_container(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A quiet or SIGTERM-resistant benchmark cannot outlive its capture step."""
+
+    command = _timeout_command(("docker", "run", "example"), timeout_seconds=300)
+    assert command[:4] == [
+        str(TIMEOUT_BINARY),
+        "--foreground",
+        "--kill-after=30s",
+        "300s",
+    ]
+
+    calls: list[list[str]] = []
+
+    def fake_run(command: list[str], **_: object) -> SimpleNamespace:
+        calls.append(command)
+        return SimpleNamespace(returncode=1, stderr="No such container")
+
+    monkeypatch.setattr(
+        "scripts.quality.capture_isolated_benchmarks.subprocess.run", fake_run
+    )
+    container_name = "quality-benchmark-" + "b" * 32
+    _force_remove_container(container_name)
+
+    assert calls == [
+        [str(DOCKER_BINARY), "container", "rm", "--force", container_name],
+        [str(DOCKER_BINARY), "container", "inspect", container_name],
+    ]
+
+
+@pytest.mark.parametrize(
+    ("failure", "failure_phase"),
+    [
+        (OSError("Docker client is unavailable"), "remove"),
+        (subprocess.TimeoutExpired(["docker"], 30), "remove"),
+        (OSError("Docker client is unavailable"), "inspect"),
+        (subprocess.TimeoutExpired(["docker"], 30), "inspect"),
+    ],
+    ids=("remove-launch", "remove-timeout", "inspect-launch", "inspect-timeout"),
+)
+def test_force_remove_container_converts_docker_client_failures_to_capture_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    failure: BaseException,
+    failure_phase: str,
+) -> None:
+    """Unverified named-container cleanup must fail closed with a typed error."""
+
+    container_name = "quality-benchmark-" + "d" * 32
+    observed: list[tuple[list[str], object]] = []
+
+    def fake_run(command: list[str], **kwargs: object) -> SimpleNamespace:
+        observed.append((command, kwargs.get("timeout")))
+        if failure_phase == "inspect" and command[2] == "rm":
+            return SimpleNamespace(returncode=1, stdout="", stderr="still present")
+        raise failure
+
+    monkeypatch.setattr(
+        "scripts.quality.capture_isolated_benchmarks.subprocess.run", fake_run
+    )
+
+    with pytest.raises(CaptureError, match="container cleanup") as error:
+        _force_remove_container(container_name)
+
+    assert container_name in str(error.value)
+    assert observed[0] == (
+        [str(DOCKER_BINARY), "container", "rm", "--force", container_name],
+        30,
+    )
+    if failure_phase == "inspect":
+        assert observed[1] == (
+            [str(DOCKER_BINARY), "container", "inspect", container_name],
+            30,
+        )
+    else:
+        assert len(observed) == 1
+
+
+def test_private_cache_volume_uses_a_capped_owned_tmpfs(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Candidate cache storage must have a daemon-enforced size and ownership cap."""
+
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    volume_name = "quality-benchmark-cache-" + "a" * 32
+    observed_commands: list[list[str]] = []
+
+    class FinishedProcess:
+        stdout = BytesIO()
+
+        def poll(self) -> int:
+            return 0
+
+        def wait(self, *, timeout: int | None = None) -> int:
+            del timeout
+            return 0
+
+    def fake_run(command: list[str], **_: object) -> SimpleNamespace:
+        observed_commands.append(command)
+        if command[:3] == [str(DOCKER_BINARY), "volume", "create"]:
+            return SimpleNamespace(returncode=0, stdout=f"{volume_name}\n", stderr="")
+        if command[1:4] == ["container", "rm", "--force"]:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        raise AssertionError(f"Unexpected Docker command: {command}")
+
+    monkeypatch.setattr(
+        "scripts.quality.capture_isolated_benchmarks.subprocess.run", fake_run
+    )
+    captured_launches: list[list[str]] = []
+
+    def fake_popen(command: list[str], **_: object) -> FinishedProcess:
+        captured_launches.append(command)
+        return FinishedProcess()
+
+    monkeypatch.setattr(
+        "scripts.quality.capture_isolated_benchmarks.subprocess.Popen", fake_popen
+    )
+    monkeypatch.setattr(
+        "scripts.quality.capture_isolated_benchmarks.uuid.uuid4",
+        lambda: SimpleNamespace(hex="a" * 32),
+    )
+
+    volume = _create_private_volume(
+        "example.invalid/performance@sha256:" + "a" * 64,
+        artifact_root,
+        "candidate",
+    )
+
+    assert volume == volume_name
+    assert observed_commands[0] == [
+        str(DOCKER_BINARY),
+        "volume",
+        "create",
+        "--driver",
+        "local",
+        "--opt",
+        "type=tmpfs",
+        "--opt",
+        "device=tmpfs",
+        "--opt",
+        "o=size=2g,uid=10001,gid=10001,mode=0700",
+        volume_name,
+    ]
+    initialization_command = captured_launches[0]
+    assert initialization_command[:4] == [
+        str(TIMEOUT_BINARY),
+        "--foreground",
+        "--kill-after=30s",
+        "60s",
+    ]
+    initialization_command = initialization_command[4:]
+    assert initialization_command[:2] == [str(DOCKER_BINARY), "run"]
+    for option, value in (
+        ("--memory", "6g"),
+        ("--memory-swap", "6g"),
+        ("--cpus", "2.0"),
+        ("--pids-limit", "512"),
+    ):
+        assert initialization_command[initialization_command.index(option) + 1] == value
+    assert "--init" in initialization_command
+    assert (
+        initialization_command[initialization_command.index("--platform") + 1]
+        == "linux/amd64"
+    )
+    assert "--log-driver" in initialization_command
+    assert (
+        initialization_command[initialization_command.index("--log-driver") + 1]
+        == "local"
+    )
+    assert [
+        initialization_command[index + 1]
+        for index, value in enumerate(initialization_command)
+        if value == "--log-opt"
+    ] == ["max-size=16m", "max-file=1", "compress=false"]
+
+
+@pytest.mark.parametrize("offline", [False, True])
+def test_language_capture_environments_pin_their_compilers(offline: bool) -> None:
+    """Candidate toolchain files cannot select or download a different compiler."""
+
+    assert _go_environment(offline=offline)["GOTOOLCHAIN"] == "local"
+    assert _rust_environment(offline=offline)["RUSTUP_TOOLCHAIN"] == "1.94.1"
+
+
+def test_toolchain_query_uses_bounded_logs_and_a_pinned_compiler_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Version capture streams through a bounded, resource-limited Docker run."""
+
+    observed_commands: list[list[str]] = []
+    removed_containers: list[str] = []
+
+    class FinishedProcess:
+        stdout = BytesIO(b"go version go1.26.5\n")
+
+        def poll(self) -> int:
+            return 0
+
+        def wait(self, *, timeout: int | None = None) -> int:
+            del timeout
+            return 0
+
+    def fake_popen(command: list[str], **_: object) -> FinishedProcess:
+        observed_commands.append(command)
+        return FinishedProcess()
+
+    monkeypatch.setattr(
+        "scripts.quality.capture_isolated_benchmarks.subprocess.Popen", fake_popen
+    )
+    monkeypatch.setattr(
+        "scripts.quality.capture_isolated_benchmarks.subprocess.run",
+        lambda *_args, **_kwargs: pytest.fail(
+            "toolchain query must use bounded streaming capture"
+        ),
+    )
+    monkeypatch.setattr(
+        "scripts.quality.capture_isolated_benchmarks._force_remove_container",
+        removed_containers.append,
+    )
+
+    assert (
+        _container_tool_output(
+            "example.invalid/performance@sha256:" + "a" * 64,
+            ("go", "version"),
+            environment={"GOTOOLCHAIN": "local", "HOME": CONTAINER_HOME},
+        )
+        == "go version go1.26.5"
+    )
+
+    command = observed_commands[0]
+    assert command[:4] == [
+        str(TIMEOUT_BINARY),
+        "--foreground",
+        "--kill-after=30s",
+        "30s",
+    ]
+    command = command[4:]
+    assert command[0:2] == [str(DOCKER_BINARY), "run"]
+    assert "--rm" in command
+    assert "--init" in command
+    for option, value in (
+        ("--memory", "6g"),
+        ("--memory-swap", "6g"),
+        ("--cpus", "2.0"),
+        ("--pids-limit", "512"),
+    ):
+        assert command[command.index(option) + 1] == value
+    assert command[command.index("--log-driver") + 1] == "local"
+    assert [
+        command[index + 1]
+        for index, value in enumerate(command)
+        if value == "--log-opt"
+    ] == ["max-size=16m", "max-file=1", "compress=false"]
+    assert "GOTOOLCHAIN=local" in command
+    container_name = command[command.index("--name") + 1]
+    assert removed_containers == [container_name]
+
+
+def test_toolchain_query_rejects_a_timeout_and_removes_its_named_container(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stalled version query cannot outlive its host deadline or leak a container."""
+
+    observed_commands: list[list[str]] = []
+    removed_containers: list[str] = []
+
+    class TimedOutProcess:
+        stdout = BytesIO()
+
+        def poll(self) -> int:
+            return 0
+
+        def wait(self, *, timeout: int | None = None) -> int:
+            del timeout
+            return 124
+
+    def fake_popen(command: list[str], **_: object) -> TimedOutProcess:
+        observed_commands.append(command)
+        return TimedOutProcess()
+
+    monkeypatch.setattr(
+        "scripts.quality.capture_isolated_benchmarks.subprocess.Popen", fake_popen
+    )
+    monkeypatch.setattr(
+        "scripts.quality.capture_isolated_benchmarks.subprocess.run",
+        lambda *_args, **_kwargs: pytest.fail(
+            "toolchain query must use bounded streaming capture"
+        ),
+    )
+    monkeypatch.setattr(
+        "scripts.quality.capture_isolated_benchmarks._force_remove_container",
+        removed_containers.append,
+    )
+
+    with pytest.raises(CaptureError, match="query isolated toolchain failed"):
+        _container_tool_output(
+            "example.invalid/performance@sha256:" + "a" * 64,
+            ("go", "version"),
+            environment={"GOTOOLCHAIN": "local", "HOME": CONTAINER_HOME},
+        )
+
+    assert observed_commands[0][:4] == [
+        str(TIMEOUT_BINARY),
+        "--foreground",
+        "--kill-after=30s",
+        "30s",
+    ]
+    docker_command = observed_commands[0][4:]
+    assert removed_containers == [docker_command[docker_command.index("--name") + 1]]
+
+
+def test_toolchain_query_rejects_oversized_output_and_removes_its_named_container(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A version command cannot retain an unbounded response in host memory."""
+
+    observed_commands: list[list[str]] = []
+    removed_containers: list[str] = []
+    terminated_processes: list[object] = []
+
+    class OversizedProcess:
+        stdout = BytesIO(b"123456789")
+
+        def poll(self) -> int:
+            return 0
+
+        def wait(self, *, timeout: int | None = None) -> int:
+            del timeout
+            return 0
+
+    def fake_popen(command: list[str], **_: object) -> OversizedProcess:
+        observed_commands.append(command)
+        return OversizedProcess()
+
+    monkeypatch.setattr(
+        "scripts.quality.capture_isolated_benchmarks.MAX_OUTPUT_BYTES", 8
+    )
+    monkeypatch.setattr(
+        "scripts.quality.capture_isolated_benchmarks.subprocess.Popen", fake_popen
+    )
+    monkeypatch.setattr(
+        "scripts.quality.capture_isolated_benchmarks.subprocess.run",
+        lambda *_args, **_kwargs: pytest.fail(
+            "toolchain query must use bounded streaming capture"
+        ),
+    )
+    monkeypatch.setattr(
+        "scripts.quality.capture_isolated_benchmarks._force_remove_container",
+        removed_containers.append,
+    )
+    monkeypatch.setattr(
+        "scripts.quality.capture_isolated_benchmarks._terminate_capture_process",
+        terminated_processes.append,
+    )
+
+    with pytest.raises(CaptureError, match="output exceeds"):
+        _container_tool_output(
+            "example.invalid/performance@sha256:" + "a" * 64,
+            ("go", "version"),
+            environment={"GOTOOLCHAIN": "local", "HOME": CONTAINER_HOME},
+        )
+
+    assert observed_commands[0][3] == "30s"
+    docker_command = observed_commands[0][4:]
+    assert terminated_processes
+    assert removed_containers == [docker_command[docker_command.index("--name") + 1]]
+
+
+def test_control_plane_timeout_becomes_a_capture_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stuck Docker API query has a finite client deadline and typed failure."""
+
+    observed_timeouts: list[object] = []
+
+    def fake_run(command: list[str], **kwargs: object) -> SimpleNamespace:
+        observed_timeouts.append(kwargs.get("timeout"))
+        raise subprocess.TimeoutExpired(command, 30)
+
+    monkeypatch.setattr(
+        "scripts.quality.capture_isolated_benchmarks.subprocess.run", fake_run
+    )
+
+    with pytest.raises(CaptureError, match="within 30 seconds"):
+        _docker_server_version()
+
+    assert observed_timeouts == [30]
+
+
+@pytest.mark.parametrize(
+    ("cleanup", "identifier", "expected_command"),
+    [
+        (
+            _remove_volume,
+            "quality-benchmark-cache-test",
+            [
+                str(DOCKER_BINARY),
+                "volume",
+                "rm",
+                "--force",
+                "quality-benchmark-cache-test",
+            ],
+        ),
+        (
+            _remove_image,
+            "quality-performance-rust:test",
+            [
+                str(DOCKER_BINARY),
+                "image",
+                "rm",
+                "--force",
+                "quality-performance-rust:test",
+            ],
+        ),
+    ],
+)
+def test_best_effort_cleanup_cannot_mask_a_timed_out_docker_client(
+    monkeypatch: pytest.MonkeyPatch,
+    cleanup: object,
+    identifier: str,
+    expected_command: list[str],
+) -> None:
+    """Failure to remove a disposable daemon object cannot mask the main result."""
+
+    observed: list[tuple[list[str], object]] = []
+
+    def fake_run(command: list[str], **kwargs: object) -> SimpleNamespace:
+        observed.append((command, kwargs.get("timeout")))
+        raise subprocess.TimeoutExpired(command, 30)
+
+    monkeypatch.setattr(
+        "scripts.quality.capture_isolated_benchmarks.subprocess.run", fake_run
+    )
+
+    assert callable(cleanup)
+    cleanup(identifier)
+
+    assert observed == [(expected_command, 30)]
+
+
+@pytest.mark.parametrize(
+    ("format_name", "expected_key", "expected_version", "environment_entry"),
+    [
+        ("go", "go", "go version go1.26.5", "GOTOOLCHAIN=local"),
+        (
+            "rust",
+            "rustc",
+            "rustc 1.94.1 (e408947bf 2026-03-25)",
+            "RUSTUP_TOOLCHAIN=1.94.1",
+        ),
+    ],
+)
+def test_toolchain_report_records_the_effective_pinned_compiler(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    format_name: str,
+    expected_key: str,
+    expected_version: str,
+    environment_entry: str,
+) -> None:
+    """The report records the actual version queried under the pinned environment."""
+
+    control_plane_commands: list[list[str]] = []
+    capture_commands: list[list[str]] = []
+
+    class FinishedProcess:
+        stdout = BytesIO(f"{expected_version}\n".encode())
+
+        def poll(self) -> int:
+            return 0
+
+        def wait(self, *, timeout: int | None = None) -> int:
+            del timeout
+            return 0
+
+    def fake_run(command: list[str], **_: object) -> SimpleNamespace:
+        control_plane_commands.append(command)
+        if command[1:2] == ["version"]:
+            return SimpleNamespace(returncode=0, stdout="29.6.2\n", stderr="")
+        if command[1:3] == ["image", "inspect"]:
+            return SimpleNamespace(
+                returncode=0, stdout="sha256:" + "b" * 64 + "\n", stderr=""
+            )
+        raise AssertionError(f"Unexpected Docker command: {command}")
+
+    def fake_popen(command: list[str], **_: object) -> FinishedProcess:
+        capture_commands.append(command)
+        return FinishedProcess()
+
+    monkeypatch.setattr(
+        "scripts.quality.capture_isolated_benchmarks.subprocess.run", fake_run
+    )
+    monkeypatch.setattr(
+        "scripts.quality.capture_isolated_benchmarks.subprocess.Popen", fake_popen
+    )
+    monkeypatch.setattr(
+        "scripts.quality.capture_isolated_benchmarks._force_remove_container",
+        lambda _name: None,
+    )
+    monkeypatch.setattr(
+        "scripts.quality.capture_isolated_benchmarks.os.uname",
+        lambda: SimpleNamespace(sysname="Linux", release="6.0", machine="x86_64"),
+        raising=False,
+    )
+
+    _write_toolchain(
+        artifact_root=tmp_path,
+        format_name=format_name,
+        image="example.invalid/performance@sha256:" + "a" * 64,
+        base_revision="a" * 40,
+        rust_dockerfile=None,
+    )
+
+    report = json.loads((tmp_path / "toolchain.json").read_text(encoding="utf-8"))
+    assert report[expected_key] == expected_version
+    run_command = capture_commands[0][4:]
+    assert run_command[0:2] == [str(DOCKER_BINARY), "run"]
+    assert environment_entry in run_command
+    assert [
+        run_command[index + 1]
+        for index, value in enumerate(run_command)
+        if value == "--log-opt"
+    ] == ["max-size=16m", "max-file=1", "compress=false"]
+
+
+def test_cleanup_failure_cannot_leave_github_command_parsing_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The stop-command marker is always closed, even when daemon cleanup fails."""
+
+    class FinishedProcess:
+        stdout = BytesIO()
+
+        def poll(self) -> int:
+            return 0
+
+        def wait(self, *, timeout: int | None = None) -> int:
+            del timeout
+            return 0
+
+    monkeypatch.setattr(
+        "scripts.quality.capture_isolated_benchmarks.subprocess.Popen",
+        lambda *_args, **_kwargs: FinishedProcess(),
+    )
+
+    def cleanup_failure(_: str) -> None:
+        raise CaptureError("simulated daemon cleanup failure")
+
+    monkeypatch.setattr(
+        "scripts.quality.capture_isolated_benchmarks._force_remove_container",
+        cleanup_failure,
+    )
+    container_name = "quality-benchmark-" + "c" * 32
+
+    with pytest.raises(CaptureError, match="simulated daemon cleanup failure"):
+        _safe_capture(
+            ("docker", "run", "example"),
+            tmp_path / "capture.txt",
+            description="test capture",
+            timeout_seconds=1,
+            container_name=container_name,
+        )
+
+    marker_lines = capsys.readouterr().out.splitlines()
+    assert marker_lines[0].startswith("::stop-commands::")
+    marker = marker_lines[0].removeprefix("::stop-commands::")
+    assert marker_lines[-1] == f"::{marker}::"
+
+
+def test_base_exception_cleanup_paths_have_required_audit_rationales() -> None:
+    """Broad cleanup catches stay reviewable because they re-raise after cleanup."""
+
+    source = (
+        REPOSITORY_ROOT / "scripts" / "quality" / "capture_isolated_benchmarks.py"
+    ).read_text(encoding="utf-8")
+    assert source.count("BaseException") == 2
+    assert source.count("# RZ-22-01-JUSTIFIED:") == 2
+
+
+def test_artifact_root_must_be_a_fresh_host_only_runner_temp_directory(
+    tmp_path: Path,
+) -> None:
+    """A candidate checkout must never choose a symlinkable evidence path."""
+
+    runner_temp = tmp_path / "runner-temp"
+    runner_temp.mkdir()
+    candidate_root = tmp_path / "candidate"
+    candidate_root.mkdir()
+
+    with pytest.raises(CaptureError, match="under the trusted runner temp"):
+        prepare_artifact_root(candidate_root / "artifacts", runner_temp)
+
+    artifact_root = runner_temp / "performance-evidence"
+    assert prepare_artifact_root(artifact_root, runner_temp) == artifact_root
+    assert artifact_root.is_dir()
+
+    with pytest.raises(CaptureError, match="must not already exist"):
+        prepare_artifact_root(artifact_root, runner_temp)
+
+
+def test_build_rust_image_removes_the_deterministic_tag_after_a_build_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A failed build cannot leave a tag that later capture could accidentally reuse."""
+
+    base_worktree = tmp_path / "base"
+    dockerfile = (
+        base_worktree / "containers" / "quality" / "Dockerfile.performance-rust"
+    )
+    dockerfile.parent.mkdir(parents=True)
+    dockerfile.write_text("FROM scratch\n", encoding="utf-8")
+    runner_temp = tmp_path / "runner-temp"
+    runner_temp.mkdir()
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    removed_images: list[str] = []
+
+    def fail_build(*_args: object, **_kwargs: object) -> None:
+        raise CaptureError("simulated build failure")
+
+    monkeypatch.setattr(
+        "scripts.quality.capture_isolated_benchmarks._safe_capture", fail_build
+    )
+    monkeypatch.setattr(
+        "scripts.quality.capture_isolated_benchmarks._remove_image",
+        removed_images.append,
+    )
+
+    with pytest.raises(CaptureError, match="simulated build failure"):
+        _build_rust_image(
+            dockerfile=dockerfile,
+            base_worktree=base_worktree,
+            runner_temp=runner_temp,
+            artifact_root=artifact_root,
+            base_revision="a" * 40,
+        )
+
+    assert removed_images == ["quality-performance-rust:" + "a" * 12]
+
+
+def test_build_rust_image_uses_a_fresh_dockerfile_only_context(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The Docker daemon receives neither base nor candidate source as context."""
+
+    base_worktree = tmp_path / "base"
+    dockerfile = (
+        base_worktree / "containers" / "quality" / "Dockerfile.performance-rust"
+    )
+    dockerfile.parent.mkdir(parents=True)
+    dockerfile.write_text("FROM scratch\n", encoding="utf-8")
+    candidate_worktree = tmp_path / "candidate"
+    candidate_worktree.mkdir()
+    (candidate_worktree / "candidate-only.txt").write_text(
+        "untrusted\n", encoding="utf-8"
+    )
+    runner_temp = tmp_path / "runner-temp"
+    runner_temp.mkdir()
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    observed_commands: list[list[str]] = []
+
+    class FinishedProcess:
+        stdout = BytesIO(b"trusted image build\n")
+
+        def poll(self) -> int:
+            return 0
+
+        def wait(self, *, timeout: int | None = None) -> int:
+            del timeout
+            return 0
+
+    def fake_popen(command: list[str], **_: object) -> FinishedProcess:
+        docker_index = command.index(str(DOCKER_BINARY))
+        docker_command = command[docker_index:]
+        observed_commands.append(docker_command)
+        dockerfile_index = docker_command.index("--file") + 1
+        build_context = Path(docker_command[-1])
+
+        assert docker_command[:2] == [str(DOCKER_BINARY), "build"]
+        assert "--pull" in docker_command
+        assert build_context.is_dir()
+        assert Path(docker_command[dockerfile_index]).parent == build_context
+        assert {entry.name for entry in build_context.iterdir()} == {"Dockerfile"}
+        assert (
+            Path(docker_command[dockerfile_index]).read_bytes()
+            == dockerfile.read_bytes()
+        )
+        assert str(base_worktree) not in docker_command
+        assert str(candidate_worktree) not in docker_command
+        return FinishedProcess()
+
+    monkeypatch.setattr(
+        "scripts.quality.capture_isolated_benchmarks.subprocess.Popen", fake_popen
+    )
+
+    image = _build_rust_image(
+        dockerfile=dockerfile,
+        base_worktree=base_worktree,
+        runner_temp=runner_temp,
+        artifact_root=artifact_root,
+        base_revision="a" * 40,
+    )
+
+    assert image == "quality-performance-rust:" + "a" * 12
+    assert observed_commands[0][0:2] == [str(DOCKER_BINARY), "build"]
+    assert (
+        artifact_root / "build-rust-image.log"
+    ).read_bytes() == b"trusted image build\n"
+
+
+def test_rust_benchmark_image_cannot_copy_candidate_build_context() -> None:
+    """The trusted image must be reproducible without candidate-controlled files."""
+
+    dockerfile = (
+        REPOSITORY_ROOT / "containers" / "quality" / "Dockerfile.performance-rust"
+    )
+    lines = dockerfile.read_text(encoding="utf-8").splitlines()
+    instructions = [
+        line.strip()
+        for line in lines
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+    python_image = (
+        "python:3.14-slim-bookworm@"
+        "sha256:23c59390fc717bf09f9336908199a0ae75d9c4264bf296123f94ad772fea3b52"
+    )
+    rust_image = (
+        "rust:1.94.1-slim-bookworm@"
+        "sha256:cf9dd0ec73e75f827fe59123fff9dc65af1a1c8363c3c31ee8d7f8ad0b6a5fb2"
+    )
+    copy_lines = [
+        line for line in instructions if line.split(maxsplit=1)[0].upper() == "COPY"
+    ]
+
+    assert any("#checkov:skip=CKV_DOCKER_2" in line for line in lines)
+    assert [line for line in instructions if line.startswith("FROM ")] == [
+        f"FROM {python_image}"
+    ]
+    assert not any(line.split(maxsplit=1)[0].upper() == "ADD" for line in instructions)
+    assert copy_lines == [
+        f"COPY --from={rust_image} /usr/local/rustup /usr/local/rustup",
+        f"COPY --from={rust_image} /usr/local/cargo /usr/local/cargo",
+    ]
+    assert "USER benchmark" in lines

--- a/tests/test_compare_paired_benchmarks.py
+++ b/tests/test_compare_paired_benchmarks.py
@@ -1,0 +1,539 @@
+import json
+from collections.abc import Callable, Sequence
+from pathlib import Path
+
+import pytest
+
+from scripts.quality.compare_paired_benchmarks import (
+    EvidenceIntegrityError,
+    load_paired_samples,
+    main,
+    parse_bencher_output,
+    parse_go_benchmark_output,
+)
+
+BASE_REVISION = "a" * 40
+CANDIDATE_REVISION = "b" * 40
+GO_PACKAGE = "github.com/university-ecosystem/ws-hub/pkg/hub"
+
+
+def _go_record(
+    value: float,
+    *,
+    benchmark: str = "BenchmarkLookup-8",
+    allocation_value: float | None = None,
+    package: str = GO_PACKAGE,
+) -> str:
+    allocation_value = value if allocation_value is None else allocation_value
+    return (
+        f"pkg: {package}\n{benchmark} 100 {value} ns/op {allocation_value} B/op "
+        f"{allocation_value} allocs/op\n"
+    )
+
+
+def _bencher_record(value: float, *, benchmark: str = "native_conflicts/100") -> str:
+    return f"test {benchmark} ... bench: {value} ns/iter (+/- 4)\n"
+
+
+def _write_pairs(
+    base_dir: Path,
+    candidate_dir: Path,
+    base_record: Callable[[int], str],
+    candidate_record: Callable[[int], str],
+) -> None:
+    base_dir.mkdir()
+    candidate_dir.mkdir()
+    for index in range(1, 13):
+        (base_dir / f"pair-{index:02d}.txt").write_text(
+            base_record(index), encoding="utf-8"
+        )
+        (candidate_dir / f"pair-{index:02d}.txt").write_text(
+            candidate_record(index), encoding="utf-8"
+        )
+
+
+def _run_cli(
+    tmp_path: Path,
+    *,
+    output: Path,
+    format_name: str = "go",
+    expected_pairs: int = 12,
+    base_revision: str = BASE_REVISION,
+    candidate_revision: str = CANDIDATE_REVISION,
+) -> int:
+    toolchain = tmp_path / "toolchain.json"
+    toolchain.write_text(json.dumps({"go": "go version go1.26.5"}), encoding="utf-8")
+    return main(
+        [
+            "--format",
+            format_name,
+            "--base-dir",
+            str(tmp_path / "base"),
+            "--candidate-dir",
+            str(tmp_path / "candidate"),
+            "--expected-pairs",
+            str(expected_pairs),
+            "--base-revision",
+            base_revision,
+            "--candidate-revision",
+            candidate_revision,
+            "--toolchain-json",
+            str(toolchain),
+            "--output",
+            str(output),
+        ]
+    )
+
+
+def test_go_pair_loader_normalizes_processor_suffix_and_preserves_all_metrics(
+    tmp_path: Path,
+) -> None:
+    """Catches a parser that treats a Go processor suffix as benchmark identity."""
+
+    base_dir = tmp_path / "base"
+    candidate_dir = tmp_path / "candidate"
+    _write_pairs(
+        base_dir,
+        candidate_dir,
+        lambda _: _go_record(12.5, allocation_value=0.0),
+        lambda _: _go_record(13.0, allocation_value=0.0),
+    )
+
+    loaded = load_paired_samples(base_dir, candidate_dir, 12, parse_go_benchmark_output)
+
+    assert loaded[(f"{GO_PACKAGE}::BenchmarkLookup", "ns/op")] == (
+        (12.5,) * 12,
+        (13.0,) * 12,
+    )
+    assert loaded[(f"{GO_PACKAGE}::BenchmarkLookup", "B/op")] == (
+        (0.0,) * 12,
+        (0.0,) * 12,
+    )
+    assert loaded[(f"{GO_PACKAGE}::BenchmarkLookup", "allocs/op")] == (
+        (0.0,) * 12,
+        (0.0,) * 12,
+    )
+
+
+def test_pair_loader_rejects_an_extra_directory_with_twelve_valid_pairs(
+    tmp_path: Path,
+) -> None:
+    """The evidence directory is canonical only when no extra entries exist."""
+
+    base_dir = tmp_path / "base"
+    candidate_dir = tmp_path / "candidate"
+    _write_pairs(
+        base_dir,
+        candidate_dir,
+        lambda _: _go_record(10.0),
+        lambda _: _go_record(11.0),
+    )
+    (base_dir / "unexpected-directory").mkdir()
+
+    with pytest.raises(EvidenceIntegrityError, match="Unexpected pair evidence"):
+        load_paired_samples(base_dir, candidate_dir, 12, parse_go_benchmark_output)
+
+
+def test_go_parser_namespaces_identical_benchmark_names_by_package() -> None:
+    """Catches an ambiguous full-module capture when packages reuse a benchmark name."""
+
+    other_package = "github.com/university-ecosystem/ws-hub/pkg/other"
+
+    parsed = parse_go_benchmark_output(
+        _go_record(10.0) + _go_record(11.0, package=other_package)
+    )
+
+    assert set(parsed) == {
+        f"{GO_PACKAGE}::BenchmarkLookup",
+        f"{other_package}::BenchmarkLookup",
+    }
+
+
+def test_go_parser_rejects_a_benchmark_record_without_package_identity() -> None:
+    """Catches a parser that cannot distinguish identical names across packages."""
+
+    with pytest.raises(EvidenceIntegrityError, match="package identity"):
+        parse_go_benchmark_output("BenchmarkLookup-8 100 12 ns/op 4 B/op 1 allocs/op\n")
+
+
+def test_bencher_pair_loader_normalizes_ns_per_iteration_to_ns_per_operation(
+    tmp_path: Path,
+) -> None:
+    """Catches a Criterion parser that drops or mislabels ns/iter measurements."""
+
+    base_dir = tmp_path / "base"
+    candidate_dir = tmp_path / "candidate"
+    _write_pairs(
+        base_dir,
+        candidate_dir,
+        lambda _: _bencher_record(120.0),
+        lambda _: _bencher_record(121.0),
+    )
+
+    loaded = load_paired_samples(base_dir, candidate_dir, 12, parse_bencher_output)
+
+    assert loaded[("native_conflicts/100", "ns/op")] == (
+        (120.0,) * 12,
+        (121.0,) * 12,
+    )
+    assert parse_bencher_output(_bencher_record(120.0)) == {
+        "native_conflicts/100": {"ns/op": 120.0}
+    }
+
+
+def test_go_pair_loader_rejects_missing_required_benchmem_metrics(
+    tmp_path: Path,
+) -> None:
+    """Catches a gate that silently drops allocation metrics from ``-benchmem``."""
+
+    base_dir = tmp_path / "base"
+    candidate_dir = tmp_path / "candidate"
+    _write_pairs(
+        base_dir,
+        candidate_dir,
+        lambda _: f"pkg: {GO_PACKAGE}\nBenchmarkLookup-8 100 12.5 ns/op\n",
+        lambda _: f"pkg: {GO_PACKAGE}\nBenchmarkLookup-8 100 13.0 ns/op\n",
+    )
+
+    with pytest.raises(
+        EvidenceIntegrityError, match="Incomplete Go benchmark metric set"
+    ):
+        load_paired_samples(base_dir, candidate_dir, 12, parse_go_benchmark_output)
+
+
+@pytest.mark.parametrize(
+    ("base_record", "candidate_record", "mutation"),
+    [
+        (
+            lambda _: _go_record(10.0),
+            lambda _: _go_record(11.0),
+            lambda base_dir, _candidate_dir: (base_dir / "pair-12.txt").unlink(),
+        ),
+        (
+            lambda _: _go_record(10.0),
+            lambda _: _go_record(11.0),
+            lambda base_dir, _candidate_dir: (base_dir / "unexpected.txt").write_text(
+                "unexpected", encoding="utf-8"
+            ),
+        ),
+        (
+            lambda _: _go_record(10.0),
+            lambda _: _go_record(11.0),
+            lambda base_dir, _candidate_dir: (base_dir / "pair-01.txt").write_text(
+                _go_record(10.0) + _go_record(11.0), encoding="utf-8"
+            ),
+        ),
+        (
+            lambda _: _go_record(10.0),
+            lambda _: _go_record(11.0),
+            lambda base_dir, _candidate_dir: (base_dir / "pair-01.txt").write_text(
+                "BenchmarkLookup-8 100 not-a-number ns/op 4 B/op 1 allocs/op\n",
+                encoding="utf-8",
+            ),
+        ),
+        (
+            lambda _: _go_record(10.0),
+            lambda _: _go_record(11.0),
+            lambda base_dir, _candidate_dir: (base_dir / "pair-01.txt").write_text(
+                "BenchmarkLookup-8 100 nan ns/op 4 B/op 1 allocs/op\n",
+                encoding="utf-8",
+            ),
+        ),
+        (
+            lambda _: _go_record(10.0),
+            lambda _: _go_record(11.0),
+            lambda base_dir, _candidate_dir: (base_dir / "pair-01.txt").write_text(
+                "BenchmarkLookup-8 100 inf ns/op 4 B/op 1 allocs/op\n",
+                encoding="utf-8",
+            ),
+        ),
+        (
+            lambda _: _go_record(10.0),
+            lambda _: _go_record(11.0),
+            lambda _base_dir, candidate_dir: (candidate_dir / "pair-01.txt").write_text(
+                "BenchmarkLookup-8 100 11 ns/op 11 B/op\n", encoding="utf-8"
+            ),
+        ),
+        (
+            lambda _: _go_record(10.0),
+            lambda _: _go_record(11.0),
+            lambda _base_dir, candidate_dir: (candidate_dir / "pair-01.txt").write_text(
+                _go_record(11.0, benchmark="BenchmarkOther-8"), encoding="utf-8"
+            ),
+        ),
+    ],
+)
+def test_pair_loader_rejects_incomplete_or_ambiguous_evidence(
+    tmp_path: Path,
+    base_record: Callable[[int], str],
+    candidate_record: Callable[[int], str],
+    mutation: Callable[[Path, Path], None],
+) -> None:
+    """Catches any path that turns malformed paired evidence into a comparison."""
+
+    base_dir = tmp_path / "base"
+    candidate_dir = tmp_path / "candidate"
+    _write_pairs(base_dir, candidate_dir, base_record, candidate_record)
+    mutation(base_dir, candidate_dir)
+
+    with pytest.raises(EvidenceIntegrityError):
+        load_paired_samples(base_dir, candidate_dir, 12, parse_go_benchmark_output)
+
+
+@pytest.mark.parametrize(
+    ("ratios", "expected_exit"),
+    [
+        ([1.10] * 12, 0),
+        ([1.00] * 5 + [1.11] * 7, 0),
+        ([1.12] * 12, 1),
+    ],
+)
+def test_cli_applies_the_strict_regression_boundary(
+    tmp_path: Path,
+    ratios: Sequence[float],
+    expected_exit: int,
+) -> None:
+    """Catches a gate that fails at 1.10 or without a proven lower bound."""
+
+    _write_pairs(
+        tmp_path / "base",
+        tmp_path / "candidate",
+        lambda _: _go_record(100.0),
+        lambda index: _go_record(100.0 * ratios[index - 1]),
+    )
+    output = tmp_path / "comparison.json"
+
+    exit_code = _run_cli(tmp_path, output=output)
+    report = json.loads(output.read_text(encoding="utf-8"))
+
+    assert exit_code == expected_exit
+    assert report["decision"] == ("regression" if expected_exit == 1 else "pass")
+    assert report["threshold_ratio"] == 1.1
+
+
+def test_cli_writes_byte_identical_report_with_metadata_and_raw_values(
+    tmp_path: Path,
+) -> None:
+    """Catches non-deterministic bootstrap output or omitted audit evidence."""
+
+    _write_pairs(
+        tmp_path / "base",
+        tmp_path / "candidate",
+        lambda _: _go_record(100.0),
+        lambda _: _go_record(105.0),
+    )
+    first = tmp_path / "first.json"
+    second = tmp_path / "second.json"
+
+    assert _run_cli(tmp_path, output=first) == 0
+    assert _run_cli(tmp_path, output=second) == 0
+    assert first.read_bytes() == second.read_bytes()
+
+    report = json.loads(first.read_text(encoding="utf-8"))
+    ns_metric = next(
+        metric for metric in report["metrics"] if metric["metric"] == "ns/op"
+    )
+    assert report["base_revision"] == BASE_REVISION
+    assert report["candidate_revision"] == CANDIDATE_REVISION
+    assert report["toolchain"] == {"go": "go version go1.26.5"}
+    assert ns_metric["base_values"] == [100.0] * 12
+    assert ns_metric["candidate_values"] == [105.0] * 12
+    assert ns_metric["ratios"] == [1.05] * 12
+
+
+def test_cli_marks_stable_zero_allocation_metrics_as_an_explicit_pass(
+    tmp_path: Path,
+) -> None:
+    """Catches a gate that mistakes a no-allocation benchmark for invalid data."""
+
+    _write_pairs(
+        tmp_path / "base",
+        tmp_path / "candidate",
+        lambda _: _go_record(100.0, allocation_value=0.0),
+        lambda _: _go_record(105.0, allocation_value=0.0),
+    )
+    output = tmp_path / "comparison.json"
+
+    assert _run_cli(tmp_path, output=output) == 0
+
+    report = json.loads(output.read_text(encoding="utf-8"))
+    allocation_metrics = [
+        metric
+        for metric in report["metrics"]
+        if metric["metric"] in {"B/op", "allocs/op"}
+    ]
+    assert len(allocation_metrics) == 2
+    for metric in allocation_metrics:
+        assert metric["base_values"] == [0.0] * 12
+        assert metric["candidate_values"] == [0.0] * 12
+        assert metric["ratios"] == [None] * 12
+        assert metric["median_ratio"] is None
+        assert metric["one_sided_95_lower_bound"] is None
+        assert metric["comparison_mode"] == "zero_stable"
+        assert metric["decision"] == "pass"
+
+
+def test_cli_marks_new_allocations_against_a_zero_baseline_as_a_regression(
+    tmp_path: Path,
+) -> None:
+    """Catches a gate that hides allocations newly introduced by the candidate."""
+
+    _write_pairs(
+        tmp_path / "base",
+        tmp_path / "candidate",
+        lambda _: _go_record(100.0, allocation_value=0.0),
+        lambda _: _go_record(100.0, allocation_value=1.0),
+    )
+    output = tmp_path / "comparison.json"
+
+    assert _run_cli(tmp_path, output=output) == 1
+
+    report_bytes = output.read_bytes()
+    report = json.loads(report_bytes.decode("utf-8"))
+    allocation_metric = next(
+        metric for metric in report["metrics"] if metric["metric"] == "B/op"
+    )
+    assert allocation_metric["base_values"] == [0.0] * 12
+    assert allocation_metric["candidate_values"] == [1.0] * 12
+    assert allocation_metric["ratios"] == [None] * 12
+    assert allocation_metric["median_ratio"] is None
+    assert allocation_metric["one_sided_95_lower_bound"] is None
+    assert allocation_metric["comparison_mode"] == "zero_baseline_regression"
+    assert allocation_metric["decision"] == "regression"
+    assert b"Infinity" not in report_bytes
+    assert b"NaN" not in report_bytes
+
+
+def test_cli_rejects_a_mixed_zero_and_nonzero_allocation_baseline(
+    tmp_path: Path,
+) -> None:
+    """Catches a relative comparison that treats an intermittent zero baseline as valid."""
+
+    _write_pairs(
+        tmp_path / "base",
+        tmp_path / "candidate",
+        lambda index: _go_record(100.0, allocation_value=0.0 if index % 2 else 1.0),
+        lambda _: _go_record(100.0, allocation_value=0.0),
+    )
+    output = tmp_path / "comparison.json"
+
+    assert _run_cli(tmp_path, output=output) == 2
+    report = json.loads(output.read_text(encoding="utf-8"))
+    assert report["decision"] == "invalid_evidence"
+
+
+def test_cli_rejects_a_zero_ns_per_operation_baseline(tmp_path: Path) -> None:
+    """Catches a time comparison that divides by an unusable zero baseline."""
+
+    _write_pairs(
+        tmp_path / "base",
+        tmp_path / "candidate",
+        lambda _: _go_record(0.0, allocation_value=0.0),
+        lambda _: _go_record(100.0, allocation_value=0.0),
+    )
+    output = tmp_path / "comparison.json"
+
+    assert _run_cli(tmp_path, output=output) == 2
+    report = json.loads(output.read_text(encoding="utf-8"))
+    assert report["decision"] == "invalid_evidence"
+
+
+@pytest.mark.parametrize("revision", ["0" * 40, "g" * 40])
+def test_cli_rejects_non_immutable_base_revision_with_an_invalid_evidence_report(
+    tmp_path: Path,
+    revision: str,
+) -> None:
+    """Catches an acceptance path for the all-zero or malformed base SHA."""
+
+    _write_pairs(
+        tmp_path / "base",
+        tmp_path / "candidate",
+        lambda _: _go_record(100.0),
+        lambda _: _go_record(101.0),
+    )
+    output = tmp_path / "comparison.json"
+
+    assert _run_cli(tmp_path, output=output, base_revision=revision) == 2
+
+    report = json.loads(output.read_text(encoding="utf-8"))
+    assert report["base_revision"] == revision
+    assert report["decision"] == "invalid_evidence"
+    assert report["metrics"] == []
+
+
+def test_cli_rejects_identical_valid_revisions_with_an_invalid_evidence_report(
+    tmp_path: Path,
+) -> None:
+    """A syntactically valid self-comparison cannot supply regression evidence."""
+
+    _write_pairs(
+        tmp_path / "base",
+        tmp_path / "candidate",
+        lambda _: _go_record(100.0),
+        lambda _: _go_record(101.0),
+    )
+    output = tmp_path / "comparison.json"
+
+    assert (
+        _run_cli(
+            tmp_path,
+            output=output,
+            base_revision=BASE_REVISION,
+            candidate_revision=BASE_REVISION,
+        )
+        == 2
+    )
+
+    report = json.loads(output.read_text(encoding="utf-8"))
+    assert report["base_revision"] == BASE_REVISION
+    assert report["candidate_revision"] == BASE_REVISION
+    assert report["decision"] == "invalid_evidence"
+    assert report["metrics"] == []
+    assert "must differ" in report["error"]
+
+
+def test_cli_fails_the_whole_report_when_one_benchmark_regresses(
+    tmp_path: Path,
+) -> None:
+    """Catches aggregate success when one measured benchmark is proven slower."""
+
+    _write_pairs(
+        tmp_path / "base",
+        tmp_path / "candidate",
+        lambda _: _go_record(100.0) + _go_record(100.0, benchmark="BenchmarkSlow-8"),
+        lambda _: _go_record(100.0) + _go_record(112.0, benchmark="BenchmarkSlow-8"),
+    )
+    output = tmp_path / "comparison.json"
+
+    assert _run_cli(tmp_path, output=output) == 1
+
+    report = json.loads(output.read_text(encoding="utf-8"))
+    decisions = {
+        (metric["benchmark"], metric["decision"]) for metric in report["metrics"]
+    }
+    assert report["decision"] == "regression"
+    assert (f"{GO_PACKAGE}::BenchmarkLookup", "pass") in decisions
+    assert (f"{GO_PACKAGE}::BenchmarkSlow", "regression") in decisions
+
+
+def test_cli_writes_invalid_evidence_report_and_rejects_non_twelve_pair_count(
+    tmp_path: Path,
+) -> None:
+    """Catches invalid input being reported as success or a weakened sample count."""
+
+    _write_pairs(
+        tmp_path / "base",
+        tmp_path / "candidate",
+        lambda _: _go_record(100.0),
+        lambda _: _go_record(101.0),
+    )
+    (tmp_path / "base" / "pair-12.txt").unlink()
+    invalid_output = tmp_path / "invalid.json"
+
+    assert _run_cli(tmp_path, output=invalid_output) == 2
+    invalid_report = json.loads(invalid_output.read_text(encoding="utf-8"))
+    assert invalid_report["decision"] == "invalid_evidence"
+    assert invalid_report["metrics"] == []
+
+    count_output = tmp_path / "count.json"
+    assert _run_cli(tmp_path, output=count_output, expected_pairs=11) == 2

--- a/tests/test_quality_configuration.py
+++ b/tests/test_quality_configuration.py
@@ -60,6 +60,12 @@ def test_governance_quality_configuration_matches_contract() -> None:
     codeowners = _read_text(".github/CODEOWNERS")
     assert "@security-team" not in codeowners
     assert "@devops-team" not in codeowners
+    for protected_path in (
+        "scripts/quality/compare_paired_benchmarks.py",
+        "scripts/quality/capture_isolated_benchmarks.py",
+        "containers/quality/Dockerfile.performance-rust",
+    ):
+        assert f"{protected_path} @egorribun" in codeowners
 
     codecov = yaml.safe_load(_read_text("codecov.yml"))
     expected_flags = {
@@ -122,6 +128,7 @@ def test_mutmut_uses_the_unit_population_instead_of_a_single_probe_file() -> Non
         ".pre-commit-config.yaml",
         "Makefile",
         "docs",
+        "containers/quality",
         "k8s/kyverno",
         "crates/pyo3-sanitizer/src",
         "frontend/scripts",


### PR DESCRIPTION
## Summary

- Adds the base-trusted paired benchmark comparator, isolated container capture helper, and pinned Rust benchmark image.
- Adds their deterministic unit/contract coverage and ownership/config prerequisites.
- Documents the explicit two-phase bootstrap required before workflow activation.

## Verification

- `68 passed` — comparator, isolated-capture, and quality-configuration suites on fresh `origin/main`.
- `ruff check` and `ruff format --check` passed for all added Python files.
- `git diff --cached --check` passed.
- `npm run typecheck` passed in this clean worktree as part of the pre-push gate.
- Independent review: no P0/P1/P2 findings.

## Required one-time bootstrap exception

This PR deliberately contains **zero** `.github/workflows/**` changes. The base is missing base-trusted performance tooling, so it cannot safely enable the workflows that must execute the helper/comparator from the immutable base worktree.

Documented bypass reason: `asset bootstrap / no safe preexisting required context; base is missing base-trusted performance tooling; retaining path filter avoids widening legacy writable PR workflow`.

Before the one-time `RepositoryRole` admin bypass, the owner must review this complete staged diff. This bypass is not performance proof. Phase 2 will be opened only after this SHA is on `main`, and will use ordinary required contexts without a bypass.