### PR TITLE
fix(quality): keep isolated benchmark caches mounted

### DIFF
--- a/docs/superpowers/plans/2026-08-11-same-run-performance-gates.md
+++ b/docs/superpowers/plans/2026-08-11-same-run-performance-gates.md
@@ -226,8 +226,9 @@ For `ns/op` and any positive-valued allocation metric, compute `candidate_value 
   and create a detached base worktree under `${RUNNER_TEMP}`. Hash and retain
   the base comparator before the helper runs. Invoke the base-only helper with
   distinct base/candidate source mounts and a new host-only evidence root below
-  `${RUNNER_TEMP}`; it creates private per-side caches, prefetches over the
-  network, and makes every recorded measurement offline in a non-root,
+  `${RUNNER_TEMP}`; it creates private per-side caches and keeps a
+  non-networked holder mounted for each side, prefetches over the network,
+  and makes every recorded measurement offline in a non-root,
   read-only, capability-dropped Docker container with CPU/memory/PID/output
   bounds. It records the container tool version, image reference/content ID,
   Docker version, and trusted Rust-Dockerfile hash.

--- a/docs/superpowers/specs/2026-08-11-same-run-performance-gate-design.md
+++ b/docs/superpowers/specs/2026-08-11-same-run-performance-gate-design.md
@@ -85,8 +85,12 @@ capabilities, no-new-privileges, a non-root uid, PID/CPU/memory/swap limits,
 and bounded tmpfs mounts. A short networked dependency-prefetch run is allowed
 only before measurement, with the same source and resource boundary. Raw
 stdout is captured by the trusted host helper into a fresh directory beneath
-`RUNNER_TEMP`; the helper disables GitHub workflow-command parsing while it
-captures output, enforces a streaming size limit, and kills an overflowing
+`RUNNER_TEMP`; the helper keeps one non-networked holder container alive for
+each private cache volume so Docker daemons that scope tmpfs mounts to a
+container cannot discard prefetched dependencies between runs. Short-lived
+prefetch, warm-up, and measurement containers attach only to that
+side-specific cache. The helper disables GitHub workflow-command parsing while
+it captures output, enforces a streaming size limit, and kills an overflowing
 capture.
 
 The Go image is digest-pinned. The Rust image is built from a Dockerfile copied

--- a/scripts/quality/capture_isolated_benchmarks.py
+++ b/scripts/quality/capture_isolated_benchmarks.py
@@ -55,6 +55,10 @@ _IMAGE_ID_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 _CONTAINER_NAME_RE = re.compile(r"^quality-benchmark-[0-9a-f]{32}$")
 _VOLUME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
 _FORBIDDEN_ENV_PREFIXES = ("GITHUB_", "RUNNER_", "DOCKER_")
+# Docker's local tmpfs volume driver can unmount a named volume when its last
+# container exits on some hosted daemons.  Keep one non-networked holder alive
+# for each side so every short-lived capture observes the same cache mount.
+_CACHE_HOLDERS: dict[str, str] = {}
 
 
 class CaptureError(RuntimeError):
@@ -254,6 +258,7 @@ def build_container_command(
     image: str,
     source_worktree: Path,
     cache_volume: str,
+    cache_holder: str | None = None,
     container_name: str,
     workdir: str,
     network: str,
@@ -267,6 +272,8 @@ def build_container_command(
         raise CaptureError("Container image reference is invalid")
     if _VOLUME_RE.fullmatch(cache_volume) is None:
         raise CaptureError(f"Container cache volume is invalid: {cache_volume!r}")
+    if cache_holder is not None:
+        _validate_container_name(cache_holder)
     # The mount root itself is a valid workdir for the Rust workspace; nested
     # paths remain constrained below that read-only source mount.
     if workdir != "/src" and not workdir.startswith("/src/"):
@@ -284,12 +291,14 @@ def build_container_command(
         (
             "--mount",
             f"type=bind,src={source},dst=/src,readonly",
-            "--mount",
-            f"type=volume,src={cache_volume},dst=/cache",
             "--workdir",
             workdir,
         )
     )
+    if cache_holder is None:
+        command.extend(("--mount", f"type=volume,src={cache_volume},dst=/cache"))
+    else:
+        command.extend(("--volumes-from", cache_holder))
     for key in sorted(environment):
         command.extend(("--env", f"{key}={environment[key]}"))
     return [*command, image, *program]
@@ -540,7 +549,58 @@ def _create_private_volume(image: str, artifact_root: Path, side: str) -> str:
     return volume
 
 
+def _start_cache_holder(*, image: str, cache_volume: str, side: str) -> str:
+    """Keep a side cache mounted while short-lived containers come and go.
+
+    The holder has no source checkout, no network, and the same resource and
+    privilege bounds as benchmark containers.  ``--volumes-from`` then shares
+    this exact mount with prefetch, warm-up, and measurement containers.
+    """
+
+    if _VOLUME_RE.fullmatch(cache_volume) is None:
+        raise CaptureError(f"Container cache volume is invalid: {cache_volume!r}")
+    holder = _new_container_name()
+    command = _bounded_docker_run_options(
+        container_name=holder,
+        network="none",
+        tmpfs_mounts=(CONTAINER_SMALL_TMPFS,),
+    )
+    command.extend(
+        (
+            "--mount",
+            f"type=volume,src={cache_volume},dst=/cache",
+            "--workdir",
+            "/",
+            "--detach",
+            image,
+            "sh",
+            "-ec",
+            "while :; do sleep 3600; done",
+        )
+    )
+    try:
+        completed = _run_checked(command, f"start {side} cache holder")
+    except CaptureError:
+        _best_effort_docker_cleanup(
+            [str(DOCKER_BINARY), "container", "rm", "--force", holder]
+        )
+        raise
+    container_id = completed.stdout.strip()
+    if re.fullmatch(r"[0-9a-f]{12,64}", container_id) is None:
+        _best_effort_docker_cleanup(
+            [str(DOCKER_BINARY), "container", "rm", "--force", holder]
+        )
+        raise CaptureError("Docker returned an invalid cache-holder identifier")
+    _CACHE_HOLDERS[cache_volume] = holder
+    return holder
+
+
 def _remove_volume(volume: str) -> None:
+    holder = _CACHE_HOLDERS.pop(volume, None)
+    if holder is not None:
+        _best_effort_docker_cleanup(
+            [str(DOCKER_BINARY), "container", "rm", "--force", holder]
+        )
     _best_effort_docker_cleanup([str(DOCKER_BINARY), "volume", "rm", "--force", volume])
 
 
@@ -782,6 +842,7 @@ def _capture_pair(
             image=image,
             source_worktree=source_worktree,
             cache_volume=cache_volume,
+            cache_holder=_CACHE_HOLDERS.get(cache_volume),
             container_name=container_name,
             workdir=workdir,
             network="none",
@@ -812,6 +873,7 @@ def _prefetch(
             image=image,
             source_worktree=source_worktree,
             cache_volume=cache_volume,
+            cache_holder=_CACHE_HOLDERS.get(cache_volume),
             container_name=container_name,
             workdir=workdir,
             network="bridge",
@@ -941,6 +1003,10 @@ def capture(arguments: CaptureArguments) -> None:
 
         base_volume = _create_private_volume(image, artifact_root, "base")
         candidate_volume = _create_private_volume(image, artifact_root, "candidate")
+        _start_cache_holder(image=image, cache_volume=base_volume, side="base")
+        _start_cache_holder(
+            image=image, cache_volume=candidate_volume, side="candidate"
+        )
         for side, worktree, volume in (
             ("base", base_worktree, base_volume),
             ("candidate", candidate_worktree, candidate_volume),

--- a/tests/test_capture_isolated_benchmarks.py
+++ b/tests/test_capture_isolated_benchmarks.py
@@ -148,6 +148,30 @@ def test_container_command_allows_the_read_only_source_mount_root(
     assert command[command.index("--workdir") + 1] == "/src"
 
 
+def test_container_command_reuses_a_persistent_cache_holder(
+    tmp_path: Path,
+) -> None:
+    """Short-lived benchmark runs attach to the side's persistent cache holder."""
+
+    source = tmp_path / "candidate-source"
+    source.mkdir()
+    holder = "quality-benchmark-" + "b" * 32
+    command = build_container_command(
+        image="example.invalid/performance@sha256:" + "a" * 64,
+        source_worktree=source,
+        cache_volume="private-candidate-cache",
+        cache_holder=holder,
+        container_name="quality-benchmark-" + "a" * 32,
+        workdir="/src/services/ws-hub",
+        network="none",
+        environment={"HOME": CONTAINER_HOME},
+        program=("go", "test", "-mod=readonly", "-bench=.", "./..."),
+    )
+
+    assert command[command.index("--volumes-from") + 1] == holder
+    assert "type=volume,src=private-candidate-cache,dst=/cache" not in command
+
+
 def test_limited_capture_stops_writing_before_an_untrusted_stream_can_fill_disk(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -261,6 +285,10 @@ def test_capture_rejects_a_mismatched_worktree_head_before_benchmark_setup(
         lambda **_kwargs: benchmark_setup.append("prefetch"),
     )
     monkeypatch.setattr(
+        "scripts.quality.capture_isolated_benchmarks._start_cache_holder",
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(
         "scripts.quality.capture_isolated_benchmarks._capture_pair",
         lambda **_kwargs: benchmark_setup.append("capture"),
     )
@@ -342,6 +370,10 @@ def test_capture_accepts_worktrees_with_matching_declared_heads(
     )
     monkeypatch.setattr(
         "scripts.quality.capture_isolated_benchmarks._prefetch", lambda **_kwargs: None
+    )
+    monkeypatch.setattr(
+        "scripts.quality.capture_isolated_benchmarks._start_cache_holder",
+        lambda **_kwargs: None,
     )
     monkeypatch.setattr(
         "scripts.quality.capture_isolated_benchmarks._capture_pair",


### PR DESCRIPTION
## Summary\n- keep a non-networked holder container mounted for each private benchmark cache\n- attach prefetch, warm-up, and measurement containers through the holder so hosted Docker tmpfs mounts cannot lose dependencies between runs\n- preserve offline/network-none recorded measurements and add lifecycle contract coverage\n\n## Verification\n- 75 targeted tests passed\n- Ruff, format, py_compile, diff check passed\n- Go and Rust Docker smoke prefetch-to-offline-warm passed\n- frontend  px tsc --noEmit passed\n\nThis is a trusted-base hotfix required before the Phase2 candidate performance gate can exercise the updated helper. 

## Admin bypass record

All required checks will be green at merge time. Administrator merge is used solely because the active main ruleset requires CODEOWNER review and the sole maintainer cannot provide a second CODEOWNER approval; no status-check bypass is being used.